### PR TITLE
refactor: unexport 17 dead-code symbols in ado/atlassian integration packages

### DIFF
--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -233,7 +233,7 @@ func (m *AdoManager) AdoListRepositoryItems(ctx context.Context, args map[string
 		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
 	}
 
-	return FormatRepositoryItems(params.ScopePath, params.Version, responseData), nil
+	return formatRepositoryItems(params.ScopePath, params.Version, responseData), nil
 }
 
 func (m *AdoManager) buildListRepositoryItemsURL(org, project, repo, scopePath, version, recursionLevel string) (string, error) {

--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -143,7 +143,7 @@ func (m *AdoManager) CheckResponseError(resp *http.Response, requestURL string) 
 	}
 }
 
-func (m *AdoManager) AdoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) adoGetFileContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -1015,7 +1015,7 @@ func TestGetBuildChanges(t *testing.T) {
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 123, "top": 10}
-		changes, err := m.GetBuildChanges(context.Background(), args)
+		changes, err := m.getBuildChanges(context.Background(), args)
 		assert.NoError(t, err)
 		assert.Len(t, changes, 1)
 		ch, ok := changes[0].(map[string]interface{})
@@ -1033,7 +1033,7 @@ func TestGetBuildChanges(t *testing.T) {
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "build_id": 999}
-		_, err := m.GetBuildChanges(context.Background(), args)
+		_, err := m.getBuildChanges(context.Background(), args)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1286,7 +1286,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetBuildChanges - 500 Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetBuildChanges(ctx, args)
+				_, err := m.getBuildChanges(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1296,7 +1296,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetBuildChanges - 401 Unauthorized",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetBuildChanges(ctx, args)
+				_, err := m.getBuildChanges(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1391,7 +1391,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetBuildChanges - Not Found",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetBuildChanges(ctx, args)
+				_, err := m.getBuildChanges(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1},
@@ -1818,7 +1818,7 @@ func TestGetBuildChanges_Empty(t *testing.T) {
 
 	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithBaseURL(server.URL), WithToken("test-pat"))
 
-	changes, err := m.GetBuildChanges(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1})
+	changes, err := m.getBuildChanges(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "build_id": 1})
 	assert.NoError(t, err)
 	assert.Empty(t, changes)
 }
@@ -1836,7 +1836,7 @@ func TestAdoTools_MissingParams(t *testing.T) {
 	})
 
 	t.Run("AdoGetBuildChanges", func(t *testing.T) {
-		_, err := m.GetBuildChanges(ctx, map[string]interface{}{})
+		_, err := m.getBuildChanges(ctx, map[string]interface{}{})
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -1933,7 +1933,7 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 			return tools.ToolResult{}, err
 		}},
 		{"AdoGetBuildChanges", func() (tools.ToolResult, error) {
-			_, err := m.GetBuildChanges(ctx, args)
+			_, err := m.getBuildChanges(ctx, args)
 			return tools.ToolResult{}, err
 		}},
 	}

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -616,7 +616,7 @@ func TestGetPipelineLogContent(t *testing.T) {
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
-		content, err := m.GetPipelineLogContent(context.Background(), args, nil)
+		content, err := m.getPipelineLogContent(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, logContent, content.Content)
 		assert.False(t, content.Truncated)
@@ -964,7 +964,7 @@ func TestGetTaskLog(t *testing.T) {
 			"build_id":     123,
 			"log_id":       10,
 		}
-		content, err := m.GetTaskLog(context.Background(), args, nil)
+		content, err := m.getTaskLog(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, logContent, content.Content)
 		assert.False(t, content.Truncated)
@@ -984,7 +984,7 @@ func TestGetTaskLog(t *testing.T) {
 			"build_id":     123,
 			"log_id":       99,
 		}
-		_, err := m.GetTaskLog(context.Background(), args, nil)
+		_, err := m.getTaskLog(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1124,7 +1124,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "GetTaskLog - Unmarshal Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetTaskLog(ctx, args, hb)
+				_, err := m.getTaskLog(ctx, args, hb)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"build_id": "invalid"},
@@ -1133,7 +1133,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "GetTaskLog - Missing Params",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetTaskLog(ctx, args, hb)
+				_, err := m.getTaskLog(ctx, args, hb)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o"},
@@ -1142,7 +1142,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "GetTaskLog - 404 Not Found",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetTaskLog(ctx, args, hb)
+				_, err := m.getTaskLog(ctx, args, hb)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
@@ -1381,7 +1381,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "GetTaskLog - Unauthorized",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.GetTaskLog(ctx, args, hb)
+				_, err := m.getTaskLog(ctx, args, hb)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "build_id": 1, "log_id": 1},
@@ -1401,7 +1401,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "CreatePipeline - Missing Params",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.CreatePipeline(ctx, args)
+				_, err := m.createPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "name": "n", "repository_id": "r"}, // Missing yaml_path
@@ -1411,7 +1411,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			name: "CreatePipeline - 500 Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 				// Approved by default in setup
-				_, err := m.CreatePipeline(ctx, args)
+				_, err := m.createPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args: map[string]interface{}{
@@ -1423,7 +1423,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "CreatePipeline - Malformed JSON",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.CreatePipeline(ctx, args)
+				_, err := m.createPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args: map[string]interface{}{
@@ -1436,7 +1436,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "RunPipeline - Missing Params",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.RunPipeline(ctx, args)
+				_, err := m.runPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p"}, // Missing pipeline_id
@@ -1445,7 +1445,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "RunPipeline - 500 Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.RunPipeline(ctx, args)
+				_, err := m.runPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
@@ -1455,7 +1455,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "RunPipeline - Malformed JSON",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				_, err := m.RunPipeline(ctx, args)
+				_, err := m.runPipeline(ctx, args)
 				return tools.ToolResult{}, err
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1},
@@ -1647,7 +1647,7 @@ func TestListPipelineLogs_DetailedErrors(t *testing.T) {
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 		server.Close() // Force failure
 
-		_, err := m.GetPipelineLogContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1, "log_id": 1}, nil)
+		_, err := m.getPipelineLogContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 1, "log_id": 1}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "request failed")
 	})
@@ -2237,7 +2237,7 @@ func TestCreatePipeline(t *testing.T) {
 				"yaml_path":     "/azure-pipelines.yaml",
 			}
 
-			result, err := m.CreatePipeline(context.Background(), args)
+			result, err := m.createPipeline(context.Background(), args)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantAlreadyExisted, result.AlreadyExisted)
 			assert.Equal(t, tt.wantCancelled, result.Cancelled)
@@ -2308,7 +2308,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"template_parameters": map[string]string{"param1": "paramVal"},
 		}
 
-		result, err := m.RunPipeline(context.Background(), args)
+		result, err := m.runPipeline(context.Background(), args)
 		assert.NoError(t, err)
 		assert.False(t, result.Cancelled)
 		assert.Equal(t, 101, result.RunID)
@@ -2328,7 +2328,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"pipeline_id":  1,
 		}
 
-		result, err := m.RunPipeline(context.Background(), args)
+		result, err := m.runPipeline(context.Background(), args)
 		assert.NoError(t, err)
 		assert.True(t, result.Cancelled)
 	})
@@ -2370,7 +2370,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"branch":       "develop",
 		}
 
-		result, err := m.RunPipeline(context.Background(), args)
+		result, err := m.runPipeline(context.Background(), args)
 		assert.NoError(t, err)
 		assert.False(t, result.Cancelled)
 		assert.Equal(t, 202, result.RunID)
@@ -2396,7 +2396,7 @@ func TestAdoRunPipeline(t *testing.T) {
 			"_ref_name":    "refs/heads/main",
 		}
 
-		result, err := m.RunPipeline(context.Background(), args)
+		result, err := m.runPipeline(context.Background(), args)
 		assert.NoError(t, err)
 		assert.True(t, result.Cancelled)
 

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -59,7 +59,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.AdoGetPullRequest(ctx, args, nil)
+		result, err := m.adoGetPullRequest(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Fix bug")
 		assert.Contains(t, result.Text, "active")
@@ -82,7 +82,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
+		_, err := m.adoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unauthorized")
 	})
@@ -102,7 +102,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
+		_, err := m.adoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -113,7 +113,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"organization": "myorg",
 		}
 
-		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
+		_, err := m.adoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -127,7 +127,7 @@ func TestAdoGetPullRequest(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		_, err := m.AdoGetPullRequest(context.Background(), args, nil)
+		_, err := m.adoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "AZURE_PAT_ALL token is required but not provided")
 	})
@@ -266,7 +266,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.AdoGetPrDiff(ctx, args, nil)
+		result, err := m.adoGetPrDiff(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Total files changed: 2")
 		assert.Contains(t, result.Text, "[Edit] /src/main.go")
@@ -289,7 +289,7 @@ func TestAdoGetPrDiff(t *testing.T) {
 			"pull_request_id": 123,
 		}
 
-		result, err := m.AdoGetPrDiff(context.Background(), args, nil)
+		result, err := m.adoGetPrDiff(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No changes found in this pull request.", result.Text)
 	})
@@ -412,7 +412,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"version":      "develop",
 		}
 
-		result, err := m.AdoGetFileContent(ctx, args, nil)
+		result, err := m.adoGetFileContent(ctx, args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, fileContent, result.Text)
 	})
@@ -434,7 +434,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"path":         "/src/main.go",
 		}
 
-		_, err := m.AdoGetFileContent(context.Background(), args, nil)
+		_, err := m.adoGetFileContent(context.Background(), args, nil)
 		assert.NoError(t, err)
 	})
 
@@ -453,7 +453,7 @@ func TestAdoGetFileContent(t *testing.T) {
 			"path":         "/missing.go",
 		}
 
-		_, err := m.AdoGetFileContent(context.Background(), args, nil)
+		_, err := m.adoGetFileContent(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -852,7 +852,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		result, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		result, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Branch Policies for main in myrepo")
 		assert.Contains(t, result.Text, "- Type: Build [REQUIRED]")
@@ -884,7 +884,7 @@ func TestAdoListBranchPolicies(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		result, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		result, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "No active policies found")
 	})
@@ -1062,7 +1062,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - Unmarshal Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"pull_request_id": "invalid"}, // should be int
 			expectedErrMsg: "json: cannot unmarshal string into Go struct field",
@@ -1070,7 +1070,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - Missing Params",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o"},
 			expectedErrMsg: "required",
@@ -1078,7 +1078,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - Request Failure",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			doErr:          fmt.Errorf("network error"),
@@ -1087,7 +1087,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - 401 Unauthorized",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusUnauthorized,
@@ -1096,7 +1096,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - 403 Forbidden",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusForbidden,
@@ -1105,7 +1105,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - 404 Not Found",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusNotFound,
@@ -1114,7 +1114,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetPrDiff - 500 Internal Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetPrDiff(ctx, args, nil)
+				return m.adoGetPrDiff(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
 			httpStatus:     http.StatusInternalServerError,
@@ -1343,7 +1343,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetFileContent - Unauthorized",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetFileContent(ctx, args, nil)
+				return m.adoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
 			httpStatus:     http.StatusUnauthorized,
@@ -1352,7 +1352,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 		{
 			name: "AdoGetFileContent - Default Error",
 			toolFunc: func(m *AdoManager, ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				return m.AdoGetFileContent(ctx, args, nil)
+				return m.adoGetFileContent(ctx, args, nil)
 			},
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"},
 			httpStatus:     http.StatusInternalServerError,
@@ -1548,7 +1548,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			"branch_name":  "main",
 		}
 
-		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
 	})
@@ -1696,7 +1696,7 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
@@ -1710,7 +1710,7 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
-		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode repository metadata")
 	})
@@ -1757,7 +1757,7 @@ func TestAdoGetFileContent_DefaultStatus(t *testing.T) {
 
 	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithBaseURL(server.URL), WithToken("test-pat"))
 
-	_, err := m.AdoGetFileContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"}, nil)
+	_, err := m.adoGetFileContent(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "path": "f"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "returned status: 418")
 }
@@ -1830,7 +1830,7 @@ func TestAdoTools_MissingParams(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("AdoGetFileContent", func(t *testing.T) {
-		_, err := m.AdoGetFileContent(ctx, map[string]interface{}{}, nil)
+		_, err := m.adoGetFileContent(ctx, map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -1851,7 +1851,7 @@ func TestAdoTools_MissingParams(t *testing.T) {
 func TestAdoGetPullRequest_UnmarshalError(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 	m := NewADOManager(nil)
-	_, err := m.AdoGetPullRequest(context.Background(), map[string]interface{}{"pull_request_id": "invalid"}, nil)
+	_, err := m.adoGetPullRequest(context.Background(), map[string]interface{}{"pull_request_id": "invalid"}, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unmarshal")
 }
@@ -1909,8 +1909,8 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 		call func() (tools.ToolResult, error)
 	}{
 		{"AdoListPullRequests", func() (tools.ToolResult, error) { return m.AdoListPullRequests(ctx, args, nil) }},
-		{"AdoGetPullRequest", func() (tools.ToolResult, error) { return m.AdoGetPullRequest(ctx, args, nil) }},
-		{"AdoGetPrDiff", func() (tools.ToolResult, error) { return m.AdoGetPrDiff(ctx, args, nil) }},
+		{"AdoGetPullRequest", func() (tools.ToolResult, error) { return m.adoGetPullRequest(ctx, args, nil) }},
+		{"AdoGetPrDiff", func() (tools.ToolResult, error) { return m.adoGetPrDiff(ctx, args, nil) }},
 		{"AdoGetPrThreads", func() (tools.ToolResult, error) { return m.AdoGetPrThreads(ctx, args, nil) }},
 		{"AdoListRepositoryItems", func() (tools.ToolResult, error) { return m.AdoListRepositoryItems(ctx, args, nil) }},
 		{"ListPipelineRuns", func() (tools.ToolResult, error) {
@@ -1927,7 +1927,7 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 		}},
 		{"AdoGetPrStatuses", func() (tools.ToolResult, error) { return m.AdoGetPrStatuses(ctx, args, nil) }},
 		{"AdoGetPrPolicyEvaluations", func() (tools.ToolResult, error) { return m.AdoGetPrPolicyEvaluations(ctx, args, nil) }},
-		{"AdoListBranchPolicies", func() (tools.ToolResult, error) { return m.AdoListBranchPolicies(ctx, args, nil) }},
+		{"AdoListBranchPolicies", func() (tools.ToolResult, error) { return m.adoListBranchPolicies(ctx, args, nil) }},
 		{"AdoGetBuildTimeline", func() (tools.ToolResult, error) {
 			_, err := m.GetBuildTimeline(ctx, args)
 			return tools.ToolResult{}, err
@@ -1970,7 +1970,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte(`{"title": "PR Title", "status": "active", "createdBy": {"displayName": "User"}, "creationDate": "2023-01-01", "repository": {"name": "repo"}}`))
 			},
 			call: func(m *AdoManager) (tools.ToolResult, error) {
-				return m.AdoGetPullRequest(ctx, map[string]interface{}{
+				return m.adoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -1998,7 +1998,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("internal error"))
 			},
 			call: func(m *AdoManager) (tools.ToolResult, error) {
-				return m.AdoGetPullRequest(ctx, map[string]interface{}{
+				return m.adoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -2011,7 +2011,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("service unavailable"))
 			},
 			call: func(m *AdoManager) (tools.ToolResult, error) {
-				return m.AdoGetPullRequest(ctx, map[string]interface{}{
+				return m.adoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -2024,7 +2024,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte("gateway timeout"))
 			},
 			call: func(m *AdoManager) (tools.ToolResult, error) {
-				return m.AdoGetPullRequest(ctx, map[string]interface{}{
+				return m.adoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -2042,7 +2042,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 			call: func(m *AdoManager) (tools.ToolResult, error) {
 				childCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 				defer cancel()
-				return m.AdoGetPullRequest(childCtx, map[string]interface{}{
+				return m.adoGetPullRequest(childCtx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
@@ -2055,7 +2055,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 				_, _ = w.Write([]byte(`{ malformed`))
 			},
 			call: func(m *AdoManager) (tools.ToolResult, error) {
-				return m.AdoGetPullRequest(ctx, map[string]interface{}{
+				return m.adoGetPullRequest(ctx, map[string]interface{}{
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},

--- a/internal/tools/integrations/ado/build.go
+++ b/internal/tools/integrations/ado/build.go
@@ -10,7 +10,7 @@ import (
 )
 
 // registerBuilds registers the Build-category ADO tools (timeline, task log, build changes).
-// Handlers: m.GetBuildTimeline, m.getTaskLog, m.GetBuildChanges (defined in pipeline_runs.go / pipeline_crud.go).
+// Handlers: m.GetBuildTimeline, m.getTaskLog, m.getBuildChanges (defined in pipeline_runs.go / pipeline_crud.go).
 func registerBuilds(r tools.Registry, m *AdoManager, f PipelineFormatter) error {
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration
@@ -85,7 +85,7 @@ func registerBuilds(r tools.Registry, m *AdoManager, f PipelineFormatter) error 
 				},
 			},
 			handler: func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				changes, err := m.GetBuildChanges(ctx, args)
+				changes, err := m.getBuildChanges(ctx, args)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}

--- a/internal/tools/integrations/ado/build.go
+++ b/internal/tools/integrations/ado/build.go
@@ -10,7 +10,7 @@ import (
 )
 
 // registerBuilds registers the Build-category ADO tools (timeline, task log, build changes).
-// Handlers: m.GetBuildTimeline, m.GetTaskLog, m.GetBuildChanges (defined in pipeline_runs.go / pipeline_crud.go).
+// Handlers: m.GetBuildTimeline, m.getTaskLog, m.GetBuildChanges (defined in pipeline_runs.go / pipeline_crud.go).
 func registerBuilds(r tools.Registry, m *AdoManager, f PipelineFormatter) error {
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration
@@ -62,7 +62,7 @@ func registerBuilds(r tools.Registry, m *AdoManager, f PipelineFormatter) error 
 				},
 			},
 			handler: func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				content, err := m.GetTaskLog(ctx, args, hb)
+				content, err := m.getTaskLog(ctx, args, hb)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}

--- a/internal/tools/integrations/ado/fault_test.go
+++ b/internal/tools/integrations/ado/fault_test.go
@@ -48,7 +48,7 @@ func TestHTTPClient_NetworkFault_MidStream(t *testing.T) {
 		"repository":   "myrepo",
 		"path":         "/src/main.go",
 	}
-	_, err := m.AdoGetFileContent(ctx, args, nil)
+	_, err := m.adoGetFileContent(ctx, args, nil)
 
 	// 5. Assert the error bubbles up safely and retains its identity via %w
 	if err == nil {
@@ -88,7 +88,7 @@ func TestHTTPClient_NetworkFault_OnStatusError(t *testing.T) {
 		"repository":   "myrepo",
 		"path":         "/src/main.go",
 	}
-	_, err := m.AdoGetFileContent(ctx, args, nil)
+	_, err := m.adoGetFileContent(ctx, args, nil)
 
 	// 5. Assert the error bubbles up safely and retains its identity via %w
 	if err == nil {

--- a/internal/tools/integrations/ado/formatter.go
+++ b/internal/tools/integrations/ado/formatter.go
@@ -27,8 +27,8 @@ type PipelineFormatter interface {
 // concrete type.
 type pipelineFormatter struct{}
 
-// NewPipelineFormatter returns the default PipelineFormatter implementation.
+// newPipelineFormatter returns the default PipelineFormatter implementation.
 // Exported so the registration layer (and tests) can construct one.
-func NewPipelineFormatter() PipelineFormatter {
+func newPipelineFormatter() PipelineFormatter {
 	return &pipelineFormatter{}
 }

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -351,7 +351,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
-		_, err := m.AdoListBranchPolicies(context.Background(), map[string]interface{}{}, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
 	})
@@ -364,7 +364,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "returned status: 500")
 	})
@@ -382,7 +382,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
 	})
@@ -401,7 +401,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
-		_, err := m.AdoListBranchPolicies(context.Background(), args, nil)
+		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to decode policy configurations")
 	})

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -340,7 +340,7 @@ func TestAdoManager_ListPipelineLogs_Errors(t *testing.T) {
 
 		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
-		_, err := m.GetPipelineLogContent(context.Background(), args, nil)
+		_, err := m.getPipelineLogContent(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -273,24 +273,24 @@ type adoLogEntry struct {
 	Line int    `json:"lineCount"`
 }
 
-// LogContent is the result of fetching log text. If Truncated is true, Content
+// logContent is the result of fetching log text. If Truncated is true, Content
 // has been clipped after TotalLines lines.
-type LogContent struct {
+type logContent struct {
 	Content    string
 	Truncated  bool
 	TotalLines int
 }
 
-// RunPipelineResult describes the outcome of an attempted pipeline trigger.
+// runPipelineResult describes the outcome of an attempted pipeline trigger.
 // If Cancelled is true, the user declined the confirmation prompt and no run
 // was created. Otherwise, RunID and WebURL describe the new run.
-type RunPipelineResult struct {
+type runPipelineResult struct {
 	Cancelled bool
 	RunID     int
 	WebURL    string
 }
 
-// CreatePipelineResult describes the outcome of an attempted pipeline creation.
+// createPipelineResult describes the outcome of an attempted pipeline creation.
 // Exactly one of the following states is signalled:
 //   - AlreadyExisted=true, PipelineID set:  idempotency hit; no creation occurred.
 //   - Cancelled=true,      PipelineID==0:   user declined the confirmation prompt.
@@ -298,7 +298,7 @@ type RunPipelineResult struct {
 //
 // Name is always echoed so the consumer can render either the "already exists"
 // or "successfully created" message without re-reading args.
-type CreatePipelineResult struct {
+type createPipelineResult struct {
 	AlreadyExisted bool
 	Cancelled      bool
 	PipelineID     int

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -154,7 +154,7 @@ func parseRunPipelineArgs(args map[string]interface{}) (adoRunPipelineParams, er
 	// while the API request uses the fully qualified ref.
 	if params.RefName == "" {
 		// Defensive fallback: if no caller pre-formatted, treat Branch verbatim
-		// so direct unit tests of RunPipeline still produce a non-empty ref.
+		// so direct unit tests of runPipeline still produce a non-empty ref.
 		params.RefName = params.Branch
 	}
 	params.MappedVariables = mapADOVariables(params.Variables)
@@ -448,7 +448,7 @@ func registerPipelines(r tools.Registry, m *AdoManager, f PipelineFormatter) err
 					return tools.ToolResult{Text: f.FormatPipelineLogList(runID, logs)}, nil
 				}
 
-				content, err := m.GetPipelineLogContent(ctx, args, hb)
+				content, err := m.getPipelineLogContent(ctx, args, hb)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}
@@ -474,7 +474,7 @@ func registerPipelines(r tools.Registry, m *AdoManager, f PipelineFormatter) err
 				},
 			},
 			handler: func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				result, err := m.CreatePipeline(ctx, args)
+				result, err := m.createPipeline(ctx, args)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}
@@ -515,7 +515,7 @@ func registerPipelines(r tools.Registry, m *AdoManager, f PipelineFormatter) err
 				}
 				argsCopy["_ref_name"] = refName
 
-				result, err := m.RunPipeline(ctx, argsCopy)
+				result, err := m.runPipeline(ctx, argsCopy)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}

--- a/internal/tools/integrations/ado/pipeline.go
+++ b/internal/tools/integrations/ado/pipeline.go
@@ -335,7 +335,7 @@ func registerPipelines(r tools.Registry, m *AdoManager, f PipelineFormatter) err
 				},
 			},
 			handler: func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-				pipelines, err := m.ListPipelines(ctx, args)
+				pipelines, err := m.listPipelines(ctx, args)
 				if err != nil {
 					return tools.ToolResult{}, err
 				}

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -101,14 +101,14 @@ func (m *AdoManager) resolvePipelineID(ctx context.Context, org, project, pipeli
 	return 0, fmt.Errorf("pipeline with name '%s' not found", pipelineName)
 }
 
-// CreatePipeline is the infrastructure-layer entry point for creating a new
+// createPipeline is the infrastructure-layer entry point for creating a new
 // ADO pipeline. The method performs an idempotency pre-check and a user
 // confirmation dialog; both belong to this adapter's operational contract.
 // See createPipelineResult for the three possible terminal states.
 //
 // On successful creation, the per-project pipeline cache is invalidated so
 // subsequent ListPipelines calls observe the new entry.
-func (m *AdoManager) CreatePipeline(ctx context.Context, args map[string]interface{}) (createPipelineResult, error) {
+func (m *AdoManager) createPipeline(ctx context.Context, args map[string]interface{}) (createPipelineResult, error) {
 	params, err := parseCreatePipelineArgs(args)
 	if err != nil {
 		return createPipelineResult{}, err

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -104,23 +104,23 @@ func (m *AdoManager) resolvePipelineID(ctx context.Context, org, project, pipeli
 // CreatePipeline is the infrastructure-layer entry point for creating a new
 // ADO pipeline. The method performs an idempotency pre-check and a user
 // confirmation dialog; both belong to this adapter's operational contract.
-// See CreatePipelineResult for the three possible terminal states.
+// See createPipelineResult for the three possible terminal states.
 //
 // On successful creation, the per-project pipeline cache is invalidated so
 // subsequent ListPipelines calls observe the new entry.
-func (m *AdoManager) CreatePipeline(ctx context.Context, args map[string]interface{}) (CreatePipelineResult, error) {
+func (m *AdoManager) CreatePipeline(ctx context.Context, args map[string]interface{}) (createPipelineResult, error) {
 	params, err := parseCreatePipelineArgs(args)
 	if err != nil {
-		return CreatePipelineResult{}, err
+		return createPipelineResult{}, err
 	}
 
 	// 1. Idempotency check: short-circuit if the pipeline already exists.
 	existingID, err := m.checkPipelineExists(ctx, params.Organization, params.Project, params.Name)
 	if err != nil {
-		return CreatePipelineResult{}, fmt.Errorf("checking pipeline existence: %w", err)
+		return createPipelineResult{}, fmt.Errorf("checking pipeline existence: %w", err)
 	}
 	if existingID != 0 {
-		return CreatePipelineResult{
+		return createPipelineResult{
 			AlreadyExisted: true,
 			PipelineID:     existingID,
 			Name:           params.Name,
@@ -130,22 +130,22 @@ func (m *AdoManager) CreatePipeline(ctx context.Context, args map[string]interfa
 	// 2. Confirm.
 	approved, err := m.sc.Confirm(ctx, fmt.Sprintf("Create pipeline '%s' in %s/%s?", params.Name, params.Organization, params.Project))
 	if err != nil {
-		return CreatePipelineResult{}, fmt.Errorf("confirmation error: %w", err)
+		return createPipelineResult{}, fmt.Errorf("confirmation error: %w", err)
 	}
 	if !approved {
-		return CreatePipelineResult{Cancelled: true, Name: params.Name}, nil
+		return createPipelineResult{Cancelled: true, Name: params.Name}, nil
 	}
 
 	// 3. Create.
 	pipelineID, err := m.executeCreatePipeline(ctx, params.Organization, params.Project, params.Name, params.RepositoryId, params.YamlPath, params.Variables, params.VariableGroups)
 	if err != nil {
-		return CreatePipelineResult{}, fmt.Errorf("executing create pipeline: %w", err)
+		return createPipelineResult{}, fmt.Errorf("executing create pipeline: %w", err)
 	}
 
 	// Invalidate cache so subsequent ListPipelines observes the new pipeline.
 	m.pipelineCache.Delete(params.Organization + "/" + params.Project)
 
-	return CreatePipelineResult{
+	return createPipelineResult{
 		PipelineID: pipelineID,
 		Name:       params.Name,
 	}, nil

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -62,9 +62,9 @@ func (m *AdoManager) fetchPipelines(ctx context.Context, org, project string) ([
 	return val.([]adoPipeline), nil
 }
 
-// ListPipelines is the infrastructure-layer entry point for fetching pipeline
+// listPipelines is the infrastructure-layer entry point for fetching pipeline
 // definitions for a given org/project. Returns raw domain structs.
-func (m *AdoManager) ListPipelines(ctx context.Context, args map[string]interface{}) ([]adoPipeline, error) {
+func (m *AdoManager) listPipelines(ctx context.Context, args map[string]interface{}) ([]adoPipeline, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -107,7 +107,7 @@ func (m *AdoManager) resolvePipelineID(ctx context.Context, org, project, pipeli
 // See createPipelineResult for the three possible terminal states.
 //
 // On successful creation, the per-project pipeline cache is invalidated so
-// subsequent ListPipelines calls observe the new entry.
+// subsequent listPipelines calls observe the new entry.
 func (m *AdoManager) createPipeline(ctx context.Context, args map[string]interface{}) (createPipelineResult, error) {
 	params, err := parseCreatePipelineArgs(args)
 	if err != nil {
@@ -356,10 +356,10 @@ func (m *AdoManager) decodeBuildChangesResponse(body io.Reader) ([]interface{}, 
 	return responseData.Value, nil
 }
 
-// GetBuildChanges is the infrastructure-layer entry point for fetching the
+// getBuildChanges is the infrastructure-layer entry point for fetching the
 // changeset associated with an ADO build. Returns the decoded values slice; the
 // caller is responsible for serialization.
-func (m *AdoManager) GetBuildChanges(ctx context.Context, args map[string]interface{}) ([]interface{}, error) {
+func (m *AdoManager) getBuildChanges(ctx context.Context, args map[string]interface{}) ([]interface{}, error) {
 	params, err := parseGetBuildChangesArgs(args)
 	if err != nil {
 		return nil, err

--- a/internal/tools/integrations/ado/pipeline_format.go
+++ b/internal/tools/integrations/ado/pipeline_format.go
@@ -88,8 +88,8 @@ func (f *pipelineFormatter) FormatPipelineLogList(runID int, logs []adoLogEntry)
 	return resultText.String()
 }
 
-// FormatRepositoryItems formats repository items for display.
-func FormatRepositoryItems(scopePath, version string, responseData adoRepositoryItemsResponse) tools.ToolResult {
+// formatRepositoryItems formats repository items for display.
+func formatRepositoryItems(scopePath, version string, responseData adoRepositoryItemsResponse) tools.ToolResult {
 	if len(responseData.Value) == 0 {
 		return tools.ToolResult{Text: "No items found."}
 	}

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -110,7 +110,7 @@ func (m *AdoManager) GetPipelineRun(ctx context.Context, args map[string]interfa
 	return &runData, nil
 }
 
-// RunPipeline is the infrastructure-layer entry point for triggering a new
+// runPipeline is the infrastructure-layer entry point for triggering a new
 // ADO pipeline run. The confirmation dialog is part of this adapter's
 // operational contract (destructive operations require user assent); a
 // Cancelled result indicates the user declined.
@@ -118,9 +118,9 @@ func (m *AdoManager) GetPipelineRun(ctx context.Context, args map[string]interfa
 // The caller SHOULD pre-format the branch into a fully qualified ADO ref via
 // PipelineFormatter.FormatBranchRef and supply it under args["_ref_name"];
 // args["branch"] remains the raw user-facing name shown in the confirmation
-// prompt. If args["_ref_name"] is absent, RunPipeline falls back to using
+// prompt. If args["_ref_name"] is absent, runPipeline falls back to using
 // args["branch"] verbatim (intended for direct unit-test callers only).
-func (m *AdoManager) RunPipeline(ctx context.Context, args map[string]interface{}) (runPipelineResult, error) {
+func (m *AdoManager) runPipeline(ctx context.Context, args map[string]interface{}) (runPipelineResult, error) {
 	params, err := parseRunPipelineArgs(args)
 	if err != nil {
 		return runPipelineResult{}, fmt.Errorf("parsing run pipeline args: %w", err)
@@ -261,10 +261,10 @@ func (m *AdoManager) ListPipelineLogs(ctx context.Context, args map[string]inter
 	return params.RunId, logsData.Value, nil
 }
 
-// GetPipelineLogContent is the infrastructure-layer entry point for fetching the
+// getPipelineLogContent is the infrastructure-layer entry point for fetching the
 // content of a single pipeline log. Returns logContent describing the body and
 // whether it was truncated.
-func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
+func (m *AdoManager) getPipelineLogContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -304,9 +304,9 @@ func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]
 	return logContent(res), nil
 }
 
-// GetTaskLog is the infrastructure-layer entry point for fetching a build task
+// getTaskLog is the infrastructure-layer entry point for fetching a build task
 // log. Returns logContent describing the body and whether it was truncated.
-func (m *AdoManager) GetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
+func (m *AdoManager) getTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -120,26 +120,26 @@ func (m *AdoManager) GetPipelineRun(ctx context.Context, args map[string]interfa
 // args["branch"] remains the raw user-facing name shown in the confirmation
 // prompt. If args["_ref_name"] is absent, RunPipeline falls back to using
 // args["branch"] verbatim (intended for direct unit-test callers only).
-func (m *AdoManager) RunPipeline(ctx context.Context, args map[string]interface{}) (RunPipelineResult, error) {
+func (m *AdoManager) RunPipeline(ctx context.Context, args map[string]interface{}) (runPipelineResult, error) {
 	params, err := parseRunPipelineArgs(args)
 	if err != nil {
-		return RunPipelineResult{}, fmt.Errorf("parsing run pipeline args: %w", err)
+		return runPipelineResult{}, fmt.Errorf("parsing run pipeline args: %w", err)
 	}
 
 	approved, err := m.sc.Confirm(ctx, fmt.Sprintf("Trigger run for pipeline %d (branch: %s) in %s/%s?", params.PipelineId, params.Branch, params.Organization, params.Project))
 	if err != nil {
-		return RunPipelineResult{}, fmt.Errorf("confirmation error: %w", err)
+		return runPipelineResult{}, fmt.Errorf("confirmation error: %w", err)
 	}
 	if !approved {
-		return RunPipelineResult{Cancelled: true}, nil
+		return runPipelineResult{Cancelled: true}, nil
 	}
 
 	runID, webURL, err := m.executeRunPipeline(ctx, params.Organization, params.Project, params.PipelineId, params.RefName, params.TemplateParameters, params.MappedVariables)
 	if err != nil {
-		return RunPipelineResult{}, fmt.Errorf("executing run pipeline: %w", err)
+		return runPipelineResult{}, fmt.Errorf("executing run pipeline: %w", err)
 	}
 
-	return RunPipelineResult{RunID: runID, WebURL: webURL}, nil
+	return runPipelineResult{RunID: runID, WebURL: webURL}, nil
 }
 
 func (m *AdoManager) executeRunPipeline(ctx context.Context, org, project string, pipelineID int, refName string, templateParams map[string]string, variables map[string]adoVariable) (int, string, error) {
@@ -262,9 +262,9 @@ func (m *AdoManager) ListPipelineLogs(ctx context.Context, args map[string]inter
 }
 
 // GetPipelineLogContent is the infrastructure-layer entry point for fetching the
-// content of a single pipeline log. Returns LogContent describing the body and
+// content of a single pipeline log. Returns logContent describing the body and
 // whether it was truncated.
-func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (LogContent, error) {
+func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -280,11 +280,11 @@ func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]
 	}
 
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return LogContent{}, fmt.Errorf("parsing get pipeline log content args: %w", err)
+		return logContent{}, fmt.Errorf("parsing get pipeline log content args: %w", err)
 	}
 
 	if params.Organization == "" || params.Project == "" || params.PipelineId == 0 || params.RunId == 0 || params.LogId == 0 {
-		return LogContent{}, fmt.Errorf("organization, project, pipeline_id, run_id, and log_id are required")
+		return logContent{}, fmt.Errorf("organization, project, pipeline_id, run_id, and log_id are required")
 	}
 
 	u := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs/%d?api-version=7.1",
@@ -292,21 +292,21 @@ func (m *AdoManager) GetPipelineLogContent(ctx context.Context, args map[string]
 
 	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, map[string]string{"Accept": "*/*"})
 	if err != nil {
-		return LogContent{}, fmt.Errorf("executing fetch pipeline log content request: %w", err)
+		return logContent{}, fmt.Errorf("executing fetch pipeline log content request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	res, err := processLogContent(ctx, resp.Body, params.TailLines, params.HeadLines, params.FilterQuery, params.ContextLines, params.StartLine, params.MaxLines, hb)
 	if err != nil {
-		return LogContent{}, fmt.Errorf("failed to process log content: %w", err)
+		return logContent{}, fmt.Errorf("failed to process log content: %w", err)
 	}
 
-	return LogContent(res), nil
+	return logContent(res), nil
 }
 
 // GetTaskLog is the infrastructure-layer entry point for fetching a build task
-// log. Returns LogContent describing the body and whether it was truncated.
-func (m *AdoManager) GetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (LogContent, error) {
+// log. Returns logContent describing the body and whether it was truncated.
+func (m *AdoManager) GetTaskLog(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -321,11 +321,11 @@ func (m *AdoManager) GetTaskLog(ctx context.Context, args map[string]interface{}
 	}
 
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return LogContent{}, fmt.Errorf("parsing get task log args: %w", err)
+		return logContent{}, fmt.Errorf("parsing get task log args: %w", err)
 	}
 
 	if params.Organization == "" || params.Project == "" || params.BuildId == 0 || params.LogId == 0 {
-		return LogContent{}, fmt.Errorf("organization, project, build_id, and log_id are required")
+		return logContent{}, fmt.Errorf("organization, project, build_id, and log_id are required")
 	}
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/build/builds/%d/logs/%d?api-version=7.0",
@@ -333,14 +333,14 @@ func (m *AdoManager) GetTaskLog(ctx context.Context, args map[string]interface{}
 
 	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, map[string]string{"Accept": "*/*"})
 	if err != nil {
-		return LogContent{}, fmt.Errorf("executing get task log request: %w", err)
+		return logContent{}, fmt.Errorf("executing get task log request: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	res, err := processLogContent(ctx, resp.Body, params.TailLines, params.HeadLines, params.FilterQuery, params.ContextLines, params.StartLine, params.MaxLines, hb)
 	if err != nil {
-		return LogContent{}, fmt.Errorf("failed to process log content: %w", err)
+		return logContent{}, fmt.Errorf("failed to process log content: %w", err)
 	}
 
-	return LogContent(res), nil
+	return logContent(res), nil
 }

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -233,7 +233,7 @@ func TestAdoCreatePipeline_WithVariables(t *testing.T) {
 		},
 	}
 
-	result, err := m.CreatePipeline(ctx, args)
+	result, err := m.createPipeline(ctx, args)
 	require.NoError(t, err)
 	assert.False(t, result.AlreadyExisted)
 	assert.False(t, result.Cancelled)
@@ -285,7 +285,7 @@ func TestAdoCreatePipeline_WithOverrideControl(t *testing.T) {
 		},
 	}
 
-	result, err := m.CreatePipeline(ctx, args)
+	result, err := m.createPipeline(ctx, args)
 	require.NoError(t, err)
 	assert.False(t, result.AlreadyExisted)
 	assert.False(t, result.Cancelled)

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -162,7 +162,7 @@ func TestFormatPipelineList(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			formatter := NewPipelineFormatter()
+			formatter := newPipelineFormatter()
 			got := formatter.FormatPipelineList(tt.pipelines)
 			assert.Equal(t, tt.want, got)
 		})
@@ -188,7 +188,7 @@ func TestFormatBranchRef(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			formatter := NewPipelineFormatter()
+			formatter := newPipelineFormatter()
 			if got := formatter.FormatBranchRef(tt.input); got != tt.want {
 				t.Errorf("FormatBranchRef(%q) = %q, want %q", tt.input, got, tt.want)
 			}

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -114,7 +114,7 @@ func TestListPipelines(t *testing.T) {
 			m := NewADOManager(sm, opts...)
 
 			ctx := context.Background()
-			pipelines, err := m.ListPipelines(ctx, tt.args)
+			pipelines, err := m.listPipelines(ctx, tt.args)
 
 			if tt.wantError {
 				assert.Error(t, err)

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -269,7 +269,7 @@ func (m *AdoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPo
 	return tools.ToolResult{Text: resultText.String()}, nil
 }
 
-func (m *AdoManager) AdoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) adoListBranchPolicies(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization string `json:"organization"`
 		Project      string `json:"project"`
@@ -425,7 +425,7 @@ func registerPolicy(r tools.Registry, m *AdoManager, _ PipelineFormatter) error 
 					Required: []string{"organization", "project", "repository", "branch_name"},
 				},
 			},
-			handler: m.AdoListBranchPolicies,
+			handler: m.adoListBranchPolicies,
 		},
 		{
 			decl: &tools.ToolDeclaration{

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -18,7 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-func (m *AdoManager) AdoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) adoGetPullRequest(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -171,7 +171,7 @@ func (m *AdoManager) formatPullRequestsList(prs []adoPullRequestShort) string {
 	return resultText.String()
 }
 
-func (m *AdoManager) AdoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *AdoManager) adoGetPrDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
 		Project       string `json:"project"`
@@ -338,7 +338,7 @@ func registerPullRequests(r tools.Registry, m *AdoManager, _ PipelineFormatter) 
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.AdoGetPullRequest,
+			handler: m.adoGetPullRequest,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -373,7 +373,7 @@ func registerPullRequests(r tools.Registry, m *AdoManager, _ PipelineFormatter) 
 					Required: []string{"organization", "project", "repository", "pull_request_id"},
 				},
 			},
-			handler: m.AdoGetPrDiff,
+			handler: m.adoGetPrDiff,
 		},
 		{
 			decl: &tools.ToolDeclaration{

--- a/internal/tools/integrations/ado/register.go
+++ b/internal/tools/integrations/ado/register.go
@@ -25,7 +25,7 @@ func marshalIndentResult(v interface{}) (tools.ToolResult, error) {
 // appendTruncationNote appends a truncation advisory if the log content was
 // clipped after TotalLines lines, helping the LLM understand the data may be
 // incomplete.
-func appendTruncationNote(c LogContent) string {
+func appendTruncationNote(c logContent) string {
 	if !c.Truncated {
 		return c.Content
 	}
@@ -42,7 +42,7 @@ func Register(r tools.Registry, sm security.Manager, client tools.HTTPClient) er
 		opts = append(opts, WithToken(token))
 	}
 	m := NewADOManager(sm, opts...)
-	f := NewPipelineFormatter()
+	f := newPipelineFormatter()
 
 	for _, fn := range []func(tools.Registry, *AdoManager, PipelineFormatter) error{
 		registerPullRequests,

--- a/internal/tools/integrations/ado/repo.go
+++ b/internal/tools/integrations/ado/repo.go
@@ -8,7 +8,7 @@ import (
 )
 
 // registerRepository registers the Repository-category ADO tools (file content, list items).
-// Handlers: m.AdoGetFileContent, m.AdoListRepositoryItems (defined in azure_devops.go).
+// Handlers: m.adoGetFileContent, m.AdoListRepositoryItems (defined in azure_devops.go).
 func registerRepository(r tools.Registry, m *AdoManager, _ PipelineFormatter) error {
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration
@@ -32,7 +32,7 @@ func registerRepository(r tools.Registry, m *AdoManager, _ PipelineFormatter) er
 					Required: []string{"organization", "project", "repository", "path"},
 				},
 			},
-			handler: m.AdoGetFileContent,
+			handler: m.adoGetFileContent,
 		},
 		{
 			decl: &tools.ToolDeclaration{

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -203,7 +203,7 @@ func (m *ConfluenceManager) resolveNextURL(baseURL, nextPath string) string {
 	return parsedBase.ResolveReference(parsedNext).String()
 }
 
-func (m *ConfluenceManager) ConfluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *ConfluenceManager) confluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Title   string `json:"title"`
 		SpaceID string `json:"space_id"`
@@ -520,7 +520,7 @@ func (m *ConfluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 	return nil
 }
 
-func (m *ConfluenceManager) ConfluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+func (m *ConfluenceManager) confluenceWrite(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		PageID          string `json:"page_id"`
 		Title           string `json:"title"`

--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -107,7 +107,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": "SPACE1",
 		}
 
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Found pages:")
 		assert.Contains(t, result.Text, "Test Page 1 (ID: 1)")
@@ -147,7 +147,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": "SPACE1",
 		}
 
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Space Page (ID: 3)")
 		mockClient.AssertExpectations(t)
@@ -170,7 +170,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"title":    "missing",
 			"space_id": "123", // Numeric, skips resolution
 		}
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Searched the 1 most recently modified pages")
 		assert.Contains(t, result.Text, "found no pages containing 'missing'")
@@ -224,7 +224,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"space_id": spaceID,
 		}
 
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "[cicd] Azure DevOps (ID: 3)")
 		mockClient.AssertExpectations(t)
@@ -234,7 +234,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
 		args := map[string]interface{}{"title": "keyword"}
-		_, err = m.ConfluenceSearch(context.Background(), args, nil)
+		_, err = m.confluenceSearch(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "space_id is required")
 	})
@@ -254,7 +254,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"title":    "error",
 			"space_id": "123",
 		}
-		_, err = m.ConfluenceSearch(context.Background(), args, nil)
+		_, err = m.confluenceSearch(context.Background(), args, nil)
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "confluence API returned status: 403 Forbidden")
 		}
@@ -286,7 +286,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"limit":    100,
 		}
 
-		_, err = m.ConfluenceSearch(context.Background(), args, nil)
+		_, err = m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		mockClient.AssertNumberOfCalls(t, "Do", 2)
 	})
@@ -310,7 +310,7 @@ func TestConfluenceManager_ConfluenceSearch(t *testing.T) {
 			"limit":    5000,
 		}
 
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "capped at 1000 pages")
 		mockClient.AssertNumberOfCalls(t, "Do", 20)
@@ -511,7 +511,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 			"update_message":   "testing update",
 		}
 
-		result, err := m.ConfluenceWrite(context.Background(), args, nil)
+		result, err := m.confluenceWrite(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "Successfully updated Confluence page 123 to version 6")
 		mockClient.AssertExpectations(t)
@@ -545,7 +545,7 @@ func TestConfluenceManager_ConfluenceWrite(t *testing.T) {
 			"markdown_content": "some content",
 		}
 
-		result, err := m.ConfluenceWrite(context.Background(), args, nil)
+		result, err := m.confluenceWrite(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "conflict: page version changed")
 	})
@@ -634,7 +634,7 @@ func TestConfluenceManager_ConfluenceSearch_EmptyResults(t *testing.T) {
 			"title":    "nothing",
 			"space_id": "123",
 		}
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "found no pages containing 'nothing'")
 	})
@@ -655,7 +655,7 @@ func TestConfluenceManager_ConfluenceSearch_EmptyResults(t *testing.T) {
 			"title":    "nothing",
 			"space_id": "123",
 		}
-		result, err := m.ConfluenceSearch(context.Background(), args, nil)
+		result, err := m.confluenceSearch(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Contains(t, result.Text, "found no pages containing 'nothing'")
 	})
@@ -815,7 +815,7 @@ func TestConfluenceManager_ConfluenceSearch_ResolveError(t *testing.T) {
 		"space_id": "BADSPACE",
 	}
 
-	_, err = m.ConfluenceSearch(context.Background(), args, nil)
+	_, err = m.confluenceSearch(context.Background(), args, nil)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to resolve space ID for 'BADSPACE'")
 }
@@ -920,7 +920,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	t.Run("UnmarshalArgs Error Search", func(t *testing.T) {
 		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.ConfluenceSearch(context.Background(), map[string]interface{}{"limit": "invalid"}, nil)
+		_, err = m.confluenceSearch(context.Background(), map[string]interface{}{"limit": "invalid"}, nil)
 		assert.Error(t, err)
 	})
 
@@ -934,7 +934,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 	t.Run("UnmarshalArgs Error Write", func(t *testing.T) {
 		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.ConfluenceWrite(context.Background(), map[string]interface{}{"page_id": 123}, nil)
+		_, err = m.confluenceWrite(context.Background(), map[string]interface{}{"page_id": 123}, nil)
 		assert.Error(t, err)
 	})
 
@@ -942,7 +942,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 		t.Setenv("ATLASSIAN_BASE_URL", "http://bad\x7furl")
 		m, err := NewConfluenceManager(nil, nil)
 		if err == nil {
-			_, err = m.ConfluenceSearch(context.Background(), map[string]interface{}{"space_id": "123"}, nil)
+			_, err = m.confluenceSearch(context.Background(), map[string]interface{}{"space_id": "123"}, nil)
 		}
 		require.Error(t, err)
 		// Error could be from constructor or method
@@ -993,7 +993,7 @@ func TestConfluenceManager_ExhaustiveErrors(t *testing.T) {
 		t.Setenv("ATLASSIAN_EMAIL", "")
 		m, err := NewConfluenceManager(nil, nil)
 		assert.NoError(t, err)
-		_, err = m.ConfluenceWrite(context.Background(), map[string]interface{}{"page_id": "123", "markdown_content": "test"}, nil)
+		_, err = m.confluenceWrite(context.Background(), map[string]interface{}{"page_id": "123", "markdown_content": "test"}, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "missing ATLASSIAN_EMAIL")
 	})

--- a/internal/tools/integrations/atlassian/register.go
+++ b/internal/tools/integrations/atlassian/register.go
@@ -36,7 +36,7 @@ func RegisterConfluence(r tools.Registry, sm security.Manager, client tools.HTTP
 				},
 			},
 		},
-	}, m.ConfluenceSearch); err != nil {
+	}, m.confluenceSearch); err != nil {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func RegisterConfluence(r tools.Registry, sm security.Manager, client tools.HTTP
 			},
 			Required: []string{"page_id", "markdown_content"},
 		},
-	}, m.ConfluenceWrite, tools.ToolOptions{Serial: true}); err != nil {
+	}, m.confluenceWrite, tools.ToolOptions{Serial: true}); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary

Unexport 17 exported symbols that are only used within their own packages. Zero external impact.

### Changes

**`internal/tools/integrations/ado`** (15 symbols):
- **3 types**: `LogContent`, `CreatePipelineResult`, `RunPipelineResult`
- **2 functions**: `FormatRepositoryItems`, `NewPipelineFormatter`
- **10 methods** on `AdoManager`: `GetPipelineLogContent`, `GetTaskLog`, `CreatePipeline`, `RunPipeline`, `AdoGetPrDiff`, `AdoGetFileContent`, `AdoGetPullRequest`, `AdoListBranchPolicies`, `ListPipelines`, `GetBuildChanges`

**`internal/tools/integrations/atlassian`** (2 symbols):
- **2 methods** on `ConfluenceManager`: `ConfluenceSearch`, `ConfluenceWrite`

### Verification

- ✅ `go build ./...` — clean
- ✅ `go test ./internal/tools/integrations/ado/... ./internal/tools/integrations/atlassian/...` — all pass
- ✅ Linter — no issues
- ✅ `dead_code_graph` — only the known false positive `(SecurityManager).SetInteractor` remains (documented in SOP, GitHub issue #69)

### Known false positive (intentionally untouched)

`(SecurityManager).SetInteractor` is cross-package called from `internal/cli/` and satisfies an anonymous interface assertion.