### PR TITLE
docs(adr-029): accept Fallible Reconfigure Delegate Chain

### DIFF
--- a/docs/adr/2026-05-fallible-reconfigure-delegate-chain.md
+++ b/docs/adr/2026-05-fallible-reconfigure-delegate-chain.md
@@ -6,7 +6,10 @@ SPDX-License-Identifier: MIT
 # ADR-029: Fallible `Reconfigure` Delegate Chain in Agent Hot-Reload
 
 ## Status
-Proposed
+Accepted
+
+## Decision Date
+2026-05-04
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,7 +30,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-022** | Tool-Result Error Convention | 2026-04 | Accepted | [2026-04-tool-result-error-convention.md](2026-04-tool-result-error-convention.md) |
 | **ADR-023** | Reasoning-Token Accounting for OpenAI-Compatible Providers | 2026-04 | Accepted | [2026-04-reasoning-token-accounting.md](2026-04-reasoning-token-accounting.md) |
 | **ADR-028** | Delegate Registration Logic to Integration Sub-Packages | 2026-05 | Accepted | [2026-05-subpackage-registration-pattern.md](2026-05-subpackage-registration-pattern.md) |
-| **ADR-029** | Fallible `Reconfigure` Delegate Chain in Agent Hot-Reload | 2026-05 | Proposed | [2026-05-fallible-reconfigure-delegate-chain.md](2026-05-fallible-reconfigure-delegate-chain.md) |
+| **ADR-029** | Fallible `Reconfigure` Delegate Chain in Agent Hot-Reload | 2026-05 | Accepted | [2026-05-fallible-reconfigure-delegate-chain.md](2026-05-fallible-reconfigure-delegate-chain.md) |
 
 ## How to Create a New ADR
 


### PR DESCRIPTION
Implements T1 of #141.

This is a documentation-only change with no code modifications. It flips ADR-029 status from Proposed to Accepted and adds a Decision Date. T2–T7 will follow in a separate PR.

Refs: #141