### PR TITLE
feat(adr-029): make Engine.Reconfigure fallible (T3)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -188,12 +188,14 @@ func (a *agent) applyConfig(ctx context.Context) error {
 	}
 
 	if a.engine != nil {
-		a.engine.Reconfigure(orchestrator.RuntimeConfig{
+		if err := a.engine.Reconfigure(orchestrator.RuntimeConfig{
 			ProviderName:     newCfg.ProviderName,
 			Model:            newCfg.Model,
 			Mode:             newCfg.Mode,
 			PricingOverrides: newCfg.PricingOverrides,
-		}, tracker)
+		}, tracker); err != nil {
+			return err
+		}
 	}
 	if a.ctxManager != nil {
 		a.ctxManager.Reconfigure(newCfg.Limits)

--- a/internal/agent/agent_chat_test.go
+++ b/internal/agent/agent_chat_test.go
@@ -38,7 +38,8 @@ func TestAgent_Chat_Success(t *testing.T) {
 	hManager := &agenttest.MockHistoryManager{}
 	sm := &mockSecurityManager{AllowAll: true}
 
-	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm))
+	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
 	}
@@ -85,7 +86,8 @@ func TestAgent_Chat_EngineFailure(t *testing.T) {
 	hManager := &agenttest.MockHistoryManager{}
 	sm := &mockSecurityManager{AllowAll: true}
 
-	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm))
+	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
 	}
@@ -110,7 +112,8 @@ func TestAgent_Chat_ContextCancellation(t *testing.T) {
 	hManager := &agenttest.MockHistoryManager{}
 	sm := &mockSecurityManager{AllowAll: true}
 
-	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm))
+	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
 	}
@@ -194,7 +197,8 @@ func TestAgent_Chat_TelemetryFailure_Actual(t *testing.T) {
 	hManager := &agenttest.MockHistoryManager{}
 	sm := &mockSecurityManager{AllowAll: true}
 
-	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm))
+	a, err := NewAgent(gw, bus, reg, WithHistoryManager(hManager), WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	if err != nil {
 		t.Fatalf("failed to create agent: %v", err)
 	}

--- a/internal/agent/agent_lifecycle_test.go
+++ b/internal/agent/agent_lifecycle_test.go
@@ -66,7 +66,8 @@ func TestAgent_InternalState_MutationAndReadback(t *testing.T) {
 	reg := agenttest.NewMockToolRegistry()
 	sm := &mockSecurityManager{AllowAll: true}
 
-	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm))
+	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	require.NoError(t, err)
 
 	a := asAgent(t, chatter)
@@ -118,7 +119,8 @@ func TestAgent_SetLimits(t *testing.T) {
 		}
 	})
 
-	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm))
+	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	require.NoError(t, err)
 
 	err = chatter.SetLimits(ctx, 5, 1000, 10)

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -38,7 +38,8 @@ func TestAgent_ApplyConfig_ExportedWrapper(t *testing.T) {
 	reg := agenttest.NewMockToolRegistry()
 	sm := &mockSecurityManager{AllowAll: true}
 
-	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm))
+	chatter, err := NewAgent(gw, bus, reg, WithSecurityManager(sm),
+		WithProviderName("test-provider"), WithPricing("test-model", "test-mode", nil))
 	require.NoError(t, err)
 
 	// AsInternal returns the agent typed as InternalAccessor — the same

--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -117,7 +117,20 @@ func (e *Engine) ApplyOptions(opts ...engineOption) {
 }
 
 // Reconfigure propagates configuration changes to the engine.
-func (e *Engine) Reconfigure(cfg RuntimeConfig, tracker domain_pricing.CostTracker) {
+//
+// Per ADR-029, this method is fallible: cfg.Validate() is invoked before
+// any state mutation. If validation fails, the engine retains its previous
+// configuration — no rollback is necessary because no fields are written
+// on the failure path. The error is returned so the caller (typically
+// (*agent).applyConfig) can fail fast and surface the misconfiguration.
+//
+// The cost tracker is not validated here; nil trackers are tolerated by
+// downstream consumers and represent "no cost accounting" mode.
+func (e *Engine) Reconfigure(cfg RuntimeConfig, tracker domain_pricing.CostTracker) error {
+	if err := cfg.Validate(); err != nil {
+		return fmt.Errorf("engine reconfigure: %w", err)
+	}
+
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -129,6 +142,8 @@ func (e *Engine) Reconfigure(cfg RuntimeConfig, tracker domain_pricing.CostTrack
 	newCfg.PricingOverrides = cfg.PricingOverrides
 	newCfg.CostTracker = tracker
 	e.config.Store(&newCfg)
+
+	return nil
 }
 
 // NewEngine creates a new Engine with a default pipeline.

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -85,7 +85,9 @@ func TestEngine_Reconfigure(t *testing.T) {
 		},
 	}
 
-	e.Reconfigure(runtimeCfg, tracker)
+	if err := e.Reconfigure(runtimeCfg, tracker); err != nil {
+		t.Fatalf("expected nil error on valid reconfigure, got %v", err)
+	}
 
 	cfg := e.config.Load()
 	assert.Equal(t, "new-provider", cfg.ProviderName)

--- a/tests/integration/agent/agent_integration_test.go
+++ b/tests/integration/agent/agent_integration_test.go
@@ -105,6 +105,7 @@ func TestAgent_Chat(t *testing.T) {
 	a, err := agent.NewAgent(mockClient, bus, reg,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 	)
 	require.NoError(t, err)
@@ -190,6 +191,7 @@ func TestAgent_ToolFlow_Retry(t *testing.T) {
 	a, err := agent.NewAgent(mockClient, bus, reg,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 		agent.WithClock(mockClock),
 	)
@@ -286,6 +288,7 @@ func TestAgent_ContextExhaustion_Error(t *testing.T) {
 	a, err := agent.NewAgent(mockClient, bus, reg,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 	)
 	require.NoError(t, err)
@@ -391,6 +394,7 @@ func setupPinningFlowTest(t *testing.T) (ports.Chatter, ports.HistoryManager, co
 	a, err := agent.NewAgent(&agenttest.MockLLMClient{}, bus, reg,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 		agent.WithInternalTools(),
 	)
@@ -446,6 +450,7 @@ func setupPinningTest(t *testing.T) (ports.Chatter, ports.HistoryManager, contex
 	a, err := agent.NewAgent(mockClient, bus, reg,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 		agent.WithInternalTools(),
 	)

--- a/tests/integration/agent/regression_test.go
+++ b/tests/integration/agent/regression_test.go
@@ -87,6 +87,7 @@ func TestAgent_InLoopPruning(t *testing.T) {
 	a, err := agent.NewAgent(client, bus, registry,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 	)
 	require.NoError(t, err)
@@ -132,6 +133,7 @@ func TestAgent_MultiModalFlow(t *testing.T) {
 	a, err := agent.NewAgent(mockClient, bus, registry,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
+		agent.WithPricing("test-model", "test-mode", nil),
 		agent.WithSecurityManager(sm),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Implements T3 of #141.

Signature change: `Engine.Reconfigure` now returns `error`.
Validation invoked via `cfg.Validate()` before any state mutation
(ADR-029 §4: no rollback because no writes on failure path).

Caller updates:
- `(*agent).applyConfig` propagates the error as-is.
- Test fixtures in `engine_test.go`, `agent_chat_test.go`,
  `agent_lifecycle_test.go`, `agent_test.go`,
  `agent_integration_test.go`, `regression_test.go`
  updated to supply valid `RuntimeConfig`.

Out of scope (deferred):
- `Manager.Reconfigure` remains void → T4
- Formal fail-fast ordering enforcement → T5
- Dedicated delegate-chain failure tests → T6

Issue #141 remains open until T7 ships.