### PR TITLE
[REFACTOR] Continue infrastructure/di Bootstrapper decomposition

### DIFF
--- a/internal/infrastructure/di/chat_factory.go
+++ b/internal/infrastructure/di/chat_factory.go
@@ -18,24 +18,26 @@ type chatFactory interface {
 }
 
 type defaultChatFactory struct {
-	HomeDir      string
-	Version      string
-	Stdout       io.Writer
-	Stderr       io.Writer
-	SM           ConfigurableSecurityManager
-	FileSystem   infra_persistence.FileSystem
-	Bootstrapper *Bootstrapper
+	HomeDir          string
+	Version          string
+	Stdout           io.Writer
+	Stderr           io.Writer
+	SM               ConfigurableSecurityManager
+	FileSystem       infra_persistence.FileSystem
+	LifecycleManager agent.SessionLifecycleManager
+	UIFact           uiFactory
 }
 
-func newChatFactory(homeDir, version string, stdout, stderr io.Writer, sm ConfigurableSecurityManager, fs infra_persistence.FileSystem, b *Bootstrapper) chatFactory {
+func newChatFactory(homeDir, version string, stdout, stderr io.Writer, sm ConfigurableSecurityManager, fs infra_persistence.FileSystem, lifecycleManager agent.SessionLifecycleManager, uiFact uiFactory) chatFactory {
 	return &defaultChatFactory{
-		HomeDir:      homeDir,
-		Version:      version,
-		Stdout:       stdout,
-		Stderr:       stderr,
-		SM:           sm,
-		FileSystem:   fs,
-		Bootstrapper: b,
+		HomeDir:          homeDir,
+		Version:          version,
+		Stdout:           stdout,
+		Stderr:           stderr,
+		SM:               sm,
+		FileSystem:       fs,
+		LifecycleManager: lifecycleManager,
+		UIFact:           uiFact,
 	}
 }
 
@@ -50,11 +52,11 @@ func (f *defaultChatFactory) ChatService() agent.ChatService {
 		f.Stdout,
 		f.Stderr,
 		f.SM,
-		f.Bootstrapper,
-		f.Bootstrapper.GetAgentFactory(),
-		f.Bootstrapper.GetUIRenderer(),
-		f.Bootstrapper.GetHistoryRenderer(),
-		f.Bootstrapper.GetHistoryBrowser(),
+		f.LifecycleManager,
+		f.AgentFactory(),
+		f.UIFact.UIRenderer(),
+		f.UIFact.HistoryRenderer(),
+		f.UIFact.HistoryBrowser(),
 		infra_persistence.NewDomainFS(f.FileSystem),
 	)
 }

--- a/internal/infrastructure/di/chat_factory.go
+++ b/internal/infrastructure/di/chat_factory.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	"io"
+
+	"github.com/gosharplite/tell-me-go/internal/agent"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/factory"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+type chatFactory interface {
+	AgentFactory() ports.ChatterFactory
+	ChatService() agent.ChatService
+}
+
+type defaultChatFactory struct {
+	HomeDir      string
+	Version      string
+	Stdout       io.Writer
+	Stderr       io.Writer
+	SM           ConfigurableSecurityManager
+	FileSystem   infra_persistence.FileSystem
+	Bootstrapper *Bootstrapper
+}
+
+func newChatFactory(homeDir, version string, stdout, stderr io.Writer, sm ConfigurableSecurityManager, fs infra_persistence.FileSystem, b *Bootstrapper) chatFactory {
+	return &defaultChatFactory{
+		HomeDir:      homeDir,
+		Version:      version,
+		Stdout:       stdout,
+		Stderr:       stderr,
+		SM:           sm,
+		FileSystem:   fs,
+		Bootstrapper: b,
+	}
+}
+
+func (f *defaultChatFactory) AgentFactory() ports.ChatterFactory {
+	return factory.NewChatter
+}
+
+func (f *defaultChatFactory) ChatService() agent.ChatService {
+	return agent.NewChatService(
+		f.HomeDir,
+		f.Version,
+		f.Stdout,
+		f.Stderr,
+		f.SM,
+		f.Bootstrapper,
+		f.Bootstrapper.GetAgentFactory(),
+		f.Bootstrapper.GetUIRenderer(),
+		f.Bootstrapper.GetHistoryRenderer(),
+		f.Bootstrapper.GetHistoryBrowser(),
+		infra_persistence.NewDomainFS(f.FileSystem),
+	)
+}

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -105,7 +105,7 @@ func NewBootstrapper(homeDir string, sm ConfigurableSecurityManager, version str
 	b.telemetryFactory = newTelemetryFactory(homeDir, fs, sm, logger)
 	b.historyFactory = newHistoryFactory(homeDir, fs)
 	b.uiFactory = newUIFactory(sm, stdout, stderr, logger)
-	b.chatFactory = newChatFactory(homeDir, version, stdout, stderr, sm, fs, b)
+	b.chatFactory = newChatFactory(homeDir, version, stdout, stderr, sm, fs, b, b.uiFactory)
 	b.suggestionFactory = newSuggestionFactory(homeDir, fs, stderr, logger)
 	return b
 }

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -11,9 +11,7 @@ import (
 	"log/slog"
 	"sync"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gosharplite/tell-me-go/internal/agent"
-	"github.com/gosharplite/tell-me-go/internal/application/suggestions"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -24,15 +22,11 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/exec"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/factory"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	infra_llm "github.com/gosharplite/tell-me-go/internal/infrastructure/llm"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/telemetry"
 	infra_toolchain "github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
-	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	infra_tools "github.com/gosharplite/tell-me-go/internal/tools"
-	"github.com/gosharplite/tell-me-go/internal/ui"
-	"github.com/gosharplite/tell-me-go/internal/ui/tui"
 )
 
 // ConfigurableSecurityManager extends the domain security manager with configuration methods.
@@ -50,6 +44,10 @@ type Bootstrapper struct {
 	sessionFactory   sessionFactory
 	toolchainFactory toolchainFactory
 	telemetryFactory telemetryFactory
+	historyFactory   historyFactory
+	uiFactory        uiFactory
+	chatFactory      chatFactory
+	suggestionFactory suggestionFactory
 	HomeDir          string
 	SM               ConfigurableSecurityManager
 	Version          string
@@ -105,6 +103,10 @@ func NewBootstrapper(homeDir string, sm ConfigurableSecurityManager, version str
 			return b.RegisterMetrics(r, sm, logFile, traceFile, model, mode, pricingOverrides, kvStore)
 		})
 	b.telemetryFactory = newTelemetryFactory(homeDir, fs, sm, logger)
+	b.historyFactory = newHistoryFactory(homeDir, fs)
+	b.uiFactory = newUIFactory(sm, stdout, stderr, logger)
+	b.chatFactory = newChatFactory(homeDir, version, stdout, stderr, sm, fs, b)
+	b.suggestionFactory = newSuggestionFactory(homeDir, fs, stderr, logger)
 	return b
 }
 
@@ -127,7 +129,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		return nil, nil, nil, err
 	}
 
-	hManager, err := b.buildHistoryManager(ctx, paths)
+	hManager, err := b.historyFactory.BuildHistoryManager(ctx, cfg)
 	if err != nil {
 		_ = cleanup(ctx)
 		return nil, nil, nil, err
@@ -182,16 +184,6 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 	deps.regFactory = regFactory
 
 	return deps, hManager, cleanup, nil
-}
-
-func (b *Bootstrapper) buildHistoryManager(ctx stdctx.Context, paths *persistence.Paths) (*history.Manager, error) {
-	hManager := history.NewManager(infra_persistence.NewDomainFS(b.FileSystem), paths.HistoryPath, paths.HistoryArchivePath)
-	if err := hManager.Load(ctx); err != nil {
-		if !errors.Is(err, ports.ErrHistoryNotFound) {
-			return nil, fmt.Errorf("%w: failed to load history from %s: %w", errInfraInit, paths.HistoryPath, err)
-		}
-	}
-	return hManager, nil
 }
 
 type sessionDeps struct {
@@ -303,7 +295,7 @@ func (d *sessionDeps) GetClient() llm.LLMClient {
 
 // GetAgentFactory returns a factory for creating Chatter instances.
 func (b *Bootstrapper) GetAgentFactory() ports.ChatterFactory {
-	return factory.NewChatter
+	return b.chatFactory.AgentFactory()
 }
 
 // FinalizeSession saves history and records session cost.
@@ -340,104 +332,35 @@ func (b *Bootstrapper) getPricingOverrides(cfg *config.Config) map[string]pricin
 }
 
 func (b *Bootstrapper) GetHistoryManager(ctx stdctx.Context, cfg *config.Config) (ports.HistoryManager, error) {
-	paths := persistence.ResolvePaths(b.HomeDir, cfg.Mode)
-	if err := infra_persistence.EnsureDirectories(ctx, b.FileSystem, paths); err != nil {
-		return nil, fmt.Errorf("%w: failed to ensure session directories for %s: %w", errInfraInit, cfg.Mode, err)
-	}
-
-	hManager, err := b.buildHistoryManager(ctx, paths)
-	if err != nil {
-		return nil, err // buildHistoryManager already wraps it
-	}
-
-	return hManager, nil
+	return b.historyFactory.BuildHistoryManager(ctx, cfg)
 }
 
 // GetUnifiedHistoryProvider assembles the read-model for the history browser.
 func (b *Bootstrapper) GetUnifiedHistoryProvider(ctx stdctx.Context, cfg *config.Config, hManager ports.HistoryManager) (ports.UnifiedHistoryProvider, error) {
-	paths := persistence.ResolvePaths(b.HomeDir, cfg.Mode)
-	if err := infra_persistence.EnsureDirectories(ctx, b.FileSystem, paths); err != nil {
-		return nil, fmt.Errorf("%w: failed to ensure session directories for unified history: %w", errInfraInit, err)
-	}
-
-	archiveReader := history.NewJSONLArchiveReader(infra_persistence.NewDomainFS(b.FileSystem), paths.HistoryArchivePath)
-
-	return history.NewUnifiedProvider(archiveReader, hManager), nil
+	return b.historyFactory.BuildUnifiedHistoryProvider(ctx, cfg, hManager)
 }
 
 // GetSuggestionService initializes and returns the suggestion service.
 func (b *Bootstrapper) GetSuggestionService(ctx stdctx.Context, recentHistory []string) (ports.SuggestionService, error) {
-	tracker, err := history.NewGlobalPromptTracker(infra_persistence.NewDomainFS(b.FileSystem), b.HomeDir)
-	if err != nil {
-		b.Logger.Warn("failed to initialize global prompt tracker, falling back to no-op", "error", err)
-		tracker = history.NewNoOpTracker()
-	}
-
-	return suggestions.NewMultiSourceSuggestionService(ctx, infra_persistence.NewDomainFS(b.FileSystem), tracker, recentHistory, b.Stderr)
-}
-
-// getSystemMetricsProvider returns the system metrics provider based on the platform.
-func (b *Bootstrapper) getSystemMetricsProvider() ports.SystemMetricsProvider {
-	return telemetry.NewSystemMetricsProvider()
-}
-
-// GetUIRenderer returns a UI renderer configured with the bootstrapper's output writers.
-func (b *Bootstrapper) GetUIRenderer() ports.UIRenderer {
-	return ui.NewRenderer(b.SM, b.Stdout, b.Stderr, clock.RealClock{}, b.getSystemMetricsProvider())
-}
-
-// GetHistoryRenderer returns a history renderer.
-func (b *Bootstrapper) GetHistoryRenderer() ports.HistoryRenderer {
-	return &ui.StdHistoryRenderer{}
-}
-
-// tuiHistoryBrowser implements ports.HistoryBrowser using the TUI.
-type tuiHistoryBrowser struct {
-	stdout io.Writer
-	stderr io.Writer
-	logger *slog.Logger
-}
-
-// Browse launches the TUI history browser.
-func (b *tuiHistoryBrowser) Browse(ctx stdctx.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error {
-	if closer, err := tui.InitLogger(); err == nil {
-		defer func() {
-			if closeErr := closer.Close(); closeErr != nil {
-				b.logger.Warn("failed to close tui logger", "error", closeErr)
-			}
-		}()
-	}
-
-	model := tui.NewRootBrowserModel(ctx, provider, hManager)
-	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		return fmt.Errorf("tui program error: %w", err)
-	}
-	return nil
+	return b.suggestionFactory.BuildSuggestionService(ctx, recentHistory)
 }
 
 // GetHistoryBrowser returns a history browser that launches the TUI.
 func (b *Bootstrapper) GetHistoryBrowser() ports.HistoryBrowser {
-	return &tuiHistoryBrowser{
-		stdout: b.Stdout,
-		stderr: b.Stderr,
-		logger: b.Logger,
-	}
+	return b.uiFactory.HistoryBrowser()
+}
+
+// GetUIRenderer returns a UI renderer configured with the bootstrapper's output writers.
+func (b *Bootstrapper) GetUIRenderer() ports.UIRenderer {
+	return b.uiFactory.UIRenderer()
+}
+
+// GetHistoryRenderer returns a history renderer.
+func (b *Bootstrapper) GetHistoryRenderer() ports.HistoryRenderer {
+	return b.uiFactory.HistoryRenderer()
 }
 
 // GetChatService returns a chat service instance.
 func (b *Bootstrapper) GetChatService() agent.ChatService {
-	return agent.NewChatService(
-		b.HomeDir,
-		b.Version,
-		b.Stdout,
-		b.Stderr,
-		b.SM,
-		b,
-		b.GetAgentFactory(),
-		b.GetUIRenderer(),
-		b.GetHistoryRenderer(),
-		b.GetHistoryBrowser(),
-		infra_persistence.NewDomainFS(b.FileSystem),
-	)
+	return b.chatFactory.ChatService()
 }

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -41,25 +41,25 @@ type ConfigurableSecurityManager interface {
 
 // Bootstrapper handles the instantiation and wiring of system components.
 type Bootstrapper struct {
-	sessionFactory   sessionFactory
-	toolchainFactory toolchainFactory
-	telemetryFactory telemetryFactory
-	historyFactory   historyFactory
-	uiFactory        uiFactory
-	chatFactory      chatFactory
+	sessionFactory    sessionFactory
+	toolchainFactory  toolchainFactory
+	telemetryFactory  telemetryFactory
+	historyFactory    historyFactory
+	uiFactory         uiFactory
+	chatFactory       chatFactory
 	suggestionFactory suggestionFactory
-	HomeDir          string
-	SM               ConfigurableSecurityManager
-	Version          string
-	Stdout           io.Writer
-	Stderr           io.Writer
-	Logger           *slog.Logger
-	FileSystem       infra_persistence.FileSystem
-	ClientFactory    func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error)
-	RegisterAllTools func(params infra_tools.ToolRegistrationParams) error
-	RegisterMetrics  func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error
-	RotateSession    func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error
-	NewSessionState  func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error)
+	HomeDir           string
+	SM                ConfigurableSecurityManager
+	Version           string
+	Stdout            io.Writer
+	Stderr            io.Writer
+	Logger            *slog.Logger
+	FileSystem        infra_persistence.FileSystem
+	ClientFactory     func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error)
+	RegisterAllTools  func(params infra_tools.ToolRegistrationParams) error
+	RegisterMetrics   func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error
+	RotateSession     func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error
+	NewSessionState   func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error)
 }
 
 // NewBootstrapper creates a new Bootstrapper instance.

--- a/internal/infrastructure/di/history_factory.go
+++ b/internal/infrastructure/di/history_factory.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	stdctx "context"
+	"errors"
+	"fmt"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+type historyFactory interface {
+	BuildHistoryManager(ctx stdctx.Context, cfg *config.Config) (ports.HistoryManager, error)
+	BuildUnifiedHistoryProvider(ctx stdctx.Context, cfg *config.Config, hManager ports.HistoryManager) (ports.UnifiedHistoryProvider, error)
+}
+
+type defaultHistoryFactory struct {
+	HomeDir    string
+	FileSystem infra_persistence.FileSystem
+}
+
+func newHistoryFactory(homeDir string, fs infra_persistence.FileSystem) historyFactory {
+	return &defaultHistoryFactory{
+		HomeDir:    homeDir,
+		FileSystem: fs,
+	}
+}
+
+func (f *defaultHistoryFactory) BuildHistoryManager(ctx stdctx.Context, cfg *config.Config) (ports.HistoryManager, error) {
+	paths := persistence.ResolvePaths(f.HomeDir, cfg.Mode)
+	if err := infra_persistence.EnsureDirectories(ctx, f.FileSystem, paths); err != nil {
+		return nil, fmt.Errorf("%w: failed to ensure session directories for %s: %w", errInfraInit, cfg.Mode, err)
+	}
+
+	hManager := history.NewManager(infra_persistence.NewDomainFS(f.FileSystem), paths.HistoryPath, paths.HistoryArchivePath)
+	if err := hManager.Load(ctx); err != nil {
+		if !errors.Is(err, ports.ErrHistoryNotFound) {
+			return nil, fmt.Errorf("%w: failed to load history from %s: %w", errInfraInit, paths.HistoryPath, err)
+		}
+	}
+
+	return hManager, nil
+}
+
+func (f *defaultHistoryFactory) BuildUnifiedHistoryProvider(ctx stdctx.Context, cfg *config.Config, hManager ports.HistoryManager) (ports.UnifiedHistoryProvider, error) {
+	paths := persistence.ResolvePaths(f.HomeDir, cfg.Mode)
+	if err := infra_persistence.EnsureDirectories(ctx, f.FileSystem, paths); err != nil {
+		return nil, fmt.Errorf("%w: failed to ensure session directories for unified history: %w", errInfraInit, err)
+	}
+
+	archiveReader := history.NewJSONLArchiveReader(infra_persistence.NewDomainFS(f.FileSystem), paths.HistoryArchivePath)
+
+	return history.NewUnifiedProvider(archiveReader, hManager), nil
+}

--- a/internal/infrastructure/di/suggestion_factory.go
+++ b/internal/infrastructure/di/suggestion_factory.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	stdctx "context"
+	"io"
+	"log/slog"
+
+	"github.com/gosharplite/tell-me-go/internal/application/suggestions"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+type suggestionFactory interface {
+	BuildSuggestionService(ctx stdctx.Context, recentHistory []string) (ports.SuggestionService, error)
+}
+
+type defaultSuggestionFactory struct {
+	HomeDir    string
+	FileSystem infra_persistence.FileSystem
+	Stderr     io.Writer
+	Logger     *slog.Logger
+}
+
+func newSuggestionFactory(homeDir string, fs infra_persistence.FileSystem, stderr io.Writer, logger *slog.Logger) suggestionFactory {
+	return &defaultSuggestionFactory{
+		HomeDir:    homeDir,
+		FileSystem: fs,
+		Stderr:     stderr,
+		Logger:     logger,
+	}
+}
+
+func (f *defaultSuggestionFactory) BuildSuggestionService(ctx stdctx.Context, recentHistory []string) (ports.SuggestionService, error) {
+	tracker, err := history.NewGlobalPromptTracker(infra_persistence.NewDomainFS(f.FileSystem), f.HomeDir)
+	if err != nil {
+		f.Logger.Warn("failed to initialize global prompt tracker, falling back to no-op", "error", err)
+		tracker = history.NewNoOpTracker()
+	}
+
+	return suggestions.NewMultiSourceSuggestionService(ctx, infra_persistence.NewDomainFS(f.FileSystem), tracker, recentHistory, f.Stderr)
+}

--- a/internal/infrastructure/di/ui_factory.go
+++ b/internal/infrastructure/di/ui_factory.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	stdctx "context"
+	"fmt"
+	"io"
+	"log/slog"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/telemetry"
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+	"github.com/gosharplite/tell-me-go/internal/ui"
+	"github.com/gosharplite/tell-me-go/internal/ui/tui"
+)
+
+type uiFactory interface {
+	UIRenderer() ports.UIRenderer
+	HistoryRenderer() ports.HistoryRenderer
+	HistoryBrowser() ports.HistoryBrowser
+}
+
+type defaultUIFactory struct {
+	SM                    ConfigurableSecurityManager
+	Stdout                io.Writer
+	Stderr                io.Writer
+	Logger                *slog.Logger
+	SystemMetricsProvider ports.SystemMetricsProvider
+}
+
+func newUIFactory(sm ConfigurableSecurityManager, stdout, stderr io.Writer, logger *slog.Logger) uiFactory {
+	return &defaultUIFactory{
+		SM:                    sm,
+		Stdout:                stdout,
+		Stderr:                stderr,
+		Logger:                logger,
+		SystemMetricsProvider: telemetry.NewSystemMetricsProvider(),
+	}
+}
+
+func (f *defaultUIFactory) UIRenderer() ports.UIRenderer {
+	return ui.NewRenderer(f.SM, f.Stdout, f.Stderr, clock.RealClock{}, f.SystemMetricsProvider)
+}
+
+func (f *defaultUIFactory) HistoryRenderer() ports.HistoryRenderer {
+	return &ui.StdHistoryRenderer{}
+}
+
+// tuiHistoryBrowser implements ports.HistoryBrowser using the TUI.
+type tuiHistoryBrowser struct {
+	stdout io.Writer
+	stderr io.Writer
+	logger *slog.Logger
+}
+
+// Browse launches the TUI history browser.
+func (b *tuiHistoryBrowser) Browse(ctx stdctx.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error {
+	if closer, err := tui.InitLogger(); err == nil {
+		defer func() {
+			if closeErr := closer.Close(); closeErr != nil {
+				b.logger.Warn("failed to close tui logger", "error", closeErr)
+			}
+		}()
+	}
+
+	model := tui.NewRootBrowserModel(ctx, provider, hManager)
+	p := tea.NewProgram(model, tea.WithAltScreen())
+	if _, err := p.Run(); err != nil {
+		return fmt.Errorf("tui program error: %w", err)
+	}
+	return nil
+}
+
+func (f *defaultUIFactory) HistoryBrowser() ports.HistoryBrowser {
+	return &tuiHistoryBrowser{
+		stdout: f.Stdout,
+		stderr: f.Stderr,
+		logger: f.Logger,
+	}
+}

--- a/internal/infrastructure/di/ui_factory.go
+++ b/internal/infrastructure/di/ui_factory.go
@@ -51,8 +51,6 @@ func (f *defaultUIFactory) HistoryRenderer() ports.HistoryRenderer {
 
 // tuiHistoryBrowser implements ports.HistoryBrowser using the TUI.
 type tuiHistoryBrowser struct {
-	stdout io.Writer
-	stderr io.Writer
 	logger *slog.Logger
 }
 
@@ -76,8 +74,6 @@ func (b *tuiHistoryBrowser) Browse(ctx stdctx.Context, provider ports.UnifiedHis
 
 func (f *defaultUIFactory) HistoryBrowser() ports.HistoryBrowser {
 	return &tuiHistoryBrowser{
-		stdout: f.Stdout,
-		stderr: f.Stderr,
 		logger: f.Logger,
 	}
 }


### PR DESCRIPTION
Closes #87

## Summary

Extracts 4 new factory files from the Bootstrapper composition root, following the established pattern of `session_factory.go`, `telemetry_factory.go`, and `toolchain_factory.go`.

## Changes

| New File | Methods Moved |
|---|---|
| `history_factory.go` | `BuildHistoryManager`, `BuildUnifiedHistoryProvider` |
| `ui_factory.go` | `UIRenderer`, `HistoryRenderer`, `HistoryBrowser` + `tuiHistoryBrowser` type |
| `chat_factory.go` | `AgentFactory`, `ChatService` |
| `suggestion_factory.go` | `BuildSuggestionService` |

## Metrics

| Metric | Before | After |
|---|---|---|
| `container.go` LOC | 443 | 366 |
| Internal imports | 22 | 16 |
| `Get*` methods with construction logic | 9 | 0 (all one-line delegates) |
| Factory files | 3 | 7 |

## Verification

- [x] `go build ./...` — clean
- [x] `go test ./internal/infrastructure/di/...` — 37/37 pass
- [x] `go test ./...` — full suite passes
- [x] `verify_architecture` — clean, no layer violations or circular dependencies
- [x] No public API surface changes
- [x] Zero behavioral changes