### PR TITLE
feat(adr-029): add Validate() to RuntimeConfig and events.Limits (T2)

### DIFF
--- a/internal/agent/orchestrator/engine_types.go
+++ b/internal/agent/orchestrator/engine_types.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
@@ -21,6 +22,37 @@ type RuntimeConfig struct {
 	Model            string
 	Mode             string
 	PricingOverrides map[string]domain_pricing.ModelPricing
+}
+
+// Validate checks that the RuntimeConfig contains the minimum viable
+// fields required by the orchestrator Engine. It is called by
+// Engine.Reconfigure to fail fast on malformed runtime configuration.
+// See ADR-029.
+//
+// Rules (minimum viable set per ADR-029 §6):
+//   - ProviderName must be non-empty.
+//   - Model must be non-empty.
+//   - Mode must be non-empty.
+//   - PricingOverrides may be nil or empty; if non-empty, no key may be the empty string.
+//
+// Additional validation rules will be added in separate, individually-tracked issues
+// per ADR-029 negative-consequence mitigation. Do not extend this method ad-hoc.
+func (c RuntimeConfig) Validate() error {
+	if c.ProviderName == "" {
+		return fmt.Errorf("runtime config: provider name must not be empty")
+	}
+	if c.Model == "" {
+		return fmt.Errorf("runtime config: model must not be empty")
+	}
+	if c.Mode == "" {
+		return fmt.Errorf("runtime config: mode must not be empty")
+	}
+	for k := range c.PricingOverrides {
+		if k == "" {
+			return fmt.Errorf("runtime config: pricing overrides contain empty key")
+		}
+	}
+	return nil
 }
 
 // engineConfig defines the lock-free runtime state for the Engine.

--- a/internal/agent/orchestrator/runtime_config_validate_test.go
+++ b/internal/agent/orchestrator/runtime_config_validate_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+
+	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
+)
+
+func TestRuntimeConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       RuntimeConfig
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name: "valid minimal config",
+			cfg: RuntimeConfig{
+				ProviderName: "openai",
+				Model:        "gpt-4",
+				Mode:         "chat",
+			},
+		},
+		{
+			name: "valid with non-empty pricing override",
+			cfg: RuntimeConfig{
+				ProviderName:     "openai",
+				Model:            "gpt-4",
+				Mode:             "chat",
+				PricingOverrides: map[string]domain_pricing.ModelPricing{"gpt-4": {}},
+			},
+		},
+		{
+			name: "valid with nil pricing overrides",
+			cfg: RuntimeConfig{
+				ProviderName:     "openai",
+				Model:            "gpt-4",
+				Mode:             "chat",
+				PricingOverrides: nil,
+			},
+		},
+		{
+			name:      "empty provider name",
+			cfg:       RuntimeConfig{Model: "gpt-4", Mode: "chat"},
+			wantErr:   true,
+			errSubstr: "provider name",
+		},
+		{
+			name:      "empty model",
+			cfg:       RuntimeConfig{ProviderName: "openai", Mode: "chat"},
+			wantErr:   true,
+			errSubstr: "model",
+		},
+		{
+			name:      "empty mode",
+			cfg:       RuntimeConfig{ProviderName: "openai", Model: "gpt-4"},
+			wantErr:   true,
+			errSubstr: "mode",
+		},
+		{
+			name: "empty pricing override key",
+			cfg: RuntimeConfig{
+				ProviderName:     "openai",
+				Model:            "gpt-4",
+				Mode:             "chat",
+				PricingOverrides: map[string]domain_pricing.ModelPricing{"": {}},
+			},
+			wantErr:   true,
+			errSubstr: "empty key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error = %q; want substring %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/domain/events/limits_validate_test.go
+++ b/internal/domain/events/limits_validate_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package events
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLimits_Validate(t *testing.T) {
+	tests := []struct {
+		name      string
+		limits    Limits
+		wantErr   bool
+		errSubstr string
+	}{
+		{
+			name:   "all zero (defaults sentinel)",
+			limits: Limits{},
+		},
+		{
+			name:   "all positive",
+			limits: Limits{MaxHistoryTokens: 8000, MaxToolTurns: 10, MaxHistoryTurns: 50},
+		},
+		{
+			name:      "negative MaxHistoryTokens",
+			limits:    Limits{MaxHistoryTokens: -1},
+			wantErr:   true,
+			errSubstr: "max history tokens",
+		},
+		{
+			name:      "negative MaxToolTurns",
+			limits:    Limits{MaxToolTurns: -1},
+			wantErr:   true,
+			errSubstr: "max tool turns",
+		},
+		{
+			name:      "negative MaxHistoryTurns",
+			limits:    Limits{MaxHistoryTurns: -1},
+			wantErr:   true,
+			errSubstr: "max history turns",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.limits.Validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.errSubstr)
+				}
+				if !strings.Contains(err.Error(), tt.errSubstr) {
+					t.Errorf("error = %q; want substring %q", err.Error(), tt.errSubstr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/internal/domain/events/types.go
+++ b/internal/domain/events/types.go
@@ -5,6 +5,7 @@ package events
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -18,6 +19,35 @@ type Limits struct {
 	MaxToolTurns     int
 	MaxHistoryTurns  int
 	ContextWindow    int
+}
+
+// Validate checks that the Limits contain non-negative values required by the
+// session context Manager. It is called by Manager.Reconfigure to fail fast on
+// malformed limits. See ADR-029.
+//
+// Rules (minimum viable set per ADR-029 §6):
+//   - MaxHistoryTokens must be >= 0.
+//   - MaxToolTurns must be >= 0.
+//   - MaxHistoryTurns must be >= 0.
+//
+// A value of zero is treated as "use default / unlimited" by downstream
+// consumers and is therefore valid here. Negative values are nonsensical and
+// indicate misconfiguration.
+//
+// Additional validation rules will be added in separate, individually-tracked
+// issues per ADR-029 negative-consequence mitigation. Do not extend this method
+// ad-hoc.
+func (l Limits) Validate() error {
+	if l.MaxHistoryTokens < 0 {
+		return fmt.Errorf("limits: max history tokens must be >= 0, got %d", l.MaxHistoryTokens)
+	}
+	if l.MaxToolTurns < 0 {
+		return fmt.Errorf("limits: max tool turns must be >= 0, got %d", l.MaxToolTurns)
+	}
+	if l.MaxHistoryTurns < 0 {
+		return fmt.Errorf("limits: max history turns must be >= 0, got %d", l.MaxHistoryTurns)
+	}
+	return nil
 }
 
 // ConfigUpdated signals that the agent's configuration has changed.


### PR DESCRIPTION
Implements T2 of #141.

Pure additive change:
- `RuntimeConfig.Validate()` in `internal/agent/orchestrator`
- `events.Limits.Validate()` in `internal/domain/events`
- Table-driven tests for both, ≥95% coverage

No existing signatures or call sites modified. The methods are not yet
invoked — T3/T4 will wire them into `Engine.Reconfigure` and
`Manager.Reconfigure` respectively.

Issue #141 remains open until T7 ships.