### PR TITLE
[TECHNICAL DEBT] Decouple astCache from implicit global working directory (fixes #108)

### DIFF
--- a/docs/adr/2026-05-astcache-path-resolution.md
+++ b/docs/adr/2026-05-astcache-path-resolution.md
@@ -1,0 +1,95 @@
+# ADR-022: astCache path resolution via injected baseDir
+
+**Status:** Accepted
+**Date:** 2026-05
+**Deciders:** Architect, Coder
+**Supersedes:** N/A
+**Superseded by:** N/A
+**Related:** Issue #108
+
+## Context
+
+`astCache` was implicitly coupled to the process-global current working
+directory (`os.Getwd()`). Every call to `os.Stat(path)`, `parser.ParseFile`,
+and every cache key (map, FIFO order, singleflight) used caller-supplied
+paths directly. When callers passed relative paths — which all 5 production
+call sites did — correctness depended on the unsynchronized, mutable
+`os.Getwd()`.
+
+This forced tests to use `os.Chdir()`, which is process-global and
+non-parallelizable. It also blocked future concurrent multi-repository
+analysis from a single process.
+
+## Decision
+
+**`astCache` receives a `baseDir string` at construction time. All path
+resolution happens inside the cache via a single `absPath` helper. Callers
+continue to pass paths as-is and remain agnostic of the root.**
+
+### Resolution rules (implemented in `absPath`)
+
+1. If `baseDir` is empty: path is used as-is (backward compat for
+   zero-value construction).
+2. If the caller-supplied path is already absolute (`filepath.IsAbs`):
+   path passes through unchanged.
+3. Otherwise: `filepath.Join(baseDir, path)` produces the absolute path
+   used for all I/O and cache keys.
+
+### Affected methods
+
+| Method | Resolution point |
+|---|---|
+| `Get(path)` | Resolves at top; `abs` used for `getValidEntry`, `os.Stat`, `parser.ParseFile`, `singleflight.Do`, `updateCache` |
+| `GetCachedLineCount(path, info)` | Resolves before cache lookup |
+| `GetFileSkeletonGo(filePath)` | Resolves before calling `Get` |
+| `getValidEntry(path)` | Internal; resolves on entry |
+| `updateCache(path, ...)` | Internal; resolves on entry |
+
+### Composition root
+
+`registration.go` injects `"."` — matching the existing `newIndexer(".")`
+pattern. Tests that need a different root construct `newASTCache(tmpDir)`.
+
+### Caller contract
+
+Callers SHOULD pass paths relative to the cache's `baseDir`. Callers MAY
+pass absolute paths (e.g., from `SP.IsPathSafe`) — these are explicitly
+supported via the pass-through rule in `absPath`.
+
+## Consequences
+
+### Positive
+
+- **No `os.Chdir` in any test.** `t.Parallel()` is restored everywhere.
+- **Single point of resolution.** Adding a new analyzer or cache method
+  cannot accidentally reintroduce `os.Getwd()` coupling.
+- **Multi-repository analysis is unblocked.** Two `astCache` instances
+  with different `baseDir` values can operate independently.
+- **Cache key stability.** All keys are absolute paths, eliminating
+  collision risk between same-named files in different directories.
+
+### Negative
+
+- **One additional field on `astCache`.** Negligible.
+- **Callers passing already-absolute paths rely on pass-through behavior**
+  which is documented but less explicit than stripping the prefix.
+  Mitigated by the `absPath` helper being the single choke-point.
+
+## Alternatives Considered
+
+1. **Per-consumer `BaseDir` (issue #107).** Every call site joins paths
+   before calling the cache. Rejected: violates DRY; the cache itself
+   remains globally-coupled; must replicate at every current and future
+   call site.
+2. **`fs.FS` abstraction.** Premature. `parser.ParseFile` supports
+   `fs.FS`, but cache invalidation via `ModTime()` has inconsistent
+   semantics across virtual filesystems. Defer until a concrete
+   sandboxing requirement appears.
+
+## Compliance
+
+- `go test -race -count=10 ./internal/tools/analysis/...` must pass
+  cleanly on every commit touching `astCache`.
+- New callers of `astCache` methods must pass paths consistent with
+  the contract documented in this ADR.
+- Any future change to path-resolution semantics requires an ADR update.

--- a/internal/tools/analysis/astutil.go
+++ b/internal/tools/analysis/astutil.go
@@ -352,8 +352,7 @@ func findTypeSpec(f *ast.File, name string) (*ast.TypeSpec, *ast.GenDecl) {
 // GetFileSkeletonGo extracts exported types and function signatures from a Go file.
 // filePath must be relative to the cache's baseDir.
 func (c *astCache) GetFileSkeletonGo(filePath string) (string, error) {
-	abs := c.absPath(filePath)
-	f, fset, err := c.Get(abs)
+	f, fset, err := c.Get(filePath) // Get is the single resolution point per ADR-022
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/analysis/astutil.go
+++ b/internal/tools/analysis/astutil.go
@@ -11,6 +11,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -28,6 +29,7 @@ type cachedFile struct {
 }
 
 type astCache struct {
+	baseDir string // injected once; all paths resolved relative to this root
 	mu      sync.RWMutex
 	files   map[string]cachedFile
 	order   []string
@@ -35,12 +37,20 @@ type astCache struct {
 	maxSize int
 }
 
-func newASTCache() *astCache {
+func newASTCache(baseDir string) *astCache {
 	return &astCache{
+		baseDir: baseDir,
 		files:   make(map[string]cachedFile),
 		order:   make([]string, 0),
 		maxSize: 1000,
 	}
+}
+
+func (c *astCache) absPath(relPath string) string {
+	if c.baseDir == "" || filepath.IsAbs(relPath) {
+		return relPath
+	}
+	return filepath.Join(c.baseDir, relPath)
 }
 
 func (cf cachedFile) isValid(info os.FileInfo) bool {
@@ -48,10 +58,10 @@ func (cf cachedFile) isValid(info os.FileInfo) bool {
 }
 
 func (c *astCache) GetCachedLineCount(path string, info os.FileInfo) (int, bool) {
+	abs := c.absPath(path)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-
-	entry, ok := c.files[path]
+	entry, ok := c.files[abs]
 	if ok && entry.isValid(info) {
 		return entry.lineCount, true
 	}
@@ -59,28 +69,25 @@ func (c *astCache) GetCachedLineCount(path string, info os.FileInfo) (int, bool)
 }
 
 func (c *astCache) getValidEntry(path string) (cachedFile, bool) {
+	abs := c.absPath(path)
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-
-	entry, ok := c.files[path]
+	entry, ok := c.files[abs]
 	if !ok {
 		return cachedFile{}, false
 	}
-
-	info, err := os.Stat(path)
+	info, err := os.Stat(abs)
 	if err != nil || !entry.modTime.Equal(info.ModTime()) {
 		return cachedFile{}, false
 	}
-
 	return entry, true
 }
 
 func (c *astCache) updateCache(path string, info os.FileInfo, f *ast.File, fset *token.FileSet) cachedFile {
+	abs := c.absPath(path)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-
-	_, exists := c.files[path]
-
+	_, exists := c.files[abs]
 	// Eviction policy: FIFO
 	if !exists && len(c.files) >= c.maxSize {
 		if len(c.order) > 0 {
@@ -89,53 +96,45 @@ func (c *astCache) updateCache(path string, info os.FileInfo, f *ast.File, fset 
 			delete(c.files, victim)
 		}
 	}
-
 	newEntry := cachedFile{
 		file:    f,
 		fset:    fset,
 		modTime: info.ModTime(),
 	}
-
 	if fset != nil && f != nil {
 		if tf := fset.File(f.Pos()); tf != nil {
 			newEntry.lineCount = tf.LineCount()
 		}
 	}
-
-	c.files[path] = newEntry
+	c.files[abs] = newEntry
 	if !exists {
-		c.order = append(c.order, path)
+		c.order = append(c.order, abs)
 	}
 	return newEntry
 }
 
 func (c *astCache) Get(path string) (*ast.File, *token.FileSet, error) {
+	abs := c.absPath(path)
 	// 1. Fast path: Check cache
-	if entry, ok := c.getValidEntry(path); ok {
+	if entry, ok := c.getValidEntry(abs); ok {
 		return entry.file, entry.fset, nil
 	}
-
-	// 2. Slow path: Use singleflight to deduplicate concurrent requests for the same path
-	res, err, _ := c.sf.Do(path, func() (interface{}, error) {
-		info, err := os.Stat(path)
+	// 2. Slow path: singleflight with absolute key
+	res, err, _ := c.sf.Do(abs, func() (interface{}, error) {
+		info, err := os.Stat(abs)
 		if err != nil {
 			return nil, err
 		}
-
-		// Parse using a local FileSet to allow full concurrency across DIFFERENT files.
 		fset := token.NewFileSet()
-		f, err := parser.ParseFile(fset, path, nil, parser.ParseComments)
+		f, err := parser.ParseFile(fset, abs, nil, parser.ParseComments)
 		if err != nil {
 			return nil, err
 		}
-
-		return c.updateCache(path, info, f, fset), nil
+		return c.updateCache(abs, info, f, fset), nil
 	})
-
 	if err != nil {
 		return nil, nil, err
 	}
-
 	cf := res.(cachedFile)
 	return cf.file, cf.fset, nil
 }
@@ -351,8 +350,10 @@ func findTypeSpec(f *ast.File, name string) (*ast.TypeSpec, *ast.GenDecl) {
 }
 
 // GetFileSkeletonGo extracts exported types and function signatures from a Go file.
+// filePath must be relative to the cache's baseDir.
 func (c *astCache) GetFileSkeletonGo(filePath string) (string, error) {
-	f, fset, err := c.Get(filePath)
+	abs := c.absPath(filePath)
+	f, fset, err := c.Get(abs)
 	if err != nil {
 		return "", err
 	}

--- a/internal/tools/analysis/astutil_race_test.go
+++ b/internal/tools/analysis/astutil_race_test.go
@@ -11,7 +11,7 @@ import (
 func TestASTCache_Concurrency_Race(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache := newASTCache()
+	cache := newASTCache(".")
 	numFiles := 10
 	files := make([]string, numFiles)
 	for i := 0; i < numFiles; i++ {

--- a/internal/tools/analysis/astutil_race_test.go
+++ b/internal/tools/analysis/astutil_race_test.go
@@ -11,12 +11,12 @@ import (
 func TestASTCache_Concurrency_Race(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	cache := newASTCache(".")
+	cache := newASTCache(tmpDir)
 	numFiles := 10
 	files := make([]string, numFiles)
 	for i := 0; i < numFiles; i++ {
-		path := filepath.Join(tmpDir, fmt.Sprintf("file%d.go", i))
-		if err := os.WriteFile(path, []byte(fmt.Sprintf("package p%d\nfunc F%d() {}\n", i, i)), 0644); err != nil {
+		path := fmt.Sprintf("file%d.go", i)
+		if err := os.WriteFile(filepath.Join(tmpDir, path), []byte(fmt.Sprintf("package p%d\nfunc F%d() {}\n", i, i)), 0644); err != nil {
 			t.Fatal(err)
 		}
 		files[i] = path

--- a/internal/tools/analysis/astutil_test.go
+++ b/internal/tools/analysis/astutil_test.go
@@ -223,7 +223,7 @@ func TestASTCache(t *testing.T) {
 }
 
 func testASTCacheGet(t *testing.T, path string) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 	f, _, err := cache.Get(path)
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
@@ -234,7 +234,7 @@ func testASTCacheGet(t *testing.T, path string) {
 }
 
 func testASTCacheHit(t *testing.T, path string) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 	f1, fset1, err := cache.Get(path)
 	if err != nil {
 		t.Fatal(err)
@@ -249,7 +249,7 @@ func testASTCacheHit(t *testing.T, path string) {
 }
 
 func testASTCacheInvalidation(t *testing.T, path string) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 
 	// Set initial time
 	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -281,7 +281,7 @@ func testASTCacheInvalidation(t *testing.T, path string) {
 }
 
 func testASTCacheNonExistent(t *testing.T) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 	_, _, err := cache.Get("non_existent.go")
 	if err == nil {
 		t.Error("expected error for non-existent file")
@@ -289,7 +289,7 @@ func testASTCacheNonExistent(t *testing.T) {
 }
 
 func testASTCacheSyntaxError(t *testing.T, tmpDir string) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 	invalidPath := filepath.Join(tmpDir, "invalid.go")
 	if err := os.WriteFile(invalidPath, []byte("package"), 0644); err != nil {
 		t.Fatal(err)
@@ -301,7 +301,7 @@ func testASTCacheSyntaxError(t *testing.T, tmpDir string) {
 }
 
 func testASTCacheEviction(t *testing.T, tmpDir string) {
-	cache := newASTCache()
+	cache := newASTCache(".")
 	cache.maxSize = 2
 
 	files := []string{
@@ -358,7 +358,7 @@ func unexportedFunc() {}
 		t.Fatal(err)
 	}
 
-	cache := newASTCache()
+	cache := newASTCache(".")
 	skeleton, err := cache.GetFileSkeletonGo(path)
 	if err != nil {
 		t.Fatalf("GetFileSkeletonGo failed: %v", err)
@@ -391,7 +391,7 @@ func TestGetCachedLineCount(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cache := newASTCache()
+	cache := newASTCache(".")
 
 	// 1. Set specific time
 	t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -442,7 +442,7 @@ func TestASTCache_DeterministicEviction(t *testing.T) {
 
 	// Repeat 100 times to ensure determinism
 	for i := 0; i < 100; i++ {
-		cache := newASTCache()
+		cache := newASTCache(".")
 		cache.maxSize = 2
 
 		f1 := filepath.Join(tmpDir, "f1.go")

--- a/internal/tools/analysis/changes_test.go
+++ b/internal/tools/analysis/changes_test.go
@@ -17,7 +17,7 @@ func TestChangeAnalyzer_SemanticDiff(t *testing.T) {
 	setupSemanticDiffFile(t, tmpDir, relPath)
 
 	mockExec := setupSemanticDiffMock(relPath)
-	cache := newASTCache()
+	cache := newASTCache(".")
 
 	oldDir := changeToTempDir(t, tmpDir)
 	defer restoreDir(t, oldDir)

--- a/internal/tools/analysis/changes_test.go
+++ b/internal/tools/analysis/changes_test.go
@@ -9,18 +9,13 @@ import (
 )
 
 func TestChangeAnalyzer_SemanticDiff(t *testing.T) {
-	// NOTE: NOT parallel – this test calls os.Chdir(), which mutates
-	// process-global state and would race with any other test that
-	// depends on the current working directory (e.g., packages.Load).
+	t.Parallel()
 	tmpDir := t.TempDir()
 	relPath := "test.go"
 	setupSemanticDiffFile(t, tmpDir, relPath)
 
 	mockExec := setupSemanticDiffMock(relPath)
-	cache := newASTCache(".")
-
-	oldDir := changeToTempDir(t, tmpDir)
-	defer restoreDir(t, oldDir)
+	cache := newASTCache(tmpDir)
 
 	analyzer := newChangeAnalyzer(cache, mockExec)
 	res, err := analyzer.SemanticDiff(context.Background(), map[string]interface{}{"target": "HEAD~1"}, nil)
@@ -59,23 +54,6 @@ func setupSemanticDiffMock(relPath string) *mockExecutor {
 			}
 			return nil, nil
 		},
-	}
-}
-
-func changeToTempDir(t *testing.T, tmpDir string) string {
-	oldDir, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatal(err)
-	}
-	return oldDir
-}
-
-func restoreDir(t *testing.T, oldDir string) {
-	if err := os.Chdir(oldDir); err != nil {
-		t.Errorf("failed to restore working directory: %v", err)
 	}
 }
 

--- a/internal/tools/analysis/complexity_test.go
+++ b/internal/tools/analysis/complexity_test.go
@@ -26,7 +26,7 @@ func Complex(a, b bool) {
 		t.Fatal(err)
 	}
 
-	cache := newASTCache()
+	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 	analyzer := newComplexityAnalyzer(cache, sp)
 
@@ -57,7 +57,7 @@ func C() {} // 1
 		t.Fatal(err)
 	}
 
-	cache := newASTCache()
+	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 	analyzer := newComplexityAnalyzer(cache, sp)
 

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -140,7 +140,7 @@ func TestHealthManager_GetCodeHealth(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	idx, _ := newIndexer(".")
-	cache := newASTCache()
+	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
 	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem())
@@ -173,7 +173,7 @@ func TestHealthManager_GetCodeHealth_Cancelled(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	idx, _ := newIndexer(".")
-	cache := newASTCache()
+	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
 	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem())

--- a/internal/tools/analysis/info.go
+++ b/internal/tools/analysis/info.go
@@ -60,6 +60,8 @@ func (m *infoManager) recordGoStats(ctx context.Context, path string, info os.Fi
 	var loc int
 	var ok bool
 	if m.Cache != nil {
+		// path is from filepath.Walk, rooted at "." — matches cache.baseDir.
+		// absPath resolves it to absolute internally.
 		loc, ok = m.Cache.GetCachedLineCount(path, info)
 	}
 
@@ -268,6 +270,8 @@ func (m *infoManager) GetFileSkeleton(ctx context.Context, args map[string]inter
 
 	var res tools.ToolResult
 	if filepath.Ext(path) == ".go" {
+		// path is absolute from IsPathSafe. absPath inside the cache
+		// detects absolute paths and passes them through unchanged.
 		skeleton, err := m.Cache.GetFileSkeletonGo(path)
 		if err == nil {
 			res = tools.ToolResult{Text: skeleton}

--- a/internal/tools/analysis/manager_test.go
+++ b/internal/tools/analysis/manager_test.go
@@ -21,7 +21,7 @@ func setupAnalysisManager(t *testing.T) (*analysisManager, string) {
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	cache := newASTCache()
+	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 
 	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem())

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -15,7 +15,7 @@ import (
 // Register adds all consolidated analysis tools to the registry.
 func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem) (tools.ToolFunc, error) {
 	idx, _ := newIndexer(".")
-	cache := newASTCache()
+	cache := newASTCache(".")
 	m := newAnalysisManager(idx, cache, sm, bus, executor, fs)
 
 	type toolSpec struct {

--- a/internal/tools/analysis/types_test.go
+++ b/internal/tools/analysis/types_test.go
@@ -87,7 +87,7 @@ type I2 interface {
 			}
 
 			idx, _ := newIndexer(tmpDir)
-			cache := newASTCache()
+			cache := newASTCache(".")
 			sp := &mockSecurityProvider{}
 			m := newTypeManager(idx, cache, sp)
 
@@ -122,7 +122,7 @@ func (s S) M() {}
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	m := newTypeManager(idx, newASTCache(), &mockSecurityProvider{})
+	m := newTypeManager(idx, newASTCache("."), &mockSecurityProvider{})
 
 	res, err := m.ListImplementations(context.Background(), map[string]interface{}{"interface_name": "I"}, nil)
 	if err != nil {
@@ -150,7 +150,7 @@ const C = 1
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	m := newTypeManager(idx, newASTCache(), &mockSecurityProvider{})
+	m := newTypeManager(idx, newASTCache("."), &mockSecurityProvider{})
 	res, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": tmpDir}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +179,7 @@ func F() {
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	m := newTypeManager(idx, newASTCache(), &mockSecurityProvider{})
+	m := newTypeManager(idx, newASTCache("."), &mockSecurityProvider{})
 	res, err := m.FindUsages(context.Background(), map[string]interface{}{"path": tmpDir, "query": "F"}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -204,7 +204,7 @@ func MyFunc() {}
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	m := newTypeManager(idx, newASTCache(), &mockSecurityProvider{})
+	m := newTypeManager(idx, newASTCache("."), &mockSecurityProvider{})
 	res, err := m.FindDefinitions(context.Background(), map[string]interface{}{"path": tmpDir, "query": "MyFunc"}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -231,7 +231,7 @@ func TestTypeManager_ListImplementations_Error(t *testing.T) {
 func TestComplexityAnalyzer_Analyze_Empty(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
-	analyzer := newComplexityAnalyzer(newASTCache(), &mockSecurityProvider{})
+	analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{})
 	res, err := analyzer.Analyze(context.Background(), map[string]interface{}{"path": tmpDir}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -256,7 +256,7 @@ func unexported() {}
 	}
 
 	idx, _ := newIndexer(tmpDir)
-	m := newTypeManager(idx, newASTCache(), &mockSecurityProvider{})
+	m := newTypeManager(idx, newASTCache("."), &mockSecurityProvider{})
 	res, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": tmpDir, "exported_only": true}, nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## Summary

Eliminates the implicit coupling between `astCache` and `os.Getwd()` by injecting a `baseDir` at construction time. All path resolution now happens inside the cache via a single `absPath` helper. Callers continue to pass paths as-is and remain agnostic of the root.

Fixes #108. Supersedes #107.

## Changes

### Phase A — Mechanical (`ef60cc7f`)
- Add `baseDir string` field to `astCache` struct
- Change constructor to `newASTCache(baseDir string)`
- Add `absPath` helper with three resolution rules (empty, absolute, relative)
- Resolve paths in all 5 cache methods: `Get`, `GetCachedLineCount`, `GetFileSkeletonGo`, `getValidEntry`, `updateCache`
- All cache keys (map, FIFO order, singleflight) now use absolute paths
- Update 1 production + 23 test call sites: `newASTCache(".")`

### Phase B — Behavioral fix (`ead3458c`)
- `TestChangeAnalyzer_SemanticDiff`: inject `newASTCache(tmpDir)` instead of `os.Chdir()`
- Delete `changeToTempDir` / `restoreDir` helper functions
- Restore `t.Parallel()`

### Phase C — Cleanup (`b871dfb3`)
- Document collision points in `info.go` (Walk paths and IsPathSafe pass-through)
- Migrate `astutil_race_test.go` to `newASTCache(tmpDir)` + relative paths
- Add ADR-022 documenting the path-resolution policy

## Verification

```
go build ./...
go test -race -count=10 ./internal/tools/analysis/...
```

All 10 runs pass cleanly. Zero remaining `os.Chdir` references in the analysis package.