### PR TITLE
refactor: eliminate SetInteractor post-construction setter via lazy provider injection

### DIFF
--- a/cmd/tell-me-go/main.go
+++ b/cmd/tell-me-go/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/env"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/logging"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
+
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 )
 
 // Compile-time assertion to ensure DI Bootstrapper implements the CLI requirement.
@@ -124,7 +126,14 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 	homeDir := env.ResolveHomeDir(os.Getenv, os.UserHomeDir)
 
 	// 2. Initialize Core Infrastructure
-	sm := security.NewSecurityManager(nil)
+	var interactor domain_security.UserInteractor
+	interactorProvider := func() domain_security.UserInteractor {
+		if interactor != nil {
+			return interactor
+		}
+		return security.NoOpInteractor()
+	}
+	sm := security.NewSecurityManager(interactorProvider)
 
 	// 3. Setup Logger
 	isDebug := os.Getenv("TELL_ME_DEBUG") == "1"
@@ -155,6 +164,7 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 		Bootstrapper: bootstrapper,
 		ConfigLoader: configLoader,
 		ChatService:  chatService,
+		Interactor:   &interactor,
 	}, os.Getenv)
 
 	if err != nil {

--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -34,6 +34,7 @@ type chatCommand struct {
 	HomeDir      string
 	MockPrompt   string
 	MockAnswer   string
+	Interactor   *domain_security.UserInteractor
 }
 
 type cliOptions struct {
@@ -77,6 +78,7 @@ func newChatCommand(ctx *context, opts *cliOptions) *cobra.Command {
 		HomeDir:      ctx.HomeDir,
 		MockPrompt:   ctx.MockPrompt,
 		MockAnswer:   ctx.MockAnswer,
+		Interactor:   ctx.Interactor,
 	}
 
 	if opts == nil {
@@ -242,11 +244,8 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 			}
 		}
 
-		if sm, ok := c.SM.(interface {
-			SetInteractor(domain_security.UserInteractor)
-		}); ok {
-			// capturer already implements UserInteractor via CapturerInteractor
-			sm.SetInteractor(capturer)
+		if c.Interactor != nil {
+			*c.Interactor = capturer
 		}
 		return capturer, cleanup
 	}
@@ -259,10 +258,8 @@ func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Con
 	if !ok {
 		return nil, func(stdctx.Context) error { return nil }
 	}
-	if sm, ok := c.SM.(interface {
-		SetInteractor(domain_security.UserInteractor)
-	}); ok {
-		sm.SetInteractor(capturerInterface)
+	if c.Interactor != nil {
+		*c.Interactor = capturerInterface
 	}
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)

--- a/internal/cli/chat_command_test.go
+++ b/internal/cli/chat_command_test.go
@@ -154,10 +154,9 @@ type mockSM struct {
 	domain_security.Manager
 }
 
-func (m *mockSM) SetInteractor(interactor domain_security.UserInteractor) {}
-func (m *mockSM) TerminalLock()                                           {}
-func (m *mockSM) TerminalUnlock()                                         {}
-func (m *mockSM) Close() error                                            { return nil }
+func (m *mockSM) TerminalLock()   {}
+func (m *mockSM) TerminalUnlock() {}
+func (m *mockSM) Close() error    { return nil }
 
 func setupMocks() (*mockBootstrapper, *chatMockLoader, *mockChatService) {
 	mb := &mockBootstrapper{}
@@ -336,54 +335,6 @@ func TestChatCommand_Execute_Retry_Aborted(t *testing.T) {
 
 	if !mService.lastParams.Retry {
 		t.Error("expected Retry to be true")
-	}
-}
-
-func TestChatCommand_Execute_TUIPrompt_SetsInteractor(t *testing.T) {
-	t.Parallel()
-
-	var stdout, stderr strings.Builder
-	var setInteractorCalled bool
-
-	sm := &mockSM{}
-	// Override SetInteractor locally using a mock struct that tracks calls
-	trackingSM := &trackingMockSM{
-		mockSM:          sm,
-		setInteractorCb: func() { setInteractorCalled = true },
-	}
-
-	mb, ml, mService := setupMocks()
-
-	cmdCtx := &context{
-		Version:      "1.0.0",
-		Stdin:        strings.NewReader("hello\n"),
-		Stdout:       &stdout,
-		Stderr:       &stderr,
-		SM:           trackingSM,
-		ChatService:  mService,
-		Bootstrapper: mb,
-		Loader:       ml,
-		HomeDir:      t.TempDir(),
-	}
-
-	err := executeChatCommand(cmdCtx, []string{"--interactive"})
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if !setInteractorCalled {
-		t.Error("expected SetInteractor to be called when TUI prompt is enabled")
-	}
-}
-
-type trackingMockSM struct {
-	*mockSM
-	setInteractorCb func()
-}
-
-func (m *trackingMockSM) SetInteractor(interactor domain_security.UserInteractor) {
-	if m.setInteractorCb != nil {
-		m.setInteractorCb()
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,6 +36,7 @@ type AppDependencies struct {
 	Bootstrapper Bootstrapper
 	ConfigLoader domain_config.ConfigLoader
 	ChatService  agent.ChatService
+	Interactor   *domain_security.UserInteractor
 }
 
 // App represents the tell-me-go application.
@@ -49,6 +50,7 @@ type App struct {
 	bootstrapper Bootstrapper
 	configLoader domain_config.ConfigLoader
 	chatService  agent.ChatService
+	interactor   *domain_security.UserInteractor
 	mockPrompt   string
 	mockAnswer   string
 }
@@ -91,6 +93,7 @@ func New(deps AppDependencies, getenv func(string) string) (*App, error) {
 		bootstrapper: deps.Bootstrapper,
 		configLoader: deps.ConfigLoader,
 		chatService:  deps.ChatService,
+		interactor:   deps.Interactor,
 		mockPrompt:   getenv("TELL_ME_MOCK_PROMPT"),
 		mockAnswer:   getenv("TELL_ME_MOCK_ANSWER"),
 	}, nil
@@ -120,6 +123,7 @@ func (a *App) Run(ctx stdctx.Context, args []string) error {
 		Loader:       a.configLoader,
 		MockPrompt:   a.mockPrompt,
 		MockAnswer:   a.mockAnswer,
+		Interactor:   a.interactor,
 	}
 
 	chatCmd := newChatCommand(cmdCtx, nil)

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/gosharplite/tell-me-go/internal/ui"
 	"github.com/spf13/cobra"
@@ -69,10 +68,8 @@ func (c *browseCommand) runBrowse(ctx stdctx.Context, configPath string) error {
 
 func (c *browseCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Context) error) {
 	capturer := ui.NewCapturer(c.ctx.Stdin, c.ctx.Stdout, c.ctx.Stderr, c.ctx.SM, clock.RealClock{}, c.ctx.MockPrompt, c.ctx.MockAnswer, false).(agent.CapturerInteractor)
-	if sm, ok := c.ctx.SM.(interface {
-		SetInteractor(domain_security.UserInteractor)
-	}); ok {
-		sm.SetInteractor(capturer)
+	if c.ctx.Interactor != nil {
+		*c.ctx.Interactor = capturer
 	}
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)

--- a/internal/cli/interface.go
+++ b/internal/cli/interface.go
@@ -38,4 +38,5 @@ type context struct {
 	Loader       domain_config.ConfigLoader
 	MockPrompt   string
 	MockAnswer   string
+	Interactor   *domain_security.UserInteractor
 }

--- a/internal/infrastructure/security/auditor.go
+++ b/internal/infrastructure/security/auditor.go
@@ -16,7 +16,6 @@ import (
 type auditLogger interface {
 	LogAudit(action string, args ...any)
 	SetLogFile(path string)
-	SetInteractor(interactor domain.UserInteractor)
 	Close() error
 }
 
@@ -25,19 +24,14 @@ type auditor struct {
 	mu         sync.Mutex
 	file       *os.File
 	logger     *slog.Logger
-	interactor domain.UserInteractor
+	interactor func() domain.UserInteractor
 }
 
 // newAuditor creates a new auditor.
-func newAuditor() *auditor {
-	return &auditor{}
-}
-
-// SetInteractor sets the user interactor for warnings.
-func (a *auditor) SetInteractor(interactor domain.UserInteractor) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.interactor = interactor
+func newAuditor(interactorProvider func() domain.UserInteractor) *auditor {
+	return &auditor{
+		interactor: interactorProvider,
+	}
 }
 
 // SetLogFile sets the path for logging executed commands.
@@ -57,8 +51,8 @@ func (a *auditor) SetLogFile(path string) {
 
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
-		if a.interactor != nil {
-			a.interactor.Warn(fmt.Sprintf("[Warning] Failed to open command log file: %v", err))
+		if ui := a.interactor(); ui != nil {
+			ui.Warn(fmt.Sprintf("[Warning] Failed to open command log file: %v", err))
 		}
 		return
 	}

--- a/internal/infrastructure/security/auditor_test.go
+++ b/internal/infrastructure/security/auditor_test.go
@@ -8,13 +8,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	domain "github.com/gosharplite/tell-me-go/internal/domain/security"
 )
 
 func TestAuditor_LogAudit(t *testing.T) {
 	t.Parallel()
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "audit.log")
-	a := newAuditor()
+	a := newAuditor(nil)
 	a.SetLogFile(logFile)
 
 	a.LogAudit("TEST_ACTION", "Action", "Test", "Detail", "Something")
@@ -41,7 +43,7 @@ func TestAuditor_LogAudit(t *testing.T) {
 
 func TestAuditor_NoLogFile(t *testing.T) {
 	t.Parallel()
-	a := newAuditor()
+	a := newAuditor(nil)
 	// Should not panic or fail when logFile is empty
 	a.LogAudit("TEST", "Action", "Test")
 }
@@ -49,8 +51,7 @@ func TestAuditor_NoLogFile(t *testing.T) {
 func TestAuditor_SetLogFileError(t *testing.T) {
 	t.Parallel()
 	mock := &mockInteractor{}
-	a := newAuditor()
-	a.SetInteractor(mock)
+	a := newAuditor(func() domain.UserInteractor { return mock })
 
 	// Try to open a path that shouldn't be writable or is a directory
 	tmpDir := t.TempDir()
@@ -69,7 +70,7 @@ func TestAuditor_SetLogFileError(t *testing.T) {
 
 func TestAuditor_Close(t *testing.T) {
 	t.Run("closes open file successfully", func(t *testing.T) {
-		a := newAuditor()
+		a := newAuditor(nil)
 
 		// Use t.TempDir() for guaranteed isolated cleanup
 		logFile := filepath.Join(t.TempDir(), "audit.log")
@@ -86,7 +87,7 @@ func TestAuditor_Close(t *testing.T) {
 	})
 
 	t.Run("safe to call on uninitialized file", func(t *testing.T) {
-		a := newAuditor()
+		a := newAuditor(nil)
 		if err := a.Close(); err != nil {
 			t.Fatalf("expected nil error when closing uninitialized auditor, got %v", err)
 		}

--- a/internal/infrastructure/security/interaction.go
+++ b/internal/infrastructure/security/interaction.go
@@ -14,22 +14,17 @@ import (
 
 // interactionHandler manages terminal locking and user prompts via a UserInteractor.
 type interactionHandler struct {
-	terminalMu sync.Mutex
-	auditor    auditLogger
-	interactor domain.UserInteractor
+	terminalMu         sync.Mutex
+	auditor            auditLogger
+	interactorProvider func() domain.UserInteractor
 }
 
 // newInteractionHandler creates a new interactionHandler.
-func newInteractionHandler(interactor domain.UserInteractor, auditor auditLogger) *interactionHandler {
+func newInteractionHandler(interactorProvider func() domain.UserInteractor, auditor auditLogger) *interactionHandler {
 	return &interactionHandler{
-		auditor:    auditor,
-		interactor: interactor,
+		auditor:            auditor,
+		interactorProvider: interactorProvider,
 	}
-}
-
-// SetInteractor updates the user interactor.
-func (h *interactionHandler) SetInteractor(interactor domain.UserInteractor) {
-	h.interactor = interactor
 }
 
 // TerminalLock locks the terminal for exclusive access.
@@ -47,13 +42,15 @@ func (h *interactionHandler) ConfirmAction(ctx context.Context, action, target, 
 	h.TerminalLock()
 	defer h.TerminalUnlock()
 
+	ui := h.interactorProvider()
+
 	detailLog := detail
 	if len(detailLog) > 500 {
 		detailLog = detailLog[:500] + "... (truncated)"
 	}
 
 	if bypass {
-		h.interactor.Warn(fmt.Sprintf("[Auto-Approved] Action '%s' on '%s' auto-approved (bypass_confirmation enabled).", action, target))
+		ui.Warn(fmt.Sprintf("[Auto-Approved] Action '%s' on '%s' auto-approved (bypass_confirmation enabled).", action, target))
 		if h.auditor != nil {
 			h.auditor.LogAudit("CONFIRM_ACTION",
 				"ACTION", action+" on "+target,
@@ -73,7 +70,7 @@ func (h *interactionHandler) ConfirmAction(ctx context.Context, action, target, 
 	}
 	sb.WriteString("Proceed? (y/N) ")
 
-	confirmed, err := h.interactor.Confirm(ctx, sb.String())
+	confirmed, err := ui.Confirm(ctx, sb.String())
 	if err != nil {
 		return false, err
 	}
@@ -92,16 +89,23 @@ func (h *interactionHandler) ConfirmAction(ctx context.Context, action, target, 
 
 // ReadSingleKey waits for a single key press.
 func (h *interactionHandler) ReadSingleKey(ctx context.Context) (string, error) {
-	return h.interactor.ReadSingleKey(ctx)
+	ui := h.interactorProvider()
+	return ui.ReadSingleKey(ctx)
 }
 
 // ReadLine reads a line of input.
 func (h *interactionHandler) ReadLine(ctx context.Context) (string, error) {
-	return h.interactor.ReadLine(ctx)
+	ui := h.interactorProvider()
+	return ui.ReadLine(ctx)
 }
 
 // noOpInteractor is a dummy interactor that does nothing and denies all confirmations.
 type noOpInteractor struct{}
+
+// NoOpInteractor returns a UserInteractor that does nothing and denies all confirmations.
+func NoOpInteractor() domain.UserInteractor {
+	return &noOpInteractor{}
+}
 
 // Confirm always returns false.
 func (i *noOpInteractor) Confirm(ctx context.Context, message string) (bool, error) {

--- a/internal/infrastructure/security/interaction_test.go
+++ b/internal/infrastructure/security/interaction_test.go
@@ -38,8 +38,7 @@ func (m *mockAuditor) getArgValue(callIdx int, key string) any {
 	return nil
 }
 
-func (m *mockAuditor) SetLogFile(path string)                         {}
-func (m *mockAuditor) SetInteractor(interactor domain.UserInteractor) {}
+func (m *mockAuditor) SetLogFile(path string) {}
 func (m *mockAuditor) Close() error                                   { return nil }
 
 // spyInteractor captures calls to UserInteractor methods.
@@ -170,7 +169,7 @@ func TestInteractionHandler_ConfirmAction(t *testing.T) {
 				tt.mockSetup(&spy.mockInteractor)
 			}
 			auditor := &mockAuditor{}
-			handler := newInteractionHandler(spy, auditor)
+			handler := newInteractionHandler(func() domain.UserInteractor { return spy }, auditor)
 
 			got, err := handler.ConfirmAction(ctx, tt.action, tt.target, tt.detail, tt.bypass)
 
@@ -195,7 +194,7 @@ func TestInteractionHandler_ReadMethods(t *testing.T) {
 	t.Parallel()
 	spy := &spyInteractor{}
 	spy.Answer = "hello"
-	handler := newInteractionHandler(spy, nil)
+	handler := newInteractionHandler(func() domain.UserInteractor { return spy }, nil)
 
 	ctx := context.Background()
 	key, err := handler.ReadSingleKey(ctx)
@@ -212,21 +211,6 @@ func TestInteractionHandler_ReadMethods(t *testing.T) {
 	}
 	if line != "hello" {
 		t.Errorf("ReadLine returned %q, expect 'hello'", line)
-	}
-}
-
-func TestInteractionHandler_SetInteractor(t *testing.T) {
-	t.Parallel()
-	spy1 := &spyInteractor{}
-	handler := newInteractionHandler(spy1, nil)
-	if handler.interactor != spy1 {
-		t.Error("Initial interactor mismatch")
-	}
-
-	spy2 := &spyInteractor{}
-	handler.SetInteractor(spy2)
-	if handler.interactor != spy2 {
-		t.Error("SetInteractor failed")
 	}
 }
 
@@ -288,7 +272,7 @@ func TestMockInteractor_EdgeCases(t *testing.T) {
 
 func TestInteractionHandler_TerminalLocking(t *testing.T) {
 	t.Parallel()
-	handler := newInteractionHandler(&noOpInteractor{}, nil)
+	handler := newInteractionHandler(NoOpInteractor, nil)
 	// Just verify they don't panic and can be called
 	handler.TerminalLock()
 	handler.TerminalUnlock()

--- a/internal/infrastructure/security/interaction_test.go
+++ b/internal/infrastructure/security/interaction_test.go
@@ -39,7 +39,7 @@ func (m *mockAuditor) getArgValue(callIdx int, key string) any {
 }
 
 func (m *mockAuditor) SetLogFile(path string) {}
-func (m *mockAuditor) Close() error                                   { return nil }
+func (m *mockAuditor) Close() error           { return nil }
 
 // spyInteractor captures calls to UserInteractor methods.
 type spyInteractor struct {

--- a/internal/infrastructure/security/manager.go
+++ b/internal/infrastructure/security/manager.go
@@ -24,16 +24,15 @@ type SecurityManager struct {
 }
 
 // NewSecurityManager creates a new SecurityManager.
-func NewSecurityManager(interactor domain.UserInteractor) *SecurityManager {
-	if interactor == nil {
-		interactor = &noOpInteractor{}
+func NewSecurityManager(interactorProvider func() domain.UserInteractor) *SecurityManager {
+	if interactorProvider == nil {
+		interactorProvider = NoOpInteractor
 	}
-	auditor := newAuditor()
-	auditor.SetInteractor(interactor)
+	auditor := newAuditor(interactorProvider)
 	policy := domain.DefaultPolicy()
 	return &SecurityManager{
 		policy:       newPathPolicy(nil),
-		interaction:  newInteractionHandler(interactor, auditor),
+		interaction:  newInteractionHandler(interactorProvider, auditor),
 		auditor:      auditor,
 		domainPolicy: policy,
 		safety:       domain.NewSafetyService(policy),
@@ -84,12 +83,12 @@ func (sm *SecurityManager) LogAudit(action string, args ...any) {
 
 // Warn prints a security warning.
 func (sm *SecurityManager) Warn(message string) {
-	sm.interaction.interactor.Warn(message)
+	sm.interaction.interactorProvider().Warn(message)
 }
 
 // Prompt prints an inline prompt.
 func (sm *SecurityManager) Prompt(message string) {
-	sm.interaction.interactor.Prompt(message)
+	sm.interaction.interactorProvider().Prompt(message)
 }
 
 // Confirm prompts the user for confirmation.
@@ -97,16 +96,10 @@ func (sm *SecurityManager) Confirm(ctx context.Context, message string) (bool, e
 	if domain.IsCurrentToolApproved(ctx) || sm.IsBypassActive() {
 		sm.interaction.TerminalLock()
 		defer sm.interaction.TerminalUnlock()
-		sm.interaction.interactor.Warn(fmt.Sprintf("[Auto-Approved] %s", message))
+		sm.interaction.interactorProvider().Warn(fmt.Sprintf("[Auto-Approved] %s", message))
 		return true, nil
 	}
-	return sm.interaction.interactor.Confirm(ctx, message)
-}
-
-// SetInteractor updates the user interactor.
-func (sm *SecurityManager) SetInteractor(interactor domain.UserInteractor) {
-	sm.interaction.SetInteractor(interactor)
-	sm.auditor.SetInteractor(interactor)
+	return sm.interaction.interactorProvider().Confirm(ctx, message)
 }
 
 // IsBypassActive returns the current state of bypass_confirmation.
@@ -190,7 +183,7 @@ func (sm *SecurityManager) getSafetyService() *domain.SafetyService {
 
 // getInteractor returns the user interactor.
 func (sm *SecurityManager) getInteractor() domain.UserInteractor {
-	return sm.interaction.interactor
+	return sm.interaction.interactorProvider()
 }
 
 // internalSecurityProvider extends domain.Manager with methods used only within the security package.

--- a/internal/infrastructure/security/manager_test.go
+++ b/internal/infrastructure/security/manager_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestSecurityManager_Bypass(t *testing.T) {
 	t.Parallel()
-	sm := NewSecurityManager(&mockInteractor{Answer: "y"})
+	sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "y"} })
 
 	// Default
 	if sm.IsBypassActive() {
@@ -64,7 +64,8 @@ func TestSecurityManager_Authorize(t *testing.T) {
 	t.Parallel()
 	// 1. Authorize when isSafe=true
 
-	sm := NewSecurityManager(nil)
+	var mi domain.UserInteractor
+	sm := NewSecurityManager(func() domain.UserInteractor { return mi })
 	ok, err := sm.Authorize(context.Background(), "label", "detail", "reason", true)
 	assertAuthorization(t, "Authorize(isSafe=true)", ok, err, true)
 
@@ -75,12 +76,12 @@ func TestSecurityManager_Authorize(t *testing.T) {
 
 	// 3. Authorize with user interaction (Yes)
 	sm.SetBypassActive(false)
-	sm.SetInteractor(&mockInteractor{Answer: "y"})
+	mi = &mockInteractor{Answer: "y"}
 	ok, err = sm.Authorize(context.Background(), "label", "detail", "reason", false)
 	assertAuthorization(t, "Authorize(user=y)", ok, err, true)
 
 	// 4. Authorize with user interaction (No)
-	sm.SetInteractor(&mockInteractor{Answer: "n"})
+	mi = &mockInteractor{Answer: "n"}
 	ok, err = sm.Authorize(context.Background(), "label", "detail", "reason", false)
 	assertAuthorization(t, "Authorize(user=n)", ok, err, false)
 
@@ -126,7 +127,7 @@ func contains(slice []string, val string) bool {
 
 func TestSecurityManager_Misc(t *testing.T) {
 	t.Parallel()
-	sm := NewSecurityManager(&mockInteractor{Answer: "y"})
+	sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "y"} })
 	defer func() {
 		_ = sm.Close()
 	}()
@@ -185,7 +186,7 @@ func TestSecurityManager_Confirm_Bypass(t *testing.T) {
 	t.Parallel()
 	// Default behavior (no bypass) - user says No
 	interactor := &mockInteractor{Answer: "n"}
-	sm := NewSecurityManager(interactor)
+	sm := NewSecurityManager(func() domain.UserInteractor { return interactor })
 	defer func() {
 		_ = sm.Close()
 	}()

--- a/internal/infrastructure/security/policy.go
+++ b/internal/infrastructure/security/policy.go
@@ -356,13 +356,13 @@ func (t *policyTool) confirmAction(ctx context.Context, title, path, reason stri
 	}
 
 	sb.WriteString(t.getPrompt(lowerTitle))
-	confirmed, err := t.sm.interaction.interactor.Confirm(ctx, sb.String())
+	confirmed, err := t.sm.interaction.interactorProvider().Confirm(ctx, sb.String())
 	if err != nil || !confirmed {
 		return false, err
 	}
 
 	if doubleConfirm {
-		confirmed, err = t.sm.interaction.interactor.Confirm(ctx, fmt.Sprintf("[DOUBLE CONFIRM] %s (y/N) ", t.getDoubleMsg(lowerTitle)))
+		confirmed, err = t.sm.interaction.interactorProvider().Confirm(ctx, fmt.Sprintf("[DOUBLE CONFIRM] %s (y/N) ", t.getDoubleMsg(lowerTitle)))
 		if err != nil || !confirmed {
 			return false, err
 		}

--- a/internal/infrastructure/security/policy_test.go
+++ b/internal/infrastructure/security/policy_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	domain "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/stretchr/testify/mock"
 )
@@ -35,7 +36,7 @@ func (m *mockKVStore) GetAll(ctx context.Context) (map[string]string, error) {
 }
 
 func setupPolicyTest(t *testing.T) (*SecurityManager, *policyTool, context.Context) {
-	sm := NewSecurityManager(&mockInteractor{Answer: "y"})
+	sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "y"} })
 
 	mockKV := new(mockKVStore)
 	mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -254,8 +255,14 @@ func TestPolicyTool_DeniedInteractions(t *testing.T) {
 
 	t.Run("RegisterSafePath denied", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		path := filepath.Join(t.TempDir(), "denied")
 		res, err := p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
 		if err != nil {
@@ -268,8 +275,14 @@ func TestPolicyTool_DeniedInteractions(t *testing.T) {
 
 	t.Run("BypassConfirmation denied", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		res, err := p.BypassConfirmation(ctx, nil, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -285,9 +298,15 @@ func TestPolicyTool_BypassBehavior(t *testing.T) {
 
 	t.Run("RegisterSafePath bypass", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		sm.SetBypassActive(true)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
 		path := filepath.Join(t.TempDir(), "b1")
 		res, err := p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "r"}, nil)
 		if err != nil {
@@ -300,9 +319,15 @@ func TestPolicyTool_BypassBehavior(t *testing.T) {
 
 	t.Run("RemoveSafePath bypass", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		sm.SetBypassActive(true)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
 		path := filepath.Join(t.TempDir(), "b1")
 		res, err := p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
 		if err != nil {
@@ -315,9 +340,15 @@ func TestPolicyTool_BypassBehavior(t *testing.T) {
 
 	t.Run("RegisterReadPath bypass", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		sm.SetBypassActive(true)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
 		path := filepath.Join(t.TempDir(), "b2")
 		res, err := p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "r"}, nil)
 		if err != nil {
@@ -330,9 +361,15 @@ func TestPolicyTool_BypassBehavior(t *testing.T) {
 
 	t.Run("RemoveReadPath bypass", func(t *testing.T) {
 		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
+		mockKV := new(mockKVStore)
+		mockKV.On("Set", mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+		sm := NewSecurityManager(func() domain.UserInteractor { return &mockInteractor{Answer: "n"} })
+		p, err := newPolicyTool(sm, mockKV)
+		if err != nil {
+			t.Fatalf("failed to create policyTool: %v", err)
+		}
+		ctx := context.Background()
 		sm.SetBypassActive(true)
-		sm.SetInteractor(&mockInteractor{Answer: "n"})
 		path := filepath.Join(t.TempDir(), "b2")
 		res, err := p.RemoveReadPath(ctx, map[string]interface{}{"path": path}, nil)
 		if err != nil {

--- a/internal/tools/toolstest/mock_security_manager.go
+++ b/internal/tools/toolstest/mock_security_manager.go
@@ -93,8 +93,4 @@ func (m *MockSecurityManager) SetBypassActive(active bool) {
 	m.BypassActive = active
 }
 
-func (m *MockSecurityManager) SetInteractor(i security.UserInteractor) {
-	m.Interactor = i
-}
-
 func (m *MockSecurityManager) RegisterSafePath(path string) {}

--- a/internal/tools/workspace/interaction_test.go
+++ b/internal/tools/workspace/interaction_test.go
@@ -17,7 +17,7 @@ func TestInteractionTool(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Ask User", func(t *testing.T) {
-		sm.SetInteractor(&toolstest.MockInteractor{Answer: "The answer is 42\n"})
+		sm.Interactor = &toolstest.MockInteractor{Answer: "The answer is 42\n"}
 		res, err := it.askUser(ctx, map[string]interface{}{
 			"question": "What is the answer?",
 		}, nil)
@@ -30,7 +30,7 @@ func TestInteractionTool(t *testing.T) {
 	})
 
 	t.Run("Ask User EOF", func(t *testing.T) {
-		sm.SetInteractor(&toolstest.MockInteractor{Answer: ""}) // Immediate EOF
+		sm.Interactor = &toolstest.MockInteractor{Answer: ""} // Immediate EOF
 		res, err := it.askUser(ctx, map[string]interface{}{
 			"question": "What is the answer?",
 		}, nil)
@@ -43,7 +43,7 @@ func TestInteractionTool(t *testing.T) {
 	})
 
 	t.Run("Ask User Read Error", func(t *testing.T) {
-		sm.SetInteractor(&toolstest.MockInteractor{Err: context.DeadlineExceeded})
+		sm.Interactor = &toolstest.MockInteractor{Err: context.DeadlineExceeded}
 		_, err := it.askUser(ctx, map[string]interface{}{
 			"question": "What is the answer?",
 		}, nil)


### PR DESCRIPTION
## Summary

Closes #131. Supersedes #128 and #130.

Eliminates the `SetInteractor` post-construction setter pattern by injecting a lazy provider function (`func() domain.UserInteractor`) at construction time, breaking the bootstrap ordering cycle between `SecurityManager` and `Capturer`.

## Changes

### Core refactoring
- **`interaction.go` / `auditor.go`**: Store `func() domain.UserInteractor` instead of `domain.UserInteractor`; invoke provider per call; delete `SetInteractor`
- **`manager.go`**: `NewSecurityManager(func() domain.UserInteractor)`; nil-guard defaults to `NoOpInteractor`; delete `SetInteractor`
- **`main.go`**: Provider closure captures `&interactor` pointer; passed via `AppDependencies`

### Wiring
- **`interface.go` / `cli.go`**: `*domain.UserInteractor` threaded through `AppDependencies` → `App` → `context` → commands
- **`chat_command.go` / `cmd_browse.go`**: 3 anonymous interface assertions replaced with `*c.Interactor = capturer`

### Test cleanup
- Deleted `SetInteractor` from all mocks (`mockSM`, `mockAuditor`, `MockSecurityManager`)
- Deleted `TestChatCommand_TUIPrompt_SetsInteractor` and `TestInteractionHandler_SetInteractor`
- Wrapped interactors in provider closures for `NewSecurityManager` calls

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages)
- `dead_code_graph`: `SetInteractor` no longer flagged ✅
- Zero `SetInteractor` references remain in production or test code