### PR TITLE
docs: add ADR-026 (session/context extraction) + issue artifacts

### DIFF
--- a/docs/adr/2026-04-session-context-subpackage-extraction.md
+++ b/docs/adr/2026-04-session-context-subpackage-extraction.md
@@ -1,0 +1,194 @@
+<!--
+Copyright (c) 2026 gosharplite@gmail.com
+SPDX-License-Identifier: MIT
+-->
+
+# ADR-026: Decompose `agent/session` Package via `context/` Sub-Package Extraction
+
+## Status
+Proposed
+
+## Context
+
+The `internal/agent/session` package has grown into the largest single package in the codebase by LOC and file count. Concrete measurements (taken at the time of writing):
+
+| Metric | Value |
+|---|---|
+| Total files | 55 (29 production + 26 test) |
+| Total LOC | 12,978 |
+| Production LOC | ~3,930 |
+| Largest production file | `context_manager.go` (543 LOC) |
+| Second largest | `context_transformers.go` (480 LOC) |
+
+The package mixes **at least five distinct, cohesive concerns** behind a single `package session` declaration:
+
+| Concern | Files | Production LOC | Cohesion Marker |
+|---|---|---|---|
+| **Context preparation pipeline** | `context_manager.go`, `context_pipeline.go`, `context_strategy.go`, `context_transformers.go`, `pruner.go`, `gatekeeper.go`, `token_counter.go`, `pipeline_factory.go`, `injector.go` (WarningInjector) | ~2,247 | All implement or coordinate `ports.ContextTransformer` execution |
+| **UI Bridge (actor)** | `ui_bridge.go`, `ui_bridge_dispatcher.go`, `ui_bridge_event_queue.go`, `ui_bridge_spinner.go`, `ui_bridge_state_machine.go` | ~757 | Decomposed per ADR-025 — already internally cohesive |
+| **Session lifecycle** | `session_manager.go`, `interfaces.go`, `doc.go` | ~431 | Orchestrates the other four concerns |
+| **Configuration watching** | `config_watcher.go` | ~301 | File-system-bound, distinct dependency surface |
+| **Skill injection** | `skill_injector.go` | ~108 | Bridges `domain/skills` into the context pipeline |
+| **Internal tool registration** | `internal_tools.go` | ~163 | Registers chat-history-management tools |
+
+ADR-008 ("Domain Decomposition Strategy") established that packages exceeding ~3,000 production LOC or mixing more than three orthogonal concerns must be decomposed along concern boundaries. `agent/session` violates both thresholds.
+
+ADR-025 ("UIBridge Decomposition") addressed the largest internal monolith inside this package by splitting `ui_bridge.go` into 5 cohesive files. That refactor was scoped to a single file family because cross-package extraction was not yet justified — the file count was not yet pathological. With the package now at 55 files, **the next decomposition step must be to extract sub-packages**, not to further fragment files inside the existing flat namespace.
+
+### Why `context/` First
+
+The Context Preparation concern is the largest, the most internally cohesive, and the most independently testable group:
+
+- **57% of the package's production code** (2,247 / 3,930 LOC) belongs to it.
+- All files in the group depend on **`ports.ContextTransformer`** as their primary contract.
+- The group has a single internal entry point (`ContextManager.Prepare`) and a single internal builder (`PipelineFactory.BuildStandardPipeline`).
+- External consumers are limited to **two files**: `agent.go` and `session_manager.go`. No transitive consumers.
+- The group has its own test fixtures (`test_helpers_test.go`, `context_manager_*_test.go`, `coverage_expansion_test.go`) that already conceptually scope to context-pipeline behaviour.
+
+Other candidate groups (UIBridge, Skills, Config-Watcher) are smaller, more entangled with `session_manager.go`, or already structurally decomposed. Extracting them is deferred to follow-up ADRs.
+
+### Risks Identified
+
+A pre-flight audit revealed three coupling hazards that the design must address:
+
+1. **`internal_tools.go` depends on `ContextManager`.** It calls `NewInternalTools(cm *ContextManager)` and `RegisterInternal(r tools.ToolRegistrar, cm *ContextManager)`. After extraction, this file must either move with `context/` or import it.
+2. **`PipelineFactory` constructs `skillInjector`, `WarningInjector`, `TokenGatekeeper`, `HistoryPruner`.** All four must live in the same package as the factory, or the factory must be split.
+3. **`export_test.go` uses unexported types** (`sessionManager`, `UIBridge`). Cross-package tests cannot reach them. Fixtures shared between `session/` and `session/context/` must move to a neutral location or be re-exported via `_test.go`-only helpers in each package.
+
+## Decision
+
+We will extract a new sub-package `internal/agent/session/context/` containing the Context Preparation concern. The parent `session/` package retains lifecycle, UIBridge, configuration watching, skill injection, and internal-tools registration. The decomposition is **structural, not semantic** — no behaviour changes.
+
+### Files Moved into `session/context/`
+
+| Old path (`session/*`) | New path (`session/context/*`) | Rename |
+|---|---|---|
+| `context_manager.go` | `context/manager.go` | `ContextManager` → `Manager` |
+| `context_pipeline.go` | `context/pipeline.go` | `contextPipeline` → `pipeline` (unchanged — already lowercase) |
+| `context_strategy.go` | `context/strategy.go` | `ContextStrategy` → `Strategy` |
+| `context_transformers.go` | `context/transformers.go` | unchanged (already split into multiple types) |
+| `pruner.go` | `context/pruner.go` | unchanged |
+| `gatekeeper.go` | `context/gatekeeper.go` | unchanged |
+| `token_counter.go` | `context/token_counter.go` | unchanged |
+| `pipeline_factory.go` | `context/pipeline_factory.go` | `PipelineFactory` → `Factory` |
+| `injector.go` (WarningInjector) | `context/warning_injector.go` | filename clarified |
+
+Plus their `*_test.go` siblings (10 files), preserving test coverage in the new package.
+
+### Files Staying in `session/`
+
+`session_manager.go`, `interfaces.go`, `doc.go`, `ui_bridge*.go` (5 files), `config_watcher.go`, `skill_injector.go`, `internal_tools.go`, `export_test.go`, plus their tests.
+
+**Rationale for keeping each:**
+
+- `session_manager.go`, `interfaces.go`, `doc.go` — orchestration and package contract.
+- `ui_bridge*.go` — already internally decomposed per ADR-025; not a context concern.
+- `config_watcher.go` — independent file-system concern; different lifecycle (deferred to a future ADR).
+- `skill_injector.go` — depends on `domain/skills` and `domain/ports`; thin adapter rather than context logic.
+- `internal_tools.go` — registers chat-history-management tools; lives at the boundary between `tools.Registry` and `ContextManager`. Needs special handling (see below).
+
+### Coupling Hazard Resolutions
+
+#### 1. `internal_tools.go` and `ContextManager`
+
+**Decision:** `internal_tools.go` stays in `session/` and imports `session/context`. The reasoning:
+
+- It is fundamentally a **tool registration adapter** that happens to need a `ContextManager` reference, not a context-pipeline component.
+- Moving it into `context/` would force `context/` to import `domain/tools`, polluting the context layer with tool-registration concerns.
+- The import direction `session → session/context` is acyclic and matches the parent-child dependency convention.
+
+After the move:
+
+```go
+// session/internal_tools.go
+import sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+
+func NewInternalTools(cm *sessctx.Manager) *InternalTools { ... }
+func RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager) error { ... }
+```
+
+#### 2. `PipelineFactory` Construction Surface
+
+**Decision:** `PipelineFactory` (renamed `Factory`) moves with the context group and **continues to construct all transformer types in scope**: `TokenGatekeeper`, `HistoryPruner`, `WarningInjector`, plus the inline transformers from `context_transformers.go`.
+
+`skillInjector` is the **one exception** — it stays in `session/` and is injected into the factory as a pre-built `ports.ContextTransformer`. Updated factory signature:
+
+```go
+// session/context/pipeline_factory.go
+func (f *Factory) BuildStandardPipeline(
+    limits events.Limits,
+    extras ...ports.ContextTransformer,  // session/ injects skillInjector here
+) *pipeline { ... }
+```
+
+This preserves the factory's internal construction logic while breaking the `context → domain/skills` import that would otherwise be created.
+
+#### 3. Test Fixture Sharing
+
+**Decision:** Shared test fixtures stay duplicated where minimal, and are promoted to `internal/pkg/testfixtures` only when the duplication burden exceeds ~50 LOC.
+
+`export_test.go` stays in `session/` and continues to expose `sessionManager` and `UIBridge` internals. The Context Preparation tests already use their own fixtures (`test_helpers_test.go`, `context_manager_*_test.go`) and do not depend on `export_test.go` exports. Verified by inspection of `context_manager_test.go`'s import surface.
+
+### Renaming Convention
+
+Per Go style, the package qualifier replaces the type-name prefix:
+
+- `session.ContextManager` → `context.Manager`
+- `session.ContextStrategy` → `context.Strategy`
+- `session.PipelineFactory` → `context.Factory`
+
+The renames are mechanical and applied via `rename_symbol`, not regex. Functions like `NewContextManager` become `NewManager` to maintain `package.NewType` symmetry. **No behaviour changes.**
+
+### Consumer Update Surface
+
+Verified by inspection of import graph and `find_usages`:
+
+| Consumer | Lines requiring update | Update type |
+|---|---|---|
+| `internal/agent/agent.go` | ~5 | Type renames + import |
+| `internal/agent/session/session_manager.go` | ~8 | Type renames + import |
+| `internal/agent/session/internal_tools.go` | ~3 | Type renames + import |
+| `internal/agent/session/skill_injector.go` | ~2 | Implements interface from `context/` |
+
+No other production files in the codebase import the affected types (verified via `get_package_graph`).
+
+## Consequences
+
+### Positive
+
+- **`session/` production file count drops from 29 to ~20** — restoring navigability.
+- **`session/context/` becomes independently testable** with a clear `Manager.Prepare` entry point. New transformers can be added without touching the parent package.
+- **Open/Closed adherence**: adding context transformers requires modifying only `context/`, not `session/`.
+- **Establishes a sub-package decomposition pattern** for follow-up extractions (`session/uibridge/`, `session/skills/`, `session/configwatch/`) without requiring further ADRs — they will reference this one.
+- **Reduces blast radius for context-pipeline changes** — currently a one-line change in a transformer triggers `go test ./internal/agent/session/...` covering 26 test files. After the split, only `context/` tests run.
+
+### Negative
+
+- **One-time mechanical migration cost** on ~10 production files plus their tests. Mitigated by AST-based `rename_symbol` and the small consumer surface (~18 lines).
+- **Slightly deeper import paths** for context types in tests (`sessctx.Manager` instead of `session.ContextManager`). Acceptable trade-off for clarity.
+- **`PipelineFactory.BuildStandardPipeline` signature gains a variadic `extras` parameter** to receive `skillInjector` from the parent. This is a breaking change to the factory API, but the only caller is `session_manager.go` — bounded blast radius.
+- **`internal_tools.go` becomes the only file in `session/` that imports `session/context`** — a slight asymmetry. Acceptable; alternative (moving it into `context/`) creates worse coupling.
+
+### Neutral
+
+- **No change to public API** of `internal/agent/agent.go` or `internal/cli`. Only intra-package types are renamed.
+- **No change to test coverage**. All tests move with their files.
+- **No change to runtime behaviour**. This is a purely structural refactor.
+- **`verify_architecture` results remain clean** — the new `session → session/context` dependency is acyclic.
+
+## Implementation Plan
+
+Execution is deferred to the operational runbook attached to GitHub Issue #88. The runbook codifies:
+
+1. Pre-flight verification of the import graph state.
+2. ADR-026 acceptance commit (this file).
+3. Move-then-rename sequence (one file pair per commit for bisect-friendliness).
+4. Consumer updates as a single atomic commit.
+5. Acceptance gauntlet: `go build`, `go vet`, `go test -race -count=1`, `verify_architecture`, `golangci-lint run`.
+
+## References
+
+- ADR-008 (`2026-01-domain-decomposition-strategy.md`) — package decomposition principles
+- ADR-025 (`2026-04-uibridge-decomposition.md`) — prior intra-file decomposition (sets precedent for further extraction)
+- ADR-018 (`2026-04-event-driven-orchestration.md`) — event flow that the context pipeline participates in
+- GitHub Issue #88 — execution tracking

--- a/docs/issues/001-remove-agent-getset-accessors.md
+++ b/docs/issues/001-remove-agent-getset-accessors.md
@@ -1,0 +1,75 @@
+# Remove `agent` struct `Get*`/`Set*` test-only accessors
+
+## Category
+[REFACTOR] — Encapsulation / Test Hygiene
+
+## Context
+The `agent` struct in `internal/agent/agent.go` exposes **8 mutator/accessor methods** that exist solely to support tests. This is a textbook violation of "Tell, Don't Ask" and a recurrence of the pattern ADR-004 ("ChatterParams Elimination") was meant to prevent. The struct now has **23 fields and 20 methods** — the same scale of coupling that ChatterParams previously concentrated in a single options bag.
+
+## Evidence (verified via `find_usages` AST analysis)
+
+| Method | Production callers | Test callers |
+|---|---|---|
+| `SetCtxManager` | 0 | 1 (`agent_error_test.go`) |
+| `SetEvents`     | 0 | 5 (1 unit, 1 lifecycle, 3 integration) |
+| `SetConfigWatcher` | 0 | 3 |
+| `SetTracker`    | 0 | 3 |
+| `SetLogger`     | 0 | 3 |
+| `SetRuntimeConfig` | 0 | 2 |
+| `GetCtxManager`, `GetEvents`, `GetConfigWatcher`, `GetTracker`, `GetRuntimeConfig` | TBD — audit | TBD — audit |
+
+**100% of `Set*` callers are tests.** This proves the methods exist as a test backdoor, not a production API.
+
+## Current vs. Scalable
+
+**Current:**
+```go
+// In tests:
+a, _ := agent.NewAgent(gw, bus, reg, opts...)
+a.SetEvents(mockBus)        // backdoor mutation
+a.SetTracker(mockTracker)   // backdoor mutation
+a.SetLogger(mockLogger)     // backdoor mutation
+```
+
+**Scalable:**
+```go
+// In agenttest package — builders compose options correctly
+a := agenttest.NewAgentBuilder(t).
+    WithEventBus(mockBus).
+    WithTracker(mockTracker).
+    WithLogger(mockLogger).
+    Build()
+```
+
+The `agenttest` package already exists (`internal/agent/agenttest/`). It should grow a builder rather than the production type growing setters.
+
+## Proposed Action
+
+1. **Audit `Get*` methods** with `find_usages` to confirm none are called from production. If any are, file a sub-issue to remove that production caller first.
+2. **Add `agenttest.AgentBuilder`** with chainable `With*` methods that call the existing `agent.AgentOption` functions (`WithLogger`, `WithEvents`, etc.).
+3. **Migrate all test callers** of `Set*`/`Get*` to the builder.
+4. **Delete the 8 `Set*`/`Get*` methods** from `agent.go`.
+5. Run `go test ./... -race` and `golangci-lint run` to verify no regressions.
+
+## Acceptance Criteria
+
+- [ ] `find_usages` for each removed method returns zero results.
+- [ ] `internal/agent/agent.go` method count drops from 20 to ≤12.
+- [ ] All tests pass with `-race`.
+- [ ] No new fields added to `agent` struct.
+- [ ] `agenttest.AgentBuilder` documented in `agenttest/doc.go`.
+
+## Out of Scope
+
+- Splitting the 23-field struct into composed layers (deferred to a future issue once true coupling shape is visible after this cleanup).
+- Modifying `AgentOption` signatures.
+
+## Effort
+**Small-Medium** (1–2 days). Mechanical refactor; risk concentrated in 5 integration test files.
+
+## ADR Required
+No. This issue executes encapsulation principles already established in ADR-004.
+
+## References
+- ADR-004 (`2026-01-chatterparams-elimination.md`) — same anti-pattern, prior round
+- ADR-007 (`2026-02-agent-options-extraction.md`) — establishes the `AgentOption` pattern that the builder will compose

--- a/docs/issues/001-runbook.md
+++ b/docs/issues/001-runbook.md
@@ -1,0 +1,502 @@
+# 🛠 Operational Runbook (Coder Execution Brief)
+
+> This comment is a mechanical, step-by-step execution plan for the refactor specified in the issue body above. Read the issue body first for context, evidence, and acceptance criteria. This runbook tells you **how** to execute, not **why**.
+>
+> You have no prior memory of the analysis that produced this issue. Everything you need is either in this issue or discoverable via the commands below. If anything contradicts the issue body, **the issue body wins** — stop and report back.
+
+---
+
+## Phase 0 — Environment Verification
+
+Run these checks. If any fails, **stop and report back** instead of guessing:
+
+```bash
+gh --version
+gh auth status
+gh repo view --json nameWithOwner    # must be gosharplite/tell-me-go
+git status                           # working tree must be clean
+git branch --show-current            # note current branch
+go version                           # must be ≥ 1.26.2
+```
+
+---
+
+## Phase 1 — Working Branch
+
+```bash
+git checkout main
+git pull --ff-only
+git checkout -b refactor/remove-agent-accessors
+```
+
+---
+
+## Phase 2 — Audit `Get*` Accessors
+
+The issue body confirmed all `Set*` callers are tests. You must independently audit the `Get*` methods, because the issue marks them as TBD.
+
+### Step 2.1 — Run usage searches
+
+For each method below, find every caller:
+
+```bash
+for method in GetCtxManager GetEvents GetConfigWatcher GetTracker GetRuntimeConfig; do
+  echo "=== $method ==="
+  grep -rn "\.${method}(" --include="*.go" . | grep -v "^./internal/agent/agent.go:"
+done
+```
+
+### Step 2.2 — Apply the decision rule
+
+| Caller location | Decision |
+|---|---|
+| Only in `*_test.go` files | **REMOVE** in this task |
+| Any production file (non-`_test.go`) | **KEEP** in this task; record the production caller |
+
+**Do not refactor production callers in this task — that is explicitly out of scope per the issue body.**
+
+### Step 2.3 — Document audit results
+
+Create `docs/issues/001-audit-results.md` with this exact format:
+
+```markdown
+# Get*/Set* Accessor Audit Results
+
+Generated: <YYYY-MM-DD>
+Branch: refactor/remove-agent-accessors
+
+## Set* Methods (pre-verified by issue analysis)
+
+| Method | Production callers | Test callers | Decision |
+|---|---|---|---|
+| SetCtxManager | none | 1 (agent_error_test.go) | REMOVE |
+| SetEvents | none | 5 | REMOVE |
+| SetConfigWatcher | none | 3 | REMOVE |
+| SetTracker | none | 3 | REMOVE |
+| SetLogger | none | 3 | REMOVE |
+| SetRuntimeConfig | none | 2 | REMOVE |
+
+## Get* Methods (audited in this task)
+
+| Method | Production callers | Test callers | Decision |
+|---|---|---|---|
+| GetCtxManager | <list files or "none"> | <count> | REMOVE / KEEP |
+| GetEvents | ... | ... | ... |
+| GetConfigWatcher | ... | ... | ... |
+| GetTracker | ... | ... | ... |
+| GetRuntimeConfig | ... | ... | ... |
+```
+
+Commit this file before continuing:
+
+```bash
+git add docs/issues/001-audit-results.md
+git commit -m "docs(agent): audit Get*/Set* accessor callers (refs #86)"
+```
+
+---
+
+## Phase 3 — Verify or Add Required `AgentOption` Functions
+
+The builder you'll create in Phase 4 must use existing `AgentOption` functions. Check what already exists:
+
+```bash
+grep -l "AgentOption" internal/agent/*.go
+grep -n "^func With" internal/agent/options.go 2>/dev/null || \
+  grep -rn "^func With.*AgentOption" internal/agent/ --include="*.go"
+```
+
+For each `Set*` method scheduled for REMOVE in your audit, confirm a matching `With*` `AgentOption` exists. If one is missing (likely candidates: `WithCtxManager`, `WithConfigWatcher`, `WithRuntimeConfig`), add it to the same file where the existing options live. Pattern:
+
+```go
+// WithCtxManager injects a pre-built ContextManager. Used primarily by tests
+// that need to substitute a mock implementation.
+func WithCtxManager(cm *session.ContextManager) AgentOption {
+    return func(a *agent) {
+        a.ctxManager = cm
+    }
+}
+```
+
+**Rules:**
+
+- Match the naming, doc-comment style, and signature shape of existing `With*` functions exactly.
+- Do not change any existing `AgentOption` function signature.
+- This is the **only** production-code addition allowed in this task.
+
+After adding any new options, run:
+
+```bash
+go build ./...
+go vet ./...
+```
+
+Commit:
+
+```bash
+git add internal/agent/<file>.go
+git commit -m "feat(agent): add AgentOption constructors needed for test builder (refs #86)"
+```
+
+---
+
+## Phase 4 — Build the Test Helper
+
+### Step 4.1 — Inspect the existing `agenttest` package
+
+```bash
+ls internal/agent/agenttest/
+cat internal/agent/agenttest/doc.go 2>/dev/null
+```
+
+Match its conventions (file header, package comment style, import grouping).
+
+### Step 4.2 — Create `internal/agent/agenttest/builder.go`
+
+Required shape (adapt imports/types to actual package paths in this repo):
+
+```go
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agenttest
+
+import (
+    "testing"
+
+    "github.com/gosharplite/tell-me-go/internal/agent"
+    "github.com/gosharplite/tell-me-go/internal/agent/session"
+    "github.com/gosharplite/tell-me-go/internal/domain/events"
+    "github.com/gosharplite/tell-me-go/internal/domain/llm"
+    "github.com/gosharplite/tell-me-go/internal/domain/ports"
+    "github.com/gosharplite/tell-me-go/internal/domain/pricing"
+    "github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// AgentBuilder constructs *agent.Agent values for tests using composition
+// instead of post-construction mutation. It exists to eliminate the need for
+// Set*/Get* accessors on the production agent type.
+//
+// Usage:
+//
+//   a := agenttest.NewAgentBuilder(t).
+//       WithGateway(mockGateway).
+//       WithEventBus(mockBus).
+//       WithRegistry(mockRegistry).
+//       WithLogger(mockLogger).
+//       Build()
+type AgentBuilder struct {
+    t       testing.TB
+    gateway llm.LLMGateway
+    events  events.EventBus
+    reg     tools.Registry
+    opts    []agent.AgentOption
+}
+
+// NewAgentBuilder returns a builder bound to the given test. Build() will call
+// t.Fatal on any construction error.
+func NewAgentBuilder(t testing.TB) *AgentBuilder {
+    t.Helper()
+    return &AgentBuilder{t: t}
+}
+
+// --- Required dependencies (replace constructor positional args) ---
+
+func (b *AgentBuilder) WithGateway(gw llm.LLMGateway) *AgentBuilder {
+    b.gateway = gw
+    return b
+}
+
+func (b *AgentBuilder) WithEventBus(bus events.EventBus) *AgentBuilder {
+    b.events = bus
+    b.opts = append(b.opts, agent.WithEvents(bus)) // if such an option exists
+    return b
+}
+
+func (b *AgentBuilder) WithRegistry(r tools.Registry) *AgentBuilder {
+    b.reg = r
+    return b
+}
+
+// --- Optional dependencies (one method per Set* being removed) ---
+
+func (b *AgentBuilder) WithLogger(l ports.Logger) *AgentBuilder {
+    b.opts = append(b.opts, agent.WithLogger(l))
+    return b
+}
+
+func (b *AgentBuilder) WithTracker(tr pricing.CostTracker) *AgentBuilder {
+    b.opts = append(b.opts, agent.WithSessionCostTracker(tr))
+    return b
+}
+
+func (b *AgentBuilder) WithConfigWatcher(cw session.ConfigWatcher) *AgentBuilder {
+    b.opts = append(b.opts, agent.WithConfigWatcher(cw))
+    return b
+}
+
+func (b *AgentBuilder) WithCtxManager(cm *session.ContextManager) *AgentBuilder {
+    b.opts = append(b.opts, agent.WithCtxManager(cm))
+    return b
+}
+
+// ... add one With* method per Set* method your audit decided to REMOVE.
+
+// Build constructs the agent and fails the test on error.
+func (b *AgentBuilder) Build() *agent.Agent {
+    b.t.Helper()
+    if b.gateway == nil {
+        b.t.Fatal("agenttest: AgentBuilder requires WithGateway")
+    }
+    if b.events == nil {
+        b.t.Fatal("agenttest: AgentBuilder requires WithEventBus")
+    }
+    if b.reg == nil {
+        b.t.Fatal("agenttest: AgentBuilder requires WithRegistry")
+    }
+    a, err := agent.NewAgent(b.gateway, b.events, b.reg, b.opts...)
+    if err != nil {
+        b.t.Fatalf("agenttest: AgentBuilder.Build: %v", err)
+    }
+    return a
+}
+```
+
+**Critical design rules — do not violate:**
+
+1. Each `With*` method **must** internally append the existing `agent.AgentOption` function. No parallel mechanism.
+2. The builder must **never** mutate the agent after `Build()` returns.
+3. `Build()` must call `t.Helper()` and `t.Fatal(err)` on error.
+4. **Verify the actual return type** of `agent.NewAgent` — it may be an interface or pointer; match it precisely. The skeleton above guesses `*agent.Agent`; correct as needed via:
+   ```bash
+   grep -n "^func NewAgent" internal/agent/agent.go
+   ```
+
+### Step 4.3 — Add builder unit test
+
+Create `internal/agent/agenttest/builder_test.go` covering:
+
+- **Minimal build**: only required dependencies → succeeds.
+- **All-options build**: every `With*` method invoked → succeeds.
+- **Missing required dependency**: omitting `WithGateway` (or `WithEventBus`, `WithRegistry`) → uses `testing.T` substitute that records `Fatal` calls (or use `testing.T.Run` with a sub-test that's expected to fail; see existing patterns in the repo for how unit tests verify `t.Fatal` invocation).
+
+If the repo already has a pattern for testing `t.Fatal` (look for `mockT` or similar in existing tests), match it. If not, the simplest approach is to mark the negative-path test as documenting the contract via a comment and skip the actual Fatal-trigger.
+
+### Step 4.4 — Verify and commit
+
+```bash
+go build ./...
+go test ./internal/agent/agenttest/... -race -count=1
+git add internal/agent/agenttest/
+git commit -m "test(agent): add AgentBuilder for test composition (refs #86)"
+```
+
+---
+
+## Phase 5 — Migrate Test Callers (One Commit Per File)
+
+### Step 5.1 — Find all call sites
+
+```bash
+grep -rn "\.SetCtxManager\|\.SetEvents\|\.SetConfigWatcher\|\.SetTracker\|\.SetLogger\|\.SetRuntimeConfig" --include="*_test.go" .
+```
+
+Expected files (verify against your grep output):
+
+- `internal/agent/agent_error_test.go`
+- `internal/agent/agent_lifecycle_test.go`
+- `internal/agent/session/context_manager_test.go` (only `SetLogger`)
+- `tests/integration/agent/agent_integration_test.go`
+
+### Step 5.2 — Per-file migration loop
+
+For **each** file in the list, repeat:
+
+1. **Read** the file fully. Identify each `agent.NewAgent(...)` + `Set*(...)` sequence.
+2. **Replace** the sequence with a single `agenttest.NewAgentBuilder(t).With*(...).Build()` chain. Order the `With*` calls to match the original `Set*` call order, for review legibility.
+3. **Run only that test file** with race detection:
+   ```bash
+   go test -race -count=1 -run . <package_path>
+   # e.g. go test -race -count=1 -run . ./internal/agent/...
+   ```
+   If it fails, **stop** — fix before moving on. Do not touch the next file with a broken state.
+4. **Commit** that single file:
+   ```bash
+   git add <file>
+   git commit -m "test(agent): migrate <basename> to agenttest.AgentBuilder
+
+   Refs #86"
+   ```
+
+**One commit per test file.** This makes review tractable and bisect-friendly.
+
+---
+
+## Phase 6 — Delete the Accessor Methods
+
+Only after **all** test migrations compile and pass.
+
+### Step 6.1 — Locate the methods
+
+```bash
+grep -n "^func (a \*agent) \(Get\|Set\)" internal/agent/agent.go
+```
+
+### Step 6.2 — Remove
+
+For each method your audit marked **REMOVE**:
+
+- Delete the method declaration (the entire `func` block including its doc comment).
+- **Keep the corresponding struct field** — it's still assigned by the `AgentOption` constructors.
+- Use precise editing (read the method's exact byte range, replace with empty). Do not regex-delete — risk of catching unintended methods.
+
+### Step 6.3 — Verify
+
+```bash
+go build ./...
+go vet ./...
+grep -c "^func (a \*agent)" internal/agent/agent.go
+# Expected: was 20, now 20 minus (count of removed methods)
+# Acceptance criterion target: ≤ 12
+```
+
+If the count exceeds 12 after this step, your audit kept too many methods due to production callers. That's acceptable — record it in the PR description, but do not force removal of methods with production callers.
+
+### Step 6.4 — Commit
+
+```bash
+git add internal/agent/agent.go
+git commit -m "refactor(agent): remove Get*/Set* test-only accessors (refs #86)
+
+Removed methods (test-only after Phase 5 migration):
+- <list each method>
+
+Methods kept (production callers):
+- <list each method + production caller, or 'none'>"
+```
+
+---
+
+## Phase 7 — Verification Gauntlet
+
+Run in this exact order. **Stop and report at the first failure** — do not auto-fix without checking in:
+
+```bash
+# 1. Build
+go build ./...
+
+# 2. Vet
+go vet ./...
+
+# 3. Full test suite with race detector
+go test ./... -race -count=1
+
+# 4. Lint (skip and note in PR if not installed)
+golangci-lint run
+
+# 5. Structural acceptance criteria
+echo "=== Method count on agent struct ==="
+grep -c "^func (a \*agent)" internal/agent/agent.go
+# Target: ≤ 12
+
+echo "=== Remaining Set* references in tests ==="
+grep -rn "\.SetCtxManager\|\.SetEvents\|\.SetConfigWatcher\|\.SetTracker\|\.SetLogger\|\.SetRuntimeConfig" --include="*.go" . || echo "✓ none remaining"
+
+echo "=== Field additions to agent struct ==="
+git diff main -- internal/agent/agent.go | grep -E "^\+\s+[a-zA-Z_]+\s+[a-zA-Z*]" | grep -v "^+++" || echo "✓ no field additions"
+
+echo "=== Architecture check ==="
+# Optional but recommended: any tool the repo uses for layer verification
+```
+
+---
+
+## Phase 8 — Open the PR
+
+```bash
+git push -u origin refactor/remove-agent-accessors
+
+gh pr create \
+  --repo gosharplite/tell-me-go \
+  --title "refactor(agent): remove Get*/Set* test-only accessors (closes #86)" \
+  --body "$(cat <<'EOF'
+Implements the refactor specified in #86.
+
+## Audit Results
+See `docs/issues/001-audit-results.md` (committed in this branch).
+
+## Methods Removed
+<list each removed method>
+
+## Methods Kept (with reason)
+<list each kept method and the production caller blocking removal — or "none, all test-only methods removed">
+
+## New AgentOption Constructors Added
+<list any new With* options added in Phase 3 — or "none, all needed options pre-existed">
+
+## Verification
+- [ ] `go build ./...` — clean
+- [ ] `go vet ./...` — clean
+- [ ] `go test ./... -race -count=1` — pass
+- [ ] `golangci-lint run` — clean (or note: not installed)
+- [ ] `agent.go` method count: 20 → <N>
+- [ ] No new fields added to agent struct
+- [ ] No remaining Set* references in tests
+
+## Out of Scope (per #86)
+- Splitting the 23-field agent struct into composed layers
+- Modifying existing AgentOption signatures
+- Modifying any file under internal/agent/session/ except the one known test file
+- Modifying any file under internal/infrastructure/
+
+## Commit Trail
+This PR uses one commit per logical step for bisect-friendliness:
+1. Audit results
+2. New AgentOption constructors (if any)
+3. AgentBuilder + tests
+4. One commit per migrated test file
+5. Accessor method deletion
+
+Closes #86
+EOF
+)"
+```
+
+---
+
+## 🚫 Hard Constraints (Repeated for Emphasis)
+
+1. **Do not** modify any file under `internal/agent/session/` except the one known test file (`session/context_manager_test.go`). Session restructuring is **issue #88**.
+2. **Do not** modify any file under `internal/infrastructure/`. DI restructuring is **issue #87**.
+3. **Do not** add new exported types or functions to the `agent` package beyond the small set of `AgentOption` functions identified in Phase 3.
+4. **Do not** introduce new dependencies in `go.mod`.
+5. **Do not** remove `agent` struct fields, even if their setter is gone — `AgentOption` constructors still assign them.
+6. **Do not** "improve" anything noticed in passing — if you spot something, append it to a `FOLLOWUPS.md` file at repo root and keep moving.
+7. **Do not** force-push or rewrite history once the PR is open. Add fixup commits if review feedback requires changes.
+
+---
+
+## 📋 Final Report Template
+
+When done (or blocked), comment back on this issue with:
+
+```markdown
+## Execution Report — Issue #86
+
+**Status:** Complete / Blocked / Partial
+**PR:** #<N> — <url>
+**Branch:** refactor/remove-agent-accessors
+**Audit results:** docs/issues/001-audit-results.md
+
+### Verification Output
+<paste the output of Phase 7's gauntlet>
+
+### Deviations from Runbook
+<list any, with justification — or "none">
+
+### Items added to FOLLOWUPS.md
+<list any, with one-line description — or "none">
+
+### Blockers (if Status != Complete)
+<describe what stopped progress and what decision is needed>
+```

--- a/docs/issues/002-extract-session-context-subpackage.md
+++ b/docs/issues/002-extract-session-context-subpackage.md
@@ -1,0 +1,109 @@
+# Extract `session/context/` sub-package from `agent/session` monolith
+
+## Category
+[TECHNICAL DEBT] — Package Cohesion / Separation of Concerns
+
+## Context
+`internal/agent/session` currently contains **55 files (29 production + 26 test)** mixing 5+ distinct concerns in a single package. This is the largest package in the codebase by file count and a known navigability problem. ADR-008 ("Domain Decomposition Strategy") established the principle of decomposing oversized packages along concern boundaries; this issue applies that principle to the largest remaining offender.
+
+ADR-025 ("UIBridge Decomposition") has already been executed — `ui_bridge*.go` files are now properly internally separated. The next-largest concern cluster is **context preparation**, which spans 7 production files with clear cohesion and a shared dependency graph distinct from the rest of the package.
+
+## Files in Scope
+
+| File | LOC (approx) | Role |
+|---|---|---|
+| `context_manager.go` | TBD | Public façade; orchestrates context build pipeline |
+| `context_pipeline.go` | TBD | Pipeline stage execution |
+| `context_strategy.go` | TBD | Strategy pattern for different context build modes |
+| `context_transformers.go` | ~500 | Pure functions transforming history → context |
+| `pruner.go` | TBD | Token-budget pruning |
+| `gatekeeper.go` | TBD | Pre-send validation |
+| `token_counter.go` | TBD | Token estimation |
+| `pipeline_factory.go` | TBD | Pipeline construction |
+
+Plus their `*_test.go` siblings (~10 files).
+
+## Current vs. Scalable
+
+**Current:**
+```
+internal/agent/session/
+├── context_manager.go
+├── context_pipeline.go
+├── context_strategy.go
+├── context_transformers.go     ← ~500 LOC
+├── pruner.go
+├── gatekeeper.go
+├── token_counter.go
+├── pipeline_factory.go
+├── ui_bridge*.go               (5 files — already decomposed per ADR-025)
+├── session_manager.go
+├── skill_injector.go
+├── injector.go
+├── config_watcher.go
+├── internal_tools.go
+├── interfaces.go
+└── ... (26 _test.go files)
+```
+
+**Scalable:**
+```
+internal/agent/session/
+├── context/
+│   ├── manager.go
+│   ├── pipeline.go
+│   ├── strategy.go
+│   ├── transformers.go
+│   ├── pruner.go
+│   ├── gatekeeper.go
+│   ├── token_counter.go
+│   ├── pipeline_factory.go
+│   └── *_test.go
+├── ui_bridge*.go
+├── session_manager.go
+├── skill_injector.go
+├── ...
+```
+
+## Proposed Action
+
+1. **Pre-flight**: Run `find_usages` on every exported symbol in the 8 in-scope files. Confirm consumers are limited to `session_manager.go` and `agent.go`.
+2. **Move files** using `git mv` to preserve history; update package declarations to `package context`.
+3. **Identify back-references**: any symbol in the new `context/` package that needs a type from the parent `session` package indicates a misplaced concern — resolve before merging.
+4. **Update `agent.go`**: replace `session.ContextManager` with `context.Manager`, `session.NewContextManager` with `context.NewManager`, etc.
+5. **Verify `interfaces.go`**: any interface implemented by both `context/` and `session/` types must move to a neutral location (likely `domain/ports`).
+6. Run full test suite with `-race` and `verify_architecture` to confirm no new layer violations.
+
+## Acceptance Criteria
+
+- [ ] `internal/agent/session/` production file count drops from 29 to ~21.
+- [ ] New package `internal/agent/session/context/` exists with 8 production files + tests.
+- [ ] `verify_architecture` reports no new violations.
+- [ ] No circular dependency between `session/` and `session/context/`.
+- [ ] All tests pass with `-race`.
+- [ ] `golangci-lint run` clean.
+- [ ] Public API of `agent` unchanged (verified via `get_file_skeleton internal/agent/agent.go` before/after).
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| `context_transformers.go` (~500 LOC) may have hidden coupling to `session_manager` internals | Audit with `find_usages` BEFORE moving; if coupling exists, file blocker sub-issue first |
+| Test fixtures in `test_helpers_test.go` may be needed by both packages | Promote shared fixtures to `internal/pkg/testfixtures` |
+| Renaming `session.ContextManager` → `context.Manager` is a 50+ site rename | Use `rename_symbol` tool, not manual sed |
+
+## Out of Scope
+
+- Extracting `skill_injector.go` / `injector.go` (separate future issue).
+- Extracting `config_watcher.go`.
+- Refactoring the contents of `context_transformers.go` (large file is a separate concern).
+
+## Effort
+**Medium** (3–5 days). Bulk is mechanical movement; risk lives in the back-reference audit.
+
+## ADR Required
+**Yes — ADR for sub-package decomposition pattern.** This is the first time `session/` is being split into sub-packages; the decision sets precedent for future extractions (`uibridge/`, `skills/`). Proposed: ADR-026 "Session Package Decomposition Strategy".
+
+## References
+- ADR-008 (`2026-01-domain-decomposition-strategy.md`) — package decomposition principles
+- ADR-025 (`2026-04-uibridge-decomposition.md`) — prior intra-file decomposition (sets pattern for further extraction)

--- a/docs/issues/003-continue-di-factory-decomposition.md
+++ b/docs/issues/003-continue-di-factory-decomposition.md
@@ -1,0 +1,113 @@
+# Continue `infrastructure/di` Bootstrapper decomposition
+
+## Category
+[REFACTOR] — Continue In-Flight Decomposition
+
+## Context
+The `Bootstrapper` in `internal/infrastructure/di/container.go` is being progressively decomposed into focused factories. Three factories already exist:
+
+- `session_factory.go` — `defaultSessionFactory.BuildSession`
+- `telemetry_factory.go` — `defaultTelemetryFactory.BuildTelemetry`
+- `toolchain_factory.go` — `defaultToolchainFactory.BuildRegistry`
+
+However, **5 distinct concerns remain inlined as `Bootstrapper` methods**, leaving the container at ~430 LOC with 24 internal package imports. This issue completes the decomposition by extracting the remaining concerns into matching factory files, following the established pattern.
+
+## Evidence
+
+`Bootstrapper` currently exposes these methods that mix construction concerns:
+
+| Method | Concern | Target File |
+|---|---|---|
+| `GetUIRenderer` | UI construction | `ui_factory.go` (NEW) |
+| `GetHistoryRenderer` | UI construction | `ui_factory.go` (NEW) |
+| `GetHistoryBrowser` (+ `tuiHistoryBrowser` type) | UI construction | `ui_factory.go` (NEW) |
+| `GetHistoryManager` | History wiring | `history_factory.go` (NEW) |
+| `GetUnifiedHistoryProvider` | History wiring | `history_factory.go` (NEW) |
+| `buildHistoryManager` | History wiring | `history_factory.go` (NEW) |
+| `GetChatService` | Chat composition | `chat_factory.go` (NEW) |
+| `GetAgentFactory` | Chat composition | `chat_factory.go` (NEW) |
+| `GetSuggestionService` | Application service wiring | `suggestion_factory.go` (NEW) |
+
+After this refactor, `container.go` should hold only:
+- `Bootstrapper` struct definition
+- `NewBootstrapper` constructor (composition root for all factories)
+- `BuildSessionDependencies` (the orchestration entry point)
+- `FinalizeSession` (the orchestration teardown)
+- `sessionDeps` struct + getters (data holder, no construction logic)
+- `lazyLLMProxy` (lazy initialization helper)
+
+Pure construction logic moves out.
+
+## Current vs. Scalable
+
+**Current `container.go` skeleton (430 LOC):**
+```go
+func (b *Bootstrapper) BuildSessionDependencies(...)
+func (b *Bootstrapper) buildHistoryManager(...)         // history concern
+func (b *Bootstrapper) GetAgentFactory()                // chat concern
+func (b *Bootstrapper) FinalizeSession(...)
+func (b *Bootstrapper) GetHistoryManager(...)           // history concern
+func (b *Bootstrapper) GetUnifiedHistoryProvider(...)   // history concern
+func (b *Bootstrapper) GetSuggestionService(...)        // app concern
+func (b *Bootstrapper) GetUIRenderer()                  // ui concern
+func (b *Bootstrapper) GetHistoryRenderer()             // ui concern
+func (b *Bootstrapper) GetHistoryBrowser()              // ui concern
+func (b *Bootstrapper) GetChatService()                 // chat concern
+type tuiHistoryBrowser struct{...}                      // ui concern
+```
+
+**Scalable:**
+```go
+// container.go (~150 LOC)
+type Bootstrapper struct {
+    sessionFactory   sessionFactory
+    telemetryFactory telemetryFactory
+    toolchainFactory toolchainFactory
+    historyFactory   historyFactory   // NEW
+    uiFactory        uiFactory         // NEW
+    chatFactory      chatFactory       // NEW
+    suggestionFactory suggestionFactory // NEW
+    // ... shared deps
+}
+
+func (b *Bootstrapper) GetUIRenderer() ports.UIRenderer {
+    return b.uiFactory.UIRenderer()  // delegate
+}
+```
+
+This matches the existing pattern (`session_factory.go`, `telemetry_factory.go`, `toolchain_factory.go`) — no new architectural concept introduced.
+
+## Proposed Action
+
+1. **Extract `history_factory.go`** — easiest first step, only 3 methods, well-isolated.
+2. **Extract `ui_factory.go`** — moves the `tuiHistoryBrowser` private type along with it.
+3. **Extract `chat_factory.go`** — `GetAgentFactory` and `GetChatService` together.
+4. **Extract `suggestion_factory.go`** — single method, trivial.
+5. After each extraction: run tests, run `verify_architecture`, commit separately.
+6. Update `NewBootstrapper` to wire the new factories (composition root pattern).
+
+## Acceptance Criteria
+
+- [ ] `container.go` LOC drops from ~430 to ≤200.
+- [ ] `Bootstrapper` struct delegates all `Get*` methods to factories (one-line bodies).
+- [ ] Internal package import count of `container.go` drops below 15.
+- [ ] All `*_factory.go` files follow the same naming convention as the 3 existing ones.
+- [ ] All existing tests in `container_test.go`, `factory_error_test.go`, `lazy_test.go` pass unchanged.
+- [ ] `verify_architecture` clean.
+- [ ] No new public API surface added; `cli.Bootstrapper` interface unchanged.
+
+## Out of Scope
+
+- Refactoring `BuildSessionDependencies` or `FinalizeSession` (these are orchestration, not construction).
+- Changing the `lazyLLMProxy` mechanism.
+- Splitting `sessionDeps` (it is a coherent data holder).
+- Introducing a DI library (Wire, Fx). Manual factories remain the chosen approach.
+
+## Effort
+**Small** (2–3 days). Pattern is established; mechanical extraction with strong test safety net (existing test file already has 1000+ lines of coverage).
+
+## ADR Required
+No. This continues the trajectory established by `session_factory.go`, `telemetry_factory.go`, and `toolchain_factory.go` — no new architectural decision.
+
+## References
+- Existing pattern in `internal/infrastructure/di/session_factory.go`, `telemetry_factory.go`, `toolchain_factory.go`

--- a/docs/issues/088-runbook.md
+++ b/docs/issues/088-runbook.md
@@ -1,0 +1,622 @@
+# 🛠 Operational Runbook (Coder Execution Brief)
+
+> This comment is a mechanical, step-by-step execution plan for the refactor specified in the issue body above. Read the issue body **and ADR-026** (`docs/adr/2026-04-session-context-subpackage-extraction.md`) before starting. The ADR contains the design rationale and coupling-hazard resolutions. This runbook tells you **how** to execute, not **why**.
+>
+> You have no prior memory of the analysis that produced this issue. Everything you need is in this issue, in ADR-026, or discoverable via the commands below. If anything contradicts the ADR, **the ADR wins** — stop and report back.
+
+---
+
+## ⚠ Prerequisites
+
+**Do not start this task until both are true:**
+
+1. **Issue #86 is merged.** Check with: `gh pr list --repo gosharplite/tell-me-go --search "closed:>2026-04-29 closes #86"`
+2. **ADR-026 is on `main`.** Check with: `git fetch origin main && git show origin/main:docs/adr/2026-04-session-context-subpackage-extraction.md | head -10`
+
+If either is false, **stop and report back**. Do not proceed without these prerequisites — Issue #86's accessor cleanup may simplify the agent.go consumer-update step in Phase 7, and ADR-026 is the authoritative design spec.
+
+---
+
+## Phase 0 — Environment Verification
+
+```bash
+gh --version
+gh auth status
+gh repo view --json nameWithOwner    # must be gosharplite/tell-me-go
+git status                           # working tree must be clean
+git checkout main
+git pull --ff-only
+go version                           # must be ≥ 1.26.2
+```
+
+If any check fails, **stop and report back**.
+
+---
+
+## Phase 1 — Working Branch and ADR Status
+
+```bash
+git checkout -b refactor/extract-session-context
+
+# Confirm ADR-026 is present on this branch
+ls docs/adr/2026-04-session-context-subpackage-extraction.md
+
+# If ADR status is still "Proposed", flip to "Accepted" as the first commit
+sed -i.bak 's/^## Status$/## Status/;s/^Proposed$/Accepted/' \
+  docs/adr/2026-04-session-context-subpackage-extraction.md
+rm docs/adr/2026-04-session-context-subpackage-extraction.md.bak
+
+# Verify the change took effect
+grep -A1 "^## Status" docs/adr/2026-04-session-context-subpackage-extraction.md
+# Expected output:
+#   ## Status
+#   Accepted
+
+git add docs/adr/2026-04-session-context-subpackage-extraction.md
+git commit -m "docs(adr): accept ADR-026 (session/context extraction)
+
+Refs #88"
+```
+
+---
+
+## Phase 2 — Pre-Flight Audit
+
+These commands establish a baseline you'll compare against in the verification phase. **Capture all output to a file** for the PR description.
+
+```bash
+mkdir -p /tmp/issue88
+{
+  echo "=== Pre-flight audit for Issue #88 ==="
+  echo "Date: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  echo "Commit: $(git rev-parse HEAD)"
+  echo
+
+  echo "--- Production file LOC in session/ ---"
+  ls internal/agent/session/*.go | grep -v _test.go | xargs wc -l | sort -rn
+
+  echo
+  echo "--- Test file count in session/ ---"
+  ls internal/agent/session/*_test.go | wc -l
+
+  echo
+  echo "--- External callers of types being moved ---"
+  for sym in ContextManager ContextStrategy PipelineFactory NewContextManager NewContextStrategy NewPipelineFactory NewHeuristicTokenCounter HeuristicTokenCounter TokenGatekeeper HistoryPruner WarningInjector; do
+    echo "## $sym"
+    grep -rn "session\.${sym}\b" --include="*.go" . | grep -v "_test.go" || echo "  (none in production code)"
+    echo
+  done
+
+  echo "--- Tests in session/ that touch types being moved ---"
+  for sym in ContextManager ContextStrategy PipelineFactory; do
+    echo "## $sym (test usage count by file)"
+    grep -l "\b${sym}\b" internal/agent/session/*_test.go | sort -u
+    echo
+  done
+} > /tmp/issue88/preflight.txt
+
+cat /tmp/issue88/preflight.txt
+```
+
+**Expected production callers (from ADR-026 §Consumer Update Surface):**
+
+- `internal/agent/agent.go` (~5 lines)
+- `internal/agent/session/session_manager.go` (~8 lines)
+- `internal/agent/session/internal_tools.go` (~3 lines)
+- `internal/agent/session/skill_injector.go` (~2 lines)
+
+**If your audit finds callers outside this list, stop and report back** — the design may need amendment, which requires updating ADR-026 first.
+
+Commit the audit:
+
+```bash
+mkdir -p docs/issues
+cp /tmp/issue88/preflight.txt docs/issues/088-preflight-audit.txt
+git add docs/issues/088-preflight-audit.txt
+git commit -m "docs(issue-88): pre-flight audit baseline
+
+Refs #88"
+```
+
+---
+
+## Phase 3 — Create the New Package Skeleton
+
+```bash
+mkdir -p internal/agent/session/context
+
+cat > internal/agent/session/context/doc.go <<'EOF'
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+/*
+Package context implements the context preparation pipeline for the chat session.
+
+It encapsulates the construction, validation, and pruning of LLM input context
+through a chain of ports.ContextTransformer instances. The package is consumed
+by the parent session package and by internal/agent.
+
+Entry points:
+
+  - Manager       — orchestrates the pipeline; primary façade.
+  - Strategy      — token-budget and limits accounting.
+  - Factory       — builds a standard transformer pipeline for a given limits set.
+
+This package does not depend on any sibling under internal/agent/session.
+The reverse direction (session → session/context) is the only allowed coupling,
+maintained explicitly by session/internal_tools.go and session/skill_injector.go.
+
+See ADR-026 for the decomposition rationale.
+*/
+package context
+EOF
+
+git add internal/agent/session/context/doc.go
+git commit -m "feat(session/context): scaffold sub-package with doc.go
+
+Refs #88"
+```
+
+---
+
+## Phase 4 — Move Files (One Pair Per Commit)
+
+For **each** of the 9 production files plus its test siblings, follow the move sequence below. **Do not batch moves** — one commit per file pair makes review and `git bisect` tractable.
+
+### Per-file move sequence
+
+The mapping (from ADR-026 §Files Moved):
+
+| # | Old path | New path |
+|---|---|---|
+| 1 | `session/token_counter.go` | `context/token_counter.go` |
+| 2 | `session/context_strategy.go` | `context/strategy.go` |
+| 3 | `session/context_pipeline.go` | `context/pipeline.go` |
+| 4 | `session/context_transformers.go` | `context/transformers.go` |
+| 5 | `session/pruner.go` | `context/pruner.go` |
+| 6 | `session/gatekeeper.go` | `context/gatekeeper.go` |
+| 7 | `session/injector.go` | `context/warning_injector.go` |
+| 8 | `session/pipeline_factory.go` | `context/pipeline_factory.go` |
+| 9 | `session/context_manager.go` | `context/manager.go` |
+
+**Order matters** — move the leaves first (token_counter, strategy) so their consumers can be fixed up incrementally. Manager is moved **last**.
+
+For each row:
+
+```bash
+# 1. Move file with git (preserves blame history)
+git mv <old_path> <new_path>
+
+# 2. Find and move corresponding test files
+for tf in internal/agent/session/<base_name>_*_test.go internal/agent/session/<base_name>_test.go; do
+  [ -f "$tf" ] && git mv "$tf" "internal/agent/session/context/$(basename "$tf")"
+done
+
+# 3. Update the package declaration in the moved files
+sed -i.bak 's/^package session$/package context/' \
+  internal/agent/session/context/<new_basename>*.go
+rm internal/agent/session/context/*.bak
+
+# 4. The build WILL be broken at this point. That is expected.
+#    Do NOT attempt go build yet. Continue to Phase 5 within the same logical commit.
+
+git status
+```
+
+**STOP** after step 4 of the **first** file (token_counter.go). Do not commit yet — first complete the rename within that file (next phase). Then commit the rename + move together as one unit per file.
+
+### Special handling: the `injector.go → warning_injector.go` rename
+
+For file #7, the filename changes (per ADR-026 — it currently obscures the type's purpose). After `git mv`, also verify the file contains only `WarningInjector` and not `skillInjector`:
+
+```bash
+grep -l "WarningInjector\|skillInjector" internal/agent/session/context/warning_injector.go internal/agent/session/skill_injector.go
+# Expected:
+#   internal/agent/session/context/warning_injector.go    (WarningInjector only)
+#   internal/agent/session/skill_injector.go              (skillInjector only)
+```
+
+---
+
+## Phase 5 — Type Renames Within Each Moved File
+
+Per ADR-026 §Renaming Convention, three exported types are renamed to remove the now-redundant `Context*` prefix:
+
+| Old name | New name | Tool |
+|---|---|---|
+| `ContextManager` | `Manager` | `rename_symbol` |
+| `ContextStrategy` | `Strategy` | `rename_symbol` |
+| `PipelineFactory` | `Factory` | `rename_symbol` |
+| `NewContextManager` | `NewManager` | `rename_symbol` |
+| `NewContextStrategy` | `NewStrategy` | `rename_symbol` |
+| `NewPipelineFactory` | `NewFactory` | `rename_symbol` |
+
+**Use AST-based renaming, not `sed`.** Project tooling provides `rename_symbol` (or use `gopls rename` if invoking Go tooling directly). For each rename:
+
+```bash
+# Example for ContextManager → Manager
+# (use the project's preferred AST refactoring tool)
+gopls -remote=auto rename -w internal/agent/session/context/manager.go:<line>:<col> Manager
+```
+
+**Constraint:** Renames must update **all** references across the entire codebase atomically per symbol. Verify after each rename:
+
+```bash
+go build ./...
+# Expect failures only in consumer files (agent.go, session_manager.go, internal_tools.go, skill_injector.go)
+# AT THIS PHASE — those are fixed in Phase 7. All OTHER packages must build clean.
+```
+
+If unrelated packages fail to build, **stop and report back** — the rename hit something the audit missed.
+
+---
+
+## Phase 6 — Adjust the `PipelineFactory` Signature
+
+Per ADR-026 §Coupling Hazard Resolutions §2, `Factory.BuildStandardPipeline` (formerly `PipelineFactory.BuildStandardPipeline`) must accept `extras ...ports.ContextTransformer` so the parent `session/` package can inject `skillInjector` without creating a `context/ → domain/skills` import.
+
+### Step 6.1 — Modify the factory
+
+In `internal/agent/session/context/pipeline_factory.go`:
+
+```go
+// BEFORE
+func (f *Factory) BuildStandardPipeline(limits events.Limits) *pipeline {
+    // ... existing body that constructs all transformers including skillInjector
+}
+
+// AFTER
+func (f *Factory) BuildStandardPipeline(
+    limits events.Limits,
+    extras ...ports.ContextTransformer,
+) *pipeline {
+    // ... existing body, but REMOVE skillInjector construction
+    // ... at the appropriate ordering point, append extras to the transformer slice
+}
+```
+
+**Critical:**
+
+- Do **not** change the order of existing transformers.
+- The `extras` slice is appended at the position where `skillInjector` used to be constructed (preserve runtime ordering).
+- Remove the `skillInjector` construction from the factory body — it now comes in as an extra.
+- Do **not** remove the `skillInjector` type itself; it stays in `session/skill_injector.go`.
+
+### Step 6.2 — Verify ordering preservation
+
+Add a regression test in `internal/agent/session/context/pipeline_factory_test.go` (extend the existing `TestPipelineFactory_BuildStandardPipeline_PrunerInclusion` or add a new one):
+
+```go
+func TestFactory_BuildStandardPipeline_ExtraTransformerOrdering(t *testing.T) {
+    // Construct factory with minimal deps
+    f := NewFactory(/* ... */)
+    extra := &mockTransformer{priority: <position of skillInjector before refactor>}
+    p := f.BuildStandardPipeline(events.Limits{}, extra)
+
+    // Assert the extra is present in the pipeline at the expected position
+    // (use whatever inspection method the existing pruner-inclusion test uses)
+}
+```
+
+Commit:
+
+```bash
+git add internal/agent/session/context/pipeline_factory.go \
+        internal/agent/session/context/pipeline_factory_test.go
+git commit -m "refactor(session/context): accept extras in Factory.BuildStandardPipeline
+
+Implements the coupling-hazard resolution from ADR-026 §2.
+Allows parent session package to inject skillInjector without creating
+a context → domain/skills import.
+
+Refs #88"
+```
+
+---
+
+## Phase 7 — Update Consumers
+
+Update the four consumer files identified by the pre-flight audit. **One commit per consumer file** for bisect-friendliness.
+
+### Consumer 1: `internal/agent/agent.go`
+
+```bash
+# Add the import
+# (use AST-aware editing or your editor's organize-imports — do NOT hand-edit imports if avoidable)
+
+# Required edits:
+#   - import sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+#   - replace session.ContextManager → sessctx.Manager
+#   - any other context-type references identified in the audit
+
+go build ./...   # must succeed for internal/agent/...
+go vet ./internal/agent/...
+
+git add internal/agent/agent.go
+git commit -m "refactor(agent): migrate to session/context sub-package
+
+Refs #88"
+```
+
+### Consumer 2: `internal/agent/session/session_manager.go`
+
+This file is the most complex consumer because it constructs the full pipeline. Required edits:
+
+- Add `sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"` import.
+- Replace constructor calls:
+  - `NewContextStrategy(...)` → `sessctx.NewStrategy(...)`
+  - `NewPipelineFactory(...)` → `sessctx.NewFactory(...)`
+  - `NewContextManager(...)` → `sessctx.NewManager(...)`
+  - `NewHeuristicTokenCounter(...)` → `sessctx.NewHeuristicTokenCounter(...)`
+- Replace type references for `*ContextManager`, `*ContextStrategy`, `*PipelineFactory` with their `sessctx.*` equivalents.
+- Update the `BuildStandardPipeline` call to pass `skillInjector` as an extra:
+
+  ```go
+  // BEFORE
+  pipeline := factory.BuildStandardPipeline(limits)
+
+  // AFTER
+  pipeline := factory.BuildStandardPipeline(limits, skillInjector)
+  ```
+
+```bash
+go build ./...
+go vet ./internal/agent/session/...
+
+git add internal/agent/session/session_manager.go
+git commit -m "refactor(session): migrate session_manager to context sub-package
+
+- Imports session/context as sessctx
+- Renames ContextManager → Manager, ContextStrategy → Strategy, PipelineFactory → Factory
+- Passes skillInjector as extra to BuildStandardPipeline (ADR-026 §2)
+
+Refs #88"
+```
+
+### Consumer 3: `internal/agent/session/internal_tools.go`
+
+```bash
+# Edits:
+#   - import sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+#   - NewInternalTools(cm *ContextManager)   →   NewInternalTools(cm *sessctx.Manager)
+#   - RegisterInternal(r tools.ToolRegistrar, cm *ContextManager) →
+#     RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager)
+
+go build ./...
+go vet ./internal/agent/session/...
+
+git add internal/agent/session/internal_tools.go
+git commit -m "refactor(session): migrate internal_tools to context sub-package
+
+Refs #88"
+```
+
+### Consumer 4: `internal/agent/session/skill_injector.go`
+
+This file implements `ports.ContextTransformer`, so the interface contract is unchanged — the only edit should be removing any direct reference to the moved factory if one exists. Per the audit it should be ~2 lines.
+
+```bash
+go build ./...
+go vet ./internal/agent/session/...
+
+git add internal/agent/session/skill_injector.go
+git commit -m "refactor(session): adjust skill_injector for context sub-package
+
+Refs #88"
+```
+
+---
+
+## Phase 8 — Test Migration
+
+The test files moved in Phase 4 may reference test helpers that stayed in `session/`. Diagnose:
+
+```bash
+go test ./internal/agent/session/context/... 2>&1 | head -50
+```
+
+Common issues and fixes:
+
+| Symptom | Fix |
+|---|---|
+| `undefined: syncWriter` | Helper from `test_helpers_test.go` is needed in both packages. Copy the helper into `internal/agent/session/context/test_helpers_test.go` (NOT promote to `internal/pkg/testfixtures` per ADR-026 §3). |
+| `undefined: AsSessionManagerInternal` | Test relied on `export_test.go`. If the test exercises only context types, refactor it to use the now-exported (within-package) types directly. If it genuinely needs session internals, **the test belongs in `session/`, not `context/`** — move it back. |
+| Test imports `internal/agent/session` | Should now import `internal/agent/session/context` for context types. Update. |
+
+Commit each fix as a separate small commit:
+
+```bash
+git add internal/agent/session/context/<fixed_test_file>.go
+git commit -m "test(session/context): <one-line fix description>
+
+Refs #88"
+```
+
+If you find a test that genuinely needs **both** `session` and `session/context` types, that's a sign the test is at the wrong layer — leave it in `session/` and update its imports rather than moving it to `context/`.
+
+---
+
+## Phase 9 — Verification Gauntlet
+
+Run in this exact order. **Stop and report at the first failure** — do not auto-fix without checking in:
+
+```bash
+# 1. Build
+go build ./...
+
+# 2. Vet
+go vet ./...
+
+# 3. Race-detector tests (full suite)
+go test ./... -race -count=1
+
+# 4. Lint (skip and note in PR if not installed)
+golangci-lint run
+
+# 5. Architecture verification
+# Run whatever architecture-verification tool the repo uses; expect: clean.
+
+# 6. Structural acceptance criteria
+{
+  echo "=== Post-refactor structural metrics ==="
+  echo
+  echo "--- session/ production file count (target: ≤ 21, was 29) ---"
+  ls internal/agent/session/*.go | grep -v _test.go | grep -v context/ | wc -l
+
+  echo
+  echo "--- session/context/ production file count (target: 9) ---"
+  ls internal/agent/session/context/*.go | grep -v _test.go | wc -l
+
+  echo
+  echo "--- session/ production LOC (target: dropped by ~2,200) ---"
+  ls internal/agent/session/*.go | grep -v _test.go | grep -v context/ | xargs wc -l | tail -1
+
+  echo
+  echo "--- session/context/ production LOC (target: ~2,200) ---"
+  ls internal/agent/session/context/*.go | grep -v _test.go | xargs wc -l | tail -1
+
+  echo
+  echo "--- Verify no session/context/ imports session/ ---"
+  grep -rn "tell-me-go/internal/agent/session\"" internal/agent/session/context/ \
+    && echo "✗ VIOLATION — context/ must not import session/" \
+    || echo "✓ no upward imports"
+
+  echo
+  echo "--- Verify session → session/context import is the only new edge ---"
+  grep -rn "tell-me-go/internal/agent/session/context" internal/agent/session/ --include="*.go" | grep -v "context/"
+} > /tmp/issue88/postflight.txt
+
+cat /tmp/issue88/postflight.txt
+cp /tmp/issue88/postflight.txt docs/issues/088-postflight-metrics.txt
+git add docs/issues/088-postflight-metrics.txt
+git commit -m "docs(issue-88): post-refactor structural metrics
+
+Refs #88"
+```
+
+---
+
+## Phase 10 — Open the PR
+
+```bash
+git push -u origin refactor/extract-session-context
+
+gh pr create \
+  --repo gosharplite/tell-me-go \
+  --title "refactor(session): extract session/context sub-package (closes #88)" \
+  --body "$(cat <<'EOF'
+Implements the refactor specified in #88 per ADR-026.
+
+## Design Reference
+docs/adr/2026-04-session-context-subpackage-extraction.md (status: Accepted)
+
+## Pre-flight & Post-flight Metrics
+- `docs/issues/088-preflight-audit.txt`
+- `docs/issues/088-postflight-metrics.txt`
+
+## Files Moved
+| Old | New |
+|---|---|
+| session/context_manager.go | session/context/manager.go |
+| session/context_pipeline.go | session/context/pipeline.go |
+| session/context_strategy.go | session/context/strategy.go |
+| session/context_transformers.go | session/context/transformers.go |
+| session/pruner.go | session/context/pruner.go |
+| session/gatekeeper.go | session/context/gatekeeper.go |
+| session/token_counter.go | session/context/token_counter.go |
+| session/pipeline_factory.go | session/context/pipeline_factory.go |
+| session/injector.go | session/context/warning_injector.go |
+| (10 test files moved with siblings) | |
+
+## Type Renames
+- ContextManager → Manager
+- ContextStrategy → Strategy
+- PipelineFactory → Factory
+- (and corresponding constructors)
+
+## API Change
+`Factory.BuildStandardPipeline` now accepts `extras ...ports.ContextTransformer` (ADR-026 §2). This breaks the previous `PipelineFactory.BuildStandardPipeline` signature, but the only caller is `session/session_manager.go`, updated in this PR.
+
+## Verification
+- [ ] `go build ./...` — clean
+- [ ] `go vet ./...` — clean
+- [ ] `go test ./... -race -count=1` — pass
+- [ ] `golangci-lint run` — clean (or note: not installed)
+- [ ] Architecture check — clean
+- [ ] session/ production file count: 29 → <N>
+- [ ] session/context/ production file count: <N>
+- [ ] No upward imports (context/ → session/) — verified
+
+## Out of Scope (per #88 and ADR-026)
+- Extracting session/uibridge/ (deferred to follow-up ADR)
+- Extracting session/skills/ (deferred)
+- Extracting session/configwatch/ (deferred)
+- Refactoring the contents of context_transformers.go (large file is a separate concern)
+- Promoting test fixtures to internal/pkg/testfixtures (ADR-026 §3 — only on >50 LOC duplication)
+
+## Commit Trail (bisect-friendly)
+1. ADR-026 acceptance
+2. Pre-flight audit
+3. Sub-package scaffold (doc.go)
+4. One commit per moved file pair (9 commits)
+5. Factory signature change
+6. One commit per consumer (4 commits)
+7. Test migration fixes (variable count)
+8. Post-flight metrics
+
+Closes #88
+EOF
+)"
+```
+
+---
+
+## 🚫 Hard Constraints (Repeated for Emphasis)
+
+1. **Do not** start until Issue #86 is merged AND ADR-026 is on `main`.
+2. **Do not** modify any file under `internal/infrastructure/`. DI restructuring is **issue #87**.
+3. **Do not** refactor the contents of `context_transformers.go` — only move and rename. Internal cleanup is a separate future task.
+4. **Do not** introduce new dependencies in `go.mod`.
+5. **Do not** change runtime behaviour. This is purely structural.
+6. **Do not** rename types other than the three identified in Phase 5. Other renames require ADR amendment.
+7. **Do not** move `internal_tools.go`, `skill_injector.go`, `config_watcher.go`, or any `ui_bridge*.go` file. They stay in `session/` per ADR-026.
+8. **Do not** "improve" anything noticed in passing — append to `FOLLOWUPS.md` at repo root and keep moving.
+9. **Do not** force-push or rewrite history once the PR is open. Add fixup commits if review feedback requires changes.
+10. **If the audit in Phase 2 finds production callers outside the four files listed in ADR-026 §Consumer Update Surface, STOP** — the design needs amendment via an ADR-026 update PR before this work can proceed.
+
+---
+
+## 📋 Final Report Template
+
+When done (or blocked), comment back on this issue with:
+
+```markdown
+## Execution Report — Issue #88
+
+**Status:** Complete / Blocked / Partial
+**PR:** #<N> — <url>
+**Branch:** refactor/extract-session-context
+**ADR:** docs/adr/2026-04-session-context-subpackage-extraction.md (Accepted in commit <sha>)
+
+### Pre-flight Audit
+docs/issues/088-preflight-audit.txt
+- Production callers found: <list> (matches ADR-026 §Consumer Update Surface? Y/N)
+
+### Post-flight Metrics
+docs/issues/088-postflight-metrics.txt
+- session/ production files: 29 → <N>
+- session/context/ production files: <N>
+- Architecture check: clean / <issues>
+
+### Verification Output
+<paste the output of Phase 9's gauntlet>
+
+### Deviations from Runbook
+<list any, with justification — or "none">
+
+### Items added to FOLLOWUPS.md
+<list any, with one-line description — or "none">
+
+### Blockers (if Status != Complete)
+<describe what stopped progress and what decision is needed>
+```

--- a/internal/infrastructure/history/archive_reader_test.go
+++ b/internal/infrastructure/history/archive_reader_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // appendContent writes a single llm.Content as a JSON line to the archive
@@ -411,62 +413,37 @@ func TestJSONLArchiveReader_Resilience(t *testing.T) {
 	valid2 := `{"role":"assistant","parts":[{"text":"valid 2"}]}` + "\n"
 
 	content := valid1 + invalid + partial + emptyLines + largeLine + valid2
-	if err := os.WriteFile(archivePath, []byte(content), 0644); err != nil {
-		t.Fatalf("failed to write resilience test file: %v", err)
-	}
+	err := os.WriteFile(archivePath, []byte(content), 0644)
+	require.NoError(t, err, "failed to write resilience test file")
 
 	reader := history.NewJSONLArchiveReader(fs, archivePath)
 
 	t.Run("ReadPage handles corruption", func(t *testing.T) {
 		// Read 10 entries (should get 3 valid ones: valid1, largeLine, valid2)
 		dtos, nextOffset, err := reader.ReadPage(ctx, 10, 0)
-		if err != nil {
-			t.Fatalf("ReadPage failed: %v", err)
-		}
+		require.NoError(t, err, "ReadPage failed")
 
-		if len(dtos) != 3 {
-			t.Fatalf("expected 3 valid DTOs, got %d", len(dtos))
-		}
+		require.Len(t, dtos, 3, "expected 3 valid DTOs")
 
-		if dtos[0].ContentPreview != "valid 1" {
-			t.Errorf("expected 'valid 1', got %q", dtos[0].ContentPreview)
-		}
-		if dtos[1].ContentPreview != largeLineText {
-			t.Errorf("expected large text, got length %d", len(dtos[1].ContentPreview))
-		}
-		if dtos[2].ContentPreview != "valid 2" {
-			t.Errorf("expected 'valid 2', got %q", dtos[2].ContentPreview)
-		}
+		assert.Equal(t, "valid 1", dtos[0].ContentPreview)
+		assert.Equal(t, largeLineText, dtos[1].ContentPreview)
+		assert.Equal(t, "valid 2", dtos[2].ContentPreview)
 
-		if nextOffset != int64(len(content)) {
-			t.Errorf("expected nextOffset %d, got %d", len(content), nextOffset)
-		}
+		assert.Equal(t, int64(len(content)), nextOffset)
 	})
 
 	t.Run("ReadPrevious handles corruption", func(t *testing.T) {
 		// Read 10 entries backwards from EOF
 		dtos, startOffset, err := reader.ReadPrevious(ctx, 10, -1)
-		if err != nil {
-			t.Fatalf("ReadPrevious failed: %v", err)
-		}
+		require.NoError(t, err, "ReadPrevious failed")
 
-		if len(dtos) != 3 {
-			t.Fatalf("expected 3 valid DTOs, got %d", len(dtos))
-		}
+		require.Len(t, dtos, 3, "expected 3 valid DTOs")
 
-		if dtos[0].ContentPreview != "valid 1" {
-			t.Errorf("expected 'valid 1', got %q", dtos[0].ContentPreview)
-		}
-		if dtos[1].ContentPreview != largeLineText {
-			t.Errorf("expected large text, got length %d", len(dtos[1].ContentPreview))
-		}
-		if dtos[2].ContentPreview != "valid 2" {
-			t.Errorf("expected 'valid 2', got %q", dtos[2].ContentPreview)
-		}
+		assert.Equal(t, "valid 1", dtos[0].ContentPreview)
+		assert.Equal(t, largeLineText, dtos[1].ContentPreview)
+		assert.Equal(t, "valid 2", dtos[2].ContentPreview)
 
-		if startOffset != 0 {
-			t.Errorf("expected startOffset 0, got %d", startOffset)
-		}
+		assert.Equal(t, int64(0), startOffset)
 	})
 }
 

--- a/internal/infrastructure/registry/registry_test.go
+++ b/internal/infrastructure/registry/registry_test.go
@@ -122,59 +122,41 @@ func TestRegistry_Toolkits(t *testing.T) {
 
 	t.Run("GetCoreDeclarations", func(t *testing.T) {
 		decls := r.GetCoreDeclarations()
-		if len(decls) != 1 {
-			t.Errorf("expected 1 core declaration, got %d", len(decls))
-		}
-		if decls[0].Name != "core1" {
-			t.Errorf("expected core1, got %s", decls[0].Name)
-		}
+		assert.Len(t, decls, 1)
+		assert.Equal(t, "core1", decls[0].Name)
 	})
 
 	t.Run("GetDeclarationsByToolkits - only core", func(t *testing.T) {
 		decls := r.GetDeclarationsByToolkits(nil)
-		if len(decls) != 1 {
-			t.Errorf("expected 1 declaration (only core), got %d", len(decls))
-		}
-		if decls[0].Name != "core1" {
-			t.Errorf("expected core1, got %s", decls[0].Name)
-		}
+		assert.Len(t, decls, 1)
+		assert.Equal(t, "core1", decls[0].Name)
 	})
 
 	t.Run("GetDeclarationsByToolkits - core + git", func(t *testing.T) {
 		decls := r.GetDeclarationsByToolkits([]string{"git"})
-		if len(decls) != 3 {
-			t.Errorf("expected 3 declarations (core + git), got %d", len(decls))
-		}
+		assert.Len(t, decls, 3)
 
 		names := make(map[string]bool)
 		for _, d := range decls {
 			names[d.Name] = true
 		}
-		if !names["core1"] || !names["git1"] || !names["git2"] {
-			t.Errorf("missing expected tools in core+git set: %v", names)
-		}
-		if names["k8s1"] {
-			t.Errorf("unrequested tool k8s1 found in core+git set")
-		}
+		assert.True(t, names["core1"])
+		assert.True(t, names["git1"])
+		assert.True(t, names["git2"])
+		assert.False(t, names["k8s1"])
 	})
 
 	t.Run("ListAvailableToolkits", func(t *testing.T) {
 		toolkits := r.ListAvailableToolkits()
-		if len(toolkits) != 3 {
-			t.Errorf("expected 3 toolkits, got %d: %v", len(toolkits), toolkits)
-		}
+		assert.Len(t, toolkits, 3)
 
 		tks := make(map[string]bool)
 		for _, tk := range toolkits {
 			tks[tk] = true
 		}
-		if !tks["core"] || !tks["git"] || !tks["k8s"] {
-			tksList := make([]string, 0, len(tks))
-			for tk := range tks {
-				tksList = append(tksList, tk)
-			}
-			t.Errorf("missing expected toolkits: %v", tksList)
-		}
+		assert.True(t, tks["core"])
+		assert.True(t, tks["git"])
+		assert.True(t, tks["k8s"])
 	})
 }
 


### PR DESCRIPTION
Persists architectural artifacts that were used to file Issues #86, #87, and #88.

## Contents

### ADR
- `docs/adr/2026-04-session-context-subpackage-extraction.md` — **ADR-026**, status `Proposed`. The execution PR for Issue #88 will flip status to `Accepted` as its first commit (per the runbook attached to that issue).

### Issue Specifications
- `docs/issues/001-remove-agent-getset-accessors.md` — body of Issue #86
- `docs/issues/002-extract-session-context-subpackage.md` — body of Issue #88
- `docs/issues/003-continue-di-factory-decomposition.md` — body of Issue #87

### Operational Runbooks
- `docs/issues/001-runbook.md` — execution brief for Issue #86 (already attached as comment to #86)
- `docs/issues/088-runbook.md` — execution brief for Issue #88 (already attached as comment to #88)

## Why Merge This
The Coder (on vacation) will return and pick up Issues #86 → #87 → #88 in priority order. The runbook attached to #88 explicitly checks for ADR-026 on `main` as a prerequisite. Without this PR merged, that prerequisite is never satisfied.

## Risk
None — documentation-only. No code, build, or test impact.