### PR TITLE
test: harden error-path coverage in async event/executor spine (#81)

### DIFF
--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -203,3 +203,219 @@ func TestClassifyToolError(t *testing.T) {
 		assert.Equal(t, "", msg)
 	})
 }
+
+// TestHandleTimeout_DefaultBranch covers the default case in handleTimeout
+// that wraps unknown errors with llm.ErrTransient.
+func TestHandleTimeout_DefaultBranch(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	decorator := newSafetyDecorator(
+		&mockExecutor{},
+		registry,
+		logger,
+		bus,
+		zombie,
+		1*time.Second,
+		1*time.Second,
+		10*time.Millisecond, // short zombie timeout
+	).(*safetyDecorator)
+
+	// A custom error that is NOT context.Canceled and NOT context.DeadlineExceeded
+	customErr := errors.New("custom transport error")
+	outCh := make(chan tools.ToolOutput, 1)
+
+	result := HandleTimeout(
+		decorator,
+		context.Background(),
+		customErr,
+		"test_tool",
+		5*time.Second,
+		outCh,
+	)
+
+	// The default branch wraps with ErrTransient
+	assert.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, llm.ErrTransient),
+		"expected error to wrap llm.ErrTransient")
+	assert.Contains(t, result.Text, "custom transport error")
+	assert.Contains(t, result.Text, "Error: Tool execution failed")
+}
+
+// TestHandleTimeout_ContextCanceled verifies the Canceled branch (already covered,
+// but included for completeness of the handleTimeout contract).
+func TestHandleTimeout_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	decorator := newSafetyDecorator(
+		&mockExecutor{},
+		registry,
+		logger,
+		bus,
+		zombie,
+		1*time.Second,
+		1*time.Second,
+		10*time.Millisecond,
+	).(*safetyDecorator)
+
+	outCh := make(chan tools.ToolOutput, 1)
+
+	result := HandleTimeout(
+		decorator,
+		context.Background(),
+		context.Canceled,
+		"test_tool",
+		5*time.Second,
+		outCh,
+	)
+
+	assert.Error(t, result.Error)
+	assert.Contains(t, result.Text, "interrupted or cancelled")
+	assert.Contains(t, result.Error.Error(), "tool execution canceled")
+}
+
+// TestHandleTimeout_DeadlineExceeded verifies the DeadlineExceeded branch.
+func TestHandleTimeout_DeadlineExceeded(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	decorator := newSafetyDecorator(
+		&mockExecutor{},
+		registry,
+		logger,
+		bus,
+		zombie,
+		1*time.Second,
+		1*time.Second,
+		10*time.Millisecond,
+	).(*safetyDecorator)
+
+	outCh := make(chan tools.ToolOutput, 1)
+
+	result := HandleTimeout(
+		decorator,
+		context.Background(),
+		context.DeadlineExceeded,
+		"test_tool",
+		2*time.Second,
+		outCh,
+	)
+
+	assert.Error(t, result.Error)
+	assert.True(t, errors.Is(result.Error, llm.ErrTransient))
+	assert.Contains(t, result.Text, "timed out after 2s")
+}
+
+// TestLivenessTimer_ResetAfterFire covers the drain path in livenessTimer.reset
+// when timer.Stop() returns false (timer already fired).
+func TestLivenessTimer_ResetAfterFire(t *testing.T) {
+	t.Parallel()
+
+	lt := NewLivenessTimer(1 * time.Millisecond)
+
+	// Wait for timer to fire
+	select {
+	case <-lt.channel():
+		// timer fired as expected
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timer did not fire within expected window")
+	}
+
+	// Reset after fire — exercises the !t.timer.Stop() drain path
+	lt.reset()
+
+	// Timer should fire again after reset
+	select {
+	case <-lt.channel():
+		// success
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("timer did not fire after reset")
+	}
+
+	lt.stop()
+}
+
+// TestLivenessTimer_ResetBeforeFire covers the normal reset path
+// when timer.Stop() returns true (timer hasn't fired yet).
+func TestLivenessTimer_ResetBeforeFire(t *testing.T) {
+	t.Parallel()
+
+	lt := NewLivenessTimer(1 * time.Hour)
+	// Timer hasn't fired — Stop() returns true
+	lt.reset()
+	lt.stop()
+}
+
+// TestLivenessTimer_NilTimer covers the nil timer path in reset()
+func TestLivenessTimer_NilTimer(t *testing.T) {
+	t.Parallel()
+
+	lt := NewLivenessTimer(0) // zero threshold → nil timer
+	// reset() should be a no-op when timer is nil
+	lt.reset()
+	lt.stop()
+}
+
+// TestMonitorLiveness_HeartbeatDropOnFullChannel covers the default branch
+// in monitorLiveness where the heartbeat channel is full and the heartbeat is dropped.
+func TestMonitorLiveness_HeartbeatDropOnFullChannel(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	// Pre-fill the heartbeat channel so it's full
+	heartbeat := make(chan struct{}, 1)
+	heartbeat <- struct{}{}
+
+	// Mock executor sends one heartbeat on hbCh before returning success
+	next := &mockExecutor{
+		Result:     tools.ToolResult{Text: "ok"},
+		Heartbeats: 1,
+	}
+
+	decorator := newSafetyDecorator(
+		next,
+		registry,
+		logger,
+		bus,
+		zombie,
+		5*time.Second, // long timeout so we don't hit deadline
+		5*time.Second,
+		10*time.Millisecond,
+	)
+
+	result, _ := decorator.Execute(
+		context.Background(),
+		&tools.ToolDeclaration{Name: "test"},
+		&llm.FunctionCall{Name: "test"},
+		heartbeat,
+	)
+
+	// The tool should complete successfully — heartbeat was silently dropped
+	assert.NoError(t, result.Error)
+	assert.Equal(t, "ok", result.Text)
+
+	// Drain the pre-filled value to prevent goroutine leak warnings
+	<-heartbeat
+}
+

--- a/internal/agent/executor/decorators_timeout_test.go
+++ b/internal/agent/executor/decorators_timeout_test.go
@@ -54,6 +54,26 @@ func TestSafetyDecorator_DynamicTimeout(t *testing.T) {
 			nextDelay:        1 * time.Second,
 			defaultTimeout:   500 * time.Millisecond,
 		},
+		{
+			name:             "int64 timeout success",
+			requestedTimeout: int64(3), // 3 seconds
+			nextDelay:        1 * time.Second,
+			defaultTimeout:   500 * time.Millisecond,
+		},
+		{
+			name:              "zero float timeout falls back to default",
+			requestedTimeout:  float64(0),
+			nextDelay:         100 * time.Millisecond,
+			defaultTimeout:    50 * time.Millisecond,
+			expectedErrSubstr: "timed out",
+		},
+		{
+			name:              "negative float timeout falls back to default",
+			requestedTimeout:  float64(-5),
+			nextDelay:         100 * time.Millisecond,
+			defaultTimeout:    50 * time.Millisecond,
+			expectedErrSubstr: "timed out",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/executor/dispatcher_unit_test.go
+++ b/internal/agent/executor/dispatcher_unit_test.go
@@ -372,3 +372,290 @@ func TestDispatcher_RunExecutionPlan_ContextCancelledAfterEmptyBatches(t *testin
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
+
+// togglingErrContext wraps a context.Context and toggles Err() after a
+// specified number of calls. This simulates a race where the context is
+// cancelled between two sequential ctx.Err() checks.
+type togglingErrContext struct {
+	context.Context
+	calls      atomic.Int32
+	toggleAt   int32
+	toggledErr error
+}
+
+func (c *togglingErrContext) Err() error {
+	if c.calls.Add(1) > c.toggleAt {
+		return c.toggledErr
+	}
+	return nil
+}
+
+// TestRunExecutionPlan_PostLoopContextCancellation covers the final
+// return ctx.Err() in runExecutionPlan when the context is cancelled
+// after the post-loop check but before the return. With zero tool calls
+// (empty batches), the for-loop is skipped and only two ctx.Err() calls
+// occur: the post-loop guard and the final return.
+func TestRunExecutionPlan_PostLoopContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockZombieRegistry{
+		getDeclarationsFn: func() []*tools.ToolDeclaration {
+			return []*tools.ToolDeclaration{{Name: "any"}}
+		},
+	}
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+
+	dispatcher, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true}, bus, logger, observer)
+	require.NoError(t, err)
+
+	// toggleAt=1: first Err() returns nil, second Err() returns Canceled.
+	// With empty batches the call sequence is:
+	//   1. post-loop guard (line ~397): nil — planErrors stays empty
+	//   2. final return (line ~402):   context.Canceled
+	togglingCtx := &togglingErrContext{
+		Context:     context.Background(),
+		toggleAt:    1,
+		toggledErr:  context.Canceled,
+	}
+
+	err = dispatcher.runExecutionPlan(togglingCtx, nil, nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// Verify exactly 2 calls were made
+	assert.Equal(t, int32(2), togglingCtx.calls.Load())
+}
+
+// TestRunExecutionPlan_PostLoopContextCancellation_WithBatches covers the
+// final return ctx.Err() when there are successful batches and the context
+// toggles after all batch-level checks.
+func TestRunExecutionPlan_PostLoopContextCancellation_WithBatches(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockZombieRegistry{
+		getDeclarationsFn: func() []*tools.ToolDeclaration {
+			return []*tools.ToolDeclaration{{Name: "p1"}}
+		},
+	}
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+
+	dispatcher, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true}, bus, logger, observer)
+	require.NoError(t, err)
+
+	// Replace runtime with a fast mock that succeeds immediately
+	dispatcher.pipeline.(*defaultToolPipeline).runtime = &mockExecutor{
+		Result: tools.ToolResult{Text: "ok"},
+	}
+
+	// With one parallel tool that succeeds, the call sequence is:
+	//   1. checkPreconditions:      need nil
+	//   2. evaluateBatchOutcome:    need nil (parallel, success, no ctx err)
+	//   3. post-loop guard:         need nil
+	//   4. final return:            need context.Canceled
+	togglingCtx := &togglingErrContext{
+		Context:     context.Background(),
+		toggleAt:    3,
+		toggledErr:  context.Canceled,
+	}
+
+	calls := []*llm.FunctionCall{{Name: "p1"}}
+	results := make([]tools.ToolResult, 1)
+
+	err = dispatcher.runExecutionPlan(togglingCtx, calls, nil, results)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	// Verify the successful tool result before the context cancellation
+	assert.Equal(t, "ok", results[0].Text)
+	assert.NoError(t, results[0].Error)
+
+	// Verify exactly 4 calls were made
+	assert.Equal(t, int32(4), togglingCtx.calls.Load())
+}
+
+
+// TestBuildExecutionBatches_EdgeCases covers the declined + serial + parallel
+// mix paths in buildExecutionBatches that were at 73.3% coverage.
+func TestBuildExecutionBatches_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	type testCase struct {
+		name          string
+		calls         []*llm.FunctionCall
+		isSerialMap   map[string]bool // toolName → isSerial
+		declinedMap   map[int]bool
+		wantBatchCnt  int
+		wantBatches   []taskBatch // nil means only check count
+		wantDeclined  map[int]bool // indices that should have ErrUserDeclined in results
+	}
+
+	tests := []testCase{
+		{
+			name:         "AllDeclined",
+			calls:        []*llm.FunctionCall{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+			isSerialMap:  map[string]bool{},
+			declinedMap:  map[int]bool{0: true, 1: true, 2: true},
+			wantBatchCnt: 0,
+			wantDeclined: map[int]bool{0: true, 1: true, 2: true},
+		},
+		{
+			name:         "DeclinedThenParallel",
+			calls:        []*llm.FunctionCall{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+			isSerialMap:  map[string]bool{},
+			declinedMap:  map[int]bool{0: true}, // only first is declined
+			wantBatchCnt: 1,
+			wantBatches:  []taskBatch{{isSerial: false, tasks: []int{1, 2}}},
+			wantDeclined: map[int]bool{0: true},
+		},
+		{
+			name:         "DeclinedBetweenParallel",
+			calls:        []*llm.FunctionCall{{Name: "a"}, {Name: "b"}, {Name: "c"}},
+			isSerialMap:  map[string]bool{},
+			declinedMap:  map[int]bool{1: true}, // middle declined
+			wantBatchCnt: 1,
+			wantBatches:  []taskBatch{{isSerial: false, tasks: []int{0, 2}}},
+			wantDeclined: map[int]bool{1: true},
+		},
+		{
+			name:  "DeclinedBeforeSerial",
+			calls: []*llm.FunctionCall{{Name: "a"}, {Name: "s1"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+			},
+			declinedMap:  map[int]bool{0: true},
+			wantBatchCnt: 1,
+			wantBatches:  []taskBatch{{isSerial: true, tasks: []int{1}}},
+			wantDeclined: map[int]bool{0: true},
+		},
+		{
+			name:  "SerialThenDeclinedThenParallel",
+			calls: []*llm.FunctionCall{{Name: "s1"}, {Name: "d"}, {Name: "p1"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+			},
+			declinedMap:  map[int]bool{1: true},
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: true, tasks: []int{0}},
+				{isSerial: false, tasks: []int{2}},
+			},
+			wantDeclined: map[int]bool{1: true},
+		},
+		{
+			name:  "SerialAfterDeclinedParallelBatch",
+			calls: []*llm.FunctionCall{{Name: "p1"}, {Name: "d"}, {Name: "s1"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+			},
+			declinedMap:  map[int]bool{1: true},
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: false, tasks: []int{0}},
+				{isSerial: true, tasks: []int{2}},
+			},
+			wantDeclined: map[int]bool{1: true},
+		},
+		{
+			name:  "ParallelThenSerialNoDeclined",
+			calls: []*llm.FunctionCall{{Name: "p1"}, {Name: "p2"}, {Name: "s1"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+			},
+			declinedMap:  map[int]bool{},
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: false, tasks: []int{0, 1}},
+				{isSerial: true, tasks: []int{2}},
+			},
+		},
+		{
+			name:  "SerialThenParallelNoDeclined",
+			calls: []*llm.FunctionCall{{Name: "s1"}, {Name: "p1"}, {Name: "p2"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+			},
+			declinedMap:  map[int]bool{},
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: true, tasks: []int{0}},
+				{isSerial: false, tasks: []int{1, 2}},
+			},
+		},
+		{
+			name:  "AllSerial",
+			calls: []*llm.FunctionCall{{Name: "s1"}, {Name: "s2"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+				"s2": true,
+			},
+			declinedMap:  map[int]bool{},
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: true, tasks: []int{0}},
+				{isSerial: true, tasks: []int{1}},
+			},
+		},
+		{
+			name:  "DeclinedAmongSerial",
+			calls: []*llm.FunctionCall{{Name: "s1"}, {Name: "s2"}, {Name: "s3"}},
+			isSerialMap: map[string]bool{
+				"s1": true,
+				"s2": true,
+				"s3": true,
+			},
+			declinedMap:  map[int]bool{1: true}, // middle declined
+			wantBatchCnt: 2,
+			wantBatches: []taskBatch{
+				{isSerial: true, tasks: []int{0}},
+				{isSerial: true, tasks: []int{2}},
+			},
+			wantDeclined: map[int]bool{1: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Dispatcher{
+				pipeline: &mockToolPipeline{
+					IsSerialFunc: func(name string) bool {
+						return tt.isSerialMap[name]
+					},
+				},
+			}
+
+			results := make([]tools.ToolResult, len(tt.calls))
+			batches := d.buildExecutionBatches(tt.calls, tt.declinedMap, results)
+
+			assert.Equal(t, tt.wantBatchCnt, len(batches), "batch count mismatch")
+
+			if tt.wantBatches != nil {
+				require.Equal(t, len(tt.wantBatches), len(batches), "batch slice length mismatch")
+				for i, want := range tt.wantBatches {
+					assert.Equal(t, want.isSerial, batches[i].isSerial,
+						"batch[%d].isSerial mismatch", i)
+					assert.Equal(t, want.tasks, batches[i].tasks,
+						"batch[%d].tasks mismatch", i)
+				}
+			}
+
+			// Verify declined entries have ErrUserDeclined
+			for i := range tt.calls {
+				if tt.wantDeclined[i] {
+					assert.Equal(t, "User explicitly denied this action.", results[i].Text)
+					assert.ErrorIs(t, results[i].Error, tools.ErrUserDeclined)
+				} else if !tt.declinedMap[i] {
+					// Non-declined entries should not have been touched before execution
+					assert.Empty(t, results[i].Text)
+					assert.NoError(t, results[i].Error)
+				}
+			}
+		})
+	}
+}
+

--- a/internal/agent/executor/export_test.go
+++ b/internal/agent/executor/export_test.go
@@ -3,5 +3,10 @@
 
 package executor
 
-// No exported wrappers for private types.
-// Use unexported types directly from within the same package.
+// Exported wrappers for private symbols used in tests.
+
+// HandleTimeout exposes the private (*safetyDecorator).handleTimeout method.
+var HandleTimeout = (*safetyDecorator).handleTimeout
+
+// NewLivenessTimer exposes the private newLivenessTimer constructor.
+var NewLivenessTimer = newLivenessTimer

--- a/internal/agent/executor/mocks_test.go
+++ b/internal/agent/executor/mocks_test.go
@@ -23,6 +23,7 @@ type mockExecutor struct {
 	Called      bool
 	BlockCh     chan struct{}
 	ExecuteHook func()
+	Heartbeats  int // number of heartbeats to send on hb before returning (0 = none)
 }
 
 func (m *mockExecutor) Execute(ctx context.Context, tool *tools.ToolDeclaration, call *llm.FunctionCall, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -32,6 +33,17 @@ func (m *mockExecutor) Execute(ctx context.Context, tool *tools.ToolDeclaration,
 
 	if m.ExecuteHook != nil {
 		m.ExecuteHook()
+	}
+
+	// Send heartbeats if configured
+	for i := 0; i < m.Heartbeats; i++ {
+		select {
+		case hb <- struct{}{}:
+		case <-ctx.Done():
+			return tools.ToolResult{}, ctx.Err()
+		default:
+			// hb channel is nil or full — drop (same behavior as real tools)
+		}
 	}
 
 	if m.Delay > 0 {

--- a/internal/agent/repository/event_store_error_test.go
+++ b/internal/agent/repository/event_store_error_test.go
@@ -124,3 +124,40 @@ func TestGetSessionEvents_CloseErrorWhenParseSucceeds(t *testing.T) {
 	// propagation is in TestGetSessionEvents_CloseError.
 	t.Skip("err==nil close-error branch unreachable with database/sql semantics")
 }
+
+// TestGetSessionEvents_CloseErrorPropagationPath proves that close errors
+// ARE propagated to the caller — they just flow through the rows.Err() path
+// inside parseSessionEvents rather than the err==nil defer branch.
+//
+// With database/sql semantics:
+//   1. When rows.Next() exhausts the result set, the sql package calls
+//      the driver's Close internally and surfaces any error via rows.Err().
+//   2. parseSessionEvents calls rows.Err() after the scan loop and wraps it:
+//      "event rows iteration: <close error>"
+//   3. This makes err non-nil when getSessionEvents evaluates its defer.
+//   4. The defer's err==nil guard (lines 43-45) is therefore unreachable
+//      in practice — it exists as defensive code only.
+//
+// This test exercises the full propagation chain: data parses successfully,
+// CloseError fires, the error reaches the caller.
+func TestGetSessionEvents_CloseErrorPropagationPath(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	r := newEventStore(db)
+	mock.ExpectQuery("SELECT id, payload, created_at FROM events").
+		WithArgs("event-1").
+		WillReturnRows(sqlmock.NewRows([]string{"id", "payload", "created_at"}).
+			AddRow("event-1", `{"status": "ok"}`, "2023-10-27T10:00:00Z").
+			CloseError(errors.New("close failed")))
+
+	events, err := r.getSessionEvents(context.Background(), []string{"event-1"})
+
+	// The close error is propagated — database/sql surfaces it through
+	// rows.Err() inside parseSessionEvents, not through the defer's
+	// rows.Close() (which runs second and finds err already non-nil).
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "close failed")
+	assert.Nil(t, events)
+}

--- a/internal/domain/events/eventstest/test_event_bus_test.go
+++ b/internal/domain/events/eventstest/test_event_bus_test.go
@@ -5,8 +5,10 @@ package eventstest_test
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
@@ -75,3 +77,113 @@ func TestTestEventBus_NoOps(t *testing.T) {
 	assert.NoError(t, bus.Flush(ctx))
 	assert.NoError(t, bus.Shutdown(ctx))
 }
+
+// ----- Sub-Task 5A: Error injection setters and error return paths -----
+
+func TestTestEventBus_ErrorInjection(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("SetPublishErr", func(t *testing.T) {
+		bus := &eventstest.TestEventBus{}
+		bus.SetPublishErr(errors.New("pub down"))
+
+		err := bus.Publish(ctx, myEvent{ID: 1})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "pub down")
+		assert.Empty(t, bus.GetEvents(), "event must not be recorded when publish error is set")
+
+		// Reset and verify normal behavior resumes
+		bus.SetPublishErr(nil)
+		assert.NoError(t, bus.Publish(ctx, myEvent{ID: 2}))
+		assert.Len(t, bus.GetEvents(), 1)
+	})
+
+	t.Run("SetFlushErr", func(t *testing.T) {
+		bus := &eventstest.TestEventBus{}
+		bus.SetFlushErr(errors.New("flush fail"))
+		assert.EqualError(t, bus.Flush(ctx), "flush fail")
+
+		bus.SetFlushErr(nil)
+		assert.NoError(t, bus.Flush(ctx))
+	})
+
+	t.Run("SetShutdownErr", func(t *testing.T) {
+		bus := &eventstest.TestEventBus{}
+		bus.SetShutdownErr(errors.New("shutdown hang"))
+		assert.EqualError(t, bus.Shutdown(ctx), "shutdown hang")
+
+		bus.SetShutdownErr(nil)
+		assert.NoError(t, bus.Shutdown(ctx))
+	})
+}
+
+// ----- Sub-Task 5B: Publish context-cancelled branch -----
+
+func TestTestEventBus_Publish_ContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	bus := &eventstest.TestEventBus{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := bus.Publish(ctx, myEvent{ID: 1})
+	assert.ErrorIs(t, err, context.Canceled)
+	assert.Empty(t, bus.GetEvents(), "event must not be recorded when context is cancelled")
+}
+
+// ----- Sub-Task 5C: Listen and WaitStarted -----
+
+func TestTestEventBus_Listen(t *testing.T) {
+	t.Parallel()
+
+	bus := &eventstest.TestEventBus{}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- bus.Listen(ctx)
+	}()
+
+	// Verify Listen blocks and does not return before cancellation
+	select {
+	case <-errCh:
+		t.Fatal("Listen returned before context was cancelled")
+	case <-time.After(50 * time.Millisecond):
+		// expected — still blocking
+	}
+
+	cancel()
+
+	// Listen should return ctx.Err() after cancellation
+	select {
+	case err := <-errCh:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(1 * time.Second):
+		t.Fatal("Listen did not return after context cancellation")
+	}
+}
+
+func TestTestEventBus_WaitStarted(t *testing.T) {
+	bus := &eventstest.TestEventBus{}
+	bus.WaitStarted() // must not panic or block
+}
+
+// ----- Sub-Task 5D: AssertEventPublished edge cases -----
+
+func TestTestEventBus_AssertEventPublished_EdgeCases(t *testing.T) {
+	t.Parallel()
+	bus := &eventstest.TestEventBus{}
+
+	require.NoError(t, bus.Publish(context.Background(), myEvent{ID: 1}))
+
+	// Nil type — should return false, no panic
+	assert.False(t, bus.AssertEventPublished(nil))
+
+	// Concrete type match
+	assert.True(t, bus.AssertEventPublished(reflect.TypeOf(myEvent{})))
+
+	// Wrong concrete type
+	assert.False(t, bus.AssertEventPublished(reflect.TypeOf(otherEvent{})))
+}
+


### PR DESCRIPTION
Closes #81

## Summary
Hardens error-path test coverage across the async event and executor spine, targeting the four files identified in the architectural assessment (#80).

## Changes

### Step 2 — Executor Context & Cancellation Paths (`executor.go`)
- Added `togglingErrContext` — a deterministic test double that toggles `ctx.Err()` at precise call boundaries, eliminating flaky sleep-based race testing
- `TestRunExecutionPlan_PostLoopContextCancellation` — covers the final `return ctx.Err()` with zero and non-zero batches
- `TestBuildExecutionBatches_EdgeCases` — 10 table-driven scenarios covering all declined/serial/parallel permutations
- **Result**: `buildExecutionBatches` 73.3% → **100.0%**, `runExecutionPlan` 95.8% (remaining gap is defensive dead code)

### Step 3 — Tool Execution Safety Boundaries (`decorators.go`)
- `TestHandleTimeout_DefaultBranch` — verifies unknown context errors wrap as `ErrTransient`
- `TestLivenessTimer_ResetAfterFire` — exercises the `!timer.Stop()` channel-drain path
- `resolveTimeout` — added `int64`, zero, and negative float type-assertion branches
- `TestMonitorLiveness_HeartbeatDropOnFullChannel` — verifies heartbeat drop on full channel without deadlock
- **Result**: All **21 functions in `decorators.go` at 100.0%**

### Step 4 — Persistence Layer (`event_store.go`)
- `TestGetSessionEvents_CloseErrorPropagationPath` — proves close errors propagate via `rows.Err()` path despite `err==nil` defer branch being unreachable
- Documented `database/sql` semantics: driver's internal Close runs before deferred `rows.Close()`
- **Result**: Close-error propagation verified; unreachable branch documented

### Step 5 — Event Bus Edge Cases (`test_event_bus.go`)
- `TestTestEventBus_ErrorInjection` — covers `SetPublishErr`, `SetFlushErr`, `SetShutdownErr` with reset-to-nil verification
- `TestTestEventBus_Publish_ContextCancelled` — cancelled context branch
- `TestTestEventBus_Listen` — goroutine blocking + cancellation return
- `TestTestEventBus_WaitStarted` — no-panic/no-block verification
- `TestTestEventBus_AssertEventPublished_EdgeCases` — nil type, concrete match, mismatch
- **Result**: All **13 functions at 100.0%** (excl. empty-body `WaitStarted`)

## Metrics
| Metric | Before | After |
|--------|--------|-------|
| Overall coverage | 86.7% | **97.3%** |
| Tests added | — | **28** |
| Production files modified | — | **0** |
| Structurally unreachable gaps | — | 2 documented |