### PR TITLE
fix: thread-safe interactor wiring with atomic InteractorRef (post-#134)

### DIFF
--- a/cmd/tell-me-go/main.go
+++ b/cmd/tell-me-go/main.go
@@ -126,10 +126,15 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 	homeDir := env.ResolveHomeDir(os.Getenv, os.UserHomeDir)
 
 	// 2. Initialize Core Infrastructure
-	var interactor domain_security.UserInteractor
+	//
+	// The InteractorRef is the wiring cell that breaks the bootstrap cycle:
+	// SecurityManager is built here (early), but the real UserInteractor
+	// (Capturer) is constructed later inside the CLI command. The provider
+	// closure reads the cell atomically on each interaction.
+	interactorRef := cli.NewInteractorRef()
 	interactorProvider := func() domain_security.UserInteractor {
-		if interactor != nil {
-			return interactor
+		if i := interactorRef.Get(); i != nil {
+			return i
 		}
 		return security.NoOpInteractor()
 	}
@@ -164,7 +169,7 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 		Bootstrapper: bootstrapper,
 		ConfigLoader: configLoader,
 		ChatService:  chatService,
-		Interactor:   &interactor,
+		Interactor:   interactorRef,
 	}, os.Getenv)
 
 	if err != nil {

--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -244,7 +244,7 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 			}
 		}
 
-		c.Interactor.Set(capturer)
+		c.Interactor.set(capturer)
 		return capturer, cleanup
 	}
 	return c.setupCapturer()
@@ -256,7 +256,7 @@ func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Con
 	if !ok {
 		return nil, func(stdctx.Context) error { return nil }
 	}
-	c.Interactor.Set(capturer)
+	c.Interactor.set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)
 	}

--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -34,7 +34,7 @@ type chatCommand struct {
 	HomeDir      string
 	MockPrompt   string
 	MockAnswer   string
-	Interactor   *domain_security.UserInteractor
+	Interactor   *InteractorRef
 }
 
 type cliOptions struct {
@@ -244,9 +244,7 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 			}
 		}
 
-		if c.Interactor != nil {
-			*c.Interactor = capturer
-		}
+		c.Interactor.Set(capturer)
 		return capturer, cleanup
 	}
 	return c.setupCapturer()
@@ -258,9 +256,7 @@ func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Con
 	if !ok {
 		return nil, func(stdctx.Context) error { return nil }
 	}
-	if c.Interactor != nil {
-		*c.Interactor = capturerInterface
-	}
+	c.Interactor.Set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)
 	}

--- a/internal/cli/chat_command_test.go
+++ b/internal/cli/chat_command_test.go
@@ -634,3 +634,97 @@ func TestChatCommand_Execute_Diagnostic_JSON(t *testing.T) {
 	require.NoError(t, err, "Execute should not fail")
 	mService.AssertExpectations(t)
 }
+
+func TestChatCommand_Execute_TUIPrompt_PopulatesInteractorRef(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr strings.Builder
+	sm := &mockSM{}
+	mb, ml, mService := setupMocks()
+
+	ref := NewInteractorRef()
+	if got := ref.Get(); got != nil {
+		t.Fatalf("expected empty InteractorRef before run, got %T", got)
+	}
+
+	cmdCtx := &context{
+		Version:      "1.0.0",
+		Stdin:        strings.NewReader("hello\n"),
+		Stdout:       &stdout,
+		Stderr:       &stderr,
+		SM:           sm,
+		ChatService:  mService,
+		Bootstrapper: mb,
+		Loader:       ml,
+		HomeDir:      t.TempDir(),
+		Interactor:   ref,
+	}
+
+	if err := executeChatCommand(cmdCtx, []string{"--interactive"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := ref.Get()
+	if got == nil {
+		t.Fatal("expected InteractorRef to be populated after --interactive run, got nil")
+	}
+}
+
+func TestChatCommand_Execute_NonTUI_PopulatesInteractorRef(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr strings.Builder
+	sm := &mockSM{}
+	mb, ml, mService := setupMocks()
+
+	ref := NewInteractorRef()
+
+	cmdCtx := &context{
+		Version:      "1.0.0",
+		Stdin:        strings.NewReader(""),
+		Stdout:       &stdout,
+		Stderr:       &stderr,
+		SM:           sm,
+		ChatService:  mService,
+		Bootstrapper: mb,
+		Loader:       ml,
+		MockPrompt:   "hello",
+		Interactor:   ref,
+	}
+
+	if err := executeChatCommand(cmdCtx, []string{"hello"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ref.Get() == nil {
+		t.Fatal("expected InteractorRef to be populated after non-TUI run, got nil")
+	}
+}
+
+func TestChatCommand_NilInteractorRef_DoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	// Passing a nil *InteractorRef must be safe — the InteractorRef.Set
+	// method nil-guards internally so commands run without a wiring cell
+	// (e.g., in narrowly-scoped tests).
+	var stdout, stderr strings.Builder
+	sm := &mockSM{}
+	mb, ml, mService := setupMocks()
+
+	cmdCtx := &context{
+		Version:      "1.0.0",
+		Stdin:        strings.NewReader(""),
+		Stdout:       &stdout,
+		Stderr:       &stderr,
+		SM:           sm,
+		ChatService:  mService,
+		Bootstrapper: mb,
+		Loader:       ml,
+		MockPrompt:   "hello",
+		Interactor:   nil, // explicit
+	}
+
+	if err := executeChatCommand(cmdCtx, []string{"hello"}); err != nil {
+		t.Fatalf("unexpected error with nil InteractorRef: %v", err)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -36,7 +36,7 @@ type AppDependencies struct {
 	Bootstrapper Bootstrapper
 	ConfigLoader domain_config.ConfigLoader
 	ChatService  agent.ChatService
-	Interactor   *domain_security.UserInteractor
+	Interactor   *InteractorRef
 }
 
 // App represents the tell-me-go application.
@@ -50,7 +50,7 @@ type App struct {
 	bootstrapper Bootstrapper
 	configLoader domain_config.ConfigLoader
 	chatService  agent.ChatService
-	interactor   *domain_security.UserInteractor
+	interactor   *InteractorRef
 	mockPrompt   string
 	mockAnswer   string
 }

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -68,7 +68,7 @@ func (c *browseCommand) runBrowse(ctx stdctx.Context, configPath string) error {
 
 func (c *browseCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Context) error) {
 	capturer := ui.NewCapturer(c.ctx.Stdin, c.ctx.Stdout, c.ctx.Stderr, c.ctx.SM, clock.RealClock{}, c.ctx.MockPrompt, c.ctx.MockAnswer, false).(agent.CapturerInteractor)
-	c.ctx.Interactor.Set(capturer)
+	c.ctx.Interactor.set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)
 	}

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -68,9 +68,7 @@ func (c *browseCommand) runBrowse(ctx stdctx.Context, configPath string) error {
 
 func (c *browseCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Context) error) {
 	capturer := ui.NewCapturer(c.ctx.Stdin, c.ctx.Stdout, c.ctx.Stderr, c.ctx.SM, clock.RealClock{}, c.ctx.MockPrompt, c.ctx.MockAnswer, false).(agent.CapturerInteractor)
-	if c.ctx.Interactor != nil {
-		*c.ctx.Interactor = capturer
-	}
+	c.ctx.Interactor.Set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		return capturer.Close(ctx)
 	}

--- a/internal/cli/interactor_ref.go
+++ b/internal/cli/interactor_ref.go
@@ -18,30 +18,37 @@ import (
 //   - The composition root (cmd/tell-me-go/main.go) creates one InteractorRef
 //     and passes it to both the SecurityManager (via a provider closure that
 //     calls Get) and to the CLI App (via AppDependencies.Interactor).
-//   - The CLI command (chat or browse) calls Set(capturer) once the
-//     UserInteractor-capable Capturer has been constructed.
+//   - The CLI command (chat or browse) calls set(capturer) — unexported,
+//     internal to package cli — once the Capturer has been constructed.
 //   - SecurityManager's interaction handler invokes the provider on each
-//     interaction, observing the latest Set value atomically.
+//     interaction, observing the latest set value atomically.
+//
+// Note on API surface: Get is exported so the bootstrap (cmd/tell-me-go)
+// can read the cell from its provider closure. set is intentionally
+// unexported because mutation is a CLI-internal lifecycle concern; allowing
+// external packages to mutate the cell would re-introduce the temporal-
+// coupling smell that issue #131 was designed to eliminate.
 type InteractorRef struct {
 	p atomic.Pointer[domain_security.UserInteractor]
 }
 
 // NewInteractorRef returns an empty, ready-to-use InteractorRef. Get returns
-// nil until Set is called.
+// nil until set is called.
 func NewInteractorRef() *InteractorRef {
 	return &InteractorRef{}
 }
 
-// Set atomically stores the given interactor. Safe to call from any goroutine.
-// Passing a nil interactor effectively clears the cell.
-func (r *InteractorRef) Set(i domain_security.UserInteractor) {
+// set atomically stores the given interactor. Safe to call from any goroutine.
+// Passing a nil interactor effectively clears the cell. Unexported by design
+// (see the type-level note on API surface).
+func (r *InteractorRef) set(i domain_security.UserInteractor) {
 	if r == nil {
 		return
 	}
 	r.p.Store(&i)
 }
 
-// Get atomically loads the current interactor. Returns nil if Set has not
+// Get atomically loads the current interactor. Returns nil if set has not
 // been called yet (callers should fall back to a no-op interactor).
 func (r *InteractorRef) Get() domain_security.UserInteractor {
 	if r == nil {

--- a/internal/cli/interactor_ref.go
+++ b/internal/cli/interactor_ref.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	"sync/atomic"
+
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+)
+
+// InteractorRef is a thread-safe, mutable cell that holds the active
+// UserInteractor. It exists to break the bootstrap-ordering cycle between
+// SecurityManager (constructed early) and Capturer (constructed lazily, after
+// the CLI command starts). Reads and writes are safe across goroutines.
+//
+// Wiring contract:
+//   - The composition root (cmd/tell-me-go/main.go) creates one InteractorRef
+//     and passes it to both the SecurityManager (via a provider closure that
+//     calls Get) and to the CLI App (via AppDependencies.Interactor).
+//   - The CLI command (chat or browse) calls Set(capturer) once the
+//     UserInteractor-capable Capturer has been constructed.
+//   - SecurityManager's interaction handler invokes the provider on each
+//     interaction, observing the latest Set value atomically.
+type InteractorRef struct {
+	p atomic.Pointer[domain_security.UserInteractor]
+}
+
+// NewInteractorRef returns an empty, ready-to-use InteractorRef. Get returns
+// nil until Set is called.
+func NewInteractorRef() *InteractorRef {
+	return &InteractorRef{}
+}
+
+// Set atomically stores the given interactor. Safe to call from any goroutine.
+// Passing a nil interactor effectively clears the cell.
+func (r *InteractorRef) Set(i domain_security.UserInteractor) {
+	if r == nil {
+		return
+	}
+	r.p.Store(&i)
+}
+
+// Get atomically loads the current interactor. Returns nil if Set has not
+// been called yet (callers should fall back to a no-op interactor).
+func (r *InteractorRef) Get() domain_security.UserInteractor {
+	if r == nil {
+		return nil
+	}
+	if p := r.p.Load(); p != nil {
+		return *p
+	}
+	return nil
+}

--- a/internal/cli/interactor_ref_test.go
+++ b/internal/cli/interactor_ref_test.go
@@ -39,11 +39,11 @@ func TestInteractorRef_SetThenGet(t *testing.T) {
 	t.Parallel()
 	ref := NewInteractorRef()
 	want := &stubInteractor{id: 42}
-	ref.Set(want)
+	ref.set(want)
 
 	got := ref.Get()
 	if got == nil {
-		t.Fatal("expected non-nil interactor after Set")
+		t.Fatal("expected non-nil interactor after set")
 	}
 	stub, ok := got.(*stubInteractor)
 	if !ok {
@@ -57,15 +57,15 @@ func TestInteractorRef_SetThenGet(t *testing.T) {
 func TestInteractorRef_OverwriteWins(t *testing.T) {
 	t.Parallel()
 	ref := NewInteractorRef()
-	ref.Set(&stubInteractor{id: 1})
-	ref.Set(&stubInteractor{id: 2})
+	ref.set(&stubInteractor{id: 1})
+	ref.set(&stubInteractor{id: 2})
 
 	stub, ok := ref.Get().(*stubInteractor)
 	if !ok {
 		t.Fatalf("expected *stubInteractor, got %T", ref.Get())
 	}
 	if stub.id != 2 {
-		t.Errorf("expected latest Set to win (id=2), got id=%d", stub.id)
+		t.Errorf("expected latest set to win (id=2), got id=%d", stub.id)
 	}
 }
 
@@ -74,7 +74,7 @@ func TestInteractorRef_NilReceiverIsSafe(t *testing.T) {
 	var ref *InteractorRef // intentionally nil
 
 	// Must not panic.
-	ref.Set(&stubInteractor{id: 99})
+	ref.set(&stubInteractor{id: 99})
 	if got := ref.Get(); got != nil {
 		t.Errorf("expected nil from nil receiver, got %T", got)
 	}
@@ -86,7 +86,7 @@ func TestInteractorRef_NilReceiverIsSafe(t *testing.T) {
 func TestInteractorRef_ConcurrentAccess(t *testing.T) {
 	t.Parallel()
 	ref := NewInteractorRef()
-	ref.Set(&stubInteractor{id: 0})
+	ref.set(&stubInteractor{id: 0})
 
 	const writers, readers, iters = 4, 8, 1000
 
@@ -98,7 +98,7 @@ func TestInteractorRef_ConcurrentAccess(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for i := 0; i < iters; i++ {
-				ref.Set(&stubInteractor{id: w*iters + i})
+				ref.set(&stubInteractor{id: w*iters + i})
 			}
 		}()
 	}

--- a/internal/cli/interactor_ref_test.go
+++ b/internal/cli/interactor_ref_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	stdctx "context"
+	"sync"
+	"testing"
+
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+)
+
+// Compile-time assertion: stubInteractor must satisfy UserInteractor.
+// This keeps the contract explicit and fails the build if the interface
+// drifts (e.g., a method is added to UserInteractor).
+var _ domain_security.UserInteractor = (*stubInteractor)(nil)
+
+// stubInteractor is a minimal UserInteractor used to verify atomic storage
+// in InteractorRef. It carries an identifier so tests can assert which
+// instance was loaded.
+type stubInteractor struct{ id int }
+
+func (s *stubInteractor) Confirm(_ stdctx.Context, _ string) (bool, error) { return false, nil }
+func (s *stubInteractor) Warn(_ string)                                    {}
+func (s *stubInteractor) Prompt(_ string)                                  {}
+func (s *stubInteractor) ReadSingleKey(_ stdctx.Context) (string, error)   { return "", nil }
+func (s *stubInteractor) ReadLine(_ stdctx.Context) (string, error)        { return "", nil }
+
+func TestInteractorRef_GetBeforeSetReturnsNil(t *testing.T) {
+	t.Parallel()
+	ref := NewInteractorRef()
+	if got := ref.Get(); got != nil {
+		t.Fatalf("expected nil before Set, got %T", got)
+	}
+}
+
+func TestInteractorRef_SetThenGet(t *testing.T) {
+	t.Parallel()
+	ref := NewInteractorRef()
+	want := &stubInteractor{id: 42}
+	ref.Set(want)
+
+	got := ref.Get()
+	if got == nil {
+		t.Fatal("expected non-nil interactor after Set")
+	}
+	stub, ok := got.(*stubInteractor)
+	if !ok {
+		t.Fatalf("expected *stubInteractor, got %T", got)
+	}
+	if stub.id != 42 {
+		t.Errorf("expected id=42, got id=%d", stub.id)
+	}
+}
+
+func TestInteractorRef_OverwriteWins(t *testing.T) {
+	t.Parallel()
+	ref := NewInteractorRef()
+	ref.Set(&stubInteractor{id: 1})
+	ref.Set(&stubInteractor{id: 2})
+
+	stub, ok := ref.Get().(*stubInteractor)
+	if !ok {
+		t.Fatalf("expected *stubInteractor, got %T", ref.Get())
+	}
+	if stub.id != 2 {
+		t.Errorf("expected latest Set to win (id=2), got id=%d", stub.id)
+	}
+}
+
+func TestInteractorRef_NilReceiverIsSafe(t *testing.T) {
+	t.Parallel()
+	var ref *InteractorRef // intentionally nil
+
+	// Must not panic.
+	ref.Set(&stubInteractor{id: 99})
+	if got := ref.Get(); got != nil {
+		t.Errorf("expected nil from nil receiver, got %T", got)
+	}
+}
+
+// TestInteractorRef_ConcurrentAccess exercises the atomic semantics under
+// the race detector. Without the InteractorRef refactor, this is a plain
+// interface-value read/write race that `go test -race` would flag.
+func TestInteractorRef_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+	ref := NewInteractorRef()
+	ref.Set(&stubInteractor{id: 0})
+
+	const writers, readers, iters = 4, 8, 1000
+
+	var wg sync.WaitGroup
+	wg.Add(writers + readers)
+
+	for w := 0; w < writers; w++ {
+		w := w
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				ref.Set(&stubInteractor{id: w*iters + i})
+			}
+		}()
+	}
+
+	for r := 0; r < readers; r++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				// Read must never return nil (a writer always set first)
+				// and must always satisfy the interface.
+				if v := ref.Get(); v == nil {
+					t.Error("unexpected nil read from concurrently written ref")
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/internal/cli/interface.go
+++ b/internal/cli/interface.go
@@ -38,5 +38,5 @@ type context struct {
 	Loader       domain_config.ConfigLoader
 	MockPrompt   string
 	MockAnswer   string
-	Interactor   *domain_security.UserInteractor
+	Interactor   *InteractorRef
 }

--- a/internal/infrastructure/security/interaction.go
+++ b/internal/infrastructure/security/interaction.go
@@ -102,9 +102,17 @@ func (h *interactionHandler) ReadLine(ctx context.Context) (string, error) {
 // noOpInteractor is a dummy interactor that does nothing and denies all confirmations.
 type noOpInteractor struct{}
 
+// defaultNoOp is the singleton no-op interactor returned by NoOpInteractor.
+// noOpInteractor holds no state, so a single shared instance avoids per-call
+// allocation on the hot path (every SecurityManager interaction calls the
+// provider).
+var defaultNoOp domain.UserInteractor = &noOpInteractor{}
+
 // NoOpInteractor returns a UserInteractor that does nothing and denies all confirmations.
+// The returned value is a process-wide singleton; callers must not assume identity
+// across calls is meaningful, but may rely on it being non-nil.
 func NoOpInteractor() domain.UserInteractor {
-	return &noOpInteractor{}
+	return defaultNoOp
 }
 
 // Confirm always returns false.


### PR DESCRIPTION
## Summary

Follow-up to merged PR #134. Resolves the **data race** identified in the post-merge architectural review on the `interactor` wiring cell, plus minor cleanup items.

## The Race (BLOCKER)

PR #134 introduced this pattern in `cmd/tell-me-go/main.go`:
```go
var interactor domain_security.UserInteractor       // shared mutable interface
interactorProvider := func() domain_security.UserInteractor {
    if interactor != nil { return interactor }      // READ from any goroutine
    return security.NoOpInteractor()
}
```
And in `internal/cli/chat_command.go`:
```go
*c.Interactor = capturer                            // WRITE from main goroutine
```

The `SecurityManager`'s interaction handler invokes `interactorProvider()` from any goroutine that triggers a security check (tool execution, audit logs, agent loops). With no synchronization, reading a partially-written interface value (a 2-word `(type, data)` tuple) is **undefined behavior**.

## The Fix

Introduce `internal/cli.InteractorRef` — a thin wrapper over `atomic.Pointer[domain_security.UserInteractor]` that provides:
- Atomic `Set(i UserInteractor)` and `Get() UserInteractor`
- Nil-receiver safety (`Set` and `Get` on `nil *InteractorRef` are no-ops)
- A clear contract documented at the type

Threaded end-to-end:
- `cmd/tell-me-go/main.go` — provider closure reads `interactorRef.Get()`
- `internal/cli.AppDependencies.Interactor` — `*InteractorRef`
- `internal/cli.App.interactor` / `context.Interactor` / `chatCommand.Interactor` — `*InteractorRef`
- Wire sites: `chat_command.go` (TUI + non-TUI), `cmd_browse.go` — call `c.Interactor.Set(capturer)`

## Other Review Items Addressed

- ✅ **Restored deleted test:** `TestChatCommand_Execute_TUIPrompt_PopulatesInteractorRef` (replaces the removed `..._SetsInteractor`)
- ✅ **Cached `noOpInteractor` singleton** (`defaultNoOp`) — eliminates per-call allocation on the hot path
- ✅ **Wrapped pointer-to-interface in a typed `InteractorRef`** — cleans up the public DI surface
- ✅ **`go fmt` / `goimports`** — applied via `go_tidy`

## New Tests

- `TestInteractorRef_GetBeforeSetReturnsNil`
- `TestInteractorRef_SetThenGet`
- `TestInteractorRef_OverwriteWins`
- `TestInteractorRef_NilReceiverIsSafe`
- `TestInteractorRef_ConcurrentAccess` — exercises 4 writers × 8 readers × 1000 iters; would fail `-race` without the atomic primitive
- `TestChatCommand_Execute_TUIPrompt_PopulatesInteractorRef`
- `TestChatCommand_Execute_NonTUI_PopulatesInteractorRef`
- `TestChatCommand_NilInteractorRef_DoesNotPanic`

## Verification

- `go build ./...` ✅
- `go test ./...` ✅ (all packages)
- `go test -race ./...` ✅ (all packages)
- `golangci-lint run` ✅ (0 issues)
- Zero production references to `SetInteractor` remain (only historical mentions in ADR docs and the dead-code-analyzer fixture tests, which gracefully skip when the symbol is gone)

## References

- Supersedes / fixes review on: #134
- Related: #131, #130 (closed), #128 (closed)

cc @gosharplite — Coder is on vacation; merge at your discretion. The PR is intentionally surgical (no behavioral changes beyond thread safety + the cached NoOp).