### PR TITLE
feat(adr-029): make Manager.Reconfigure fallible (T4)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -198,7 +198,9 @@ func (a *agent) applyConfig(ctx context.Context) error {
 		}
 	}
 	if a.ctxManager != nil {
-		a.ctxManager.Reconfigure(newCfg.Limits)
+		if err := a.ctxManager.Reconfigure(newCfg.Limits); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -224,7 +224,9 @@ func TestGuardStep_TDT(t *testing.T) {
 
 			hMock := &agenttest.MockHistoryManager{}
 			cm := sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil)
-			cm.Reconfigure(events.Limits{MaxToolTurns: tt.maxTurns})
+			if err := cm.Reconfigure(events.Limits{MaxToolTurns: tt.maxTurns}); err != nil {
+				t.Fatalf("Reconfigure setup failed: %v", err)
+			}
 
 			turn := &Turn{
 				Index:      tt.index,

--- a/internal/agent/orchestrator/engine_phases_test.go
+++ b/internal/agent/orchestrator/engine_phases_test.go
@@ -37,7 +37,9 @@ func TestGuardStep_Process(t *testing.T) {
 		hMock.Contents = []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}}
 		counter := &agenttest.MockTokenCounter{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
-		cm.Reconfigure(events.Limits{MaxToolTurns: 3})
+		if err := cm.Reconfigure(events.Limits{MaxToolTurns: 3}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Index:        5,
@@ -64,7 +66,9 @@ func TestGuardStep_Process(t *testing.T) {
 		hMock.Contents = []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}}
 		counter := &agenttest.MockTokenCounter{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, nil, nil)
-		cm.Reconfigure(events.Limits{MaxToolTurns: 10})
+		if err := cm.Reconfigure(events.Limits{MaxToolTurns: 10}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Index:        1,
@@ -92,7 +96,9 @@ func TestGuardStep_Process(t *testing.T) {
 		hMock.Contents = []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}}
 		counter := &agenttest.MockTokenCounter{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
-		cm.Reconfigure(events.Limits{MaxToolTurns: 10})
+		if err := cm.Reconfigure(events.Limits{MaxToolTurns: 10}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Index:        1,

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -276,7 +276,9 @@ func TestExecutionStep_PayloadValidation(t *testing.T) {
 
 		hMock := &agenttest.MockHistoryManager{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
-		cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000})
+		if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Events:       bus,
@@ -302,7 +304,9 @@ func TestExecutionStep_PayloadValidation(t *testing.T) {
 
 		hMock := &agenttest.MockHistoryManager{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
-		cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000})
+		if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Events:       bus,
@@ -334,7 +338,9 @@ func TestExecutionStep_PayloadValidation(t *testing.T) {
 
 		hMock := &agenttest.MockHistoryManager{}
 		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
-		cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000})
+		if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 1000}); err != nil {
+			t.Fatalf("Reconfigure setup failed: %v", err)
+		}
 
 		turn := &Turn{
 			Events:       bus,

--- a/internal/agent/session/context/context_manager_test.go
+++ b/internal/agent/session/context/context_manager_test.go
@@ -269,7 +269,9 @@ func TestManager_Reconfigure_UpdatesPipeline(t *testing.T) {
 		ContextWindow:    2000,
 	}
 
-	cm.Reconfigure(newLimits)
+	if err := cm.Reconfigure(newLimits); err != nil {
+		t.Fatalf("expected nil error on valid reconfigure, got %v", err)
+	}
 
 	p1 := cm.Pipeline
 	assert.NotNil(t, p1, "Pipeline should be built after Reconfigure")
@@ -281,7 +283,9 @@ func TestManager_Reconfigure_UpdatesPipeline(t *testing.T) {
 
 	// Reconfigure again to ensure it updates again (rebuilds pipeline)
 	newLimits.MaxHistoryTokens = 8888
-	cm.Reconfigure(newLimits)
+	if err := cm.Reconfigure(newLimits); err != nil {
+		t.Fatalf("expected nil error on second reconfigure, got %v", err)
+	}
 
 	p2 := cm.Pipeline
 	assert.NotNil(t, p2)
@@ -505,7 +509,9 @@ type versionBumpingTransformer struct {
 func (t *versionBumpingTransformer) Priority() int { return 200 } // transient: runs after persistFn
 
 func (t *versionBumpingTransformer) Transform(ctx context.Context, req *ports.ContextRequest) error {
-	t.cm.Reconfigure(events.Limits{})
+	if err := t.cm.Reconfigure(events.Limits{}); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/agent/session/context/manager.go
+++ b/internal/agent/session/context/manager.go
@@ -77,8 +77,18 @@ func WithSessionProvider(sp ports.SessionProvider) contextManagerOption {
 	}
 }
 
-// Reconfigure updates the context manager's pipeline and strategy based on new limits.
-func (cm *Manager) Reconfigure(limits events.Limits) {
+// Reconfigure updates the manager's runtime limits.
+//
+// Per ADR-029, this method is fallible: limits.Validate() is invoked before
+// any state mutation. If validation fails, the manager retains its previous
+// configuration — no rollback is necessary because no fields are written
+// on the failure path. The error is returned so the caller (typically
+// (*agent).applyConfig) can fail fast and surface the misconfiguration.
+func (cm *Manager) Reconfigure(limits events.Limits) error {
+	if err := limits.Validate(); err != nil {
+		return fmt.Errorf("context manager reconfigure: %w", err)
+	}
+
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 	cm.version++
@@ -89,6 +99,8 @@ func (cm *Manager) Reconfigure(limits events.Limits) {
 	if cm.Factory != nil {
 		cm.Pipeline = cm.Factory.BuildStandardPipeline(limits, cm.Factory.Extras...)
 	}
+
+	return nil
 }
 
 // cloneContentSlice creates a deep clone of a slice of Content.

--- a/tests/integration/agent/session/auto_summarize_test.go
+++ b/tests/integration/agent/session/auto_summarize_test.go
@@ -76,7 +76,9 @@ func TestContextManager_AutoSummarizeTrigger(t *testing.T) {
 
 	// Set a token limit to trigger auto-summarization.
 	// Use 100000. Safety limit = 99000. 90% = 90000.
-	cm.Reconfigure(events.Limits{MaxHistoryTokens: 100000, MaxToolTurns: 10, MaxHistoryTurns: 20})
+	if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 100000, MaxToolTurns: 10, MaxHistoryTurns: 20}); err != nil {
+		t.Fatalf("Reconfigure setup failed: %v", err)
+	}
 
 	// Add 95k tokens of history.
 	longText := strings.Repeat("A", 32000) // approx 10k tokens
@@ -126,7 +128,9 @@ func TestAutoSummarize_Logging(t *testing.T) {
 	defer server.Close()
 
 	// Set a limit to trigger auto-summarization (90% threshold = 90k tokens)
-	cm.Reconfigure(events.Limits{MaxHistoryTokens: 100000, MaxToolTurns: 10, MaxHistoryTurns: 20})
+	if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 100000, MaxToolTurns: 10, MaxHistoryTurns: 20}); err != nil {
+		t.Fatalf("Reconfigure setup failed: %v", err)
+	}
 
 	// Add enough turns to exceed 90k tokens
 	addHeavyHistory(t, hManager, 9)
@@ -244,7 +248,9 @@ func TestContextManager_AutoSummarizeWithSystemInstructions(t *testing.T) {
 		Events:     bus,
 	}
 	cm := sessctx.NewManager(strategy, hManager, bus, factory)
-	cm.Reconfigure(events.Limits{MaxHistoryTokens: 3500, MaxToolTurns: 10, MaxHistoryTurns: 20}) // Limit to trigger summarization
+	if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 3500, MaxToolTurns: 10, MaxHistoryTurns: 20}); err != nil {
+		t.Fatalf("Reconfigure setup failed: %v", err)
+	} // Limit to trigger summarization
 
 	// Add some turns (approx 3451 tokens with base overhead and tools)
 	longText := strings.Repeat("A", 1600) // approx 500 tokens
@@ -335,7 +341,9 @@ func TestToolInjectedTokenBudgetPressure(t *testing.T) {
 	// Tools ~2000.
 	// Total overhead ~2300.
 	// Set limit to 3000.
-	cm.Reconfigure(events.Limits{MaxHistoryTokens: 3000, MaxToolTurns: 10, MaxHistoryTurns: 20})
+	if err := cm.Reconfigure(events.Limits{MaxHistoryTokens: 3000, MaxToolTurns: 10, MaxHistoryTurns: 20}); err != nil {
+		t.Fatalf("Reconfigure setup failed: %v", err)
+	}
 
 	// 4. Add history (600 tokens)
 	// Total = 2300 (overhead) + 600 (history) = 2900.


### PR DESCRIPTION
Implements T4 of #141.

Signature change: `Manager.Reconfigure` now returns `error`.
Validation invoked via `limits.Validate()` before any state mutation
(ADR-029 §4: no rollback because no writes on failure path).

Caller updates:
- `(*agent).applyConfig` propagates the error as-is.
- Test fixtures in `context_manager_test.go`, orchestrator engine tests,
  and integration tests in `tests/integration/agent/session/auto_summarize_test.go`
  updated to handle the new return value.

Architectural milestone: after this PR, all three delegates
downstream of `applyConfig` (SafePublish, Engine.Reconfigure,
Manager.Reconfigure) return error. The fail-fast contract from
ADR-029 §3 is structurally enforced by short-circuit `return err`.

Out of scope (deferred):
- Formal ordering comments / godoc on void delegates → T5
- Dedicated delegate-chain failure tests → T6

Issue #141 remains open until T7 ships.