### PR TITLE
refactor: continue sub-package extraction — integrations (ado/atlassian) and session/ui

### DIFF
--- a/docs/adr/2026-05-integrations-and-session-ui-subpackage-extraction.md
+++ b/docs/adr/2026-05-integrations-and-session-ui-subpackage-extraction.md
@@ -1,0 +1,273 @@
+<!--
+Copyright (c) 2026 gosharplite@gmail.com
+SPDX-License-Identifier: MIT
+-->
+
+# ADR-027: Continue Sub-Package Extraction — Integrations (ado/atlassian) and Session (ui/)
+
+## Status
+Accepted
+
+## Context
+
+ADR-026 established the sub-package extraction pattern for `session/context/`, demonstrating that extracting a cohesive concern cluster into a child package reduces file count, improves navigability, and enables independent testing — all without semantic changes.
+
+Two remaining clusters in the codebase violated the single-responsibility thresholds established by ADR-008 ("Domain Decomposition Strategy"):
+
+| Cluster | Files | Concern families | Threshold violation |
+|---|---|---|---|
+| `internal/tools/integrations/` | 25 | Azure DevOps (11), Atlassian (6), Other (8) | Three integration families in one flat package |
+| `internal/agent/session/` | 14 `ui_bridge_*` files | UI Bridge actor | Still in parent after `context/` extraction; largest remaining cluster |
+
+ADR-025 had already decomposed `ui_bridge.go` into 5 cohesive files (dispatcher, event queue, spinner, state machine, core bridge). Extraction to a sub-package was the natural next step — the file count and internal cohesion justified its own namespace.
+
+### Why Now
+
+| Trigger | Impact |
+|---|---|
+| `integrations/` hit 25 files | Navigation cost: linear scan of flat namespace to find a specific integration provider |
+| `session/` still at 41 files after `context/` extraction | The `ui_bridge_*` prefix pattern is a naming convention papering over a missing package boundary |
+| ADR-021 ("Test Doubles in `*test` Sub-Packages") | Established that test fixtures co-locate with their subjects; sub-packages carry their own test infrastructure |
+
+### Scope Boundaries
+
+This ADR covers two extractions executed in sequence on the same branch (Issue #101):
+
+1. **Workstream A**: `integrations/ado/` and `integrations/atlassian/`
+2. **Workstream B**: `session/ui/`
+
+Both follow the same move-then-rename-then-wire pattern established by ADR-026. The two workstreams share this ADR because they share the same rationale, constraints, and acceptance criteria — only the package subject differs.
+
+## Decision
+
+### 1. Extract `integrations/ado/` and `integrations/atlassian/`
+
+**Files moved into `integrations/ado/`** (5 source + 6 test):
+
+| Old path (`integrations/`) | New path (`integrations/ado/`) | Rename rationale |
+|---|---|---|
+| `azure_devops.go` | `ado/azure_devops.go` | Retained — primary type file |
+| `azure_devops_pipeline.go` | `ado/pipeline.go` | Drop `azure_devops_` prefix |
+| `azure_devops_pipeline_logs.go` | `ado/pipeline_logs.go` | Drop `azure_devops_` prefix |
+| `azure_devops_policy.go` | `ado/policy.go` | Drop `azure_devops_` prefix |
+| `azure_devops_pr.go` | `ado/pr.go` | Drop `azure_devops_` prefix |
+| `azure_devops_test.go` | `ado/azure_devops_test.go` | Retained |
+| `azure_devops_pipeline_test.go` | `ado/pipeline_test.go` | Drop prefix |
+| `azure_devops_fault_test.go` | `ado/fault_test.go` | Drop prefix |
+| `azure_devops_integration_test.go` | `ado/integration_test.go` | Drop prefix |
+| `azure_devops_negative_test.go` | `ado/negative_test.go` | Drop prefix |
+| `log_processor_test.go` | `ado/log_processor_test.go` | Retained |
+
+**Files moved into `integrations/atlassian/`** (3 source + 3 test):
+
+| Old path | New path | Rename rationale |
+|---|---|---|
+| `atlassian_common.go` | `atlassian/provider.go` | Name reflects role: shared auth/token provider |
+| `atlassian_common_test.go` | `atlassian/provider_test.go` | Mirrors source rename |
+| `confluence.go` | `atlassian/confluence.go` | Retained |
+| `confluence_test.go` | `atlassian/confluence_test.go` | Retained |
+| `jira.go` | `atlassian/jira.go` | Retained |
+| `jira_test.go` | `atlassian/jira_test.go` | Retained |
+
+**Export decisions for `ado/`:**
+
+| Symbol | Decision | Rationale |
+|---|---|---|
+| `adoManager` → `AdoManager` | Exported | Needed by `registration.go` composition root and shared parent tests |
+| `newADOManager` → `NewADOManager` | Exported | Constructor for composition root |
+| `adoOption` → `AdoOption` | Exported | Functional-options type exposed to `registration.go` |
+| `withHTTPClient` → `WithHTTPClient` | Exported | Functional option |
+| `withToken` → `WithToken` | Exported | Functional option |
+| `withBaseURL` → `WithBaseURL` | Exported | Needed by parent-level fault-injection tests |
+| `executeRequest` → `ExecuteRequest` | Exported | Needed by parent-level fault-injection tests |
+| `checkResponseError` → `CheckResponseError` | Exported | Needed by parent-level I/O error tests |
+| `baseURL` → `BaseURL` | Exported (field) | Needed by parent-level tests |
+| 20 handler methods (`adoGet*` → `AdoGet*`) | Exported | All consumed by `registration.go` tool specs |
+
+**Export decisions for `atlassian/`:**
+
+| Symbol | Decision | Rationale |
+|---|---|---|
+| `atlassianProvider` → `AtlassianProvider` | Exported | Needed by parent-level fault-injection and wait-time tests |
+| `newAtlassianProvider` → `NewAtlassianProvider` | Exported | Constructor |
+| `email`, `token`, `baseDelay` → `Email`, `Token`, `BaseDelay` | Exported (fields) | Needed by parent-level tests |
+| `confluenceManager` → `ConfluenceManager` | Exported | Needed by parent-level fault-injection tests |
+| `newConfluenceManager` → `NewConfluenceManager` | Exported | Constructor for `registration.go` |
+| `jiraManager` → `JiraManager` | Exported | Needed by parent-level fault-injection tests |
+| `newJiraManager` → `NewJiraManager` | Exported | Constructor for `registration.go` |
+| `fetchSearchPage` → `FetchSearchPage` | Exported | Needed by parent-level tests |
+| `getWaitTime` → `GetWaitTime` | Exported | Needed by parent-level wait-time tests |
+| `confluenceSearch`/`Read`/`Write` → `ConfluenceSearch`/`Read`/`Write` | Exported | All consumed by `registration.go` tool specs |
+| `jiraSearchIssues`/`jiraGetIssue` → `JiraSearchIssues`/`JiraGetIssue` | Exported | All consumed by `registration.go` tool specs |
+
+### 2. Extract `session/ui/`
+
+**Files moved into `session/ui/`** (5 source + 9 test):
+
+| Old path (`session/`) | New path (`session/ui/`) | Rename rationale |
+|---|---|---|
+| `ui_bridge.go` | `ui/bridge.go` | Drop `ui_` prefix; package name `ui` already scopes it |
+| `ui_bridge_dispatcher.go` | `ui/dispatcher.go` | Drop prefix |
+| `ui_bridge_event_queue.go` | `ui/event_queue.go` | Drop prefix |
+| `ui_bridge_spinner.go` | `ui/spinner.go` | Drop prefix |
+| `ui_bridge_state_machine.go` | `ui/state_machine.go` | Drop prefix |
+| `ui_bridge_test.go` | `ui/bridge_test.go` | Drop prefix |
+| `ui_bridge_backpressure_test.go` | `ui/backpressure_test.go` | Drop prefix |
+| `ui_bridge_concurrency_test.go` | `ui/concurrency_test.go` | Drop prefix |
+| `ui_bridge_consent_test.go` | `ui/consent_test.go` | Drop prefix |
+| `ui_bridge_fixture_test.go` | `ui/fixture_test.go` | Drop prefix |
+| `ui_bridge_idempotency_test.go` | `ui/idempotency_test.go` | Drop prefix |
+| `ui_bridge_panic_test.go` | `ui/panic_test.go` | Drop prefix |
+| `ui_bridge_refactor_test.go` | `ui/refactor_test.go` | Drop prefix |
+| `ui_bridge_routing_test.go` | `ui/routing_test.go` | Drop prefix |
+
+**Type rename:**
+
+| Old Name | New Name | Rationale |
+|---|---|---|
+| `UIBridge` | `Bridge` | Package name `ui` already provides the `UI` namespace |
+| `NewUIBridge` | `NewBridge` | Constructor mirrors type rename |
+
+Other types (`eventDispatcher`, `eventQueue`, `spinnerCoord`, `uiStateMachine`) were already correctly named — unexported, without redundant `UI` prefix — and required no renaming.
+
+**Export decisions for `ui/`:**
+
+| Symbol | Decision | Rationale |
+|---|---|---|
+| `UIBridge` → `Bridge` | Already exported | Type rename only; `session_manager.go` references `*ui.Bridge` |
+| `NewUIBridge` → `NewBridge` | Already exported | Constructor for `session_manager.go` |
+| `WithBridgeThoughts`, `WithBridgeTools`, etc. | Retained as-is | Already exported; package qualifier `ui.WithBridgeThoughts` is clear |
+| `withBridgeClock` → `WithBridgeClock` | Exported | Previously unexported; needed by `session_manager.go` |
+| `wg` → `WG` | Exported (field) | Previously unexported; accessed by `session_manager.go` for teardown |
+
+### Coupling Hazard Resolutions
+
+#### 1. `registration.go` as Composition Root
+
+`registration.go` is the natural composition root for the `integrations/` package. After extraction:
+
+```go
+// registration.go — imports both sub-packages
+import (
+    "github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+    "github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
+)
+
+func registerAzureDevOps(r tools.Registry, sm ..., client ...) error {
+    m := ado.NewADOManager(sm, ado.WithHTTPClient(client), ado.WithToken(token))
+    // ... register 20 ado_* tools using m.AdoGet* handlers ...
+}
+
+func registerConfluence(r tools.Registry, sm ..., client ...) error {
+    m, err := atlassian.NewConfluenceManager(sm, client)
+    // ... register confluence_* tools using m.Confluence* handlers ...
+}
+```
+
+The import direction is `integrations → integrations/ado` and `integrations → integrations/atlassian`. These are acyclic parent-child dependencies.
+
+#### 2. `session_manager.go` as Composition Root
+
+`session_manager.go` is the natural composition root for `session/`. After extraction:
+
+```go
+// session_manager.go — imports ui sub-package
+import "github.com/gosharplite/tell-me-go/internal/agent/session/ui"
+
+func (o *sessionManager) setupUIRendering(...) *ui.Bridge {
+    bridge := ui.NewBridge(o.UIRenderer,
+        ui.WithBridgeThoughts(cfg.ShowThoughts),
+        ui.WithBridgeTools(cfg.ShowTools),
+        // ...
+    )
+    return bridge
+}
+```
+
+The import direction is `session → session/ui`. Acyclic; matches the `session → session/context` pattern established by ADR-026.
+
+#### 3. Shared Test Fixtures
+
+**`fault_injection_test.go` and `io_error_test.go`** (parent `integrations/` package) test error paths across both ADO and Atlassian sub-packages. These stayed at the parent level and import both `ado` and `atlassian`:
+
+```go
+// integrations/fault_injection_test.go
+import (
+    "github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+    "github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
+)
+```
+
+`mockSecurityManager`, previously shared via the now-moved `azure_devops_test.go`, was duplicated locally in `fault_injection_test.go` — it implements `domain_security.Manager` and the duplication (~30 LOC) falls well within the ADR-026 threshold for acceptable fixture duplication.
+
+**`panic_test.go`** uses external test package `package ui_test`. It references `ui.Bridge` via qualified import and calls `ui.SyncBridge` (exported from `ui/export_test.go`) for deterministic synchronization:
+
+```go
+// session/ui/panic_test.go — package ui_test
+import "github.com/gosharplite/tell-me-go/internal/agent/session/ui"
+
+bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ...)
+ui.SyncBridge(t, bridge, mRenderer)
+```
+
+**`syncBridge` and `syncWriter`** were moved from the parent `test_helpers_test.go` into `ui/helpers_test.go`, co-locating them with their consumers. A thin re-export (`ui/export_test.go`) exposes `SyncBridge` for the external `ui_test` package.
+
+## Consequences
+
+### Positive
+
+- **`integrations/` drops from 25 to 10 files** (3 remaining integration families: media, network, teams; plus `registration.go` and shared tests). Each integration family is now independently navigable.
+- **`session/` drops 14 UI bridge files**. After `context/` extraction (ADR-026) and `ui/` extraction (this ADR), the parent package contains only lifecycle orchestration, configuration, and skill injection.
+- **Both sub-packages are independently testable** with their own test fixtures. `go test ./integrations/ado/...` runs only Azure DevOps tests; `go test ./session/ui/...` runs only UI bridge tests.
+- **Open/Closed adherence**: adding a new Atlassian integration requires touching only `integrations/atlassian/`, not the parent. Adding a new UI event handler requires touching only `session/ui/`.
+- **Establishes the sub-package extraction pattern** across two distinct domains (tools/integrations and agent/session), proving the pattern's general applicability.
+
+### Negative
+
+- **~25 symbols exported** (were unexported) to enable composition root access from `registration.go` and `session_manager.go`. Acceptable — all were already consumed by their respective composition roots; exporting them formalizes an existing dependency rather than creating a new one.
+- **One-time mechanical migration cost** on ~80 files across 8 commits. Mitigated by `git mv` (preserves history), `perl` batch renames, and the small consumer surface (~20 lines in `registration.go`, ~10 lines in `session_manager.go`).
+- **Slightly deeper import paths** in tests (`ado.NewADOManager` instead of `newADOManager`, `sessionui.NewBridge` instead of `session.NewUIBridge`). Acceptable trade-off for clarity — the package qualifier provides context about which subsystem the symbol belongs to.
+- **Parent-level test files** (`fault_injection_test.go`, `io_error_test.go`) now import both `ado` and `atlassian`. These are the only files in the parent that cross-reference sub-packages for testing purposes.
+
+### Neutral
+
+- **No behavior changes**. This is a purely structural refactor.
+- **No change to public API** of `internal/agent/agent.go`, `internal/cli`, or any external consumer. Only intra-package types and imports are affected.
+- **`verify_architecture` results remain clean** — the new `integrations → integrations/ado`, `integrations → integrations/atlassian`, and `session → session/ui` dependencies are all acyclic parent-child relationships.
+- **No change to test coverage**. All tests move with their source files.
+
+## Implementation Plan
+
+Executed on GitHub Issue #101 across 8 commits:
+
+| Commit | Workstream | Task | Files |
+|---|---|---|---|
+| `ff6d653f` | A1 | Extract `integrations/ado/` | 11 moved |
+| `cd0c786a` | A2 | Extract `integrations/atlassian/` | 6 moved |
+| `de193112` | A3 | Wire `registration.go` | 14 edited |
+| `a66acced` | A4 | Fix shared test fixtures | 16 edited |
+| `dee9414f` | B1 | Extract `session/ui/` | 14 moved |
+| `bc004664` | B2 | Rename `UIBridge` → `Bridge` | 8 edited |
+| `079948ca` | B3 | Wire `session_manager.go` | 12 edited |
+| `a992008d` | B4 | Lint, tests, integration fixes | 2 edited |
+
+Acceptance gauntlet (all passing):
+
+| Check | Result |
+|---|---|
+| `go build ./...` | ✅ Full-module build |
+| `go test ./internal/agent/...` | ✅ All agent packages |
+| `go test ./internal/tools/integrations/...` | ✅ All three integration packages |
+| `go vet ./...` | ✅ Clean |
+| `golangci-lint run` | ✅ Clean |
+| `verify_architecture` | ✅ Acyclic |
+
+## References
+
+- ADR-008 (`2026-01-domain-decomposition-strategy.md`) — package decomposition principles and thresholds
+- ADR-025 (`2026-04-uibridge-decomposition.md`) — prior intra-file decomposition of `ui_bridge.go` (sets precedent for this extraction)
+- ADR-026 (`2026-04-session-context-subpackage-extraction.md`) — established the move-then-rename-then-wire sub-package extraction pattern
+- ADR-021 (`2026-04-test-doubles-in-pkgtest-subpackages.md`) — test fixture co-location principles
+- GitHub Issue #101 — execution tracking for this ADR
+- PR #98 — Workstream A (integrations/ado and integrations/atlassian)
+- PR #102 — Workstream B (session/ui)

--- a/internal/agent/session/doc.go
+++ b/internal/agent/session/doc.go
@@ -6,11 +6,11 @@ Package session manages the session lifecycle and coordinates between the domain
 
 # UI Concurrency (Actor Model)
 
-The UIBridge component within this package follows the Actor Model to handle asynchronous UI updates safely.
+The Bridge component within this package follows the Actor Model to handle asynchronous UI updates safely.
 All events received from the domain are funneled into a single background goroutine (the "actor loop") via
 a mailbox channel.
 
-Rules for UIBridge:
+Rules for Bridge:
   - All internal state (isRendering, activePhase, etc.) must remain private to the loop() goroutine.
   - sync.Mutex is strictly forbidden for state protection; use channels and events instead.
   - The component must be formally shut down using Cleanup() to prevent goroutine leaks.

--- a/internal/agent/session/export_test.go
+++ b/internal/agent/session/export_test.go
@@ -5,9 +5,9 @@ package session
 
 import (
 	"context"
-	"sync"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/stretchr/testify/mock"
 )
@@ -17,7 +17,7 @@ type SessionManagerInternal = sessionManager
 type SessionConfigInternal = sessionConfig
 type SessionDependenciesInternal = sessionDependencies
 
-func (o *sessionManager) ApplyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.SessionDependencies, capturer ports.Capturer) (*UIBridge, error) {
+func (o *sessionManager) ApplyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.SessionDependencies, capturer ports.Capturer) (*ui.Bridge, error) {
 	return o.applyConfiguration(ctx, chatAgent, sCfg, sd, capturer)
 }
 
@@ -25,11 +25,7 @@ func AsSessionManagerInternal(sm SessionManager) *sessionManager {
 	return sm.(*sessionManager)
 }
 
-func (b *UIBridge) Wg() *sync.WaitGroup {
-	return &b.wg
-}
-
-func SyncBridge(t *testing.T, b *UIBridge, m interface {
+func SyncBridge(t *testing.T, b *ui.Bridge, m interface {
 	On(methodName string, arguments ...interface{}) *mock.Call
 }) {
 	syncBridge(t, b, m)

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -185,7 +185,7 @@ func (o *sessionManager) Run(ctx context.Context, sc ports.SessionConfig, sd por
 		// 2. Clean up Consumer (UI) second
 		if bridge != nil {
 			if !listenStarted {
-				bridge.WG.Done()
+				bridge.AbortStart()
 			}
 			bridge.CloseInput()
 			bridge.Cleanup()

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_llm "github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -184,7 +185,7 @@ func (o *sessionManager) Run(ctx context.Context, sc ports.SessionConfig, sd por
 		// 2. Clean up Consumer (UI) second
 		if bridge != nil {
 			if !listenStarted {
-				bridge.wg.Done()
+				bridge.WG.Done()
 			}
 			bridge.CloseInput()
 			bridge.Cleanup()
@@ -259,7 +260,7 @@ func (o *sessionManager) RenderHistory(hManager ports.HistoryManager, sCfg ports
 	})
 }
 
-func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.SessionDependencies, capturer ports.Capturer) (*UIBridge, error) {
+func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.SessionDependencies, capturer ports.Capturer) (*ui.Bridge, error) {
 	cfg := sCfg.GetConfig()
 	paths := sd.GetPaths()
 	logger := sd.GetLogger()
@@ -278,17 +279,17 @@ func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports
 	return bridge, nil
 }
 
-func (o *sessionManager) setupUIRendering(ctx context.Context, chatAgent ports.Chatter, cfg *config.Config, rawOutput bool, logPath string, logger ports.Logger, capturer ports.Capturer) *UIBridge {
+func (o *sessionManager) setupUIRendering(ctx context.Context, chatAgent ports.Chatter, cfg *config.Config, rawOutput bool, logPath string, logger ports.Logger, capturer ports.Capturer) *ui.Bridge {
 	useColor := capturer.IsTTY(o.Stdout) && !rawOutput
 	o.UIRenderer.SetUseColor(useColor)
-	bridge := NewUIBridge(o.UIRenderer,
-		WithBridgeThoughts(cfg.ShowThoughts),
-		WithBridgeTools(cfg.ShowTools),
-		WithBridgeRawOutput(rawOutput),
-		WithBridgeColor(useColor),
-		WithBridgeLogFile(logPath),
-		WithBridgeLogger(logger),
-		withBridgeClock(o.Clock),
+	bridge := ui.NewBridge(o.UIRenderer,
+		ui.WithBridgeThoughts(cfg.ShowThoughts),
+		ui.WithBridgeTools(cfg.ShowTools),
+		ui.WithBridgeRawOutput(rawOutput),
+		ui.WithBridgeColor(useColor),
+		ui.WithBridgeLogFile(logPath),
+		ui.WithBridgeLogger(logger),
+		ui.WithBridgeClock(o.Clock),
 	)
 	chatAgent.Subscribe(func(ctx context.Context, e events.Event) {
 		if err := bridge.HandleEvent(ctx, e); err != nil {

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -177,7 +177,7 @@ func TestSessionManager_ApplyConfiguration_Error(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "limits error")
 	require.NotNil(t, bridge)
-	bridge.Wg().Done() // Manually satisfy constructor wg.Add(1) since Listen wasn't called
+	bridge.WG.Done() // Manually satisfy constructor wg.Add(1) since Listen wasn't called
 	bridge.CloseInput()
 	bridge.Cleanup()
 }

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -177,7 +177,7 @@ func TestSessionManager_ApplyConfiguration_Error(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "limits error")
 	require.NotNil(t, bridge)
-	bridge.WG.Done() // Manually satisfy constructor wg.Add(1) since Listen wasn't called
+	bridge.AbortStart() // Manually satisfy constructor wg.Add(1) since Listen wasn't called
 	bridge.CloseInput()
 	bridge.Cleanup()
 }

--- a/internal/agent/session/test_helpers_test.go
+++ b/internal/agent/session/test_helpers_test.go
@@ -4,10 +4,7 @@
 package session
 
 import (
-	"bytes"
 	"context"
-	"io"
-	"sync"
 	"testing"
 	"time"
 
@@ -38,54 +35,4 @@ func syncBridge(t *testing.T, b *ui.Bridge, m interface {
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for sync sentinel processing")
 	}
-}
-
-type syncWriter struct {
-	mu      sync.Mutex
-	Writer  io.Writer
-	buf     bytes.Buffer
-	onWrite chan struct{}
-}
-
-func (w *syncWriter) Write(p []byte) (int, error) {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	var n int
-	var err error
-	if w.Writer != nil {
-		n, err = w.Writer.Write(p)
-	} else {
-		n, err = w.buf.Write(p)
-	}
-
-	if w.onWrite != nil {
-		select {
-		case w.onWrite <- struct{}{}:
-		default:
-		}
-	}
-	return n, err
-}
-
-func (w *syncWriter) String() string {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.Writer != nil {
-		if s, ok := w.Writer.(interface{ String() string }); ok {
-			return s.String()
-		}
-	}
-	return w.buf.String()
-}
-
-func (w *syncWriter) Reset() {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.Writer != nil {
-		if r, ok := w.Writer.(interface{ Reset() }); ok {
-			r.Reset()
-		}
-	}
-	w.buf.Reset()
 }

--- a/internal/agent/session/ui/backpressure_test.go
+++ b/internal/agent/session/ui/backpressure_test.go
@@ -225,7 +225,7 @@ func TestUIBridge_HandleEvent_BridgeShutdownDuringWait(t *testing.T) {
 func TestUIBridge_HandleEvent_AlreadyShutdown(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer)
+	bridge := NewBridge(mRenderer)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)

--- a/internal/agent/session/ui/backpressure_test.go
+++ b/internal/agent/session/ui/backpressure_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -18,51 +18,51 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 )
 
-// bridgeOption configures a UIBridge instance.
-type bridgeOption func(*UIBridge)
+// bridgeOption configures a Bridge instance.
+type bridgeOption func(*Bridge)
 
 // WithBridgeThoughts enables or disables thought rendering.
 func WithBridgeThoughts(show bool) bridgeOption {
-	return func(b *UIBridge) { b.showThoughts = show }
+	return func(b *Bridge) { b.showThoughts = show }
 }
 
 // WithBridgeTools enables or disables tool call rendering.
 func WithBridgeTools(show bool) bridgeOption {
-	return func(b *UIBridge) { b.showTools = show }
+	return func(b *Bridge) { b.showTools = show }
 }
 
 // WithBridgeRawOutput enables or disables raw output mode.
 func WithBridgeRawOutput(raw bool) bridgeOption {
-	return func(b *UIBridge) { b.rawOutput = raw }
+	return func(b *Bridge) { b.rawOutput = raw }
 }
 
 // WithBridgeColor enables or disables ANSI color support.
 func WithBridgeColor(color bool) bridgeOption {
-	return func(b *UIBridge) { b.useColor = color }
+	return func(b *Bridge) { b.useColor = color }
 }
 
 // WithBridgeLogFile sets the file path for logging usage metrics.
 func WithBridgeLogFile(path string) bridgeOption {
-	return func(b *UIBridge) { b.logFile = path }
+	return func(b *Bridge) { b.logFile = path }
 }
 
 // WithBridgeLogger sets the structured logger.
 func WithBridgeLogger(l ports.Logger) bridgeOption {
-	return func(b *UIBridge) { b.logger = l }
+	return func(b *Bridge) { b.logger = l }
 }
 
 // withBridgeClock sets the clock for deterministic timestamps.
 func withBridgeClock(c clock.Clock) bridgeOption {
-	return func(b *UIBridge) { b.clock = c }
+	return func(b *Bridge) { b.clock = c }
 }
 
 // withBridgeCleanupTimeout sets the duration to wait for the bridge to drain events during cleanup.
 func withBridgeCleanupTimeout(d time.Duration) bridgeOption {
-	return func(b *UIBridge) { b.cleanupTimeout = d }
+	return func(b *Bridge) { b.cleanupTimeout = d }
 }
 
-// UIBridge translates domain events into UI updates.
-type UIBridge struct {
+// Bridge translates domain events into UI updates.
+type Bridge struct {
 	mu                 sync.RWMutex
 	loopCtx            context.Context
 	loopCancel         context.CancelFunc
@@ -87,10 +87,10 @@ type UIBridge struct {
 	startOnce          sync.Once
 }
 
-// NewUIBridge creates a new UIBridge.
-func NewUIBridge(renderer ports.UIRenderer, opts ...bridgeOption) *UIBridge {
+// NewBridge creates a new Bridge.
+func NewBridge(renderer ports.UIRenderer, opts ...bridgeOption) *Bridge {
 	loopCtx, loopCancel := context.WithCancel(context.Background())
-	b := &UIBridge{
+	b := &Bridge{
 		loopCtx:        loopCtx,
 		loopCancel:     loopCancel,
 		renderer:       renderer,
@@ -115,10 +115,10 @@ func NewUIBridge(renderer ports.UIRenderer, opts ...bridgeOption) *UIBridge {
 	b.wg.Add(1)
 	return b
 }
-func (b *UIBridge) CloseInput() {
+func (b *Bridge) CloseInput() {
 	b.queue.closeInput()
 }
-func (b *UIBridge) Cleanup() {
+func (b *Bridge) Cleanup() {
 	b.cleanupOnce.Do(func() {
 		atomic.AddInt32(&b.cleanupInvocations, 1)
 
@@ -165,7 +165,7 @@ func (b *UIBridge) Cleanup() {
 		}
 	})
 }
-func (b *UIBridge) Listen(ctx context.Context) (err error) {
+func (b *Bridge) Listen(ctx context.Context) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	b.mu.Lock()
 	b.cancel = cancel
@@ -176,7 +176,7 @@ func (b *UIBridge) Listen(ctx context.Context) (err error) {
 	defer b.loopCancel()
 	defer func() {
 		if r := recover(); r != nil {
-			b.logger.Error("panic in UIBridge loop", "error", r, "stack", string(debug.Stack()))
+			b.logger.Error("panic in Bridge loop", "error", r, "stack", string(debug.Stack()))
 			b.spinner.stopActiveSpinner()
 			err = fmt.Errorf("uibridge panicked: %v", r)
 		}
@@ -205,18 +205,18 @@ func (b *UIBridge) Listen(ctx context.Context) (err error) {
 	}
 }
 
-func (b *UIBridge) processRecoverable(ctx context.Context, e events.Event) {
+func (b *Bridge) processRecoverable(ctx context.Context, e events.Event) {
 	defer func() {
 		if r := recover(); r != nil {
-			b.logger.Error("UIBridge actor recovered from panic", "error", r)
-			b.logger.Debug("UIBridge recovery stack trace", "stack", string(debug.Stack()))
+			b.logger.Error("Bridge actor recovered from panic", "error", r)
+			b.logger.Debug("Bridge recovery stack trace", "stack", string(debug.Stack()))
 			b.spinner.stopActiveSpinner()
 			panic(r) // Re-panic to stop the Listen loop
 		}
 	}()
 	b.processEvent(ctx, e)
 }
-func (b *UIBridge) HandleEvent(ctx context.Context, e events.Event) error {
+func (b *Bridge) HandleEvent(ctx context.Context, e events.Event) error {
 	if b.queue.isInputClosed() {
 		b.logger.Debug("Shedding event: bridge is closed")
 		return nil
@@ -225,7 +225,7 @@ func (b *UIBridge) HandleEvent(ctx context.Context, e events.Event) error {
 	defer func() {
 		if r := recover(); r != nil {
 			// Log as Warn/Error since it's now unexpected (last-resort safety)
-			b.logger.Warn("Unexpected panic in UIBridge.HandleEvent", "panic", r, "stack", string(debug.Stack()))
+			b.logger.Warn("Unexpected panic in Bridge.HandleEvent", "panic", r, "stack", string(debug.Stack()))
 		}
 	}()
 
@@ -235,7 +235,7 @@ func (b *UIBridge) HandleEvent(ctx context.Context, e events.Event) error {
 
 	return b.queue.enqueueEvent(ctx, e)
 }
-func (b *UIBridge) processEvent(ctx context.Context, e events.Event) {
+func (b *Bridge) processEvent(ctx context.Context, e events.Event) {
 	b.dispatcher.dispatch(ctx, e)
 }
 
@@ -281,10 +281,10 @@ func getSpinnerInfo(e events.Event) (spinnerInfo, bool) {
 		return spinnerInfo{}, false
 	}
 }
-func (b *UIBridge) getLoopContext() context.Context {
+func (b *Bridge) getLoopContext() context.Context {
 	return b.loopCtx
 }
 
-func (b *UIBridge) WaitStarted() {
+func (b *Bridge) WaitStarted() {
 	<-b.started
 }

--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -81,7 +81,7 @@ type Bridge struct {
 	dispatcher         *eventDispatcher
 	cleanupOnce        sync.Once
 	cleanupInvocations int32
-	WG                 sync.WaitGroup
+	wg                 sync.WaitGroup
 	cleanupTimeout     time.Duration
 	started            chan struct{}
 	startOnce          sync.Once
@@ -112,9 +112,16 @@ func NewBridge(renderer ports.UIRenderer, opts ...bridgeOption) *Bridge {
 		b.renderer, b.logger, b.stateMachine, b.spinner,
 		b.showThoughts, b.showTools, b.rawOutput, b.logFile,
 	)
-	b.WG.Add(1)
+	b.wg.Add(1)
 	return b
 }
+
+// AbortStart decrements the internal WaitGroup when Listen() will not be called.
+// This is the safe alternative to manually calling wg.Done() from outside the package.
+func (b *Bridge) AbortStart() {
+	b.wg.Done()
+}
+
 func (b *Bridge) CloseInput() {
 	b.queue.closeInput()
 }
@@ -135,7 +142,7 @@ func (b *Bridge) Cleanup() {
 					close(done)
 				}
 			}()
-			b.WG.Wait()
+			b.wg.Wait()
 			close(done)
 		}()
 
@@ -172,7 +179,7 @@ func (b *Bridge) Listen(ctx context.Context) (err error) {
 	b.mu.Unlock()
 	defer cancel()
 
-	defer b.WG.Done()
+	defer b.wg.Done()
 	defer b.loopCancel()
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -51,8 +51,8 @@ func WithBridgeLogger(l ports.Logger) bridgeOption {
 	return func(b *Bridge) { b.logger = l }
 }
 
-// withBridgeClock sets the clock for deterministic timestamps.
-func withBridgeClock(c clock.Clock) bridgeOption {
+// WithBridgeClock sets the clock for deterministic timestamps.
+func WithBridgeClock(c clock.Clock) bridgeOption {
 	return func(b *Bridge) { b.clock = c }
 }
 
@@ -81,7 +81,7 @@ type Bridge struct {
 	dispatcher         *eventDispatcher
 	cleanupOnce        sync.Once
 	cleanupInvocations int32
-	wg                 sync.WaitGroup
+	WG                 sync.WaitGroup
 	cleanupTimeout     time.Duration
 	started            chan struct{}
 	startOnce          sync.Once
@@ -112,7 +112,7 @@ func NewBridge(renderer ports.UIRenderer, opts ...bridgeOption) *Bridge {
 		b.renderer, b.logger, b.stateMachine, b.spinner,
 		b.showThoughts, b.showTools, b.rawOutput, b.logFile,
 	)
-	b.wg.Add(1)
+	b.WG.Add(1)
 	return b
 }
 func (b *Bridge) CloseInput() {
@@ -135,7 +135,7 @@ func (b *Bridge) Cleanup() {
 					close(done)
 				}
 			}()
-			b.wg.Wait()
+			b.WG.Wait()
 			close(done)
 		}()
 
@@ -172,7 +172,7 @@ func (b *Bridge) Listen(ctx context.Context) (err error) {
 	b.mu.Unlock()
 	defer cancel()
 
-	defer b.wg.Done()
+	defer b.WG.Done()
 	defer b.loopCancel()
 	defer func() {
 		if r := recover(); r != nil {

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -20,13 +20,13 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// newStartedTestBridge creates a UIBridge with default test options,
+// newStartedTestBridge creates a Bridge with default test options,
 // starts its background Listen loop, and registers cleanup.
 // Returns the bridge and a context.CancelFunc for the bridge's lifecycle.
-func newStartedTestBridge(t *testing.T) (*UIBridge, context.CancelFunc, *agenttest.MockUIRenderer) {
+func newStartedTestBridge(t *testing.T) (*Bridge, context.CancelFunc, *agenttest.MockUIRenderer) {
 	t.Helper()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer,
+	bridge := NewBridge(mRenderer,
 		WithBridgeThoughts(true),
 		WithBridgeTools(true),
 		WithBridgeRawOutput(false),
@@ -64,8 +64,8 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 		name     string
 		event    events.Event
 		setup    func(m *agenttest.MockUIRenderer) <-chan struct{}
-		preSetup func(b *UIBridge, m *agenttest.MockUIRenderer)
-		verify   func(t *testing.T, b *UIBridge)
+		preSetup func(b *Bridge, m *agenttest.MockUIRenderer)
+		verify   func(t *testing.T, b *Bridge)
 	}{
 		{
 			name: "TurnStatusEvent",
@@ -247,19 +247,19 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 				}).Return(func() {})
 				return done
 			},
-			preSetup: func(b *UIBridge, m *agenttest.MockUIRenderer) {
+			preSetup: func(b *Bridge, m *agenttest.MockUIRenderer) {
 				// Start a spinner first
 				_ = b.HandleEvent(context.Background(), events.InferenceStartedEvent{})
 				// No need for explicit waitMock here as preSetup's effects will be checked at end
 			},
-			verify: func(t *testing.T, b *UIBridge) {
+			verify: func(t *testing.T, b *Bridge) {
 				// Final wait ensures all events in sequence were processed
 			},
 		},
 		{
 			name:  "ConsentFinishedEvent (Resumes Active Phase)",
 			event: events.ConsentFinishedEvent{},
-			preSetup: func(b *UIBridge, m *agenttest.MockUIRenderer) {
+			preSetup: func(b *Bridge, m *agenttest.MockUIRenderer) {
 				// Set active phase via event
 				_ = b.HandleEvent(context.Background(), events.InferenceStartedEvent{Model: "gpt-4o"})
 				// Enter consent
@@ -296,7 +296,7 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			mRenderer := new(agenttest.MockUIRenderer)
-			bridge := NewUIBridge(mRenderer,
+			bridge := NewBridge(mRenderer,
 				WithBridgeThoughts(true),
 				WithBridgeTools(true),
 				WithBridgeRawOutput(false),
@@ -365,7 +365,7 @@ func TestUIBridge_EnsureContext(t *testing.T) {
 func TestUIBridge_Concurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -448,7 +448,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 func TestUIBridge_LogicalRace(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -493,7 +493,7 @@ func TestUIBridge_LogicalRace(t *testing.T) {
 func TestUIBridge_AbortedTurn_SpinnerCleanup(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -525,7 +525,7 @@ func TestUIBridge_AbortedTurn_SpinnerCleanup(t *testing.T) {
 func TestUIBridge_Retry_Spinner(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -583,7 +583,7 @@ func TestUIBridge_Retry_Spinner(t *testing.T) {
 func TestUIBridge_CleanupOnUnexpectedExit(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -665,7 +665,7 @@ func TestUIBridge_SpinnerTransitions(t *testing.T) {
 func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -712,7 +712,7 @@ func TestUIBridge_NilLoggerFallback(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	// Instantiate without WithLogger
-	bridge := NewUIBridge(mRenderer)
+	bridge := NewBridge(mRenderer)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -736,7 +736,7 @@ func TestUIBridge_CleanupTimeout(t *testing.T) {
 	t.Cleanup(cancel)
 
 	// Initialize bridge with a very small timeout via functional option
-	bridge := NewUIBridge(mRenderer,
+	bridge := NewBridge(mRenderer,
 		withBridgeCleanupTimeout(10*time.Millisecond),
 	)
 	errChan := make(chan error, 1)
@@ -775,7 +775,7 @@ func TestUIBridge_CleanupTimeout(t *testing.T) {
 func TestUIBridge_HandleEvent_ContextCancelled(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer)
+	bridge := NewBridge(mRenderer)
 	// We don't start the bridge's background loop to specifically test load shedding logic
 	defer func() {
 		bridge.wg.Done()

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -388,14 +388,14 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	mRenderer.On("LogToolCall", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	mRenderer.On("LogToolResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
-	var wg sync.WaitGroup
+	var WG sync.WaitGroup
 	const iterations = 1000
 	start := make(chan struct{})
 
 	// Fire InferenceStartedEvent and ResponseEvent simultaneously
-	wg.Add(2)
+	WG.Add(2)
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.InferenceStartedEvent{})
@@ -403,7 +403,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.ResponseEvent{
@@ -413,9 +413,9 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	// Fire other events to simulate real event bus behavior and increase noise
-	wg.Add(2)
+	WG.Add(2)
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.TurnStarted{})
@@ -424,7 +424,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.UsageMetricsEvent{
@@ -441,7 +441,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	close(start)
-	wg.Wait()
+	WG.Wait()
 	// No explicit sync needed here, Cleanup will wait for the loop to finish
 }
 
@@ -686,11 +686,11 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 		atomic.AddInt32(&activeSpinners, -1)
 	})
 
-	var wg sync.WaitGroup
+	var WG sync.WaitGroup
 	for i := 0; i < 50; i++ {
-		wg.Add(1)
+		WG.Add(1)
 		go func(idx int) {
-			defer wg.Done()
+			defer WG.Done()
 			if idx%2 == 0 {
 				_ = bridge.HandleEvent(context.Background(), events.SummarizationStartedEvent{})
 			} else {
@@ -698,7 +698,7 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 			}
 		}(i)
 	}
-	wg.Wait()
+	WG.Wait()
 
 	// Wait for all spinners to be stopped eventually
 	bridge.CloseInput()
@@ -750,8 +750,8 @@ func TestUIBridge_CleanupTimeout(t *testing.T) {
 	bridgeCtx := bridge.getLoopContext() // Use the internal loop context for verification
 
 	// Force a waitgroup hang to simulate a deadlocked renderer or long-running loop
-	bridge.wg.Add(1)
-	defer bridge.wg.Done() // Ensure the hung WaitGroup is eventually released to prevent goroutine leaks in the test suite.
+	bridge.WG.Add(1)
+	defer bridge.WG.Done() // Ensure the hung WaitGroup is eventually released to prevent goroutine leaks in the test suite.
 
 	// Execute Cleanup. It should timeout after 10ms and return normally.
 	done := make(chan struct{})
@@ -778,7 +778,7 @@ func TestUIBridge_HandleEvent_ContextCancelled(t *testing.T) {
 	bridge := NewBridge(mRenderer)
 	// We don't start the bridge's background loop to specifically test load shedding logic
 	defer func() {
-		bridge.wg.Done()
+		bridge.WG.Done()
 		bridge.CloseInput()
 		bridge.Cleanup()
 	}()

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -388,14 +388,14 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	mRenderer.On("LogToolCall", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 	mRenderer.On("LogToolResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
-	var WG sync.WaitGroup
+	var wg sync.WaitGroup
 	const iterations = 1000
 	start := make(chan struct{})
 
 	// Fire InferenceStartedEvent and ResponseEvent simultaneously
-	WG.Add(2)
+	wg.Add(2)
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.InferenceStartedEvent{})
@@ -403,7 +403,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.ResponseEvent{
@@ -413,9 +413,9 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	// Fire other events to simulate real event bus behavior and increase noise
-	WG.Add(2)
+	wg.Add(2)
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.TurnStarted{})
@@ -424,7 +424,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		<-start
 		for i := 0; i < iterations; i++ {
 			_ = bridge.HandleEvent(ctx, events.UsageMetricsEvent{
@@ -441,7 +441,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	}()
 
 	close(start)
-	WG.Wait()
+	wg.Wait()
 	// No explicit sync needed here, Cleanup will wait for the loop to finish
 }
 
@@ -686,11 +686,11 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 		atomic.AddInt32(&activeSpinners, -1)
 	})
 
-	var WG sync.WaitGroup
+	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {
-		WG.Add(1)
+		wg.Add(1)
 		go func(idx int) {
-			defer WG.Done()
+			defer wg.Done()
 			if idx%2 == 0 {
 				_ = bridge.HandleEvent(context.Background(), events.SummarizationStartedEvent{})
 			} else {
@@ -698,7 +698,7 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 			}
 		}(i)
 	}
-	WG.Wait()
+	wg.Wait()
 
 	// Wait for all spinners to be stopped eventually
 	bridge.CloseInput()

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -750,8 +750,8 @@ func TestUIBridge_CleanupTimeout(t *testing.T) {
 	bridgeCtx := bridge.getLoopContext() // Use the internal loop context for verification
 
 	// Force a waitgroup hang to simulate a deadlocked renderer or long-running loop
-	bridge.WG.Add(1)
-	defer bridge.WG.Done() // Ensure the hung WaitGroup is eventually released to prevent goroutine leaks in the test suite.
+	bridge.wg.Add(1)
+	defer bridge.wg.Done() // Ensure the hung WaitGroup is eventually released to prevent goroutine leaks in the test suite.
 
 	// Execute Cleanup. It should timeout after 10ms and return normally.
 	done := make(chan struct{})
@@ -778,7 +778,7 @@ func TestUIBridge_HandleEvent_ContextCancelled(t *testing.T) {
 	bridge := NewBridge(mRenderer)
 	// We don't start the bridge's background loop to specifically test load shedding logic
 	defer func() {
-		bridge.WG.Done()
+		bridge.wg.Done()
 		bridge.CloseInput()
 		bridge.Cleanup()
 	}()

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -21,7 +21,7 @@ import (
 func TestUIBridge_StressConcurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -80,7 +80,7 @@ func TestUIBridge_LogicalStateVerification(t *testing.T) {
 	testCtx := context.Background()
 
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -46,13 +46,13 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
 	const numGoroutines = 100
-	var WG sync.WaitGroup
-	WG.Add(numGoroutines)
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
 
 	start := make(chan struct{})
 	for i := 0; i < numGoroutines; i++ {
 		go func(idx int) {
-			defer WG.Done()
+			defer wg.Done()
 			<-start
 			if idx%2 == 0 {
 				_ = bridge.HandleEvent(context.Background(), events.ToolExecutionStartedEvent{ToolNames: []string{"test_tool"}})
@@ -65,7 +65,7 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	}
 
 	close(start)
-	WG.Wait()
+	wg.Wait()
 
 	// Final cleanup must stop any remaining spinner
 	syncBridge(t, bridge, mRenderer)

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -46,13 +46,13 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
 	const numGoroutines = 100
-	var wg sync.WaitGroup
-	wg.Add(numGoroutines)
+	var WG sync.WaitGroup
+	WG.Add(numGoroutines)
 
 	start := make(chan struct{})
 	for i := 0; i < numGoroutines; i++ {
 		go func(idx int) {
-			defer wg.Done()
+			defer WG.Done()
 			<-start
 			if idx%2 == 0 {
 				_ = bridge.HandleEvent(context.Background(), events.ToolExecutionStartedEvent{ToolNames: []string{"test_tool"}})
@@ -65,7 +65,7 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	}
 
 	close(start)
-	wg.Wait()
+	WG.Wait()
 
 	// Final cleanup must stop any remaining spinner
 	syncBridge(t, bridge, mRenderer)

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -146,14 +146,14 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 		bridge.Cleanup()
 	}()
 
-	var WG sync.WaitGroup
-	WG.Add(2)
+	var wg sync.WaitGroup
+	wg.Add(2)
 
 	consentActiveCh := make(chan struct{})
 	inferenceDoneCh := make(chan struct{})
 
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		// 1. Simulation of consent cycle
 		_ = bridge.HandleEvent(testCtx, events.ConsentStartedEvent{})
 
@@ -178,7 +178,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 	}()
 
 	go func() {
-		defer WG.Done()
+		defer wg.Done()
 		// 1. Wait for consent to become active
 		<-consentActiveCh
 
@@ -197,7 +197,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 		close(inferenceDoneCh)
 	}()
 
-	WG.Wait()
+	wg.Wait()
 
 	mu.Lock()
 	if overlap {

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -230,7 +230,7 @@ func TestUIBridge_DeadConsumer_Unblocks(t *testing.T) {
 	cancel()
 
 	// Wait for the consumer loop to exit to ensure it's truly dead and not reading
-	bridge.WG.Wait()
+	bridge.wg.Wait()
 
 	// Fill the bridge's event channel buffer to its capacity (100)
 	// This ensures that the enqueue blocks deterministically,

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -34,7 +34,7 @@ func TestUIBridge_ConsentSpinnerLeak(t *testing.T) {
 	}), mock.Anything).Return().Maybe()
 	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {}).Maybe()
 
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -68,7 +68,7 @@ func TestUIBridge_ConsentSpinnerLeak(t *testing.T) {
 func TestUIBridge_SystemMessageDuringConsent(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -130,7 +130,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 
 	testCtx := context.Background()
 
-	bridge := NewUIBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
+	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -210,7 +210,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 func TestUIBridge_DeadConsumer_Unblocks(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer)
+	bridge := NewBridge(mRenderer)
 
 	// Start the bridge to initialize everything
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -146,14 +146,14 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 		bridge.Cleanup()
 	}()
 
-	var wg sync.WaitGroup
-	wg.Add(2)
+	var WG sync.WaitGroup
+	WG.Add(2)
 
 	consentActiveCh := make(chan struct{})
 	inferenceDoneCh := make(chan struct{})
 
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		// 1. Simulation of consent cycle
 		_ = bridge.HandleEvent(testCtx, events.ConsentStartedEvent{})
 
@@ -178,7 +178,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 	}()
 
 	go func() {
-		defer wg.Done()
+		defer WG.Done()
 		// 1. Wait for consent to become active
 		<-consentActiveCh
 
@@ -197,7 +197,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 		close(inferenceDoneCh)
 	}()
 
-	wg.Wait()
+	WG.Wait()
 
 	mu.Lock()
 	if overlap {
@@ -230,7 +230,7 @@ func TestUIBridge_DeadConsumer_Unblocks(t *testing.T) {
 	cancel()
 
 	// Wait for the consumer loop to exit to ensure it's truly dead and not reading
-	bridge.wg.Wait()
+	bridge.WG.Wait()
 
 	// Fill the bridge's event channel buffer to its capacity (100)
 	// This ensures that the enqueue blocks deterministically,

--- a/internal/agent/session/ui/dispatcher.go
+++ b/internal/agent/session/ui/dispatcher.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/event_queue.go
+++ b/internal/agent/session/ui/event_queue.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/export_test.go
+++ b/internal/agent/session/ui/export_test.go
@@ -19,5 +19,5 @@ func SyncBridge(t *testing.T, b *Bridge, m interface {
 
 // Wg returns a pointer to the internal wait group for test synchronization.
 func (b *Bridge) Wg() *sync.WaitGroup {
-	return &b.WG
+	return &b.wg
 }

--- a/internal/agent/session/ui/export_test.go
+++ b/internal/agent/session/ui/export_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+)
+
+// SyncBridge is exported for use by external test packages (package ui_test).
+func SyncBridge(t *testing.T, b *Bridge, m interface {
+	On(methodName string, arguments ...interface{}) *mock.Call
+}) {
+	syncBridge(t, b, m)
+}
+
+// Wg returns a pointer to the internal wait group for test synchronization.
+func (b *Bridge) Wg() *sync.WaitGroup {
+	return &b.WG
+}

--- a/internal/agent/session/ui/fixture_test.go
+++ b/internal/agent/session/ui/fixture_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/fixture_test.go
+++ b/internal/agent/session/ui/fixture_test.go
@@ -66,7 +66,7 @@ func (m *controllableUIRenderer) LogToolResult(ctx context.Context, name string,
 
 // uiBridgeFixture encapsulates the bridge under test and its lifecycle.
 type uiBridgeFixture struct {
-	bridge   *UIBridge
+	bridge   *Bridge
 	renderer *controllableUIRenderer
 	ctx      context.Context
 	cancel   context.CancelFunc
@@ -86,7 +86,7 @@ func newUIBridgeFixture(t *testing.T, opts ...bridgeOption) *uiBridgeFixture {
 	// Append logger to opts to ensure it captures output for assertions.
 	opts = append(opts, WithBridgeLogger(logger))
 
-	bridge := NewUIBridge(renderer, opts...)
+	bridge := NewBridge(renderer, opts...)
 	ctx, cancel := context.WithCancel(context.Background())
 
 	f := &uiBridgeFixture{

--- a/internal/agent/session/ui/helpers_test.go
+++ b/internal/agent/session/ui/helpers_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"bytes"
@@ -11,24 +11,19 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/stretchr/testify/mock"
 )
 
-func syncBridge(t *testing.T, b *ui.Bridge, m interface {
+func syncBridge(t *testing.T, b *Bridge, m interface {
 	On(methodName string, arguments ...interface{}) *mock.Call
 }) {
 	t.Helper()
-	// Use a sentinel event that is handled by the bridge and calls a mock method.
-	// LogSystemMessage is ideal as it's safe to call when no spinner is active.
 	done := make(chan struct{})
 	m.On("LogSystemMessage", mock.Anything, "SYNC_SENTINEL", "info").Run(func(_ mock.Arguments) {
 		close(done)
 	}).Return().Once()
 
-	// Use a non-polling send via HandleEvent. SystemMessageEvent is critical
-	// and will be delivered with backpressure.
 	if err := b.HandleEvent(context.Background(), events.SystemMessageEvent{Message: "SYNC_SENTINEL", Level: "info"}); err != nil {
 		t.Fatalf("Failed to queue sync sentinel: %v", err)
 	}

--- a/internal/agent/session/ui/idempotency_test.go
+++ b/internal/agent/session/ui/idempotency_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/idempotency_test.go
+++ b/internal/agent/session/ui/idempotency_test.go
@@ -19,7 +19,7 @@ import (
 func TestUIBridge_Cleanup_Idempotent(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
-	bridge := NewUIBridge(mRenderer,
+	bridge := NewBridge(mRenderer,
 		WithBridgeThoughts(true),
 		WithBridgeTools(true),
 		WithBridgeRawOutput(false),

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
-	"github.com/gosharplite/tell-me-go/internal/agent/session"
 	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -196,7 +195,7 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 
 	// 2. Wait for the event to be processed and b.stopSpinner to be set.
 	// Use SyncBridge to ensure the first event is fully processed.
-	session.SyncBridge(t, bridge, mRenderer)
+	ui.SyncBridge(t, bridge, mRenderer)
 
 	// 3. Trigger a primary panic.
 	// This will trigger the recovery block, which calls b.stopActiveSpinner().

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session_test
+package ui_test
 
 import (
 	"context"
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
@@ -75,7 +76,7 @@ func TestUIBridge_PanicResilience(t *testing.T) {
 
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bridge := session.NewUIBridge(mock, session.WithBridgeThoughts(true), session.WithBridgeTools(true), session.WithBridgeRawOutput(false), session.WithBridgeColor(true), session.WithBridgeLogFile("test.log"), session.WithBridgeLogger(logger))
+	bridge := ui.NewUIBridge(mock, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -127,7 +128,7 @@ func TestUIBridge_PanicRecoveryLogging(t *testing.T) {
 		panic("intentional test panic")
 	}).Return(func() {})
 
-	bridge := session.NewUIBridge(mockRenderer, session.WithBridgeThoughts(true), session.WithBridgeTools(true), session.WithBridgeRawOutput(false), session.WithBridgeColor(true), session.WithBridgeLogFile("test.log"), session.WithBridgeLogger(logger))
+	bridge := ui.NewUIBridge(mockRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -174,7 +175,7 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bridge := session.NewUIBridge(mRenderer, session.WithBridgeThoughts(true), session.WithBridgeTools(true), session.WithBridgeRawOutput(false), session.WithBridgeColor(true), session.WithBridgeLogFile("test.log"), session.WithBridgeLogger(logger))
+	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	testCtx, testCancel := context.WithCancel(context.Background())
 	t.Cleanup(testCancel)
@@ -229,7 +230,7 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 		panic("first panic")
 	}).Once()
 
-	bridge := session.NewUIBridge(mRenderer, session.WithBridgeThoughts(true), session.WithBridgeTools(true), session.WithBridgeRawOutput(false), session.WithBridgeColor(true), session.WithBridgeLogFile("test.log"), session.WithBridgeLogger(logger))
+	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -263,7 +264,7 @@ func TestUIBridge_SendToClosedChannel(t *testing.T) {
 	mRenderer := new(agenttest.MockUIRenderer)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	bridge := session.NewUIBridge(mRenderer, session.WithBridgeThoughts(true), session.WithBridgeTools(true), session.WithBridgeRawOutput(false), session.WithBridgeColor(true), session.WithBridgeLogFile("test.log"), session.WithBridgeLogger(logger))
+	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -76,7 +76,7 @@ func TestUIBridge_PanicResilience(t *testing.T) {
 
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bridge := ui.NewUIBridge(mock, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
+	bridge := ui.NewBridge(mock, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -128,7 +128,7 @@ func TestUIBridge_PanicRecoveryLogging(t *testing.T) {
 		panic("intentional test panic")
 	}).Return(func() {})
 
-	bridge := ui.NewUIBridge(mockRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
+	bridge := ui.NewBridge(mockRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
@@ -156,7 +156,7 @@ func TestUIBridge_PanicRecoveryLogging(t *testing.T) {
 	}
 
 	output := logBuffer.String()
-	assert.Contains(t, output, "UIBridge actor recovered from panic")
+	assert.Contains(t, output, "Bridge actor recovered from panic")
 	assert.Contains(t, output, "intentional test panic")
 	assert.Contains(t, output, "stack")
 }
@@ -175,7 +175,7 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
+	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	done := make(chan struct{})
 	testCtx, testCancel := context.WithCancel(context.Background())
 	t.Cleanup(testCancel)
@@ -207,7 +207,7 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 
 	_ = bridge.HandleEvent(ctx, events.TurnStatusEvent{Status: events.TurnStatus{Mode: "test"}})
 
-	// 4. Assert that the UIBridge survives and cancels successfully.
+	// 4. Assert that the Bridge survives and cancels successfully.
 	select {
 	case <-done:
 		// Success: Bridge cancelled gracefully despite double-panic
@@ -230,7 +230,7 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 		panic("first panic")
 	}).Once()
 
-	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
+	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)
@@ -252,7 +252,7 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 
 	output := logBuffer.String()
 	// Should contain the first panic
-	assert.Contains(t, output, "UIBridge actor recovered from panic")
+	assert.Contains(t, output, "Bridge actor recovered from panic")
 	assert.Contains(t, output, "first panic")
 
 	// Verify that RenderResponse was NOT called (it was the second event in the queue)
@@ -264,7 +264,7 @@ func TestUIBridge_SendToClosedChannel(t *testing.T) {
 	mRenderer := new(agenttest.MockUIRenderer)
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
-	bridge := ui.NewUIBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
+	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	errChan := make(chan error, 1)

--- a/internal/agent/session/ui/refactor_test.go
+++ b/internal/agent/session/ui/refactor_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/routing_test.go
+++ b/internal/agent/session/ui/routing_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"testing"

--- a/internal/agent/session/ui/spinner.go
+++ b/internal/agent/session/ui/spinner.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 import (
 	"context"

--- a/internal/agent/session/ui/state_machine.go
+++ b/internal/agent/session/ui/state_machine.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package session
+package ui
 
 // uiState represents the possible states of the UI bridge.
 type uiState int

--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -24,36 +24,36 @@ type securityConfirmer interface {
 	Confirm(ctx context.Context, message string) (bool, error)
 }
 
-type adoManager struct {
+type AdoManager struct {
 	sc                 securityConfirmer
 	httpClient         tools.HTTPClient
 	token              string
 	authHeader         string
-	baseURL            string // For testing
+	BaseURL            string // For testing
 	pipelineCache      sync.Map
 	pipelineFetchGroup singleflight.Group
 }
 
-// AdoOption is a functional option for configuring the adoManager.
-type AdoOption func(*adoManager)
+// AdoOption is a functional option for configuring the AdoManager.
+type AdoOption func(*AdoManager)
 
-// withBaseURL sets the base URL for Azure DevOps API requests.
-func withBaseURL(url string) AdoOption {
-	return func(m *adoManager) {
-		m.baseURL = url
+// WithBaseURL sets the base URL for Azure DevOps API requests.
+func WithBaseURL(url string) AdoOption {
+	return func(m *AdoManager) {
+		m.BaseURL = url
 	}
 }
 
 // WithHTTPClient sets the HTTP client for Azure DevOps API requests.
 func WithHTTPClient(client tools.HTTPClient) AdoOption {
-	return func(m *adoManager) {
+	return func(m *AdoManager) {
 		m.httpClient = client
 	}
 }
 
 // WithToken sets the Azure DevOps Personal Access Token (PAT).
 func WithToken(token string) AdoOption {
-	return func(m *adoManager) {
+	return func(m *AdoManager) {
 		m.token = token
 		if token != "" {
 			auth := ":" + token
@@ -62,11 +62,11 @@ func WithToken(token string) AdoOption {
 	}
 }
 
-// NewADOManager creates a new instance of adoManager.
-func NewADOManager(sc securityConfirmer, opts ...AdoOption) *adoManager {
-	m := &adoManager{
+// NewADOManager creates a new instance of AdoManager.
+func NewADOManager(sc securityConfirmer, opts ...AdoOption) *AdoManager {
+	m := &AdoManager{
 		sc:         sc,
-		baseURL:    "https://dev.azure.com",
+		BaseURL:    "https://dev.azure.com",
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 
@@ -77,14 +77,14 @@ func NewADOManager(sc securityConfirmer, opts ...AdoOption) *adoManager {
 	return m
 }
 
-func (m *adoManager) getAuthHeader() (string, error) {
+func (m *AdoManager) getAuthHeader() (string, error) {
 	if m.authHeader == "" {
 		return "", fmt.Errorf("AZURE_PAT_ALL token is required but not provided")
 	}
 	return m.authHeader, nil
 }
 
-func (m *adoManager) executeRequest(ctx context.Context, method, requestURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
+func (m *AdoManager) ExecuteRequest(ctx context.Context, method, requestURL string, body io.Reader, headers map[string]string) (*http.Response, error) {
 	authHeader, err := m.getAuthHeader()
 	if err != nil {
 		return nil, err
@@ -114,14 +114,14 @@ func (m *adoManager) executeRequest(ctx context.Context, method, requestURL stri
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
 
-	if err := m.checkResponseError(resp, requestURL); err != nil {
+	if err := m.CheckResponseError(resp, requestURL); err != nil {
 		return nil, err
 	}
 
 	return resp, nil
 }
 
-func (m *adoManager) checkResponseError(resp *http.Response, requestURL string) error {
+func (m *AdoManager) CheckResponseError(resp *http.Response, requestURL string) error {
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		return nil
 	}
@@ -143,7 +143,7 @@ func (m *adoManager) checkResponseError(resp *http.Response, requestURL string) 
 	}
 }
 
-func (m *adoManager) AdoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -165,7 +165,7 @@ func (m *adoManager) AdoGetFileContent(ctx context.Context, args map[string]inte
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/items",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository)))
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository)))
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -177,7 +177,7 @@ func (m *adoManager) AdoGetFileContent(ctx context.Context, args map[string]inte
 	q.Set("api-version", "7.1")
 	u.RawQuery = q.Encode()
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u.String(), nil, map[string]string{"Accept": "*/*"})
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u.String(), nil, map[string]string{"Accept": "*/*"})
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get file content request: %w", err)
 	}
@@ -199,7 +199,7 @@ type adoRepositoryItemsResponse struct {
 	Count int `json:"count"`
 }
 
-func (m *adoManager) AdoListRepositoryItems(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoListRepositoryItems(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization   string `json:"organization"`
 		Project        string `json:"project"`
@@ -222,7 +222,7 @@ func (m *adoManager) AdoListRepositoryItems(ctx context.Context, args map[string
 		return tools.ToolResult{}, fmt.Errorf("building list repository items URL: %w", err)
 	}
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing list repository items request: %w", err)
 	}
@@ -236,7 +236,7 @@ func (m *adoManager) AdoListRepositoryItems(ctx context.Context, args map[string
 	return m.formatRepositoryItems(params.ScopePath, params.Version, responseData), nil
 }
 
-func (m *adoManager) buildListRepositoryItemsURL(org, project, repo, scopePath, version, recursionLevel string) (string, error) {
+func (m *AdoManager) buildListRepositoryItemsURL(org, project, repo, scopePath, version, recursionLevel string) (string, error) {
 	if scopePath == "" {
 		scopePath = "/"
 	}
@@ -248,7 +248,7 @@ func (m *adoManager) buildListRepositoryItemsURL(org, project, repo, scopePath, 
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/items",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo)))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo)))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -263,7 +263,7 @@ func (m *adoManager) buildListRepositoryItemsURL(org, project, repo, scopePath, 
 	return u.String(), nil
 }
 
-func (m *adoManager) formatRepositoryItems(scopePath, version string, responseData adoRepositoryItemsResponse) tools.ToolResult {
+func (m *AdoManager) formatRepositoryItems(scopePath, version string, responseData adoRepositoryItemsResponse) tools.ToolResult {
 	if len(responseData.Value) == 0 {
 		return tools.ToolResult{Text: "No items found."}
 	}

--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -34,25 +34,25 @@ type adoManager struct {
 	pipelineFetchGroup singleflight.Group
 }
 
-// adoOption is a functional option for configuring the adoManager.
-type adoOption func(*adoManager)
+// AdoOption is a functional option for configuring the adoManager.
+type AdoOption func(*adoManager)
 
 // withBaseURL sets the base URL for Azure DevOps API requests.
-func withBaseURL(url string) adoOption {
+func withBaseURL(url string) AdoOption {
 	return func(m *adoManager) {
 		m.baseURL = url
 	}
 }
 
-// withHTTPClient sets the HTTP client for Azure DevOps API requests.
-func withHTTPClient(client tools.HTTPClient) adoOption {
+// WithHTTPClient sets the HTTP client for Azure DevOps API requests.
+func WithHTTPClient(client tools.HTTPClient) AdoOption {
 	return func(m *adoManager) {
 		m.httpClient = client
 	}
 }
 
-// withToken sets the Azure DevOps Personal Access Token (PAT).
-func withToken(token string) adoOption {
+// WithToken sets the Azure DevOps Personal Access Token (PAT).
+func WithToken(token string) AdoOption {
 	return func(m *adoManager) {
 		m.token = token
 		if token != "" {
@@ -62,8 +62,8 @@ func withToken(token string) adoOption {
 	}
 }
 
-// newADOManager creates a new instance of adoManager.
-func newADOManager(sc securityConfirmer, opts ...adoOption) *adoManager {
+// NewADOManager creates a new instance of adoManager.
+func NewADOManager(sc securityConfirmer, opts ...AdoOption) *adoManager {
 	m := &adoManager{
 		sc:         sc,
 		baseURL:    "https://dev.azure.com",
@@ -143,7 +143,7 @@ func (m *adoManager) checkResponseError(resp *http.Response, requestURL string) 
 	}
 }
 
-func (m *adoManager) adoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -199,7 +199,7 @@ type adoRepositoryItemsResponse struct {
 	Count int `json:"count"`
 }
 
-func (m *adoManager) adoListRepositoryItems(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoListRepositoryItems(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization   string `json:"organization"`
 		Project        string `json:"project"`

--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -48,7 +48,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -58,7 +58,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPullRequest(ctx, args, nil)
+		result, err := m.AdoGetPullRequest(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Fix bug")
 		assert.Contains(t, result.Text, "active")
@@ -72,7 +72,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -81,7 +81,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.adoGetPullRequest(context.Background(), args, nil)
+		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
@@ -92,7 +92,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -101,24 +101,24 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.adoGetPullRequest(context.Background(), args, nil)
+		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
+		m := NewADOManager(sm)
 		args := map[string]interface{}{
 			"organization": "myorg",
 		}
 
-		_, err := m.adoGetPullRequest(context.Background(), args, nil)
+		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
 
 	t.Run("Missing PAT", func(t *testing.T) {
-		m := newADOManager(sm)
+		m := NewADOManager(sm)
 		args := map[string]interface{}{
 			"organization":    "myorg",
 			"project":         "myproj",
@@ -126,7 +126,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.adoGetPullRequest(context.Background(), args, nil)
+		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "AZURE_PAT_ALL token is required but not provided")
 	})
@@ -167,7 +167,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -176,7 +176,7 @@ func TestAdoListPullRequests(t *testing.T) {
 			"repository":   "myrepo",
 		}
 
-		result, err := m.adoListPullRequests(ctx, args, nil)
+		result, err := m.AdoListPullRequests(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Found 2 pull requests")
 		assert.Contains(t, result.Text, "[#123] Fix bug")
@@ -190,7 +190,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -198,7 +198,7 @@ func TestAdoListPullRequests(t *testing.T) {
 			"repository":   "myrepo",
 		}
 
-		result, err := m.adoListPullRequests(context.Background(), args, nil)
+		result, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No pull requests found.", result.Text)
 	})
@@ -214,7 +214,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -224,7 +224,7 @@ func TestAdoListPullRequests(t *testing.T) {
 			"top":          10,
 		}
 
-		_, err := m.adoListPullRequests(context.Background(), args, nil)
+		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.NoError(t, err)
 	})
 }
@@ -255,7 +255,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -265,7 +265,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrDiff(ctx, args, nil)
+		result, err := m.AdoGetPrDiff(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Total files changed: 2")
 		assert.Contains(t, result.Text, "[Edit] /src/main.go")
@@ -279,7 +279,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -288,7 +288,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrDiff(context.Background(), args, nil)
+		result, err := m.AdoGetPrDiff(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No changes found in this pull request.", result.Text)
 	})
@@ -340,7 +340,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -350,7 +350,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrThreads(ctx, args, nil)
+		result, err := m.AdoGetPrThreads(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Thread 1")
 		assert.Contains(t, result.Text, "Please check this logic.")
@@ -365,7 +365,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -374,7 +374,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrThreads(context.Background(), args, nil)
+		result, err := m.AdoGetPrThreads(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No discussion threads found in this pull request.", result.Text)
 	})
@@ -400,7 +400,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -411,7 +411,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"version":      "develop",
 		}
 
-		result, err := m.adoGetFileContent(ctx, args, nil)
+		result, err := m.AdoGetFileContent(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, fileContent, result.Text)
 	})
@@ -424,7 +424,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -433,7 +433,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"path":         "/src/main.go",
 		}
 
-		_, err := m.adoGetFileContent(context.Background(), args, nil)
+		_, err := m.AdoGetFileContent(context.Background(), args, nil)
 		assert.NoError(t, err)
 	})
 
@@ -443,7 +443,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -452,7 +452,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"path":         "/missing.go",
 		}
 
-		_, err := m.adoGetFileContent(context.Background(), args, nil)
+		_, err := m.AdoGetFileContent(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -484,7 +484,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -494,7 +494,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 			"recursion_level": "oneLevel",
 		}
 
-		result, err := m.adoListRepositoryItems(ctx, args, nil)
+		result, err := m.AdoListRepositoryItems(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "[DIR]  /src")
 		assert.Contains(t, result.Text, "[FILE] /src/main.go")
@@ -508,7 +508,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -516,7 +516,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 			"repository":   "myrepo",
 		}
 
-		result, err := m.adoListRepositoryItems(context.Background(), args, nil)
+		result, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No items found.", result.Text)
 	})
@@ -536,10 +536,10 @@ func TestAdoListPipelineRuns(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
-		result, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Run ID: 101")
 		assert.Contains(t, result.Text, "Repo: myrepo")
@@ -559,10 +559,10 @@ func TestAdoGetPipelineRun(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
-		result, err := m.adoGetPipelineRun(context.Background(), args, nil)
+		result, err := m.AdoGetPipelineRun(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Pipeline Run #101 Details")
 	})
@@ -582,10 +582,10 @@ func TestAdoGetPipelineLogs(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
-		result, err := m.adoGetPipelineLogs(context.Background(), args, nil)
+		result, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Log ID: 1")
 	})
@@ -599,10 +599,10 @@ func TestAdoGetPipelineLogs(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
-		result, err := m.adoGetPipelineLogs(context.Background(), args, nil)
+		result, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, logContent, result.Text)
 	})
@@ -639,7 +639,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -648,7 +648,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrStatuses(context.Background(), args, nil)
+		result, err := m.AdoGetPrStatuses(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Pull Request #123 Statuses")
 		assert.Contains(t, result.Text, "✅ **Build/CI**: succeeded")
@@ -662,7 +662,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -671,7 +671,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 			"pull_request_id": 999,
 		}
 
-		_, err := m.adoGetPrStatuses(context.Background(), args, nil)
+		_, err := m.AdoGetPrStatuses(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -720,7 +720,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -729,7 +729,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		result, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Pull Request #123 Policy Evaluations")
 		assert.Contains(t, result.Text, "❌ **Build Validation** [REQUIRED]: broken")
@@ -750,7 +750,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -759,7 +759,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		result, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No active policies found for this pull request.", result.Text)
 	})
@@ -778,7 +778,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -787,7 +787,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
@@ -828,7 +828,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -837,7 +837,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		result, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		result, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Branch Policies for main in myrepo")
 		assert.Contains(t, result.Text, "- Type: Build [REQUIRED]")
@@ -860,7 +860,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -869,7 +869,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		result, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		result, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "No active policies found")
 	})
@@ -898,10 +898,10 @@ func TestAdoGetBuildTimeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123}
-		result, err := m.adoGetBuildTimeline(context.Background(), args, nil)
+		result, err := m.AdoGetBuildTimeline(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, `"name": "Task 1"`)
 		assert.Contains(t, result.Text, `"log": {`)
@@ -914,10 +914,10 @@ func TestAdoGetBuildTimeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123}
-		_, err := m.adoGetBuildTimeline(context.Background(), args, nil)
+		_, err := m.AdoGetBuildTimeline(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -936,7 +936,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "o",
@@ -944,7 +944,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 			"build_id":     123,
 			"log_id":       10,
 		}
-		result, err := m.adoGetTaskLog(context.Background(), args, nil)
+		result, err := m.AdoGetTaskLog(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, logContent, result.Text)
 	})
@@ -955,7 +955,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "o",
@@ -963,7 +963,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 			"build_id":     123,
 			"log_id":       99,
 		}
-		_, err := m.adoGetTaskLog(context.Background(), args, nil)
+		_, err := m.AdoGetTaskLog(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -991,10 +991,10 @@ func TestAdoGetBuildChanges(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123, "top": 10}
-		result, err := m.adoGetBuildChanges(context.Background(), args, nil)
+		result, err := m.AdoGetBuildChanges(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, `"id": "abc123"`)
 		assert.Contains(t, result.Text, `"message": "feat: add something"`)
@@ -1006,10 +1006,10 @@ func TestAdoGetBuildChanges(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 999}
-		_, err := m.adoGetBuildChanges(context.Background(), args, nil)
+		_, err := m.AdoGetBuildChanges(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1036,61 +1036,61 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		setupPAT       string
 	}{
 		{
-			name: "adoGetPrDiff - Unmarshal Error",
+			name: "AdoGetPrDiff - Unmarshal Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"pull_request_id": "invalid"}, // should be int
 			expectedErrMsg: "json: cannot unmarshal string into Go struct field",
 		},
 		{
-			name: "adoGetPrDiff - Missing Params",
+			name: "AdoGetPrDiff - Missing Params",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
 			expectedErrMsg: "required",
 		},
 		{
-			name: "adoGetPrDiff - Request Failure",
+			name: "AdoGetPrDiff - Request Failure",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			doErr:          fmt.Errorf("network error"),
 			expectedErrMsg: "request failed",
 		},
 		{
-			name: "adoGetPrDiff - 401 Unauthorized",
+			name: "AdoGetPrDiff - 401 Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetPrDiff - 403 Forbidden",
+			name: "AdoGetPrDiff - 403 Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoGetPrDiff - 404 Not Found",
+			name: "AdoGetPrDiff - 404 Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "resource not found",
 		},
 		{
-			name: "adoGetPrDiff - 500 Internal Error",
+			name: "AdoGetPrDiff - 500 Internal Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrDiff(ctx, args, nil)
+				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusInternalServerError,
@@ -1098,51 +1098,51 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			expectedErrMsg: "returned status: 500",
 		},
 		{
-			name: "adoGetTaskLog - Unmarshal Error",
+			name: "AdoGetTaskLog - Unmarshal Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetTaskLog(ctx, args, nil)
+				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"build_id": "invalid"},
 			expectedErrMsg: "json: cannot unmarshal string into Go struct field",
 		},
 		{
-			name: "adoGetTaskLog - Missing Params",
+			name: "AdoGetTaskLog - Missing Params",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetTaskLog(ctx, args, nil)
+				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
 			expectedErrMsg: "required",
 		},
 		{
-			name: "adoGetTaskLog - 404 Not Found",
+			name: "AdoGetTaskLog - 404 Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetTaskLog(ctx, args, nil)
+				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "not found",
 		},
 		{
-			name: "adoGetBuildTimeline - Missing Params",
+			name: "AdoGetBuildTimeline - Missing Params",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildTimeline(ctx, args, nil)
+				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
 			expectedErrMsg: "required",
 		},
 		{
-			name: "adoGetBuildTimeline - 401 Unauthorized",
+			name: "AdoGetBuildTimeline - 401 Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildTimeline(ctx, args, nil)
+				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetPrPolicyEvaluations - PR Metadata Failure",
+			name: "AdoGetPrPolicyEvaluations - PR Metadata Failure",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrPolicyEvaluations(ctx, args, nil)
+				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args: map[string]interface{}{
 				"organization":    "myorg",
@@ -1154,153 +1154,153 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			expectedErrMsg: "returned status: 500",
 		},
 		{
-			name: "adoListPullRequests - Unauthorized",
+			name: "AdoListPullRequests - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListPullRequests(ctx, args, nil)
+				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoListPullRequests - Forbidden",
+			name: "AdoListPullRequests - Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListPullRequests(ctx, args, nil)
+				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoListPullRequests - Not Found",
+			name: "AdoListPullRequests - Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListPullRequests(ctx, args, nil)
+				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "resource not found",
 		},
 		{
-			name: "adoGetPrThreads - Unauthorized",
+			name: "AdoGetPrThreads - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrThreads(ctx, args, nil)
+				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetPrThreads - Forbidden",
+			name: "AdoGetPrThreads - Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrThreads(ctx, args, nil)
+				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoGetPrThreads - Not Found",
+			name: "AdoGetPrThreads - Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrThreads(ctx, args, nil)
+				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "resource not found",
 		},
 		{
-			name: "adoListRepositoryItems - Unauthorized",
+			name: "AdoListRepositoryItems - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListRepositoryItems(ctx, args, nil)
+				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoListRepositoryItems - Forbidden",
+			name: "AdoListRepositoryItems - Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListRepositoryItems(ctx, args, nil)
+				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoListRepositoryItems - Not Found",
+			name: "AdoListRepositoryItems - Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListRepositoryItems(ctx, args, nil)
+				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "resource not found",
 		},
 		{
-			name: "adoListPipelineRuns - 500 Error",
+			name: "AdoListPipelineRuns - 500 Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoListPipelineRuns(ctx, args, nil)
+				return m.AdoListPipelineRuns(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
 			httpStatus:     http.StatusInternalServerError,
 			expectedErrMsg: "status: 500",
 		},
 		{
-			name: "adoGetPipelineRun - 500 Error",
+			name: "AdoGetPipelineRun - 500 Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPipelineRun(ctx, args, nil)
+				return m.AdoGetPipelineRun(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1},
 			httpStatus:     http.StatusInternalServerError,
 			expectedErrMsg: "status: 500",
 		},
 		{
-			name: "adoGetBuildChanges - 500 Error",
+			name: "AdoGetBuildChanges - 500 Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildChanges(ctx, args, nil)
+				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
 			httpStatus:     http.StatusInternalServerError,
 			expectedErrMsg: "status: 500",
 		},
 		{
-			name: "adoGetBuildChanges - 401 Unauthorized",
+			name: "AdoGetBuildChanges - 401 Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildChanges(ctx, args, nil)
+				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetPrStatuses - 401 Unauthorized",
+			name: "AdoGetPrStatuses - 401 Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrStatuses(ctx, args, nil)
+				return m.AdoGetPrStatuses(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetPrStatuses - 403 Forbidden",
+			name: "AdoGetPrStatuses - 403 Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrStatuses(ctx, args, nil)
+				return m.AdoGetPrStatuses(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoGetPrPolicyEvaluations - 403 Forbidden",
+			name: "AdoGetPrPolicyEvaluations - 403 Forbidden",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrPolicyEvaluations(ctx, args, nil)
+				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
 			httpStatus:     http.StatusForbidden,
 			expectedErrMsg: "forbidden",
 		},
 		{
-			name: "adoGetPrPolicyEvaluations - PR Metadata Decode Failure",
+			name: "AdoGetPrPolicyEvaluations - PR Metadata Decode Failure",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPrPolicyEvaluations(ctx, args, nil)
+				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
 			httpStatus:     http.StatusOK,
@@ -1308,72 +1308,72 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			expectedErrMsg: "failed to decode PR metadata",
 		},
 		{
-			name: "adoGetFileContent - Unauthorized",
+			name: "AdoGetFileContent - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetFileContent(ctx, args, nil)
+				return m.AdoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetFileContent - Default Error",
+			name: "AdoGetFileContent - Default Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetFileContent(ctx, args, nil)
+				return m.AdoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
 			httpStatus:     http.StatusInternalServerError,
 			expectedErrMsg: "returned status: 500",
 		},
 		{
-			name: "adoGetPipelineLogs - Unauthorized",
+			name: "AdoGetPipelineLogs - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetPipelineLogs(ctx, args, nil)
+				return m.AdoGetPipelineLogs(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetBuildTimeline - Unauthorized",
+			name: "AdoGetBuildTimeline - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildTimeline(ctx, args, nil)
+				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetTaskLog - Unauthorized",
+			name: "AdoGetTaskLog - Unauthorized",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetTaskLog(ctx, args, nil)
+				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
 			httpStatus:     http.StatusUnauthorized,
 			expectedErrMsg: "unauthorized",
 		},
 		{
-			name: "adoGetBuildChanges - Not Found",
+			name: "AdoGetBuildChanges - Not Found",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoGetBuildChanges(ctx, args, nil)
+				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
 			httpStatus:     http.StatusNotFound,
 			expectedErrMsg: "resource not found",
 		},
 		{
-			name: "adoCreatePipeline - Missing Params",
+			name: "AdoCreatePipeline - Missing Params",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoCreatePipeline(ctx, args, nil)
+				return m.AdoCreatePipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "name": "n", "repository_id": "r"}, // Missing yaml_path
 			expectedErrMsg: "required",
 		},
 		{
-			name: "adoCreatePipeline - 500 Error",
+			name: "AdoCreatePipeline - 500 Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				// Approved by default in setup
-				return m.adoCreatePipeline(ctx, args, nil)
+				return m.AdoCreatePipeline(ctx, args, nil)
 			},
 			args: map[string]interface{}{
 				"organization": "o", "project": "p", "name": "n", "repository_id": "r", "yaml_path": "y",
@@ -1382,9 +1382,9 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			expectedErrMsg: "returned status: 500",
 		},
 		{
-			name: "adoCreatePipeline - Malformed JSON",
+			name: "AdoCreatePipeline - Malformed JSON",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoCreatePipeline(ctx, args, nil)
+				return m.AdoCreatePipeline(ctx, args, nil)
 			},
 			args: map[string]interface{}{
 				"organization": "o", "project": "p", "name": "n", "repository_id": "r", "yaml_path": "y",
@@ -1394,26 +1394,26 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			expectedErrMsg: "failed to decode response",
 		},
 		{
-			name: "adoRunPipeline - Missing Params",
+			name: "AdoRunPipeline - Missing Params",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoRunPipeline(ctx, args, nil)
+				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p"}, // Missing pipeline_id
 			expectedErrMsg: "required",
 		},
 		{
-			name: "adoRunPipeline - 500 Error",
+			name: "AdoRunPipeline - 500 Error",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoRunPipeline(ctx, args, nil)
+				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
 			httpStatus:     http.StatusInternalServerError,
 			expectedErrMsg: "returned status: 500",
 		},
 		{
-			name: "adoRunPipeline - Malformed JSON",
+			name: "AdoRunPipeline - Malformed JSON",
 			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.adoRunPipeline(ctx, args, nil)
+				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
 			httpStatus:     http.StatusOK,
@@ -1441,7 +1441,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			m := newADOManager(sm, withBaseURL(server.URL), withToken(pat))
+			m := NewADOManager(sm, withBaseURL(server.URL), WithToken(pat))
 
 			if tt.doErr != nil {
 				// To simulate transport error, we can close the server immediately
@@ -1456,7 +1456,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		})
 	}
 
-	t.Run("adoGetPrPolicyEvaluations - Policy List Failure", func(t *testing.T) {
+	t.Run("AdoGetPrPolicyEvaluations - Policy List Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(r.URL.Path, "/pullrequests/123") {
 				w.WriteHeader(http.StatusOK)
@@ -1469,7 +1469,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -1478,12 +1478,12 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "azure DevOps API returned status: 500")
 	})
 
-	t.Run("adoListBranchPolicies - Policy Config Fetch Failure", func(t *testing.T) {
+	t.Run("AdoListBranchPolicies - Policy Config Fetch Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if strings.Contains(r.URL.Path, "/_apis/git/repositories/myrepo") {
 				w.WriteHeader(http.StatusOK)
@@ -1496,7 +1496,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -1505,7 +1505,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
 	})
@@ -1513,7 +1513,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 
 func TestAdoTools_AuthError(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	m := newADOManager(sm)
+	m := NewADOManager(sm)
 	ctx := context.Background()
 	args := map[string]interface{}{
 		"organization": "o",
@@ -1521,7 +1521,7 @@ func TestAdoTools_AuthError(t *testing.T) {
 		"repository":   "r",
 	}
 
-	_, err := m.adoListPullRequests(ctx, args, nil)
+	_, err := m.AdoListPullRequests(ctx, args, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "AZURE_PAT_ALL token is required but not provided")
 }
@@ -1563,10 +1563,10 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 
 	t.Run("List Path - Request Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 		server.Close() // Force failure
 
-		_, err := m.adoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed")
 	})
@@ -1577,9 +1577,9 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -1591,19 +1591,19 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		result, err := m.adoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
+		result, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No logs found for this run.", result.Text)
 	})
 
 	t.Run("Content Path - Request Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 		server.Close() // Force failure
 
-		_, err := m.adoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1, "log_id": 1}, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1, "log_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed")
 	})
@@ -1619,9 +1619,9 @@ func TestAdoGetPrStatuses_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
+		_, err := m.AdoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1632,9 +1632,9 @@ func TestAdoGetPrStatuses_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
+		_, err := m.AdoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -1650,9 +1650,9 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1664,9 +1664,9 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode repository metadata")
 	})
@@ -1682,7 +1682,7 @@ func TestPerformPolicyEvaluationRequest_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.performPolicyEvaluationRequest(context.Background(), server.URL)
 		assert.Error(t, err)
@@ -1695,7 +1695,7 @@ func TestPerformPolicyEvaluationRequest_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.performPolicyEvaluationRequest(context.Background(), server.URL)
 		assert.Error(t, err)
@@ -1711,9 +1711,9 @@ func TestAdoGetFileContent_DefaultStatus(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
 
-	_, err := m.adoGetFileContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"}, nil)
+	_, err := m.AdoGetFileContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "returned status: 418")
 }
@@ -1726,9 +1726,9 @@ func TestAdoListPipelineRuns_Empty(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
 
-	result, err := m.adoListPipelineRuns(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
+	result, err := m.AdoListPipelineRuns(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "No pipeline runs found.", result.Text)
 }
@@ -1743,9 +1743,9 @@ func TestAdoGetBuildTimeline_Detailed(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
+		_, err := m.AdoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1756,9 +1756,9 @@ func TestAdoGetBuildTimeline_Detailed(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.adoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
+		_, err := m.AdoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -1772,9 +1772,9 @@ func TestAdoGetBuildChanges_Empty(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
 
-	result, err := m.adoGetBuildChanges(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
+	result, err := m.AdoGetBuildChanges(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "[]", result.Text)
 }
@@ -1782,23 +1782,23 @@ func TestAdoGetBuildChanges_Empty(t *testing.T) {
 func TestAdoTools_MissingParams(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	m := newADOManager(sm)
+	m := NewADOManager(sm)
 	ctx := context.Background()
 
-	t.Run("adoGetFileContent", func(t *testing.T) {
-		_, err := m.adoGetFileContent(ctx, map[string]interface{}{}, nil)
+	t.Run("AdoGetFileContent", func(t *testing.T) {
+		_, err := m.AdoGetFileContent(ctx, map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
 
-	t.Run("adoGetBuildChanges", func(t *testing.T) {
-		_, err := m.adoGetBuildChanges(ctx, map[string]interface{}{}, nil)
+	t.Run("AdoGetBuildChanges", func(t *testing.T) {
+		_, err := m.AdoGetBuildChanges(ctx, map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
 
-	t.Run("adoGetPrStatuses", func(t *testing.T) {
-		_, err := m.adoGetPrStatuses(ctx, map[string]interface{}{}, nil)
+	t.Run("AdoGetPrStatuses", func(t *testing.T) {
+		_, err := m.AdoGetPrStatuses(ctx, map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -1806,8 +1806,8 @@ func TestAdoTools_MissingParams(t *testing.T) {
 
 func TestAdoGetPullRequest_UnmarshalError(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
-	m := newADOManager(nil)
-	_, err := m.adoGetPullRequest(context.Background(), map[string]interface{}{"pull_request_id": "invalid"}, nil)
+	m := NewADOManager(nil)
+	_, err := m.AdoGetPullRequest(context.Background(), map[string]interface{}{"pull_request_id": "invalid"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
 }
@@ -1844,7 +1844,7 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 	ctx := context.Background()
 
 	// Define standard args that satisfy validation for most endpoints
@@ -1864,19 +1864,19 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 		name string
 		call func() (tools.ToolResult, error)
 	}{
-		{"adoListPullRequests", func() (tools.ToolResult, error) { return m.adoListPullRequests(ctx, args, nil) }},
-		{"adoGetPullRequest", func() (tools.ToolResult, error) { return m.adoGetPullRequest(ctx, args, nil) }},
-		{"adoGetPrDiff", func() (tools.ToolResult, error) { return m.adoGetPrDiff(ctx, args, nil) }},
-		{"adoGetPrThreads", func() (tools.ToolResult, error) { return m.adoGetPrThreads(ctx, args, nil) }},
-		{"adoListRepositoryItems", func() (tools.ToolResult, error) { return m.adoListRepositoryItems(ctx, args, nil) }},
-		{"adoListPipelineRuns", func() (tools.ToolResult, error) { return m.adoListPipelineRuns(ctx, args, nil) }},
-		{"adoGetPipelineRun", func() (tools.ToolResult, error) { return m.adoGetPipelineRun(ctx, args, nil) }},
-		{"adoGetPipelineLogs", func() (tools.ToolResult, error) { return m.adoGetPipelineLogs(ctx, args, nil) }},
-		{"adoGetPrStatuses", func() (tools.ToolResult, error) { return m.adoGetPrStatuses(ctx, args, nil) }},
-		{"adoGetPrPolicyEvaluations", func() (tools.ToolResult, error) { return m.adoGetPrPolicyEvaluations(ctx, args, nil) }},
-		{"adoListBranchPolicies", func() (tools.ToolResult, error) { return m.adoListBranchPolicies(ctx, args, nil) }},
-		{"adoGetBuildTimeline", func() (tools.ToolResult, error) { return m.adoGetBuildTimeline(ctx, args, nil) }},
-		{"adoGetBuildChanges", func() (tools.ToolResult, error) { return m.adoGetBuildChanges(ctx, args, nil) }},
+		{"AdoListPullRequests", func() (tools.ToolResult, error) { return m.AdoListPullRequests(ctx, args, nil) }},
+		{"AdoGetPullRequest", func() (tools.ToolResult, error) { return m.AdoGetPullRequest(ctx, args, nil) }},
+		{"AdoGetPrDiff", func() (tools.ToolResult, error) { return m.AdoGetPrDiff(ctx, args, nil) }},
+		{"AdoGetPrThreads", func() (tools.ToolResult, error) { return m.AdoGetPrThreads(ctx, args, nil) }},
+		{"AdoListRepositoryItems", func() (tools.ToolResult, error) { return m.AdoListRepositoryItems(ctx, args, nil) }},
+		{"AdoListPipelineRuns", func() (tools.ToolResult, error) { return m.AdoListPipelineRuns(ctx, args, nil) }},
+		{"AdoGetPipelineRun", func() (tools.ToolResult, error) { return m.AdoGetPipelineRun(ctx, args, nil) }},
+		{"AdoGetPipelineLogs", func() (tools.ToolResult, error) { return m.AdoGetPipelineLogs(ctx, args, nil) }},
+		{"AdoGetPrStatuses", func() (tools.ToolResult, error) { return m.AdoGetPrStatuses(ctx, args, nil) }},
+		{"AdoGetPrPolicyEvaluations", func() (tools.ToolResult, error) { return m.AdoGetPrPolicyEvaluations(ctx, args, nil) }},
+		{"AdoListBranchPolicies", func() (tools.ToolResult, error) { return m.AdoListBranchPolicies(ctx, args, nil) }},
+		{"AdoGetBuildTimeline", func() (tools.ToolResult, error) { return m.AdoGetBuildTimeline(ctx, args, nil) }},
+		{"AdoGetBuildChanges", func() (tools.ToolResult, error) { return m.AdoGetBuildChanges(ctx, args, nil) }},
 	}
 
 	for _, tt := range tests {
@@ -1911,7 +1911,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte(`{"title": "PR Title", "status": "active", "createdBy": {"displayName": "User"}, "creationDate": "2023-01-01", "repository": {"name": "repo"}}`))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoGetPullRequest(ctx, map[string]interface{}{
+				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1924,7 +1924,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte(`{"value": [{"id": 1, "buildNumber": "run1", "status": "completed", "result": "succeeded", "queueTime": "2023-10-01", "repository": {"name": "repo"}}]}`))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoListPipelineRuns(ctx, map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
+				return m.AdoListPipelineRuns(ctx, map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
 			},
 			expectedText: "Run ID: 1",
 		},
@@ -1935,7 +1935,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("internal error"))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoGetPullRequest(ctx, map[string]interface{}{
+				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1948,7 +1948,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("service unavailable"))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoGetPullRequest(ctx, map[string]interface{}{
+				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1961,7 +1961,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("gateway timeout"))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoGetPullRequest(ctx, map[string]interface{}{
+				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1979,7 +1979,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 			call: func(m *adoManager) (tools.ToolResult, error) {
 				childCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 				defer cancel()
-				return m.adoGetPullRequest(childCtx, map[string]interface{}{
+				return m.AdoGetPullRequest(childCtx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1992,7 +1992,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte(`{ malformed`))
 			},
 			call: func(m *adoManager) (tools.ToolResult, error) {
-				return m.adoGetPullRequest(ctx, map[string]interface{}{
+				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -2005,7 +2005,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(tt.handler))
 			t.Cleanup(server.Close)
 
-			m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+			m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 			result, err := tt.call(m)
 			if tt.expectedErr != "" {
@@ -2037,10 +2037,10 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_name": "cool"}
-		result, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Recent runs for pipeline 42")
 	})
@@ -2055,10 +2055,10 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "repository": "repo-b"}
-		result, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Run ID: 102")
 		assert.NotContains(t, result.Text, "Run ID: 101")
@@ -2074,10 +2074,10 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "top": 2}
-		result, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Run ID: 101")
 		assert.Contains(t, result.Text, "Run ID: 102")
@@ -2152,7 +2152,7 @@ func TestAdoCreatePipeline(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			sm := &mockSecurityManager{approved: tt.approved}
-			m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+			m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 			// Pre-populate cache to test invalidation
 			cacheKey := "myorg/myproj"
@@ -2166,7 +2166,7 @@ func TestAdoCreatePipeline(t *testing.T) {
 				"yaml_path":     "/azure-pipelines.yaml",
 			}
 
-			result, err := m.adoCreatePipeline(context.Background(), args, nil)
+			result, err := m.AdoCreatePipeline(context.Background(), args, nil)
 			assert.NoError(t, err)
 			assert.Contains(t, result.Text, tt.expectedText)
 			assert.Equal(t, tt.expectPost, postCalled, "POST call mismatch")
@@ -2221,7 +2221,7 @@ func TestAdoRunPipeline(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		sm := &mockSecurityManager{approved: true}
-		m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":        "myorg",
@@ -2232,7 +2232,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"template_parameters": map[string]string{"param1": "paramVal"},
 		}
 
-		result, err := m.adoRunPipeline(context.Background(), args, nil)
+		result, err := m.AdoRunPipeline(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Successfully triggered pipeline run ID: 101")
 		assert.Contains(t, result.Text, "Web URL: https://dev.azure.com/myorg/myproj/_build/results?buildId=101")
@@ -2240,7 +2240,7 @@ func TestAdoRunPipeline(t *testing.T) {
 
 	t.Run("Cancelled", func(t *testing.T) {
 		sm := &mockSecurityManager{approved: false}
-		m := newADOManager(sm)
+		m := NewADOManager(sm)
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -2248,7 +2248,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"pipeline_id":  1,
 		}
 
-		result, err := m.adoRunPipeline(context.Background(), args, nil)
+		result, err := m.AdoRunPipeline(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "Pipeline run cancelled by user.", result.Text)
 	})

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -48,7 +48,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -72,7 +72,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -92,7 +92,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -167,7 +167,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -190,7 +190,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -214,7 +214,7 @@ func TestAdoListPullRequests(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -255,7 +255,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -279,7 +279,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -340,7 +340,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -365,7 +365,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -400,7 +400,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -424,7 +424,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -443,7 +443,7 @@ func TestAdoGetFileContent(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -484,7 +484,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		ctx := context.Background()
 		args := map[string]interface{}{
@@ -508,7 +508,7 @@ func TestAdoListRepositoryItems(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -536,7 +536,7 @@ func TestAdoListPipelineRuns(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
@@ -559,7 +559,7 @@ func TestAdoGetPipelineRun(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
 		result, err := m.AdoGetPipelineRun(context.Background(), args, nil)
@@ -582,7 +582,7 @@ func TestAdoGetPipelineLogs(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
 		result, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
@@ -599,7 +599,7 @@ func TestAdoGetPipelineLogs(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
 		result, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
@@ -639,7 +639,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -662,7 +662,7 @@ func TestAdoGetPrStatuses(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -720,7 +720,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -750,7 +750,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -778,7 +778,7 @@ func TestAdoGetPrPolicyEvaluations(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -828,7 +828,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -860,7 +860,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -898,7 +898,7 @@ func TestAdoGetBuildTimeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123}
 		result, err := m.AdoGetBuildTimeline(context.Background(), args, nil)
@@ -914,7 +914,7 @@ func TestAdoGetBuildTimeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123}
 		_, err := m.AdoGetBuildTimeline(context.Background(), args, nil)
@@ -936,7 +936,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "o",
@@ -955,7 +955,7 @@ func TestAdoGetTaskLog(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "o",
@@ -991,7 +991,7 @@ func TestAdoGetBuildChanges(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123, "top": 10}
 		result, err := m.AdoGetBuildChanges(context.Background(), args, nil)
@@ -1006,7 +1006,7 @@ func TestAdoGetBuildChanges(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 999}
 		_, err := m.AdoGetBuildChanges(context.Background(), args, nil)
@@ -1027,7 +1027,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 
 	tests := []struct {
 		name           string
-		toolFunc       func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error)
+		toolFunc       func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error)
 		args           map[string]interface{}
 		httpStatus     int
 		respBody       string
@@ -1037,7 +1037,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 	}{
 		{
 			name: "AdoGetPrDiff - Unmarshal Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"pull_request_id": "invalid"}, // should be int
@@ -1045,7 +1045,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - Missing Params",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
@@ -1053,7 +1053,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - Request Failure",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1062,7 +1062,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - 401 Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1071,7 +1071,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - 403 Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1080,7 +1080,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - 404 Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1089,7 +1089,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrDiff - 500 Internal Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1099,7 +1099,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetTaskLog - Unmarshal Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"build_id": "invalid"},
@@ -1107,7 +1107,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetTaskLog - Missing Params",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
@@ -1115,7 +1115,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetTaskLog - 404 Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
@@ -1124,7 +1124,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildTimeline - Missing Params",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
@@ -1132,7 +1132,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildTimeline - 401 Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1141,7 +1141,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrPolicyEvaluations - PR Metadata Failure",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args: map[string]interface{}{
@@ -1155,7 +1155,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListPullRequests - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1164,7 +1164,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListPullRequests - Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1173,7 +1173,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListPullRequests - Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListPullRequests(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1182,7 +1182,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrThreads - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1191,7 +1191,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrThreads - Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1200,7 +1200,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrThreads - Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrThreads(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
@@ -1209,7 +1209,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListRepositoryItems - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1218,7 +1218,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListRepositoryItems - Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1227,7 +1227,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListRepositoryItems - Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListRepositoryItems(ctx, args, nil)
 			},
 			args:           commonArgs,
@@ -1236,7 +1236,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoListPipelineRuns - 500 Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoListPipelineRuns(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
@@ -1245,7 +1245,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPipelineRun - 500 Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPipelineRun(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1},
@@ -1254,7 +1254,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildChanges - 500 Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1263,7 +1263,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildChanges - 401 Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1272,7 +1272,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrStatuses - 401 Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrStatuses(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
@@ -1281,7 +1281,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrStatuses - 403 Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrStatuses(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
@@ -1290,7 +1290,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrPolicyEvaluations - 403 Forbidden",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
@@ -1299,7 +1299,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPrPolicyEvaluations - PR Metadata Decode Failure",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
@@ -1309,7 +1309,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetFileContent - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
@@ -1318,7 +1318,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetFileContent - Default Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
@@ -1327,7 +1327,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetPipelineLogs - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetPipelineLogs(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1},
@@ -1336,7 +1336,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildTimeline - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildTimeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1345,7 +1345,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetTaskLog - Unauthorized",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetTaskLog(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
@@ -1354,7 +1354,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoGetBuildChanges - Not Found",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoGetBuildChanges(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1363,7 +1363,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoCreatePipeline - Missing Params",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoCreatePipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "name": "n", "repository_id": "r"}, // Missing yaml_path
@@ -1371,7 +1371,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoCreatePipeline - 500 Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				// Approved by default in setup
 				return m.AdoCreatePipeline(ctx, args, nil)
 			},
@@ -1383,7 +1383,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoCreatePipeline - Malformed JSON",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoCreatePipeline(ctx, args, nil)
 			},
 			args: map[string]interface{}{
@@ -1395,7 +1395,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoRunPipeline - Missing Params",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p"}, // Missing pipeline_id
@@ -1403,7 +1403,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoRunPipeline - 500 Error",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
@@ -1412,7 +1412,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		},
 		{
 			name: "AdoRunPipeline - Malformed JSON",
-			toolFunc: func(m *adoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				return m.AdoRunPipeline(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
@@ -1441,7 +1441,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			m := NewADOManager(sm, withBaseURL(server.URL), WithToken(pat))
+			m := NewADOManager(sm, WithBaseURL(server.URL), WithToken(pat))
 
 			if tt.doErr != nil {
 				// To simulate transport error, we can close the server immediately
@@ -1469,7 +1469,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":    "myorg",
@@ -1496,7 +1496,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization": "myorg",
@@ -1547,7 +1547,7 @@ func TestGetStatusEmoji(t *testing.T) {
 }
 
 func TestPolicyMatchesBranch_MissingScope(t *testing.T) {
-	m := &adoManager{}
+	m := &AdoManager{}
 	config := adoPolicyConfig{
 		Settings: map[string]interface{}{},
 	}
@@ -1563,7 +1563,7 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 
 	t.Run("List Path - Request Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 		server.Close() // Force failure
 
 		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
@@ -1577,7 +1577,7 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
 		assert.Error(t, err)
@@ -1591,7 +1591,7 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		result, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1}, nil)
 		assert.NoError(t, err)
@@ -1600,7 +1600,7 @@ func TestAdoGetPipelineLogs_DetailedErrors(t *testing.T) {
 
 	t.Run("Content Path - Request Failure", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 		server.Close() // Force failure
 
 		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1, "log_id": 1}, nil)
@@ -1619,7 +1619,7 @@ func TestAdoGetPrStatuses_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
 		assert.Error(t, err)
@@ -1632,7 +1632,7 @@ func TestAdoGetPrStatuses_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoGetPrStatuses(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1}, nil)
 		assert.Error(t, err)
@@ -1650,7 +1650,7 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
@@ -1664,7 +1664,7 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
@@ -1682,7 +1682,7 @@ func TestPerformPolicyEvaluationRequest_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.performPolicyEvaluationRequest(context.Background(), server.URL)
 		assert.Error(t, err)
@@ -1695,7 +1695,7 @@ func TestPerformPolicyEvaluationRequest_DetailedErrors(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.performPolicyEvaluationRequest(context.Background(), server.URL)
 		assert.Error(t, err)
@@ -1711,7 +1711,7 @@ func TestAdoGetFileContent_DefaultStatus(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithBaseURL(server.URL), WithToken("test-pat"))
 
 	_, err := m.AdoGetFileContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"}, nil)
 	assert.Error(t, err)
@@ -1726,7 +1726,7 @@ func TestAdoListPipelineRuns_Empty(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithBaseURL(server.URL), WithToken("test-pat"))
 
 	result, err := m.AdoListPipelineRuns(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
 	assert.NoError(t, err)
@@ -1743,7 +1743,7 @@ func TestAdoGetBuildTimeline_Detailed(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 		assert.Error(t, err)
@@ -1756,7 +1756,7 @@ func TestAdoGetBuildTimeline_Detailed(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		_, err := m.AdoGetBuildTimeline(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 		assert.Error(t, err)
@@ -1772,7 +1772,7 @@ func TestAdoGetBuildChanges_Empty(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithBaseURL(server.URL), WithToken("test-pat"))
 
 	result, err := m.AdoGetBuildChanges(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1}, nil)
 	assert.NoError(t, err)
@@ -1844,7 +1844,7 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 	ctx := context.Background()
 
 	// Define standard args that satisfy validation for most endpoints
@@ -1900,7 +1900,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 	tests := []struct {
 		name         string
 		handler      func(w http.ResponseWriter, r *http.Request)
-		call         func(m *adoManager) (tools.ToolResult, error)
+		call         func(m *AdoManager) (tools.ToolResult, error)
 		expectedText string
 		expectedErr  string
 	}{
@@ -1910,7 +1910,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"title": "PR Title", "status": "active", "createdBy": {"displayName": "User"}, "creationDate": "2023-01-01", "repository": {"name": "repo"}}`))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
@@ -1923,7 +1923,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{"value": [{"id": 1, "buildNumber": "run1", "status": "completed", "result": "succeeded", "queueTime": "2023-10-01", "repository": {"name": "repo"}}]}`))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoListPipelineRuns(ctx, map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}, nil)
 			},
 			expectedText: "Run ID: 1",
@@ -1934,7 +1934,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusInternalServerError)
 				_, _ = w.Write([]byte("internal error"))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
@@ -1947,7 +1947,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusServiceUnavailable)
 				_, _ = w.Write([]byte("service unavailable"))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
@@ -1960,7 +1960,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusGatewayTimeout)
 				_, _ = w.Write([]byte("gateway timeout"))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
@@ -1976,7 +1976,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				}
 				w.WriteHeader(http.StatusOK)
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				childCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 				defer cancel()
 				return m.AdoGetPullRequest(childCtx, map[string]interface{}{
@@ -1991,7 +1991,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 				_, _ = w.Write([]byte(`{ malformed`))
 			},
-			call: func(m *adoManager) (tools.ToolResult, error) {
+			call: func(m *AdoManager) (tools.ToolResult, error) {
 				return m.AdoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
@@ -2005,7 +2005,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(tt.handler))
 			t.Cleanup(server.Close)
 
-			m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+			m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 			result, err := tt.call(m)
 			if tt.expectedErr != "" {
@@ -2037,7 +2037,7 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_name": "cool"}
 		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
@@ -2055,7 +2055,7 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "repository": "repo-b"}
 		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
@@ -2074,7 +2074,7 @@ func TestAdoListPipelineRuns_Features(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "top": 2}
 		result, err := m.AdoListPipelineRuns(context.Background(), args, nil)
@@ -2152,7 +2152,7 @@ func TestAdoCreatePipeline(t *testing.T) {
 			t.Cleanup(server.Close)
 
 			sm := &mockSecurityManager{approved: tt.approved}
-			m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+			m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 			// Pre-populate cache to test invalidation
 			cacheKey := "myorg/myproj"
@@ -2221,7 +2221,7 @@ func TestAdoRunPipeline(t *testing.T) {
 		t.Cleanup(server.Close)
 
 		sm := &mockSecurityManager{approved: true}
-		m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
 			"organization":        "myorg",

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/fault_test.go
+++ b/internal/tools/integrations/ado/fault_test.go
@@ -99,6 +99,6 @@ func TestHTTPClient_NetworkFault_OnStatusError(t *testing.T) {
 		t.Errorf("Expected wrapped error to match target fault. Got: %v", err)
 	}
 
-	// Verify the error message contains the expected context from checkResponseError
+	// Verify the error message contains the expected context from CheckResponseError
 	assert.Contains(t, err.Error(), "additionally, failed to read response body")
 }

--- a/internal/tools/integrations/ado/fault_test.go
+++ b/internal/tools/integrations/ado/fault_test.go
@@ -38,7 +38,7 @@ func TestHTTPClient_NetworkFault_MidStream(t *testing.T) {
 
 	// 3. Initialize your client with the mock transport
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	m := newADOManager(sm, withHTTPClient(mockClient), withToken("test-pat"))
+	m := NewADOManager(sm, WithHTTPClient(mockClient), WithToken("test-pat"))
 
 	// 4. Execute the call
 	ctx := context.Background()
@@ -48,7 +48,7 @@ func TestHTTPClient_NetworkFault_MidStream(t *testing.T) {
 		"repository":   "myrepo",
 		"path":         "/src/main.go",
 	}
-	_, err := m.adoGetFileContent(ctx, args, nil)
+	_, err := m.AdoGetFileContent(ctx, args, nil)
 
 	// 5. Assert the error bubbles up safely and retains its identity via %w
 	if err == nil {
@@ -78,7 +78,7 @@ func TestHTTPClient_NetworkFault_OnStatusError(t *testing.T) {
 
 	// 3. Initialize your client with the mock transport
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	m := newADOManager(sm, withHTTPClient(mockClient), withToken("test-pat"))
+	m := NewADOManager(sm, WithHTTPClient(mockClient), WithToken("test-pat"))
 
 	// 4. Execute the call
 	ctx := context.Background()
@@ -88,7 +88,7 @@ func TestHTTPClient_NetworkFault_OnStatusError(t *testing.T) {
 		"repository":   "myrepo",
 		"path":         "/src/main.go",
 	}
-	_, err := m.adoGetFileContent(ctx, args, nil)
+	_, err := m.AdoGetFileContent(ctx, args, nil)
 
 	// 5. Assert the error bubbles up safely and retains its identity via %w
 	if err == nil {

--- a/internal/tools/integrations/ado/fault_test.go
+++ b/internal/tools/integrations/ado/fault_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/integration_test.go
+++ b/internal/tools/integrations/ado/integration_test.go
@@ -1,6 +1,6 @@
 //go:build integration
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/integration_test.go
+++ b/internal/tools/integrations/ado/integration_test.go
@@ -22,7 +22,7 @@ func TestAdoManager_LiveNetwork_Integration(t *testing.T) {
 
 	// 2. Initialize with defaults (hits real dev.azure.com by default)
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	m := newADOManager(sm, withToken(pat))
+	m := NewADOManager(sm, WithToken(pat))
 
 	// 3. Execute real network call (Example: listing PRs in a public or accessible repo)
 	// Note: We use a placeholder organization/project/repo that would likely exist or fail gracefully.
@@ -35,7 +35,7 @@ func TestAdoManager_LiveNetwork_Integration(t *testing.T) {
 
 	// We don't expect this to necessarily succeed without a real PAT that has access,
 	// but we want to verify it actually tries to hit the network.
-	result, err := m.adoListPullRequests(ctx, args, nil)
+	result, err := m.AdoListPullRequests(ctx, args, nil)
 
 	// If it fails with unauthorized, it means it reached the server!
 	if err != nil {

--- a/internal/tools/integrations/ado/log_processor_test.go
+++ b/internal/tools/integrations/ado/log_processor_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -60,7 +60,7 @@ func TestAdoManager_ExecuteCreatePipeline_Errors(t *testing.T) {
 			t.Cleanup(ts.Close)
 
 			m := NewADOManager(sm,
-				withBaseURL(ts.URL),
+				WithBaseURL(ts.URL),
 				WithHTTPClient(ts.Client()),
 				WithToken("test-pat"),
 			)
@@ -84,12 +84,12 @@ func TestAdoManager_ExecuteRequest_NetworkError(t *testing.T) {
 
 	// We use a client that points to a non-existent port or closed server
 	m := NewADOManager(sm,
-		withBaseURL("http://127.0.0.1:1"), // Likely to fail
+		WithBaseURL("http://127.0.0.1:1"), // Likely to fail
 		WithToken("test-pat"),
 	)
 
 	ctx := context.Background()
-	_, err := m.executeRequest(ctx, http.MethodGet, m.baseURL, nil, nil)
+	_, err := m.ExecuteRequest(ctx, http.MethodGet, m.BaseURL, nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "request failed")
@@ -101,7 +101,7 @@ func TestAdoManager_ExecuteRequest_AuthMissing(t *testing.T) {
 	m := NewADOManager(sm)
 
 	ctx := context.Background()
-	_, err := m.executeRequest(ctx, http.MethodGet, "http://example.com", nil, nil)
+	_, err := m.ExecuteRequest(ctx, http.MethodGet, "http://example.com", nil, nil)
 
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "AZURE_PAT_ALL token is required but not provided")
@@ -142,7 +142,7 @@ func TestAdoManager_AdoGetPipelineRun_Errors(t *testing.T) {
 			t.Cleanup(ts.Close)
 
 			m := NewADOManager(sm,
-				withBaseURL(ts.URL),
+				WithBaseURL(ts.URL),
 				WithHTTPClient(ts.Client()),
 				WithToken("test-pat"),
 			)
@@ -170,7 +170,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, err := m.resolvePipelineID(context.Background(), "org", "proj", "name")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch pipelines")
@@ -183,7 +183,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, err := m.resolvePipelineID(context.Background(), "org", "proj", "missing")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
@@ -200,7 +200,7 @@ func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, _, err := m.executeRunPipeline(context.Background(), "org", "proj", 1, "ref", nil, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
@@ -212,7 +212,7 @@ func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, _, err := m.executeRunPipeline(context.Background(), "org", "proj", 1, "ref", nil, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 504")
@@ -235,7 +235,7 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -249,7 +249,7 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -273,7 +273,7 @@ func TestAdoManager_AdoListPipelineRuns_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		_, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -287,7 +287,7 @@ func TestAdoManager_AdoListPipelineRuns_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		_, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -311,7 +311,7 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
 		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -325,7 +325,7 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
 		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -338,7 +338,7 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
 		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -362,7 +362,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
 		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -380,7 +380,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
 		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -399,7 +399,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
 		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -423,7 +423,7 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -437,7 +437,7 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -461,7 +461,7 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123}
 		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -479,7 +479,7 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123}
 		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -503,7 +503,7 @@ func TestAdoManager_AdoGetPipelineDefinition_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		_, err := m.AdoGetPipelineDefinition(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -517,7 +517,7 @@ func TestAdoManager_AdoGetPipelineDefinition_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		_, err := m.AdoGetPipelineDefinition(context.Background(), args, nil)
 		assert.Error(t, err)
@@ -541,7 +541,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -562,7 +562,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -587,7 +587,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -609,7 +609,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		t.Cleanup(ts.Close)
 
 		deniedSM := &mockSecurityManager{approved: false}
-		m := NewADOManager(deniedSM, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		m := NewADOManager(deniedSM, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -59,10 +59,10 @@ func TestAdoManager_ExecuteCreatePipeline_Errors(t *testing.T) {
 			}))
 			t.Cleanup(ts.Close)
 
-			m := newADOManager(sm,
+			m := NewADOManager(sm,
 				withBaseURL(ts.URL),
-				withHTTPClient(ts.Client()),
-				withToken("test-pat"),
+				WithHTTPClient(ts.Client()),
+				WithToken("test-pat"),
 			)
 
 			ctx := context.Background()
@@ -83,9 +83,9 @@ func TestAdoManager_ExecuteRequest_NetworkError(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	// We use a client that points to a non-existent port or closed server
-	m := newADOManager(sm,
+	m := NewADOManager(sm,
 		withBaseURL("http://127.0.0.1:1"), // Likely to fail
-		withToken("test-pat"),
+		WithToken("test-pat"),
 	)
 
 	ctx := context.Background()
@@ -98,7 +98,7 @@ func TestAdoManager_ExecuteRequest_NetworkError(t *testing.T) {
 func TestAdoManager_ExecuteRequest_AuthMissing(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
-	m := newADOManager(sm)
+	m := NewADOManager(sm)
 
 	ctx := context.Background()
 	_, err := m.executeRequest(ctx, http.MethodGet, "http://example.com", nil, nil)
@@ -141,10 +141,10 @@ func TestAdoManager_AdoGetPipelineRun_Errors(t *testing.T) {
 			}))
 			t.Cleanup(ts.Close)
 
-			m := newADOManager(sm,
+			m := NewADOManager(sm,
 				withBaseURL(ts.URL),
-				withHTTPClient(ts.Client()),
-				withToken("test-pat"),
+				WithHTTPClient(ts.Client()),
+				WithToken("test-pat"),
 			)
 
 			args := map[string]interface{}{
@@ -153,7 +153,7 @@ func TestAdoManager_AdoGetPipelineRun_Errors(t *testing.T) {
 				"pipeline_id":  1,
 				"run_id":       101,
 			}
-			_, err := m.adoGetPipelineRun(context.Background(), args, nil)
+			_, err := m.AdoGetPipelineRun(context.Background(), args, nil)
 
 			assert.Error(t, err)
 			assert.Contains(t, err.Error(), tt.expectedErr)
@@ -170,7 +170,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, err := m.resolvePipelineID(context.Background(), "org", "proj", "name")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch pipelines")
@@ -183,7 +183,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, err := m.resolvePipelineID(context.Background(), "org", "proj", "missing")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "not found")
@@ -200,7 +200,7 @@ func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, _, err := m.executeRunPipeline(context.Background(), "org", "proj", 1, "ref", nil, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
@@ -212,7 +212,7 @@ func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, _, err := m.executeRunPipeline(context.Background(), "org", "proj", 1, "ref", nil, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 504")
@@ -223,8 +223,8 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoListRepositoryItems(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoListRepositoryItems(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -235,9 +235,9 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
-		_, err := m.adoListRepositoryItems(context.Background(), args, nil)
+		_, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -249,9 +249,9 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
-		_, err := m.adoListRepositoryItems(context.Background(), args, nil)
+		_, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
 	})
@@ -261,8 +261,8 @@ func TestAdoManager_AdoListPipelineRuns_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoListPipelineRuns(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoListPipelineRuns(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -273,9 +273,9 @@ func TestAdoManager_AdoListPipelineRuns_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
-		_, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		_, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -287,9 +287,9 @@ func TestAdoManager_AdoListPipelineRuns_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
-		_, err := m.adoListPipelineRuns(context.Background(), args, nil)
+		_, err := m.AdoListPipelineRuns(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
 	})
@@ -299,8 +299,8 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoGetPipelineLogs(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoGetPipelineLogs(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -311,9 +311,9 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
-		_, err := m.adoGetPipelineLogs(context.Background(), args, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -325,9 +325,9 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
-		_, err := m.adoGetPipelineLogs(context.Background(), args, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode logs list")
 	})
@@ -338,9 +338,9 @@ func TestAdoManager_AdoGetPipelineLogs_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
-		_, err := m.adoGetPipelineLogs(context.Background(), args, nil)
+		_, err := m.AdoGetPipelineLogs(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -350,8 +350,8 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -362,9 +362,9 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -380,9 +380,9 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
 	})
@@ -399,9 +399,9 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode policy configurations")
 	})
@@ -411,8 +411,8 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoListPullRequests(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoListPullRequests(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -423,9 +423,9 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
-		_, err := m.adoListPullRequests(context.Background(), args, nil)
+		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 502")
 	})
@@ -437,9 +437,9 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
-		_, err := m.adoListPullRequests(context.Background(), args, nil)
+		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
 	})
@@ -449,8 +449,8 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoGetPrPolicyEvaluations(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -461,9 +461,9 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123}
-		_, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -479,9 +479,9 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123}
-		_, err := m.adoGetPrPolicyEvaluations(context.Background(), args, nil)
+		_, err := m.AdoGetPrPolicyEvaluations(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
@@ -491,8 +491,8 @@ func TestAdoManager_AdoGetPipelineDefinition_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoGetPipelineDefinition(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoGetPipelineDefinition(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -503,9 +503,9 @@ func TestAdoManager_AdoGetPipelineDefinition_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
-		_, err := m.adoGetPipelineDefinition(context.Background(), args, nil)
+		_, err := m.AdoGetPipelineDefinition(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -517,9 +517,9 @@ func TestAdoManager_AdoGetPipelineDefinition_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
-		_, err := m.adoGetPipelineDefinition(context.Background(), args, nil)
+		_, err := m.AdoGetPipelineDefinition(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
 	})
@@ -529,8 +529,8 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 	sm := &mockSecurityManager{approved: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
-		m := newADOManager(sm)
-		_, err := m.adoUpdateBuildDefinitionVariables(context.Background(), map[string]interface{}{}, nil)
+		m := NewADOManager(sm)
+		_, err := m.AdoUpdateBuildDefinitionVariables(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -541,7 +541,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -550,7 +550,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 				"TEST": map[string]interface{}{"value": "val"},
 			},
 		}
-		_, err := m.adoUpdateBuildDefinitionVariables(context.Background(), args, nil)
+		_, err := m.AdoUpdateBuildDefinitionVariables(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -562,7 +562,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -571,7 +571,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 				"TEST": map[string]interface{}{"value": "val"},
 			},
 		}
-		_, err := m.adoUpdateBuildDefinitionVariables(context.Background(), args, nil)
+		_, err := m.AdoUpdateBuildDefinitionVariables(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode definition")
 	})
@@ -587,7 +587,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		m := newADOManager(sm, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(sm, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -596,7 +596,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 				"TEST": map[string]interface{}{"value": "val"},
 			},
 		}
-		_, err := m.adoUpdateBuildDefinitionVariables(context.Background(), args, nil)
+		_, err := m.AdoUpdateBuildDefinitionVariables(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 400")
 	})
@@ -609,7 +609,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		t.Cleanup(ts.Close)
 
 		deniedSM := &mockSecurityManager{approved: false}
-		m := newADOManager(deniedSM, withBaseURL(ts.URL), withHTTPClient(ts.Client()), withToken("test-pat"))
+		m := NewADOManager(deniedSM, withBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",
 			"project":       "p",
@@ -618,7 +618,7 @@ func TestAdoManager_AdoUpdateBuildDefinitionVariables_Errors(t *testing.T) {
 				"TEST": map[string]interface{}{"value": "val"},
 			},
 		}
-		res, err := m.adoUpdateBuildDefinitionVariables(context.Background(), args, nil)
+		res, err := m.AdoUpdateBuildDefinitionVariables(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, res.Text, "cancelled by user")
 	})

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"bytes"

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -186,7 +186,7 @@ func mapADOVariables(vars map[string]string) map[string]adoVariable {
 	return mapped
 }
 
-func (m *adoManager) AdoListPipelineRuns(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoListPipelineRuns(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseListPipelineRunsArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing list pipeline runs args: %w", err)
@@ -205,7 +205,7 @@ func (m *adoManager) AdoListPipelineRuns(ctx context.Context, args map[string]in
 		return tools.ToolResult{}, fmt.Errorf("building list pipeline runs URL: %w", err)
 	}
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing list pipeline runs request: %w", err)
 	}
@@ -236,7 +236,7 @@ type adoPipelineRun struct {
 	} `json:"repository"`
 }
 
-func (m *adoManager) buildListPipelineRunsURL(org, project string, pipelineId, top int) (string, error) {
+func (m *AdoManager) buildListPipelineRunsURL(org, project string, pipelineId, top int) (string, error) {
 	if top <= 0 {
 		top = 10
 	} else if top > 1000 {
@@ -244,7 +244,7 @@ func (m *adoManager) buildListPipelineRunsURL(org, project string, pipelineId, t
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/build/builds",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project)))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project)))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -258,7 +258,7 @@ func (m *adoManager) buildListPipelineRunsURL(org, project string, pipelineId, t
 	return u.String(), nil
 }
 
-func (m *adoManager) formatPipelineRunsList(pipelineId int, runs []adoPipelineRun) string {
+func (m *AdoManager) formatPipelineRunsList(pipelineId int, runs []adoPipelineRun) string {
 	if len(runs) == 0 {
 		return "No pipeline runs found."
 	}
@@ -273,7 +273,7 @@ func (m *adoManager) formatPipelineRunsList(pipelineId int, runs []adoPipelineRu
 	return resultText.String()
 }
 
-func (m *adoManager) AdoGetPipelineRun(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPipelineRun(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -290,9 +290,9 @@ func (m *adoManager) AdoGetPipelineRun(ctx context.Context, args map[string]inte
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d?api-version=7.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId, params.RunId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId, params.RunId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get pipeline run request: %w", err)
 	}
@@ -322,7 +322,7 @@ func (m *adoManager) AdoGetPipelineRun(ctx context.Context, args map[string]inte
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) AdoGetPipelineLogs(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPipelineLogs(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -352,11 +352,11 @@ func (m *adoManager) AdoGetPipelineLogs(ctx context.Context, args map[string]int
 	return m.fetchPipelineLogContent(ctx, params.Organization, params.Project, params.PipelineId, params.RunId, params.LogId, params.TailLines, params.HeadLines, params.FilterQuery, params.ContextLines, params.StartLine, params.MaxLines, hb)
 }
 
-func (m *adoManager) listPipelineLogs(ctx context.Context, org, project string, pipelineId, runId int) (tools.ToolResult, error) {
+func (m *AdoManager) listPipelineLogs(ctx context.Context, org, project string, pipelineId, runId int) (tools.ToolResult, error) {
 	u := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs?api-version=7.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), pipelineId, runId)
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), pipelineId, runId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing list pipeline logs request: %w", err)
 	}
@@ -386,11 +386,11 @@ func (m *adoManager) listPipelineLogs(ctx context.Context, org, project string, 
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) fetchPipelineLogContent(ctx context.Context, org, project string, pipelineId, runId, logId int, tailLines int, headLines int, filterQuery string, contextLines int, startLine int, maxLines int, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) fetchPipelineLogContent(ctx context.Context, org, project string, pipelineId, runId, logId int, tailLines int, headLines int, filterQuery string, contextLines int, startLine int, maxLines int, hb chan<- struct{}) (tools.ToolResult, error) {
 	u := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs/%d?api-version=7.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), pipelineId, runId, logId)
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), pipelineId, runId, logId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u, nil, map[string]string{"Accept": "*/*"})
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, map[string]string{"Accept": "*/*"})
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing fetch pipeline log content request: %w", err)
 	}
@@ -409,7 +409,7 @@ func (m *adoManager) fetchPipelineLogContent(ctx context.Context, org, project s
 	return tools.ToolResult{Text: text}, nil
 }
 
-func (m *adoManager) AdoGetBuildTimeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetBuildTimeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -425,9 +425,9 @@ func (m *adoManager) AdoGetBuildTimeline(ctx context.Context, args map[string]in
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/build/builds/%d/timeline?api-version=7.0",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get build timeline request: %w", err)
 	}
@@ -449,7 +449,7 @@ func (m *adoManager) AdoGetBuildTimeline(ctx context.Context, args map[string]in
 	return tools.ToolResult{Text: string(output)}, nil
 }
 
-func (m *adoManager) AdoGetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -472,9 +472,9 @@ func (m *adoManager) AdoGetTaskLog(ctx context.Context, args map[string]interfac
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/build/builds/%d/logs/%d?api-version=7.0",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId, params.LogId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId, params.LogId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, map[string]string{"Accept": "*/*"})
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, map[string]string{"Accept": "*/*"})
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get task log request: %w", err)
 	}
@@ -519,9 +519,9 @@ func parseGetBuildChangesArgs(args map[string]interface{}) (adoGetBuildChangesPa
 	return params, nil
 }
 
-func (m *adoManager) buildGetBuildChangesURL(params adoGetBuildChangesParams) (string, error) {
+func (m *AdoManager) buildGetBuildChangesURL(params adoGetBuildChangesParams) (string, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/build/builds/%d/changes",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId))
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.BuildId))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -534,7 +534,7 @@ func (m *adoManager) buildGetBuildChangesURL(params adoGetBuildChangesParams) (s
 	return u.String(), nil
 }
 
-func (m *adoManager) parseBuildChangesResponse(body io.Reader) (string, error) {
+func (m *AdoManager) parseBuildChangesResponse(body io.Reader) (string, error) {
 	var responseData struct {
 		Value []interface{} `json:"value"`
 	}
@@ -551,7 +551,7 @@ func (m *adoManager) parseBuildChangesResponse(body io.Reader) (string, error) {
 	return string(output), nil
 }
 
-func (m *adoManager) AdoGetBuildChanges(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetBuildChanges(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseGetBuildChangesArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, err
@@ -562,7 +562,7 @@ func (m *adoManager) AdoGetBuildChanges(ctx context.Context, args map[string]int
 		return tools.ToolResult{}, err
 	}
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get build changes request: %w", err)
 	}
@@ -581,7 +581,7 @@ type adoPipeline struct {
 	Name string `json:"name"`
 }
 
-func (m *adoManager) fetchPipelines(ctx context.Context, org, project string) ([]adoPipeline, error) {
+func (m *AdoManager) fetchPipelines(ctx context.Context, org, project string) ([]adoPipeline, error) {
 	cacheKey := org + "/" + project
 
 	// 1. Check Cache (Fast Path)
@@ -597,9 +597,9 @@ func (m *adoManager) fetchPipelines(ctx context.Context, org, project string) ([
 		}
 
 		requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines?api-version=7.1",
-			m.baseURL, url.PathEscape(org), url.PathEscape(project))
+			m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
-		resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+		resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 		if err != nil {
 			return nil, fmt.Errorf("executing fetch pipelines request: %w", err)
 		}
@@ -626,7 +626,7 @@ func (m *adoManager) fetchPipelines(ctx context.Context, org, project string) ([
 	return val.([]adoPipeline), nil
 }
 
-func (m *adoManager) AdoListPipelines(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoListPipelines(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -658,7 +658,7 @@ func (m *adoManager) AdoListPipelines(ctx context.Context, args map[string]inter
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) resolvePipelineID(ctx context.Context, org, project, pipelineName string) (int, error) {
+func (m *AdoManager) resolvePipelineID(ctx context.Context, org, project, pipelineName string) (int, error) {
 	pipelines, err := m.fetchPipelines(ctx, org, project)
 	if err != nil {
 		return 0, fmt.Errorf("failed to fetch pipelines for name resolution: %w", err)
@@ -693,7 +693,7 @@ func filterAndLimitRuns(runs []adoPipelineRun, repoFilter string, limit int) []a
 	return result
 }
 
-func (m *adoManager) AdoCreatePipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoCreatePipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseCreatePipelineArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing create pipeline args: %w", err)
@@ -729,7 +729,7 @@ func (m *adoManager) AdoCreatePipeline(ctx context.Context, args map[string]inte
 	return tools.ToolResult{Text: fmt.Sprintf("Successfully created pipeline '%s' with ID: %d", params.Name, pipelineID)}, nil
 }
 
-func (m *adoManager) checkPipelineExists(ctx context.Context, org, project, name string) (int, error) {
+func (m *AdoManager) checkPipelineExists(ctx context.Context, org, project, name string) (int, error) {
 	pipelines, err := m.fetchPipelines(ctx, org, project)
 	if err != nil {
 		return 0, fmt.Errorf("failed to check existing pipelines: %w", err)
@@ -743,7 +743,7 @@ func (m *adoManager) checkPipelineExists(ctx context.Context, org, project, name
 	return 0, nil
 }
 
-func (m *adoManager) AdoRunPipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoRunPipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseRunPipelineArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing run pipeline args: %w", err)
@@ -768,7 +768,7 @@ func (m *adoManager) AdoRunPipeline(ctx context.Context, args map[string]interfa
 	}, nil
 }
 
-func (m *adoManager) executeCreatePipeline(ctx context.Context, org, project, name, repoID, yamlPath string, variables map[string]adoVariable, variableGroups []int) (int, error) {
+func (m *AdoManager) executeCreatePipeline(ctx context.Context, org, project, name, repoID, yamlPath string, variables map[string]adoVariable, variableGroups []int) (int, error) {
 	var groups []adoVariableGroup
 	for _, id := range variableGroups {
 		groups = append(groups, adoVariableGroup{ID: id})
@@ -805,9 +805,9 @@ func (m *adoManager) executeCreatePipeline(ctx context.Context, org, project, na
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines?api-version=7.1-preview.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
-	resp, err := m.executeRequest(ctx, http.MethodPost, requestURL, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
+	resp, err := m.ExecuteRequest(ctx, http.MethodPost, requestURL, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return 0, fmt.Errorf("executing create pipeline request: %w", err)
 	}
@@ -823,7 +823,7 @@ func (m *adoManager) executeCreatePipeline(ctx context.Context, org, project, na
 	return newPipeline.Id, nil
 }
 
-func (m *adoManager) executeRunPipeline(ctx context.Context, org, project string, pipelineID int, refName string, templateParams map[string]string, variables map[string]adoVariable) (int, string, error) {
+func (m *AdoManager) executeRunPipeline(ctx context.Context, org, project string, pipelineID int, refName string, templateParams map[string]string, variables map[string]adoVariable) (int, string, error) {
 	payload := adoRunPipelineRequest{
 		Resources: adoRunPipelineResources{
 			Repositories: adoRunPipelineResourcesRepos{
@@ -842,9 +842,9 @@ func (m *adoManager) executeRunPipeline(ctx context.Context, org, project string
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs?api-version=7.1-preview.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), pipelineID)
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), pipelineID)
 
-	resp, err := m.executeRequest(ctx, http.MethodPost, requestURL, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
+	resp, err := m.ExecuteRequest(ctx, http.MethodPost, requestURL, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return 0, "", fmt.Errorf("executing run pipeline request: %w", err)
 	}
@@ -866,7 +866,7 @@ func (m *adoManager) executeRunPipeline(ctx context.Context, org, project string
 	return runResponse.Id, runResponse.Links.Web.Href, nil
 }
 
-func (m *adoManager) AdoGetPipelineDefinition(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPipelineDefinition(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -882,9 +882,9 @@ func (m *adoManager) AdoGetPipelineDefinition(ctx context.Context, args map[stri
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d?api-version=7.1-preview.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get pipeline definition request: %w", err)
 	}
@@ -944,7 +944,7 @@ func buildVariablesUpdatePayload(existingDef map[string]interface{}, inputVars m
 	return json.Marshal(existingDef)
 }
 
-func (m *adoManager) AdoUpdateBuildDefinitionVariables(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoUpdateBuildDefinitionVariables(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseUpdateBuildDefArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, err
@@ -952,9 +952,9 @@ func (m *adoManager) AdoUpdateBuildDefinitionVariables(ctx context.Context, args
 
 	// 1. GET current definition
 	u := fmt.Sprintf("%s/%s/%s/_apis/build/definitions/%d?api-version=7.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.DefinitionId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.DefinitionId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("fetching build definition: %w", err)
 	}
@@ -981,7 +981,7 @@ func (m *adoManager) AdoUpdateBuildDefinitionVariables(ctx context.Context, args
 	}
 
 	// 4. PUT updated definition
-	putResp, err := m.executeRequest(ctx, http.MethodPut, u, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
+	putResp, err := m.ExecuteRequest(ctx, http.MethodPut, u, bytes.NewReader(body), map[string]string{"Content-Type": "application/json"})
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing update build definition variables request: %w", err)
 	}

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -186,7 +186,7 @@ func mapADOVariables(vars map[string]string) map[string]adoVariable {
 	return mapped
 }
 
-func (m *adoManager) adoListPipelineRuns(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoListPipelineRuns(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseListPipelineRunsArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing list pipeline runs args: %w", err)
@@ -273,7 +273,7 @@ func (m *adoManager) formatPipelineRunsList(pipelineId int, runs []adoPipelineRu
 	return resultText.String()
 }
 
-func (m *adoManager) adoGetPipelineRun(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPipelineRun(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -322,7 +322,7 @@ func (m *adoManager) adoGetPipelineRun(ctx context.Context, args map[string]inte
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) adoGetPipelineLogs(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPipelineLogs(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -409,7 +409,7 @@ func (m *adoManager) fetchPipelineLogContent(ctx context.Context, org, project s
 	return tools.ToolResult{Text: text}, nil
 }
 
-func (m *adoManager) adoGetBuildTimeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetBuildTimeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -449,7 +449,7 @@ func (m *adoManager) adoGetBuildTimeline(ctx context.Context, args map[string]in
 	return tools.ToolResult{Text: string(output)}, nil
 }
 
-func (m *adoManager) adoGetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -551,7 +551,7 @@ func (m *adoManager) parseBuildChangesResponse(body io.Reader) (string, error) {
 	return string(output), nil
 }
 
-func (m *adoManager) adoGetBuildChanges(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetBuildChanges(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseGetBuildChangesArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, err
@@ -626,7 +626,7 @@ func (m *adoManager) fetchPipelines(ctx context.Context, org, project string) ([
 	return val.([]adoPipeline), nil
 }
 
-func (m *adoManager) adoListPipelines(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoListPipelines(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -693,7 +693,7 @@ func filterAndLimitRuns(runs []adoPipelineRun, repoFilter string, limit int) []a
 	return result
 }
 
-func (m *adoManager) adoCreatePipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoCreatePipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseCreatePipelineArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing create pipeline args: %w", err)
@@ -743,7 +743,7 @@ func (m *adoManager) checkPipelineExists(ctx context.Context, org, project, name
 	return 0, nil
 }
 
-func (m *adoManager) adoRunPipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoRunPipeline(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseRunPipelineArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("parsing run pipeline args: %w", err)
@@ -866,7 +866,7 @@ func (m *adoManager) executeRunPipeline(ctx context.Context, org, project string
 	return runResponse.Id, runResponse.Links.Web.Href, nil
 }
 
-func (m *adoManager) adoGetPipelineDefinition(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPipelineDefinition(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -944,7 +944,7 @@ func buildVariablesUpdatePayload(existingDef map[string]interface{}, inputVars m
 	return json.Marshal(existingDef)
 }
 
-func (m *adoManager) adoUpdateBuildDefinitionVariables(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoUpdateBuildDefinitionVariables(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	params, err := parseUpdateBuildDefArgs(args)
 	if err != nil {
 		return tools.ToolResult{}, err

--- a/internal/tools/integrations/ado/pipeline_logs.go
+++ b/internal/tools/integrations/ado/pipeline_logs.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"bufio"

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -104,15 +104,15 @@ func TestAdoListPipelines(t *testing.T) {
 				t.Cleanup(server.Close)
 			}
 
-			var opts []adoOption
+			var opts []AdoOption
 			if server != nil {
 				opts = append(opts, withBaseURL(server.URL))
 			}
-			opts = append(opts, withToken("test-pat"))
-			m := newADOManager(sm, opts...)
+			opts = append(opts, WithToken("test-pat"))
+			m := NewADOManager(sm, opts...)
 
 			ctx := context.Background()
-			result, err := m.adoListPipelines(ctx, tt.args, nil)
+			result, err := m.AdoListPipelines(ctx, tt.args, nil)
 
 			if tt.wantError {
 				assert.Error(t, err)
@@ -190,7 +190,7 @@ func TestAdoCreatePipeline_WithVariables(t *testing.T) {
 		},
 	}
 
-	result, err := m.adoCreatePipeline(ctx, args, nil)
+	result, err := m.AdoCreatePipeline(ctx, args, nil)
 	require.NoError(t, err)
 	assert.Contains(t, result.Text, "Successfully created pipeline 'new-pipeline' with ID: 789")
 }
@@ -239,7 +239,7 @@ func TestAdoCreatePipeline_WithOverrideControl(t *testing.T) {
 		},
 	}
 
-	result, err := m.adoCreatePipeline(ctx, args, nil)
+	result, err := m.AdoCreatePipeline(ctx, args, nil)
 	require.NoError(t, err)
 	assert.Contains(t, result.Text, "Successfully created pipeline 'locked-pipeline' with ID: 888")
 }
@@ -264,7 +264,7 @@ func setupADOManager(t *testing.T, baseURL string, approved bool) (*adoManager, 
 	t.Helper()
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 	mc := &mockConfirmer{approved: approved}
-	m := newADOManager(mc, withBaseURL(baseURL), withToken("test-pat"))
+	m := NewADOManager(mc, withBaseURL(baseURL), WithToken("test-pat"))
 	return m, context.Background()
 }
 
@@ -309,7 +309,7 @@ func TestAdoGetPipelineDefinition(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(sm, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
 
 	ctx := context.Background()
 	args := map[string]interface{}{
@@ -318,7 +318,7 @@ func TestAdoGetPipelineDefinition(t *testing.T) {
 		"pipeline_id":  123,
 	}
 
-	result, err := m.adoGetPipelineDefinition(ctx, args, nil)
+	result, err := m.AdoGetPipelineDefinition(ctx, args, nil)
 	require.NoError(t, err)
 
 	var def map[string]interface{}
@@ -389,7 +389,7 @@ func TestAdoUpdateBuildDefinitionVariables(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := newADOManager(mc, withBaseURL(server.URL), withToken("test-pat"))
+	m := NewADOManager(mc, withBaseURL(server.URL), WithToken("test-pat"))
 
 	ctx := context.Background()
 	args := map[string]interface{}{
@@ -405,7 +405,7 @@ func TestAdoUpdateBuildDefinitionVariables(t *testing.T) {
 		},
 	}
 
-	result, err := m.adoUpdateBuildDefinitionVariables(ctx, args, nil)
+	result, err := m.AdoUpdateBuildDefinitionVariables(ctx, args, nil)
 	require.NoError(t, err)
 	assert.Contains(t, result.Text, "Successfully updated variables for build definition 123")
 	assert.True(t, getCalled)

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -106,7 +106,7 @@ func TestAdoListPipelines(t *testing.T) {
 
 			var opts []AdoOption
 			if server != nil {
-				opts = append(opts, withBaseURL(server.URL))
+				opts = append(opts, WithBaseURL(server.URL))
 			}
 			opts = append(opts, WithToken("test-pat"))
 			m := NewADOManager(sm, opts...)
@@ -260,11 +260,11 @@ func setupMockPipelineServer(t *testing.T, postHandler func(w http.ResponseWrite
 	}))
 }
 
-func setupADOManager(t *testing.T, baseURL string, approved bool) (*adoManager, context.Context) {
+func setupADOManager(t *testing.T, baseURL string, approved bool) (*AdoManager, context.Context) {
 	t.Helper()
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 	mc := &mockConfirmer{approved: approved}
-	m := NewADOManager(mc, withBaseURL(baseURL), WithToken("test-pat"))
+	m := NewADOManager(mc, WithBaseURL(baseURL), WithToken("test-pat"))
 	return m, context.Background()
 }
 
@@ -309,7 +309,7 @@ func TestAdoGetPipelineDefinition(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(sm, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 	ctx := context.Background()
 	args := map[string]interface{}{
@@ -389,7 +389,7 @@ func TestAdoUpdateBuildDefinitionVariables(t *testing.T) {
 	}))
 	t.Cleanup(server.Close)
 
-	m := NewADOManager(mc, withBaseURL(server.URL), WithToken("test-pat"))
+	m := NewADOManager(mc, WithBaseURL(server.URL), WithToken("test-pat"))
 
 	ctx := context.Background()
 	args := map[string]interface{}{

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -31,7 +31,7 @@ type adoContext struct {
 	Genre string `json:"genre"`
 }
 
-func (m *adoManager) AdoGetPrStatuses(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPrStatuses(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -55,9 +55,9 @@ func (m *adoManager) AdoGetPrStatuses(ctx context.Context, args map[string]inter
 	return tools.ToolResult{Text: m.formatPrStatuses(params.PullRequestId, statusData)}, nil
 }
 
-func (m *adoManager) fetchPrStatuses(ctx context.Context, org, project, repo string, prID int) (adoStatusResponse, error) {
+func (m *AdoManager) fetchPrStatuses(ctx context.Context, org, project, repo string, prID int) (adoStatusResponse, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d/statuses",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo), prID))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo), prID))
 	if err != nil {
 		return adoStatusResponse{}, fmt.Errorf("failed to parse statuses base URL: %w", err)
 	}
@@ -66,7 +66,7 @@ func (m *adoManager) fetchPrStatuses(ctx context.Context, org, project, repo str
 	q.Set("api-version", "7.1")
 	u.RawQuery = q.Encode()
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, u.String(), nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u.String(), nil, nil)
 	if err != nil {
 		return adoStatusResponse{}, fmt.Errorf("executing fetch pr statuses request: %w", err)
 	}
@@ -79,7 +79,7 @@ func (m *adoManager) fetchPrStatuses(ctx context.Context, org, project, repo str
 	return statusData, nil
 }
 
-func (m *adoManager) formatPrStatuses(pullRequestId int, statusData adoStatusResponse) string {
+func (m *AdoManager) formatPrStatuses(pullRequestId int, statusData adoStatusResponse) string {
 	if len(statusData.Value) == 0 {
 		return "No statuses found for this pull request."
 	}
@@ -142,7 +142,7 @@ type adoPolicyType struct {
 	Id          string `json:"id"`
 }
 
-func (m *adoManager) AdoGetPrPolicyEvaluations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPrPolicyEvaluations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -173,11 +173,11 @@ func (m *adoManager) AdoGetPrPolicyEvaluations(ctx context.Context, args map[str
 	return m.formatPolicyEvaluations(params.PullRequestId, policyData)
 }
 
-func (m *adoManager) fetchPrProjectID(ctx context.Context, org, project, repo string, prID int) (string, error) {
+func (m *AdoManager) fetchPrProjectID(ctx context.Context, org, project, repo string, prID int) (string, error) {
 	prRequestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=7.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo), prID)
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo), prID)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, prRequestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, prRequestURL, nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("executing fetch pr project ID request: %w", err)
 	}
@@ -201,9 +201,9 @@ func (m *adoManager) fetchPrProjectID(ctx context.Context, org, project, repo st
 	return prData.Repository.Project.Id, nil
 }
 
-func (m *adoManager) fetchPolicyEvaluations(ctx context.Context, org, project, artifactID string) (adoPolicyResponse, error) {
+func (m *AdoManager) fetchPolicyEvaluations(ctx context.Context, org, project, artifactID string) (adoPolicyResponse, error) {
 	baseURL := fmt.Sprintf("%s/%s/%s/_apis/policy/evaluations",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -218,8 +218,8 @@ func (m *adoManager) fetchPolicyEvaluations(ctx context.Context, org, project, a
 	return m.performPolicyEvaluationRequest(ctx, u.String())
 }
 
-func (m *adoManager) performPolicyEvaluationRequest(ctx context.Context, requestURL string) (adoPolicyResponse, error) {
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+func (m *AdoManager) performPolicyEvaluationRequest(ctx context.Context, requestURL string) (adoPolicyResponse, error) {
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return adoPolicyResponse{}, fmt.Errorf("performing policy evaluation request: %w", err)
 	}
@@ -232,7 +232,7 @@ func (m *adoManager) performPolicyEvaluationRequest(ctx context.Context, request
 	return policyData, nil
 }
 
-func (m *adoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPolicyResponse) (tools.ToolResult, error) {
+func (m *AdoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPolicyResponse) (tools.ToolResult, error) {
 	var resultText strings.Builder
 	_, _ = fmt.Fprintf(&resultText, "Pull Request #%d Policy Evaluations:\n\n", pullRequestId)
 
@@ -269,7 +269,7 @@ func (m *adoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPo
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) AdoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -298,11 +298,11 @@ func (m *adoManager) AdoListBranchPolicies(ctx context.Context, args map[string]
 	return tools.ToolResult{Text: m.formatBranchPolicies(params.BranchName, params.Repository, policyConfigs, targetRepoId)}, nil
 }
 
-func (m *adoManager) fetchRepositoryId(ctx context.Context, org, project, repo string) (string, error) {
+func (m *AdoManager) fetchRepositoryId(ctx context.Context, org, project, repo string) (string, error) {
 	repoURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s?api-version=7.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo))
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, repoURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, repoURL, nil, nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to fetch repository metadata: %w", err)
 	}
@@ -317,11 +317,11 @@ func (m *adoManager) fetchRepositoryId(ctx context.Context, org, project, repo s
 	return repoData.Id, nil
 }
 
-func (m *adoManager) fetchPolicyConfigurations(ctx context.Context, org, project string) ([]adoPolicyConfig, error) {
+func (m *AdoManager) fetchPolicyConfigurations(ctx context.Context, org, project string) ([]adoPolicyConfig, error) {
 	policyURL := fmt.Sprintf("%s/%s/%s/_apis/policy/configurations?api-version=7.1",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, policyURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, policyURL, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch policy configurations: %w", err)
 	}
@@ -336,7 +336,7 @@ func (m *adoManager) fetchPolicyConfigurations(ctx context.Context, org, project
 	return policyConfigs.Value, nil
 }
 
-func (m *adoManager) formatBranchPolicies(branchName, repositoryName string, policyConfigs []adoPolicyConfig, targetRepoId string) string {
+func (m *AdoManager) formatBranchPolicies(branchName, repositoryName string, policyConfigs []adoPolicyConfig, targetRepoId string) string {
 	fullBranchRef := branchName
 	if !strings.HasPrefix(fullBranchRef, "refs/heads/") {
 		fullBranchRef = "refs/heads/" + fullBranchRef
@@ -380,7 +380,7 @@ func (m *adoManager) formatBranchPolicies(branchName, repositoryName string, pol
 	return resultText.String()
 }
 
-func (m *adoManager) policyMatchesBranch(config adoPolicyConfig, targetRepoId, fullBranchRef string) bool {
+func (m *AdoManager) policyMatchesBranch(config adoPolicyConfig, targetRepoId, fullBranchRef string) bool {
 	scope, ok := config.Settings["scope"].([]interface{})
 	if !ok {
 		return false

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -31,7 +31,7 @@ type adoContext struct {
 	Genre string `json:"genre"`
 }
 
-func (m *adoManager) adoGetPrStatuses(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPrStatuses(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -142,7 +142,7 @@ type adoPolicyType struct {
 	Id          string `json:"id"`
 }
 
-func (m *adoManager) adoGetPrPolicyEvaluations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPrPolicyEvaluations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -269,7 +269,7 @@ func (m *adoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPo
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *adoManager) adoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-func (m *adoManager) adoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -82,7 +82,7 @@ func (m *adoManager) formatPullRequestDetail(pullRequestId int, prData adoPullRe
 	return resultText.String()
 }
 
-func (m *adoManager) adoListPullRequests(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoListPullRequests(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -171,7 +171,7 @@ func (m *adoManager) formatPullRequestsList(prs []adoPullRequestShort) string {
 	return resultText.String()
 }
 
-func (m *adoManager) adoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -239,7 +239,7 @@ type adoThreadResponse struct {
 	} `json:"value"`
 }
 
-func (m *adoManager) adoGetPrThreads(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *adoManager) AdoGetPrThreads(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-func (m *adoManager) AdoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -35,9 +35,9 @@ func (m *adoManager) AdoGetPullRequest(ctx context.Context, args map[string]inte
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=7.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get pull request request: %w", err)
 	}
@@ -68,7 +68,7 @@ type adoPullRequestDetail struct {
 	} `json:"repository"`
 }
 
-func (m *adoManager) formatPullRequestDetail(pullRequestId int, prData adoPullRequestDetail) string {
+func (m *AdoManager) formatPullRequestDetail(pullRequestId int, prData adoPullRequestDetail) string {
 	var resultText strings.Builder
 	_, _ = fmt.Fprintf(&resultText, "Pull Request #%d: %s\n", pullRequestId, prData.Title)
 	_, _ = fmt.Fprintf(&resultText, "Status: %s\n", prData.Status)
@@ -82,7 +82,7 @@ func (m *adoManager) formatPullRequestDetail(pullRequestId int, prData adoPullRe
 	return resultText.String()
 }
 
-func (m *adoManager) AdoListPullRequests(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoListPullRequests(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -104,7 +104,7 @@ func (m *adoManager) AdoListPullRequests(ctx context.Context, args map[string]in
 		return tools.ToolResult{}, fmt.Errorf("building list pull requests URL: %w", err)
 	}
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing list pull requests request: %w", err)
 	}
@@ -131,7 +131,7 @@ type adoPullRequestShort struct {
 	CreationDate string `json:"creationDate"`
 }
 
-func (m *adoManager) buildListPullRequestsURL(org, project, repo, status string, top int) (string, error) {
+func (m *AdoManager) buildListPullRequestsURL(org, project, repo, status string, top int) (string, error) {
 	if status == "" {
 		status = "active"
 	}
@@ -142,7 +142,7 @@ func (m *adoManager) buildListPullRequestsURL(org, project, repo, status string,
 	}
 
 	u, err := url.Parse(fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests",
-		m.baseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo)))
+		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo)))
 	if err != nil {
 		return "", fmt.Errorf("failed to parse base URL: %w", err)
 	}
@@ -156,7 +156,7 @@ func (m *adoManager) buildListPullRequestsURL(org, project, repo, status string,
 	return u.String(), nil
 }
 
-func (m *adoManager) formatPullRequestsList(prs []adoPullRequestShort) string {
+func (m *AdoManager) formatPullRequestsList(prs []adoPullRequestShort) string {
 	if len(prs) == 0 {
 		return "No pull requests found."
 	}
@@ -171,7 +171,7 @@ func (m *adoManager) formatPullRequestsList(prs []adoPullRequestShort) string {
 	return resultText.String()
 }
 
-func (m *adoManager) AdoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -188,9 +188,9 @@ func (m *adoManager) AdoGetPrDiff(ctx context.Context, args map[string]interface
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d/iterations/1/changes?api-version=7.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get pr diff request: %w", err)
 	}
@@ -239,7 +239,7 @@ type adoThreadResponse struct {
 	} `json:"value"`
 }
 
-func (m *adoManager) AdoGetPrThreads(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) AdoGetPrThreads(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -256,9 +256,9 @@ func (m *adoManager) AdoGetPrThreads(ctx context.Context, args map[string]interf
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d/threads?api-version=7.1",
-		m.baseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
+		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.executeRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("executing get pr threads request: %w", err)
 	}
@@ -272,7 +272,7 @@ func (m *adoManager) AdoGetPrThreads(ctx context.Context, args map[string]interf
 	return tools.ToolResult{Text: m.formatPrThreads(params.PullRequestId, threadData)}, nil
 }
 
-func (m *adoManager) formatPrThreads(pullRequestId int, threadData adoThreadResponse) string {
+func (m *AdoManager) formatPrThreads(pullRequestId int, threadData adoThreadResponse) string {
 	var resultText strings.Builder
 	_, _ = fmt.Fprintf(&resultText, "Pull Request #%d Discussion Threads:\n\n", pullRequestId)
 

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package ado
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -52,8 +52,8 @@ type confluenceManager struct {
 	provider *atlassianProvider
 }
 
-// newconfluenceManager creates a new instance of confluenceManager.
-func newconfluenceManager(sm confluenceSecurity, client tools.HTTPClient) (*confluenceManager, error) {
+// NewConfluenceManager creates a new instance of confluenceManager.
+func NewConfluenceManager(sm confluenceSecurity, client tools.HTTPClient) (*confluenceManager, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
@@ -203,7 +203,7 @@ func (m *confluenceManager) resolveNextURL(baseURL, nextPath string) string {
 	return parsedBase.ResolveReference(parsedNext).String()
 }
 
-func (m *confluenceManager) confluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *confluenceManager) ConfluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Title   string `json:"title"`
 		SpaceID string `json:"space_id"`
@@ -376,7 +376,7 @@ func (m *confluenceManager) decodePageResponse(body []byte) (title, storageValue
 	return responseData.Title, responseData.Body.Storage.Value, nil
 }
 
-func (m *confluenceManager) confluenceRead(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *confluenceManager) ConfluenceRead(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		PageID string `json:"page_id"`
 	}
@@ -520,7 +520,7 @@ func (m *confluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 	return nil
 }
 
-func (m *confluenceManager) confluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *confluenceManager) ConfluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		PageID          string `json:"page_id"`
 		Title           string `json:"title"`

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -46,29 +46,29 @@ var (
 	reItalic2 = regexp.MustCompile(`_(.*?)_`)
 )
 
-type confluenceManager struct {
+type ConfluenceManager struct {
 	sm       confluenceSecurity
 	client   tools.HTTPClient
-	provider *atlassianProvider
+	provider *AtlassianProvider
 }
 
-// NewConfluenceManager creates a new instance of confluenceManager.
-func NewConfluenceManager(sm confluenceSecurity, client tools.HTTPClient) (*confluenceManager, error) {
+// NewConfluenceManager creates a new instance of ConfluenceManager.
+func NewConfluenceManager(sm confluenceSecurity, client tools.HTTPClient) (*ConfluenceManager, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
-	provider, err := newAtlassianProvider()
+	provider, err := NewAtlassianProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Atlassian provider: %w", err)
 	}
-	return &confluenceManager{
+	return &ConfluenceManager{
 		sm:       sm,
 		client:   client,
 		provider: provider,
 	}, nil
 }
 
-func (m *confluenceManager) resolveSpaceID(ctx context.Context, spaceKey string) (string, error) {
+func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string) (string, error) {
 	// If it's already numeric, return it
 	if _, err := strconv.Atoi(spaceKey); err == nil {
 		return spaceKey, nil
@@ -137,7 +137,7 @@ type pageVersionInfo struct {
 	} `json:"version"`
 }
 
-func (m *confluenceManager) fetchSearchPage(ctx context.Context, url string) (*searchResponse, error) {
+func (m *ConfluenceManager) FetchSearchPage(ctx context.Context, url string) (*searchResponse, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
@@ -171,7 +171,7 @@ type searchMatch struct {
 	Title string
 }
 
-func (m *confluenceManager) processSearchResults(results []struct {
+func (m *ConfluenceManager) processSearchResults(results []struct {
 	ID    string `json:"id"`
 	Title string `json:"title"`
 }, keyword string) []searchMatch {
@@ -185,7 +185,7 @@ func (m *confluenceManager) processSearchResults(results []struct {
 	return matches
 }
 
-func (m *confluenceManager) resolveNextURL(baseURL, nextPath string) string {
+func (m *ConfluenceManager) resolveNextURL(baseURL, nextPath string) string {
 	if nextPath == "" {
 		return ""
 	}
@@ -203,7 +203,7 @@ func (m *confluenceManager) resolveNextURL(baseURL, nextPath string) string {
 	return parsedBase.ResolveReference(parsedNext).String()
 }
 
-func (m *confluenceManager) ConfluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *ConfluenceManager) ConfluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Title   string `json:"title"`
 		SpaceID string `json:"space_id"`
@@ -234,7 +234,7 @@ func (m *confluenceManager) ConfluenceSearch(ctx context.Context, args map[strin
 	pagesProcessed := 0
 
 	for i := 0; i < maxIterations && nextURL != ""; i++ {
-		responseData, err := m.fetchSearchPage(ctx, nextURL)
+		responseData, err := m.FetchSearchPage(ctx, nextURL)
 		if err != nil {
 			return tools.ToolResult{}, err
 		}
@@ -249,7 +249,7 @@ func (m *confluenceManager) ConfluenceSearch(ctx context.Context, args map[strin
 	return m.formatSearchResults(matches, warning, pagesProcessed, params.SpaceID, params.Title), nil
 }
 
-func (m *confluenceManager) resolveSpaceIDIfNeeded(ctx context.Context, spaceID string) (string, error) {
+func (m *ConfluenceManager) resolveSpaceIDIfNeeded(ctx context.Context, spaceID string) (string, error) {
 	if spaceID == "" {
 		return "", nil
 	}
@@ -260,7 +260,7 @@ func (m *confluenceManager) resolveSpaceIDIfNeeded(ctx context.Context, spaceID 
 	return resolved, nil
 }
 
-func (m *confluenceManager) prepareSearchURL(spaceID string) (*url.URL, error) {
+func (m *ConfluenceManager) prepareSearchURL(spaceID string) (*url.URL, error) {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)
@@ -277,7 +277,7 @@ func (m *confluenceManager) prepareSearchURL(spaceID string) (*url.URL, error) {
 	return u, nil
 }
 
-func (m *confluenceManager) getSearchLimit(limit int) (int, string) {
+func (m *ConfluenceManager) getSearchLimit(limit int) (int, string) {
 	maxPages := limit
 	if maxPages <= 0 {
 		maxPages = 1000
@@ -290,7 +290,7 @@ func (m *confluenceManager) getSearchLimit(limit int) (int, string) {
 	return maxPages, warning
 }
 
-func (m *confluenceManager) formatSearchResults(matches []searchMatch, warning string, pagesProcessed int, spaceID, title string) tools.ToolResult {
+func (m *ConfluenceManager) formatSearchResults(matches []searchMatch, warning string, pagesProcessed int, spaceID, title string) tools.ToolResult {
 	if len(matches) == 0 {
 		if title != "" {
 			return tools.ToolResult{Text: fmt.Sprintf("%sSearched the %d most recently modified pages in space '%s' but found no pages containing '%s'. Please try an exact title or a different keyword.", warning, pagesProcessed, spaceID, title)}
@@ -308,7 +308,7 @@ func (m *confluenceManager) formatSearchResults(matches []searchMatch, warning s
 	return tools.ToolResult{Text: resultText.String()}
 }
 
-func (m *confluenceManager) fetchPageContent(ctx context.Context, pageID string) (*http.Response, error) {
+func (m *ConfluenceManager) fetchPageContent(ctx context.Context, pageID string) (*http.Response, error) {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)
@@ -346,7 +346,7 @@ func (m *confluenceManager) fetchPageContent(ctx context.Context, pageID string)
 	return resp, nil
 }
 
-func (m *confluenceManager) readAndValidateBody(respBody io.ReadCloser) ([]byte, error) {
+func (m *ConfluenceManager) readAndValidateBody(respBody io.ReadCloser) ([]byte, error) {
 	defer func() { _ = respBody.Close() }()
 	const maxPageSize = 5 * 1024 * 1024
 	body, err := io.ReadAll(io.LimitReader(respBody, int64(maxPageSize)+1))
@@ -360,7 +360,7 @@ func (m *confluenceManager) readAndValidateBody(respBody io.ReadCloser) ([]byte,
 	return body, nil
 }
 
-func (m *confluenceManager) decodePageResponse(body []byte) (title, storageValue string, err error) {
+func (m *ConfluenceManager) decodePageResponse(body []byte) (title, storageValue string, err error) {
 	var responseData struct {
 		Title string `json:"title"`
 		Body  struct {
@@ -376,7 +376,7 @@ func (m *confluenceManager) decodePageResponse(body []byte) (title, storageValue
 	return responseData.Title, responseData.Body.Storage.Value, nil
 }
 
-func (m *confluenceManager) ConfluenceRead(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *ConfluenceManager) ConfluenceRead(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		PageID string `json:"page_id"`
 	}
@@ -409,7 +409,7 @@ func (m *confluenceManager) ConfluenceRead(ctx context.Context, args map[string]
 	return tools.ToolResult{Text: resultText}, nil
 }
 
-func (m *confluenceManager) xhtmlToMarkdown(xhtml string) string {
+func (m *ConfluenceManager) xhtmlToMarkdown(xhtml string) string {
 	// 1. Normalize whitespace - replace all newlines and tabs with spaces
 	content := strings.ReplaceAll(xhtml, "\r", "")
 	content = strings.ReplaceAll(content, "\n", " ")
@@ -454,7 +454,7 @@ func (m *confluenceManager) xhtmlToMarkdown(xhtml string) string {
 	return strings.TrimSpace(content)
 }
 
-func (m *confluenceManager) getCurrentPageVersion(ctx context.Context, pageID string) (*pageVersionInfo, error) {
+func (m *ConfluenceManager) getCurrentPageVersion(ctx context.Context, pageID string) (*pageVersionInfo, error) {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)
@@ -484,7 +484,7 @@ func (m *confluenceManager) getCurrentPageVersion(ctx context.Context, pageID st
 	return &currentData, nil
 }
 
-func (m *confluenceManager) executeUpdate(ctx context.Context, pageID string, payload map[string]interface{}) error {
+func (m *ConfluenceManager) executeUpdate(ctx context.Context, pageID string, payload map[string]interface{}) error {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return fmt.Errorf("invalid base url: %w", err)
@@ -520,7 +520,7 @@ func (m *confluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 	return nil
 }
 
-func (m *confluenceManager) ConfluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *ConfluenceManager) ConfluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		PageID          string `json:"page_id"`
 		Title           string `json:"title"`
@@ -571,7 +571,7 @@ func (m *confluenceManager) ConfluenceWrite(ctx context.Context, args map[string
 	return tools.ToolResult{Text: fmt.Sprintf("Successfully updated Confluence page %s to version %d.", params.PageID, nextVersion)}, nil
 }
 
-func (m *confluenceManager) markdownToXhtml(markdown string) string {
+func (m *ConfluenceManager) markdownToXhtml(markdown string) string {
 	lines := strings.Split(markdown, "\n")
 	var result strings.Builder
 

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -34,7 +34,7 @@ func TestConfluenceManager_GetAuthHeader(t *testing.T) {
 	t.Run("Missing Email", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "")
 		t.Setenv("ATLASSIAN_TOKEN", "token")
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		_, err = m.provider.getAuthHeader()
 		assert.Error(t, err)
@@ -44,7 +44,7 @@ func TestConfluenceManager_GetAuthHeader(t *testing.T) {
 	t.Run("Missing Token", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "email")
 		t.Setenv("ATLASSIAN_TOKEN", "")
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		_, err = m.provider.getAuthHeader()
 		assert.Error(t, err)
@@ -56,7 +56,7 @@ func TestConfluenceManager_GetAuthHeader(t *testing.T) {
 		token := "api-token"
 		t.Setenv("ATLASSIAN_EMAIL", email)
 		t.Setenv("ATLASSIAN_TOKEN", token)
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		header, err := m.provider.getAuthHeader()
 		assert.NoError(t, err)
@@ -73,7 +73,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 
 	t.Run("Success with Title and Space", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		// 1. Mock Space Resolution
@@ -107,7 +107,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": "SPACE1",
 		}
 
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Found pages:")
 		assert.Contains(t, result.Text, "Test Page 1 (ID: 1)")
@@ -117,7 +117,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 
 	t.Run("Success Space Only", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		// 1. Mock Space Resolution
@@ -147,7 +147,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": "SPACE1",
 		}
 
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Space Page (ID: 3)")
 		mockClient.AssertExpectations(t)
@@ -155,7 +155,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 
 	t.Run("No Results with Hint", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		// 1. Mock Space Resolution (using numeric ID this time to skip resolution)
@@ -170,7 +170,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"title":    "missing",
 			"space_id": "123", // Numeric, skips resolution
 		}
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Searched the 1 most recently modified pages")
 		assert.Contains(t, result.Text, "found no pages containing 'missing'")
@@ -178,7 +178,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 
 	t.Run("Success Incremental Discovery", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		// Numeric space_id to skip resolution for brevity in this test
@@ -224,24 +224,24 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": spaceID,
 		}
 
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "[cicd] Azure DevOps (ID: 3)")
 		mockClient.AssertExpectations(t)
 	})
 
 	t.Run("Error Title without Space", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		args := map[string]interface{}{"title": "keyword"}
-		_, err = m.confluenceSearch(context.Background(), args, nil)
+		_, err = m.ConfluenceSearch(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "space_id is required")
 	})
 
 	t.Run("API Error", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -254,7 +254,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"title":    "error",
 			"space_id": "123",
 		}
-		_, err = m.confluenceSearch(context.Background(), args, nil)
+		_, err = m.ConfluenceSearch(context.Background(), args, nil)
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "confluence API returned status: 403 Forbidden")
 		}
@@ -262,7 +262,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 
 	t.Run("Success with Limit 100", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		// Page 1: No matches, has next link
@@ -286,14 +286,14 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"limit":    100,
 		}
 
-		_, err = m.confluenceSearch(context.Background(), args, nil)
+		_, err = m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		mockClient.AssertNumberOfCalls(t, "Do", 2)
 	})
 
 	t.Run("Capped at 1000", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		jsonResponse := `{"results": [], "_links": {"next": "/next"}}`
@@ -310,7 +310,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"limit":    5000,
 		}
 
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "capped at 1000 pages")
 		mockClient.AssertNumberOfCalls(t, "Do", 20)
@@ -324,7 +324,7 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		jsonResponse := `{
@@ -347,7 +347,7 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 			"page_id": "123",
 		}
 
-		result, err := m.confluenceRead(context.Background(), args, nil)
+		result, err := m.ConfluenceRead(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "# Test Page")
 		assert.Contains(t, result.Text, "# Title")
@@ -358,7 +358,7 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 
 	t.Run("Page Not Found", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -370,14 +370,14 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 			"page_id": "404",
 		}
 
-		_, err = m.confluenceRead(context.Background(), args, nil)
+		_, err = m.ConfluenceRead(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "confluence page not found: 404")
 	})
 
 	t.Run("Unauthorized", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -390,7 +390,7 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 			"page_id": "123",
 		}
 
-		_, err = m.confluenceRead(context.Background(), args, nil)
+		_, err = m.ConfluenceRead(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "authentication failed: 401 Unauthorized")
 	})
@@ -398,7 +398,7 @@ func TestConfluenceManager_ConfluenceRead(t *testing.T) {
 
 func TestConfluenceManager_XhtmlToMarkdown(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	m, err := newconfluenceManager(nil, nil)
+	m, err := NewConfluenceManager(nil, nil)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -468,7 +468,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
 		sm := &toolstest.MockSecurityManager{AllowAll: true}
-		m, err := newconfluenceManager(sm, mockClient)
+		m, err := NewConfluenceManager(sm, mockClient)
 		assert.NoError(t, err)
 
 		pageID := "123"
@@ -511,7 +511,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 			"update_message":   "testing update",
 		}
 
-		result, err := m.confluenceWrite(context.Background(), args, nil)
+		result, err := m.ConfluenceWrite(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Successfully updated Confluence page 123 to version 6")
 		mockClient.AssertExpectations(t)
@@ -520,7 +520,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 	t.Run("Conflict 409", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
 		sm := &toolstest.MockSecurityManager{AllowAll: true}
-		m, err := newconfluenceManager(sm, mockClient)
+		m, err := NewConfluenceManager(sm, mockClient)
 		assert.NoError(t, err)
 
 		// Mock GET version
@@ -545,7 +545,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 			"markdown_content": "some content",
 		}
 
-		result, err := m.confluenceWrite(context.Background(), args, nil)
+		result, err := m.ConfluenceWrite(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "conflict: page version changed")
 	})
@@ -553,7 +553,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 
 func TestConfluenceManager_MarkdownToXhtml(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	m, err := newconfluenceManager(nil, nil)
+	m, err := NewConfluenceManager(nil, nil)
 	assert.NoError(t, err)
 
 	tests := []struct {
@@ -596,7 +596,7 @@ func TestConfluenceManager_ConfluenceRead_LargePayload(t *testing.T) {
 	t.Setenv("ATLASSIAN_TOKEN", "mock-token")
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 	mockClient := new(mockConfluenceClient)
-	m, err := newconfluenceManager(nil, mockClient)
+	m, err := NewConfluenceManager(nil, mockClient)
 	assert.NoError(t, err)
 
 	largeBody := strings.Repeat("A", 5*1024*1024+10)
@@ -609,7 +609,7 @@ func TestConfluenceManager_ConfluenceRead_LargePayload(t *testing.T) {
 		"page_id": "123",
 	}
 
-	_, err = m.confluenceRead(context.Background(), args, nil)
+	_, err = m.ConfluenceRead(context.Background(), args, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "confluence page size exceeds the 5MB limit")
 }
@@ -620,7 +620,7 @@ func TestConfluenceManager_ConfluenceSearch_EmptyResults(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 	t.Run("Null Results", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		jsonResponse := `{"results": null}`
@@ -634,14 +634,14 @@ func TestConfluenceManager_ConfluenceSearch_EmptyResults(t *testing.T) {
 			"title":    "nothing",
 			"space_id": "123",
 		}
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "found no pages containing 'nothing'")
 	})
 
 	t.Run("Missing Results", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		jsonResponse := `{}`
@@ -655,7 +655,7 @@ func TestConfluenceManager_ConfluenceSearch_EmptyResults(t *testing.T) {
 			"title":    "nothing",
 			"space_id": "123",
 		}
-		result, err := m.confluenceSearch(context.Background(), args, nil)
+		result, err := m.ConfluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "found no pages containing 'nothing'")
 	})
@@ -756,7 +756,7 @@ func TestConfluenceManager_ResolveSpaceID(t *testing.T) {
 			}
 
 			mockClient := new(mockConfluenceClient)
-			m, err := newconfluenceManager(nil, mockClient)
+			m, err := NewConfluenceManager(nil, mockClient)
 			if err != nil {
 				if tt.expectedError != "" {
 					assert.Contains(t, err.Error(), tt.expectedError)
@@ -801,7 +801,7 @@ func TestConfluenceManager_ConfluenceSearch_ResolveError(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 
 	mockClient := new(mockConfluenceClient)
-	m, err := newconfluenceManager(nil, mockClient)
+	m, err := NewConfluenceManager(nil, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -815,14 +815,14 @@ func TestConfluenceManager_ConfluenceSearch_ResolveError(t *testing.T) {
 		"space_id": "BADSPACE",
 	}
 
-	_, err = m.confluenceSearch(context.Background(), args, nil)
+	_, err = m.ConfluenceSearch(context.Background(), args, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve space ID for 'BADSPACE'")
 }
 
 func TestConfluenceManager_ResolveNextURL(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	m, err := newconfluenceManager(nil, nil)
+	m, err := NewConfluenceManager(nil, nil)
 	assert.NoError(t, err)
 	baseURL := "https://test.atlassian.net"
 
@@ -858,7 +858,7 @@ func TestConfluenceManager_ResolveNextURL(t *testing.T) {
 
 func TestConfluenceManager_ProcessSearchResults(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	m, err := newconfluenceManager(nil, nil)
+	m, err := NewConfluenceManager(nil, nil)
 	assert.NoError(t, err)
 	results := []struct {
 		ID    string `json:"id"`
@@ -918,31 +918,31 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 
 	t.Run("UnmarshalArgs Error Search", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.confluenceSearch(context.Background(), map[string]interface{}{"limit": "invalid"}, nil)
+		_, err = m.ConfluenceSearch(context.Background(), map[string]interface{}{"limit": "invalid"}, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("UnmarshalArgs Error Read", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.confluenceRead(context.Background(), map[string]interface{}{"page_id": 123}, nil) // Should be string
+		_, err = m.ConfluenceRead(context.Background(), map[string]interface{}{"page_id": 123}, nil) // Should be string
 		assert.Error(t, err)
 	})
 
 	t.Run("UnmarshalArgs Error Write", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.confluenceWrite(context.Background(), map[string]interface{}{"page_id": 123}, nil)
+		_, err = m.ConfluenceWrite(context.Background(), map[string]interface{}{"page_id": 123}, nil)
 		assert.Error(t, err)
 	})
 
 	t.Run("Malformed Base URL Search", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_BASE_URL", "http://bad\x7furl")
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		if err == nil {
-			_, err = m.confluenceSearch(context.Background(), map[string]interface{}{"space_id": "123"}, nil)
+			_, err = m.ConfluenceSearch(context.Background(), map[string]interface{}{"space_id": "123"}, nil)
 		}
 		require.Error(t, err)
 		// Error could be from constructor or method
@@ -951,18 +951,18 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 
 	t.Run("Network Failure Read", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return((*http.Response)(nil), fmt.Errorf("network down"))
 
-		_, err = m.confluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
+		_, err = m.ConfluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed: network down")
 	})
 
 	t.Run("HTTP 500 Read", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
 			StatusCode: 500,
@@ -970,37 +970,37 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 			Body:       io.NopCloser(strings.NewReader("error")),
 		}, nil)
 
-		_, err = m.confluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
+		_, err = m.ConfluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "confluence API returned status: 500")
 	})
 
 	t.Run("Invalid JSON Read", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
 			StatusCode: 200,
 			Body:       io.NopCloser(strings.NewReader("{ invalid ")),
 		}, nil)
 
-		_, err = m.confluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
+		_, err = m.ConfluenceRead(context.Background(), map[string]interface{}{"page_id": "123"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode response")
 	})
 
 	t.Run("Auth Failure Write", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "")
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.confluenceWrite(context.Background(), map[string]interface{}{"page_id": "123", "markdown_content": "test"}, nil)
+		_, err = m.ConfluenceWrite(context.Background(), map[string]interface{}{"page_id": "123", "markdown_content": "test"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing ATLASSIAN_EMAIL")
 	})
 
 	t.Run("Auth Failure resolveSpaceID", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "")
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		_, err = m.resolveSpaceID(context.Background(), "SPACE")
 		assert.Error(t, err)
@@ -1008,7 +1008,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	})
 
 	t.Run("fetchSearchPage Error request creation", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		_, err = m.fetchSearchPage(context.Background(), " ://bad")
 		assert.Error(t, err)
@@ -1017,7 +1017,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 
 	t.Run("fetchSearchPage Error Do", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return((*http.Response)(nil), fmt.Errorf("do error"))
 		_, err = m.fetchSearchPage(context.Background(), "https://test.com")
@@ -1026,7 +1026,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	})
 
 	t.Run("getCurrentPageVersion Error request creation", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		t.Setenv("ATLASSIAN_BASE_URL", " ://bad")
 		// Need to manually overwrite baseURL because manager was already created
@@ -1036,7 +1036,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	})
 
 	t.Run("executeUpdate Error request creation", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		t.Setenv("ATLASSIAN_BASE_URL", " ://bad")
 		m.provider.baseURL = " ://bad"
@@ -1050,7 +1050,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	})
 
 	t.Run("MarkdownToXhtml H3-H6", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, m.markdownToXhtml("### H3"), "<h3>H3</h3>")
 		assert.Contains(t, m.markdownToXhtml("#### H4"), "<h4>H4</h4>")
@@ -1065,21 +1065,21 @@ func TestConfluenceManager_ExhaustiveErrors_V2(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 
 	t.Run("resolveNextURL_MalformedBase", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		res := m.resolveNextURL(" ://bad", "path")
 		assert.Equal(t, "", res)
 	})
 
 	t.Run("resolveNextURL_MalformedPath", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		res := m.resolveNextURL("https://test.com", " ://bad")
 		assert.Equal(t, "", res)
 	})
 
 	t.Run("formatSearchResults_EmptyTitle", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		res := m.formatSearchResults(nil, "warn", 10, "space", "")
 		assert.Contains(t, res.Text, "No pages found")
@@ -1087,7 +1087,7 @@ func TestConfluenceManager_ExhaustiveErrors_V2(t *testing.T) {
 
 	t.Run("getCurrentPageVersion_DoError", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return((*http.Response)(nil), fmt.Errorf("error"))
 		_, err = m.getCurrentPageVersion(context.Background(), "123")
@@ -1096,7 +1096,7 @@ func TestConfluenceManager_ExhaustiveErrors_V2(t *testing.T) {
 
 	t.Run("getCurrentPageVersion_DecodeError", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
 			StatusCode: 200,
@@ -1108,7 +1108,7 @@ func TestConfluenceManager_ExhaustiveErrors_V2(t *testing.T) {
 
 	t.Run("executeUpdate_DoError", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return((*http.Response)(nil), fmt.Errorf("error"))
 		err = m.executeUpdate(context.Background(), "123", nil)
@@ -1116,7 +1116,7 @@ func TestConfluenceManager_ExhaustiveErrors_V2(t *testing.T) {
 	})
 
 	t.Run("executeUpdate_MarshalError", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		// Map with non-marshalable key (complex128)
 		payload := map[string]interface{}{
@@ -1133,7 +1133,7 @@ func TestConfluenceManager_ExhaustiveErrors_V3(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 
 	t.Run("resolveSpaceIDIfNeeded_Empty", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		res, err := m.resolveSpaceIDIfNeeded(context.Background(), "")
 		assert.NoError(t, err)
@@ -1141,7 +1141,7 @@ func TestConfluenceManager_ExhaustiveErrors_V3(t *testing.T) {
 	})
 
 	t.Run("fetchPageContent_ReqError", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		_, err = m.fetchPageContent(context.Background(), " ://bad")
 		assert.Error(t, err)
@@ -1149,7 +1149,7 @@ func TestConfluenceManager_ExhaustiveErrors_V3(t *testing.T) {
 
 	t.Run("fetchPageContent_Forbidden", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return(&http.Response{
 			StatusCode: 403,
@@ -1162,7 +1162,7 @@ func TestConfluenceManager_ExhaustiveErrors_V3(t *testing.T) {
 	})
 
 	t.Run("readAndValidateBody_ReadError", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		// Custom reader that returns error
 		errReader := &errorReader{err: fmt.Errorf("read error")}
@@ -1190,7 +1190,7 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 
 	t.Run("resolveSpaceID with special characters", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
@@ -1210,7 +1210,7 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 
 	t.Run("fetchPageContent with special characters", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
@@ -1230,7 +1230,7 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 
 	t.Run("getCurrentPageVersion with special characters", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
@@ -1248,7 +1248,7 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 
 	t.Run("executeUpdate with special characters", func(t *testing.T) {
 		mockClient := new(mockConfluenceClient)
-		m, err := newconfluenceManager(nil, mockClient)
+		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 
 		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
@@ -1265,7 +1265,7 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 	})
 
 	t.Run("prepareSearchURL with special characters", func(t *testing.T) {
-		m, err := newconfluenceManager(nil, nil)
+		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		u, err := m.prepareSearchURL(specialID)
 		assert.NoError(t, err)

--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -1010,7 +1010,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	t.Run("fetchSearchPage Error request creation", func(t *testing.T) {
 		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.fetchSearchPage(context.Background(), " ://bad")
+		_, err = m.FetchSearchPage(context.Background(), " ://bad")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to create request")
 	})
@@ -1020,7 +1020,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 		m, err := NewConfluenceManager(nil, mockClient)
 		assert.NoError(t, err)
 		mockClient.On("Do", mock.Anything).Return((*http.Response)(nil), fmt.Errorf("do error"))
-		_, err = m.fetchSearchPage(context.Background(), "https://test.com")
+		_, err = m.FetchSearchPage(context.Background(), "https://test.com")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed")
 	})

--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/jira.go
+++ b/internal/tools/integrations/atlassian/jira.go
@@ -18,29 +18,29 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-type jiraManager struct {
+type JiraManager struct {
 	sm       security.PathValidator
 	client   tools.HTTPClient
-	provider *atlassianProvider
+	provider *AtlassianProvider
 }
 
-// NewJiraManager creates a new instance of jiraManager.
-func NewJiraManager(sm security.PathValidator, client tools.HTTPClient) (*jiraManager, error) {
+// NewJiraManager creates a new instance of JiraManager.
+func NewJiraManager(sm security.PathValidator, client tools.HTTPClient) (*JiraManager, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
-	provider, err := newAtlassianProvider()
+	provider, err := NewAtlassianProvider()
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize Atlassian provider: %w", err)
 	}
-	return &jiraManager{
+	return &JiraManager{
 		sm:       sm,
 		client:   client,
 		provider: provider,
 	}, nil
 }
 
-func (m *jiraManager) JiraSearchIssues(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *JiraManager) JiraSearchIssues(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		JQL   string `json:"jql"`
 		Limit int    `json:"limit"`
@@ -86,7 +86,7 @@ func (m *jiraManager) JiraSearchIssues(ctx context.Context, args map[string]inte
 	return tools.ToolResult{Text: resultText}, nil
 }
 
-func (m *jiraManager) prepareSearchURL(jql string, limit int) (*url.URL, error) {
+func (m *JiraManager) prepareSearchURL(jql string, limit int) (*url.URL, error) {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid base url: %w", err)
@@ -107,7 +107,7 @@ func (m *jiraManager) prepareSearchURL(jql string, limit int) (*url.URL, error) 
 	return u, nil
 }
 
-func (m *jiraManager) formatSearchResponse(body io.ReadCloser) (string, error) {
+func (m *JiraManager) formatSearchResponse(body io.ReadCloser) (string, error) {
 	var responseData struct {
 		Issues []struct {
 			Key    string `json:"key"`
@@ -150,7 +150,7 @@ func (m *jiraManager) formatSearchResponse(body io.ReadCloser) (string, error) {
 	return resultText.String(), nil
 }
 
-func (m *jiraManager) JiraGetIssue(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *JiraManager) JiraGetIssue(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		IssueKey string `json:"issue_key"`
 	}
@@ -199,7 +199,7 @@ func (m *jiraManager) JiraGetIssue(ctx context.Context, args map[string]interfac
 	return tools.ToolResult{Text: resultText}, nil
 }
 
-func (m *jiraManager) formatGetIssueResponse(body io.ReadCloser) (string, error) {
+func (m *JiraManager) formatGetIssueResponse(body io.ReadCloser) (string, error) {
 	var issueData struct {
 		Key    string `json:"key"`
 		Fields struct {
@@ -243,7 +243,7 @@ func (m *jiraManager) formatGetIssueResponse(body io.ReadCloser) (string, error)
 }
 
 // parseADF extracts plain text from Atlassian Document Format (ADF)
-func (m *jiraManager) parseADF(adf interface{}) string {
+func (m *JiraManager) parseADF(adf interface{}) string {
 	if adf == nil {
 		return ""
 	}
@@ -253,7 +253,7 @@ func (m *jiraManager) parseADF(adf interface{}) string {
 	return strings.TrimSpace(builder.String())
 }
 
-func (m *jiraManager) extractTextFromADF(node interface{}, builder *strings.Builder) {
+func (m *JiraManager) extractTextFromADF(node interface{}, builder *strings.Builder) {
 	switch v := node.(type) {
 	case map[string]interface{}:
 		m.handleMapNode(v, builder)
@@ -262,7 +262,7 @@ func (m *jiraManager) extractTextFromADF(node interface{}, builder *strings.Buil
 	}
 }
 
-func (m *jiraManager) handleMapNode(v map[string]interface{}, builder *strings.Builder) {
+func (m *JiraManager) handleMapNode(v map[string]interface{}, builder *strings.Builder) {
 	nodeType, _ := v["type"].(string)
 
 	if nodeType == "text" {
@@ -284,13 +284,13 @@ func (m *jiraManager) handleMapNode(v map[string]interface{}, builder *strings.B
 	}
 }
 
-func (m *jiraManager) handleContent(content []interface{}, builder *strings.Builder) {
+func (m *JiraManager) handleContent(content []interface{}, builder *strings.Builder) {
 	for _, child := range content {
 		m.extractTextFromADF(child, builder)
 	}
 }
 
-func (m *jiraManager) ensureNewline(builder *strings.Builder) {
+func (m *JiraManager) ensureNewline(builder *strings.Builder) {
 	if builder.Len() > 0 && !strings.HasSuffix(builder.String(), "\n") {
 		builder.WriteString("\n")
 	}

--- a/internal/tools/integrations/atlassian/jira.go
+++ b/internal/tools/integrations/atlassian/jira.go
@@ -24,8 +24,8 @@ type jiraManager struct {
 	provider *atlassianProvider
 }
 
-// newjiraManager creates a new instance of jiraManager.
-func newjiraManager(sm security.PathValidator, client tools.HTTPClient) (*jiraManager, error) {
+// NewJiraManager creates a new instance of jiraManager.
+func NewJiraManager(sm security.PathValidator, client tools.HTTPClient) (*jiraManager, error) {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
 	}
@@ -40,7 +40,7 @@ func newjiraManager(sm security.PathValidator, client tools.HTTPClient) (*jiraMa
 	}, nil
 }
 
-func (m *jiraManager) jiraSearchIssues(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *jiraManager) JiraSearchIssues(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		JQL   string `json:"jql"`
 		Limit int    `json:"limit"`
@@ -150,7 +150,7 @@ func (m *jiraManager) formatSearchResponse(body io.ReadCloser) (string, error) {
 	return resultText.String(), nil
 }
 
-func (m *jiraManager) jiraGetIssue(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *jiraManager) JiraGetIssue(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		IssueKey string `json:"issue_key"`
 	}

--- a/internal/tools/integrations/atlassian/jira.go
+++ b/internal/tools/integrations/atlassian/jira.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/jira_test.go
+++ b/internal/tools/integrations/atlassian/jira_test.go
@@ -159,7 +159,7 @@ func TestJiraManager_JiraSearchIssues(t *testing.T) {
 			mockClient := new(mockJiraClient)
 			m, err := NewJiraManager(nil, mockClient)
 			assert.NoError(t, err)
-			m.provider.baseDelay = 1 * time.Microsecond
+			m.provider.BaseDelay = 1 * time.Microsecond
 
 			if tt.mockResp != nil || tt.mockErr != nil {
 				mockClient.On("Do", mock.Anything).Return(tt.mockResp, tt.mockErr)
@@ -288,7 +288,7 @@ func TestJiraManager_JiraGetIssue(t *testing.T) {
 			mockClient := new(mockJiraClient)
 			m, err := NewJiraManager(nil, mockClient)
 			assert.NoError(t, err)
-			m.provider.baseDelay = 1 * time.Microsecond
+			m.provider.BaseDelay = 1 * time.Microsecond
 
 			if tt.mockResp != nil || tt.mockErr != nil {
 				mockClient.On("Do", mock.Anything).Return(tt.mockResp, tt.mockErr)

--- a/internal/tools/integrations/atlassian/jira_test.go
+++ b/internal/tools/integrations/atlassian/jira_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/jira_test.go
+++ b/internal/tools/integrations/atlassian/jira_test.go
@@ -157,7 +157,7 @@ func TestJiraManager_JiraSearchIssues(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := new(mockJiraClient)
-			m, err := newjiraManager(nil, mockClient)
+			m, err := NewJiraManager(nil, mockClient)
 			assert.NoError(t, err)
 			m.provider.baseDelay = 1 * time.Microsecond
 
@@ -170,7 +170,7 @@ func TestJiraManager_JiraSearchIssues(t *testing.T) {
 				ctx = context.Background()
 			}
 
-			result, err := m.jiraSearchIssues(ctx, tt.args, nil)
+			result, err := m.JiraSearchIssues(ctx, tt.args, nil)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)
@@ -286,7 +286,7 @@ func TestJiraManager_JiraGetIssue(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockClient := new(mockJiraClient)
-			m, err := newjiraManager(nil, mockClient)
+			m, err := NewJiraManager(nil, mockClient)
 			assert.NoError(t, err)
 			m.provider.baseDelay = 1 * time.Microsecond
 
@@ -294,7 +294,7 @@ func TestJiraManager_JiraGetIssue(t *testing.T) {
 				mockClient.On("Do", mock.Anything).Return(tt.mockResp, tt.mockErr)
 			}
 
-			result, err := m.jiraGetIssue(context.Background(), tt.args, nil)
+			result, err := m.JiraGetIssue(context.Background(), tt.args, nil)
 
 			if tt.expectedError != "" {
 				assert.Error(t, err)
@@ -309,7 +309,7 @@ func TestJiraManager_JiraGetIssue(t *testing.T) {
 
 func TestJiraManager_ParseADF(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	m, err := newjiraManager(nil, nil)
+	m, err := NewJiraManager(nil, nil)
 	assert.NoError(t, err)
 
 	t.Run("Complex ADF", func(t *testing.T) {
@@ -440,7 +440,7 @@ func TestJiraManager_ParseADF(t *testing.T) {
 func TestJiraManager_Constructor(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 	t.Run("Default Client", func(t *testing.T) {
-		m, err := newjiraManager(nil, nil)
+		m, err := NewJiraManager(nil, nil)
 		assert.NoError(t, err)
 		assert.NotNil(t, m.client)
 	})
@@ -449,11 +449,11 @@ func TestJiraManager_Constructor(t *testing.T) {
 func TestJiraManager_EdgeCases(t *testing.T) {
 	t.Run("Invalid Base URL Search", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_BASE_URL", " : invalid")
-		m, err := newjiraManager(nil, nil)
+		m, err := NewJiraManager(nil, nil)
 
 		// If constructor succeeds (URL parsing happens later), check the method
 		if err == nil {
-			_, err = m.jiraSearchIssues(context.Background(), map[string]interface{}{"jql": "test"}, nil)
+			_, err = m.JiraSearchIssues(context.Background(), map[string]interface{}{"jql": "test"}, nil)
 		}
 
 		require.Error(t, err)
@@ -462,10 +462,10 @@ func TestJiraManager_EdgeCases(t *testing.T) {
 
 	t.Run("Invalid Base URL Get", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_BASE_URL", " : invalid")
-		m, err := newjiraManager(nil, nil)
+		m, err := NewJiraManager(nil, nil)
 
 		if err == nil {
-			_, err = m.jiraGetIssue(context.Background(), map[string]interface{}{"issue_key": "PROJ-1"}, nil)
+			_, err = m.JiraGetIssue(context.Background(), map[string]interface{}{"issue_key": "PROJ-1"}, nil)
 		}
 
 		require.Error(t, err)

--- a/internal/tools/integrations/atlassian/provider.go
+++ b/internal/tools/integrations/atlassian/provider.go
@@ -17,8 +17,8 @@ import (
 
 type AtlassianProvider struct {
 	baseURL   string
-	Email string
-	Token string
+	Email     string
+	Token     string
 	BaseDelay time.Duration
 }
 

--- a/internal/tools/integrations/atlassian/provider.go
+++ b/internal/tools/integrations/atlassian/provider.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/atlassian/provider.go
+++ b/internal/tools/integrations/atlassian/provider.go
@@ -15,41 +15,41 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-type atlassianProvider struct {
+type AtlassianProvider struct {
 	baseURL   string
-	email     string
-	token     string
-	baseDelay time.Duration
+	Email string
+	Token string
+	BaseDelay time.Duration
 }
 
-func newAtlassianProvider() (*atlassianProvider, error) {
+func NewAtlassianProvider() (*AtlassianProvider, error) {
 	baseURL := os.Getenv("ATLASSIAN_BASE_URL")
 	if baseURL == "" {
 		return nil, fmt.Errorf("missing required environment variable: ATLASSIAN_BASE_URL")
 	}
 
-	return &atlassianProvider{
+	return &AtlassianProvider{
 		baseURL:   baseURL,
-		email:     os.Getenv("ATLASSIAN_EMAIL"),
-		token:     os.Getenv("ATLASSIAN_TOKEN"),
-		baseDelay: 1 * time.Second,
+		Email:     os.Getenv("ATLASSIAN_EMAIL"),
+		Token:     os.Getenv("ATLASSIAN_TOKEN"),
+		BaseDelay: 1 * time.Second,
 	}, nil
 }
 
-func (p *atlassianProvider) getAuthHeader() (string, error) {
-	if p.email == "" {
+func (p *AtlassianProvider) getAuthHeader() (string, error) {
+	if p.Email == "" {
 		return "", fmt.Errorf("missing ATLASSIAN_EMAIL environment variable")
 	}
-	if p.token == "" {
+	if p.Token == "" {
 		return "", fmt.Errorf("missing ATLASSIAN_TOKEN environment variable")
 	}
 
-	auth := fmt.Sprintf("%s:%s", p.email, p.token)
+	auth := fmt.Sprintf("%s:%s", p.Email, p.Token)
 	encoded := base64.StdEncoding.EncodeToString([]byte(auth))
 	return fmt.Sprintf("Basic %s", encoded), nil
 }
 
-func (p *atlassianProvider) Do(ctx context.Context, client tools.HTTPClient, req *http.Request) (*http.Response, error) {
+func (p *AtlassianProvider) Do(ctx context.Context, client tools.HTTPClient, req *http.Request) (*http.Response, error) {
 	authHeader, err := p.getAuthHeader()
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func (p *atlassianProvider) Do(ctx context.Context, client tools.HTTPClient, req
 			break
 		}
 
-		wait := p.getWaitTime(resp, i)
+		wait := p.GetWaitTime(resp, i)
 		_ = resp.Body.Close()
 
 		select {
@@ -92,13 +92,13 @@ func (p *atlassianProvider) Do(ctx context.Context, client tools.HTTPClient, req
 	return lastResp, nil
 }
 
-func (p *atlassianProvider) getWaitTime(resp *http.Response, retryCount int) time.Duration {
-	baseDelay := p.baseDelay
-	if baseDelay == 0 {
-		baseDelay = 1 * time.Second
+func (p *AtlassianProvider) GetWaitTime(resp *http.Response, retryCount int) time.Duration {
+	BaseDelay := p.BaseDelay
+	if BaseDelay == 0 {
+		BaseDelay = 1 * time.Second
 	}
 
-	wait := baseDelay * (1 << uint(retryCount))
+	wait := BaseDelay * (1 << uint(retryCount))
 	if retryAfter := resp.Header.Get("Retry-After"); retryAfter != "" {
 		if seconds, err := strconv.Atoi(retryAfter); err == nil {
 			wait = time.Duration(seconds) * time.Second
@@ -107,7 +107,7 @@ func (p *atlassianProvider) getWaitTime(resp *http.Response, retryCount int) tim
 	return wait
 }
 
-func (p *atlassianProvider) resetRequestBody(req *http.Request) error {
+func (p *AtlassianProvider) resetRequestBody(req *http.Request) error {
 	if req.GetBody != nil {
 		newBody, err := req.GetBody()
 		if err != nil {

--- a/internal/tools/integrations/atlassian/provider_test.go
+++ b/internal/tools/integrations/atlassian/provider_test.go
@@ -36,7 +36,7 @@ func TestAtlassianProvider_Do_RetryLogic(t *testing.T) {
 	t.Setenv("ATLASSIAN_TOKEN", "token")
 
 	t.Run("Success on first attempt", func(t *testing.T) {
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
 		mockClient := new(mockRetryClient)
 		req, _ := http.NewRequest(http.MethodGet, "https://test.com", nil)
@@ -53,9 +53,9 @@ func TestAtlassianProvider_Do_RetryLogic(t *testing.T) {
 	})
 
 	t.Run("Retry on 429 then success", func(t *testing.T) {
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
-		p.baseDelay = 1 * time.Microsecond
+		p.BaseDelay = 1 * time.Microsecond
 		mockClient := new(mockRetryClient)
 		req, _ := http.NewRequest(http.MethodGet, "https://test.com", nil)
 
@@ -83,9 +83,9 @@ func TestAtlassianProvider_Do_RetryLogic(t *testing.T) {
 	})
 
 	t.Run("Respect Retry-After header", func(t *testing.T) {
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
-		p.baseDelay = 1 * time.Microsecond
+		p.BaseDelay = 1 * time.Microsecond
 		mockClient := new(mockRetryClient)
 		req, _ := http.NewRequest(http.MethodGet, "https://test.com", nil)
 
@@ -116,9 +116,9 @@ func TestAtlassianProvider_Do_RetryLogic(t *testing.T) {
 	})
 
 	t.Run("Max retries exceeded", func(t *testing.T) {
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
-		p.baseDelay = 1 * time.Microsecond
+		p.BaseDelay = 1 * time.Microsecond
 		mockClient := new(mockRetryClient)
 		req, _ := http.NewRequest(http.MethodGet, "https://test.com", nil)
 
@@ -138,9 +138,9 @@ func TestAtlassianProvider_Do_RetryLogic(t *testing.T) {
 	})
 
 	t.Run("Context cancellation", func(t *testing.T) {
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
-		p.baseDelay = 10 * time.Millisecond
+		p.BaseDelay = 10 * time.Millisecond
 		mockClient := new(mockRetryClient)
 		req, _ := http.NewRequest(http.MethodGet, "https://test.com", nil)
 
@@ -165,7 +165,7 @@ func TestAtlassianProvider_GetAuthHeader_Errors(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 	t.Run("Missing Email", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "")
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
 		_, err = p.getAuthHeader()
 		assert.Error(t, err)
@@ -175,7 +175,7 @@ func TestAtlassianProvider_GetAuthHeader_Errors(t *testing.T) {
 	t.Run("Missing Token", func(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "test")
 		t.Setenv("ATLASSIAN_TOKEN", "")
-		p, err := newAtlassianProvider()
+		p, err := NewAtlassianProvider()
 		assert.NoError(t, err)
 		_, err = p.getAuthHeader()
 		assert.Error(t, err)
@@ -188,9 +188,9 @@ func TestAtlassianProvider_Do_RetryWithBody(t *testing.T) {
 	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
 	t.Setenv("ATLASSIAN_TOKEN", "token")
 
-	p, err := newAtlassianProvider()
+	p, err := NewAtlassianProvider()
 	assert.NoError(t, err)
-	p.baseDelay = 1 * time.Microsecond
+	p.BaseDelay = 1 * time.Microsecond
 	mockClient := new(mockRetryClient)
 
 	bodyText := "hello world"
@@ -239,7 +239,7 @@ func TestAtlassianProvider_Constructor_FailsWhenMissingURL(t *testing.T) {
 	// Ensure the environment variable is explicitly unset for this test
 	t.Setenv("ATLASSIAN_BASE_URL", "")
 
-	p, err := newAtlassianProvider()
+	p, err := NewAtlassianProvider()
 
 	require.Error(t, err)
 	require.Nil(t, p)

--- a/internal/tools/integrations/atlassian/provider_test.go
+++ b/internal/tools/integrations/atlassian/provider_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2026 gosharplite@gmail.com
 // SPDX-License-Identifier: MIT
 
-package integrations
+package atlassian
 
 import (
 	"context"

--- a/internal/tools/integrations/fault_injection_test.go
+++ b/internal/tools/integrations/fault_injection_test.go
@@ -13,9 +13,39 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// mockSecurityManager provides a test double for security.Manager used in ADO/Atlassian tests.
+type mockSecurityManager struct {
+	approved      bool
+	err           error
+	confirmCalled bool
+}
+
+func (m *mockSecurityManager) IsPathSafe(path string) (string, error) { return path, nil }
+func (m *mockSecurityManager) IsPathWritable(path string) (string, error) {
+	return path, nil
+}
+func (m *mockSecurityManager) Authorize(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+	return m.approved, m.err
+}
+func (m *mockSecurityManager) LogAudit(action string, args ...any) {}
+func (m *mockSecurityManager) TerminalLock()                       {}
+func (m *mockSecurityManager) TerminalUnlock()                     {}
+func (m *mockSecurityManager) Prompt(message string)               {}
+func (m *mockSecurityManager) Warn(message string)                 {}
+func (m *mockSecurityManager) Confirm(ctx context.Context, message string) (bool, error) {
+	m.confirmCalled = true
+	return m.approved, m.err
+}
+func (m *mockSecurityManager) ReadLine(ctx context.Context) (string, error) { return "", nil }
+func (m *mockSecurityManager) IsCommandAllowed(command string) bool         { return true }
+func (m *mockSecurityManager) IsBypassActive() bool                         { return false }
+func (m *mockSecurityManager) Close() error                                 { return nil }
 
 type mockRoundTripper struct {
 	roundTrip func(*http.Request) (*http.Response, error)
@@ -32,15 +62,15 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 		name       string
 		setupMock  func(m *mockRoundTripper)
 		inputURL   string
-		call       func(ctx context.Context, m *adoManager) error
+		call       func(ctx context.Context, m *ado.AdoManager) error
 		wantErrMsg string
 	}{
 		{
 			name: "Request Creation Failure",
 			// Invalid URL with control character to force http.NewRequestWithContext to fail
 			inputURL: "https://api.example.com/" + string([]byte{0x7f}),
-			call: func(ctx context.Context, m *adoManager) error {
-				_, err := m.executeRequest(ctx, http.MethodGet, m.baseURL, nil, nil)
+			call: func(ctx context.Context, m *ado.AdoManager) error {
+				_, err := m.ExecuteRequest(ctx, http.MethodGet, m.BaseURL, nil, nil)
 				return err
 			},
 			wantErrMsg: "failed to create request",
@@ -52,8 +82,8 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 					return nil, errors.New("network unreachable")
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
-				_, err := m.executeRequest(ctx, http.MethodGet, "https://api.example.com", nil, nil)
+			call: func(ctx context.Context, m *ado.AdoManager) error {
+				_, err := m.ExecuteRequest(ctx, http.MethodGet, "https://api.example.com", nil, nil)
 				return err
 			},
 			wantErrMsg: "network unreachable",
@@ -68,13 +98,13 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"repository":   "repo",
 				}
-				_, err := m.adoListRepositoryItems(ctx, args, nil)
+				_, err := m.AdoListRepositoryItems(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -86,8 +116,8 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 					return nil, context.Canceled
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
-				_, err := m.executeRequest(ctx, http.MethodGet, "https://api.example.com", nil, nil)
+			call: func(ctx context.Context, m *ado.AdoManager) error {
+				_, err := m.ExecuteRequest(ctx, http.MethodGet, "https://api.example.com", nil, nil)
 				return err
 			},
 			wantErrMsg: "context canceled",
@@ -102,14 +132,14 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"pipeline_id":  1,
 					"run_id":       1,
 				}
-				_, err := m.adoGetPipelineRun(ctx, args, nil)
+				_, err := m.AdoGetPipelineRun(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -129,10 +159,10 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 				baseURL = tt.inputURL
 			}
 
-			m := newADOManager(sm,
-				withBaseURL(baseURL),
-				withHTTPClient(client),
-				withToken("test-pat"),
+			m := ado.NewADOManager(sm,
+				ado.WithBaseURL(baseURL),
+				ado.WithHTTPClient(client),
+				ado.WithToken("test-pat"),
 			)
 
 			err := tt.call(context.Background(), m)
@@ -145,10 +175,10 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 
 func TestAtlassianProvider_ErrorPaths(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://jira.com")
-	p, err := newAtlassianProvider()
+	p, err := atlassian.NewAtlassianProvider()
 	require.NoError(t, err)
-	p.email = "test@example.com"
-	p.token = "test-token"
+	p.Email = "test@example.com"
+	p.Token = "test-token"
 
 	tests := []struct {
 		name       string
@@ -216,7 +246,7 @@ func TestConfluenceManager_ErrorPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		setupMock  func(m *mockRoundTripper)
-		call       func(ctx context.Context, m *confluenceManager) error
+		call       func(ctx context.Context, m *atlassian.ConfluenceManager) error
 		wantErrMsg string
 	}{
 		{
@@ -229,8 +259,8 @@ func TestConfluenceManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *confluenceManager) error {
-				_, err := m.fetchSearchPage(ctx, "https://confluence.com/api")
+			call: func(ctx context.Context, m *atlassian.ConfluenceManager) error {
+				_, err := m.FetchSearchPage(ctx, "https://confluence.com/api")
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -245,9 +275,9 @@ func TestConfluenceManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *confluenceManager) error {
+			call: func(ctx context.Context, m *atlassian.ConfluenceManager) error {
 				args := map[string]interface{}{"page_id": "123"}
-				_, err := m.confluenceRead(ctx, args, nil)
+				_, err := m.ConfluenceRead(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -266,7 +296,7 @@ func TestConfluenceManager_ErrorPaths(t *testing.T) {
 			}
 			client := &http.Client{Transport: rt}
 
-			m, err := newconfluenceManager(sm, client)
+			m, err := atlassian.NewConfluenceManager(sm, client)
 			require.NoError(t, err)
 
 			err = tt.call(context.Background(), m)
@@ -283,7 +313,7 @@ func TestJiraManager_ErrorPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		setupMock  func(m *mockRoundTripper)
-		call       func(ctx context.Context, m *jiraManager) error
+		call       func(ctx context.Context, m *atlassian.JiraManager) error
 		wantErrMsg string
 	}{
 		{
@@ -296,9 +326,9 @@ func TestJiraManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *jiraManager) error {
+			call: func(ctx context.Context, m *atlassian.JiraManager) error {
 				args := map[string]interface{}{"jql": "project=PROJ"}
-				_, err := m.jiraSearchIssues(ctx, args, nil)
+				_, err := m.JiraSearchIssues(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -313,9 +343,9 @@ func TestJiraManager_ErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *jiraManager) error {
+			call: func(ctx context.Context, m *atlassian.JiraManager) error {
 				args := map[string]interface{}{"issue_key": "PROJ-1"}
-				_, err := m.jiraGetIssue(ctx, args, nil)
+				_, err := m.JiraGetIssue(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -334,7 +364,7 @@ func TestJiraManager_ErrorPaths(t *testing.T) {
 			}
 			client := &http.Client{Transport: rt}
 
-			m, err := newjiraManager(sm, client)
+			m, err := atlassian.NewJiraManager(sm, client)
 			require.NoError(t, err)
 
 			err = tt.call(context.Background(), m)
@@ -351,7 +381,7 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		setupMock  func(m *mockRoundTripper)
-		call       func(ctx context.Context, m *adoManager) error
+		call       func(ctx context.Context, m *ado.AdoManager) error
 		wantErrMsg string
 	}{
 		{
@@ -364,13 +394,13 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"pipeline_id":  1,
 				}
-				_, err := m.adoListPipelineRuns(ctx, args, nil)
+				_, err := m.AdoListPipelineRuns(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -385,14 +415,14 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"pipeline_id":  1,
 					"run_id":       1,
 				}
-				_, err := m.adoGetPipelineLogs(ctx, args, nil)
+				_, err := m.AdoGetPipelineLogs(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode logs list",
@@ -407,13 +437,13 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"build_id":     1,
 				}
-				_, err := m.adoGetBuildTimeline(ctx, args, nil)
+				_, err := m.AdoGetBuildTimeline(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -428,13 +458,13 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"pipeline_id":  1,
 				}
-				_, err := m.adoGetPipelineDefinition(ctx, args, nil)
+				_, err := m.AdoGetPipelineDefinition(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -449,14 +479,14 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization":  "org",
 					"project":       "proj",
 					"definition_id": 1,
 					"variables":     map[string]interface{}{"K": map[string]interface{}{"value": "V"}},
 				}
-				_, err := m.adoUpdateBuildDefinitionVariables(ctx, args, nil)
+				_, err := m.AdoUpdateBuildDefinitionVariables(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode definition",
@@ -471,9 +501,9 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 			}
 			client := &http.Client{Transport: rt}
 
-			m := newADOManager(sm,
-				withHTTPClient(client),
-				withToken("test-pat"),
+			m := ado.NewADOManager(sm,
+				ado.WithHTTPClient(client),
+				ado.WithToken("test-pat"),
 			)
 
 			err := tt.call(context.Background(), m)
@@ -490,7 +520,7 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		setupMock  func(m *mockRoundTripper)
-		call       func(ctx context.Context, m *adoManager) error
+		call       func(ctx context.Context, m *ado.AdoManager) error
 		wantErrMsg string
 	}{
 		{
@@ -503,14 +533,14 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization":    "org",
 					"project":         "proj",
 					"repository":      "repo",
 					"pull_request_id": 123,
 				}
-				_, err := m.adoGetPrStatuses(ctx, args, nil)
+				_, err := m.AdoGetPrStatuses(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -525,14 +555,14 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization":    "org",
 					"project":         "proj",
 					"repository":      "repo",
 					"pull_request_id": 123,
 				}
-				_, err := m.adoGetPrPolicyEvaluations(ctx, args, nil)
+				_, err := m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode PR metadata",
@@ -553,14 +583,14 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization":    "org",
 					"project":         "proj",
 					"repository":      "repo",
 					"pull_request_id": 123,
 				}
-				_, err := m.adoGetPrPolicyEvaluations(ctx, args, nil)
+				_, err := m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -575,9 +605,9 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 			}
 			client := &http.Client{Transport: rt}
 
-			m := newADOManager(sm,
-				withHTTPClient(client),
-				withToken("test-pat"),
+			m := ado.NewADOManager(sm,
+				ado.WithHTTPClient(client),
+				ado.WithToken("test-pat"),
 			)
 
 			err := tt.call(context.Background(), m)
@@ -594,7 +624,7 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 	tests := []struct {
 		name       string
 		setupMock  func(m *mockRoundTripper)
-		call       func(ctx context.Context, m *adoManager) error
+		call       func(ctx context.Context, m *ado.AdoManager) error
 		wantErrMsg string
 	}{
 		{
@@ -607,13 +637,13 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization": "org",
 					"project":      "proj",
 					"repository":   "repo",
 				}
-				_, err := m.adoListPullRequests(ctx, args, nil)
+				_, err := m.AdoListPullRequests(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -628,14 +658,14 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 					}, nil
 				}
 			},
-			call: func(ctx context.Context, m *adoManager) error {
+			call: func(ctx context.Context, m *ado.AdoManager) error {
 				args := map[string]interface{}{
 					"organization":    "org",
 					"project":         "proj",
 					"repository":      "repo",
 					"pull_request_id": 123,
 				}
-				_, err := m.adoGetPrThreads(ctx, args, nil)
+				_, err := m.AdoGetPrThreads(ctx, args, nil)
 				return err
 			},
 			wantErrMsg: "failed to decode response",
@@ -650,9 +680,9 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 			}
 			client := &http.Client{Transport: rt}
 
-			m := newADOManager(sm,
-				withHTTPClient(client),
-				withToken("test-pat"),
+			m := ado.NewADOManager(sm,
+				ado.WithHTTPClient(client),
+				ado.WithToken("test-pat"),
 			)
 
 			err := tt.call(context.Background(), m)
@@ -665,20 +695,20 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 
 func TestAtlassianProvider_WaitTime(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
-	p, err := newAtlassianProvider()
+	p, err := atlassian.NewAtlassianProvider()
 	require.NoError(t, err)
-	p.baseDelay = 0 // Test baseDelay == 0 case
+	p.BaseDelay = 0 // Test baseDelay == 0 case
 
 	t.Run("Default baseDelay", func(t *testing.T) {
 		resp := &http.Response{Header: make(http.Header)}
-		wait := p.getWaitTime(resp, 0)
+		wait := p.GetWaitTime(resp, 0)
 		assert.Equal(t, 1*time.Second, wait)
 	})
 
 	t.Run("Invalid Retry-After", func(t *testing.T) {
-		p.baseDelay = 1 * time.Second
+		p.BaseDelay = 1 * time.Second
 		resp := &http.Response{Header: http.Header{"Retry-After": []string{"invalid"}}}
-		wait := p.getWaitTime(resp, 1)
+		wait := p.GetWaitTime(resp, 1)
 		assert.Equal(t, 2*time.Second, wait) // exponential backoff
 	})
 }

--- a/internal/tools/integrations/io_error_test.go
+++ b/internal/tools/integrations/io_error_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -34,7 +36,7 @@ func (m *mockHttpClient) Do(req *http.Request) (*http.Response, error) {
 
 func TestAzureDevOps_IOError(t *testing.T) {
 	mockClient := new(mockHttpClient)
-	m := newADOManager(nil, withHTTPClient(mockClient), withToken("test-pat"))
+	m := ado.NewADOManager(nil, ado.WithHTTPClient(mockClient), ado.WithToken("test-pat"))
 
 	mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool { return true })).Return(&http.Response{
 		StatusCode: http.StatusInternalServerError,
@@ -42,7 +44,7 @@ func TestAzureDevOps_IOError(t *testing.T) {
 		Body:       &ioErrorReader{},
 	}, nil)
 
-	err := m.checkResponseError(&http.Response{
+	err := m.CheckResponseError(&http.Response{
 		StatusCode: http.StatusInternalServerError,
 		Status:     "500 Internal Server Error",
 		Body:       &ioErrorReader{},
@@ -57,7 +59,7 @@ func TestJira_IOError(t *testing.T) {
 	t.Setenv("ATLASSIAN_TOKEN", "mock-token")
 	t.Setenv("ATLASSIAN_BASE_URL", "https://jira.com")
 	mockClient := new(mockHttpClient)
-	m, err := newjiraManager(nil, mockClient)
+	m, err := atlassian.NewJiraManager(nil, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -69,12 +71,12 @@ func TestJira_IOError(t *testing.T) {
 	ctx := context.Background()
 
 	// Test jiraSearchIssues
-	_, err = m.jiraSearchIssues(ctx, map[string]interface{}{"jql": "project=PROJ"}, nil)
+	_, err = m.JiraSearchIssues(ctx, map[string]interface{}{"jql": "project=PROJ"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read response body")
 
 	// Test jiraGetIssue
-	_, err = m.jiraGetIssue(ctx, map[string]interface{}{"issue_key": "PROJ-1"}, nil)
+	_, err = m.JiraGetIssue(ctx, map[string]interface{}{"issue_key": "PROJ-1"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read response body")
 }
@@ -84,7 +86,7 @@ func TestConfluence_IOError(t *testing.T) {
 	t.Setenv("ATLASSIAN_TOKEN", "mock-token")
 	t.Setenv("ATLASSIAN_BASE_URL", "https://confluence.com")
 	mockClient := new(mockHttpClient)
-	m, err := newconfluenceManager(nil, mockClient)
+	m, err := atlassian.NewConfluenceManager(nil, mockClient)
 	assert.NoError(t, err)
 
 	mockClient.On("Do", mock.Anything).Return(&http.Response{
@@ -96,7 +98,7 @@ func TestConfluence_IOError(t *testing.T) {
 	ctx := context.Background()
 
 	// Test fetchSearchPage
-	_, err = m.fetchSearchPage(ctx, "https://confluence.com/api")
+	_, err = m.FetchSearchPage(ctx, "https://confluence.com/api")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to read response body")
 }

--- a/internal/tools/integrations/registration.go
+++ b/internal/tools/integrations/registration.go
@@ -10,6 +10,8 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
 )
 
 // RegisterAll registers all external integration tools.
@@ -178,7 +180,7 @@ func registerTeams(r tools.Registry, sm domain_security.Manager, client tools.HT
 }
 
 func registerConfluence(r tools.Registry, sm domain_security.Manager, client tools.HTTPClient) error {
-	m, err := newconfluenceManager(sm, client)
+	m, err := atlassian.NewConfluenceManager(sm, client)
 	if err != nil {
 		// Skip registration gracefully if configuration is missing.
 		return nil
@@ -204,7 +206,7 @@ func registerConfluence(r tools.Registry, sm domain_security.Manager, client too
 				},
 			},
 		},
-	}, m.confluenceSearch); err != nil {
+	}, m.ConfluenceSearch); err != nil {
 		return err
 	}
 
@@ -221,7 +223,7 @@ func registerConfluence(r tools.Registry, sm domain_security.Manager, client too
 			},
 			Required: []string{"page_id"},
 		},
-	}, m.confluenceRead); err != nil {
+	}, m.ConfluenceRead); err != nil {
 		return err
 	}
 
@@ -251,14 +253,14 @@ func registerConfluence(r tools.Registry, sm domain_security.Manager, client too
 			},
 			Required: []string{"page_id", "markdown_content"},
 		},
-	}, m.confluenceWrite, tools.ToolOptions{Serial: true}); err != nil {
+	}, m.ConfluenceWrite, tools.ToolOptions{Serial: true}); err != nil {
 		return err
 	}
 	return nil
 }
 
 func registerJira(r tools.Registry, sm domain_security.Manager, client tools.HTTPClient) error {
-	m, err := newjiraManager(sm, client)
+	m, err := atlassian.NewJiraManager(sm, client)
 	if err != nil {
 		// Skip registration gracefully if configuration is missing.
 		return nil
@@ -281,7 +283,7 @@ func registerJira(r tools.Registry, sm domain_security.Manager, client tools.HTT
 			},
 			Required: []string{"jql"},
 		},
-	}, m.jiraSearchIssues); err != nil {
+	}, m.JiraSearchIssues); err != nil {
 		return err
 	}
 
@@ -298,21 +300,21 @@ func registerJira(r tools.Registry, sm domain_security.Manager, client tools.HTT
 			},
 			Required: []string{"issue_key"},
 		},
-	}, m.jiraGetIssue); err != nil {
+	}, m.JiraGetIssue); err != nil {
 		return err
 	}
 	return nil
 }
 
 func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client tools.HTTPClient) error {
-	var opts []adoOption
+	var opts []ado.AdoOption
 	if client != nil {
-		opts = append(opts, withHTTPClient(client))
+		opts = append(opts, ado.WithHTTPClient(client))
 	}
 	if token := os.Getenv("AZURE_PAT_ALL"); token != "" {
-		opts = append(opts, withToken(token))
+		opts = append(opts, ado.WithToken(token))
 	}
-	m := newADOManager(sm, opts...)
+	m := ado.NewADOManager(sm, opts...)
 
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration
@@ -336,7 +338,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.adoGetPullRequest,
+			handler: m.AdoGetPullRequest,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -354,7 +356,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository"},
 				},
 			},
-			handler: m.adoListPullRequests,
+			handler: m.AdoListPullRequests,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -371,7 +373,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.adoGetPrDiff,
+			handler: m.AdoGetPrDiff,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -388,7 +390,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.adoGetPrThreads,
+			handler: m.AdoGetPrThreads,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -406,7 +408,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "path"},
 				},
 			},
-			handler: m.adoGetFileContent,
+			handler: m.AdoGetFileContent,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -425,7 +427,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository"},
 				},
 			},
-			handler: m.adoListRepositoryItems,
+			handler: m.AdoListRepositoryItems,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -440,7 +442,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project"},
 				},
 			},
-			handler: m.adoListPipelines,
+			handler: m.AdoListPipelines,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -459,7 +461,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project"},
 				},
 			},
-			handler: m.adoListPipelineRuns,
+			handler: m.AdoListPipelineRuns,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -476,7 +478,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "pipeline_id", "run_id"},
 				},
 			},
-			handler: m.adoGetPipelineRun,
+			handler: m.AdoGetPipelineRun,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -492,7 +494,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "pipeline_id"},
 				},
 			},
-			handler: m.adoGetPipelineDefinition,
+			handler: m.AdoGetPipelineDefinition,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -516,7 +518,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "pipeline_id", "run_id"},
 				},
 			},
-			handler: m.adoGetPipelineLogs,
+			handler: m.AdoGetPipelineLogs,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -533,7 +535,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.adoGetPrStatuses,
+			handler: m.AdoGetPrStatuses,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -550,7 +552,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.adoGetPrPolicyEvaluations,
+			handler: m.AdoGetPrPolicyEvaluations,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -567,7 +569,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "repository", "branch_name"},
 				},
 			},
-			handler: m.adoListBranchPolicies,
+			handler: m.AdoListBranchPolicies,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -583,7 +585,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "build_id"},
 				},
 			},
-			handler: m.adoGetBuildTimeline,
+			handler: m.AdoGetBuildTimeline,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -606,7 +608,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "build_id", "log_id"},
 				},
 			},
-			handler: m.adoGetTaskLog,
+			handler: m.AdoGetTaskLog,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -623,7 +625,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "build_id"},
 				},
 			},
-			handler: m.adoGetBuildChanges,
+			handler: m.AdoGetBuildChanges,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -640,7 +642,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "definition_id", "variables"},
 				},
 			},
-			handler: m.adoUpdateBuildDefinitionVariables,
+			handler: m.AdoUpdateBuildDefinitionVariables,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -660,7 +662,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "name", "repository_id", "yaml_path"},
 				},
 			},
-			handler: m.adoCreatePipeline,
+			handler: m.AdoCreatePipeline,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -679,7 +681,7 @@ func registerAzureDevOps(r tools.Registry, sm domain_security.Manager, client to
 					Required: []string{"organization", "project", "pipeline_id"},
 				},
 			},
-			handler: m.adoRunPipeline,
+			handler: m.AdoRunPipeline,
 		},
 	}
 

--- a/tests/integration/agent/session/spinner_integration_test.go
+++ b/tests/integration/agent/session/spinner_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	sessionui "github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
@@ -196,13 +197,13 @@ func TestSpinner_ContextTimeout_Resilience(t *testing.T) {
 	uiRenderer.SetForceSpinner(true)
 
 	// Create bridge with a long-lived context
-	bridge := session.NewUIBridge(uiRenderer,
-		session.WithBridgeThoughts(true),
-		session.WithBridgeTools(true),
-		session.WithBridgeRawOutput(false),
-		session.WithBridgeColor(true),
-		session.WithBridgeLogFile("log.txt"),
-		session.WithBridgeLogger(slog.Default()),
+	bridge := sessionui.NewBridge(uiRenderer,
+		sessionui.WithBridgeThoughts(true),
+		sessionui.WithBridgeTools(true),
+		sessionui.WithBridgeRawOutput(false),
+		sessionui.WithBridgeColor(true),
+		sessionui.WithBridgeLogFile("log.txt"),
+		sessionui.WithBridgeLogger(slog.Default()),
 	)
 	sessionCtx, sessionCancel := context.WithCancel(context.Background())
 	t.Cleanup(sessionCancel)


### PR DESCRIPTION
Closes #101

## Summary

Continues the sub-package extraction pattern established by PR #98 (session/context). Three new sub-packages created:

### `integrations/ado/` (11 files)
- 5 source + 6 test files moved from `integrations/`
- `adoManager` → `AdoManager`, drop `azure_devops_` filename prefix
- Constructors + handler methods exported for `registration.go`

### `integrations/atlassian/` (6 files)
- 3 source + 3 test files moved from `integrations/`
- `atlassian_common.go` → `provider.go`
- `AtlassianProvider`, `ConfluenceManager`, `JiraManager` exported

### `session/ui/` (14 files)
- 5 source + 9 test files moved from `session/`
- `UIBridge` → `Bridge` (package name provides namespace)
- Drop `ui_bridge_` filename prefix

## Verification
- ✅ `go build ./...`
- ✅ `go test ./internal/tools/integrations/...` — all 3 packages
- ✅ `go test ./internal/agent/session/...` — all 3 packages
- ✅ `go test ./...` — full suite
- ✅ `golangci-lint run` — clean
- ✅ `verify_architecture` — clean
- ✅ `verify_release_readiness` — READY FOR RELEASE
- ✅ `make fmt` — clean
- ✅ ADR-027 documenting rationale

## Commits
10 incremental commits following the move-then-export-then-wire pattern.