### PR TITLE
refactor: decompose ShouldRetry, extract calculateBackoff (#184)

### DIFF
--- a/internal/agent/orchestrator/engine_types.go
+++ b/internal/agent/orchestrator/engine_types.go
@@ -114,9 +114,6 @@ func calculateBackoff(base time.Duration, attempt int) time.Duration {
 			return maxDelay
 		}
 		delay *= 2
-		if delay >= maxDelay {
-			return maxDelay
-		}
 	}
 	return delay
 }

--- a/internal/agent/orchestrator/engine_types.go
+++ b/internal/agent/orchestrator/engine_types.go
@@ -98,6 +98,29 @@ type DefaultRetryPolicy struct {
 	RateLimitBackoff time.Duration
 }
 
+// calculateBackoff computes the exponential backoff delay, doubling per attempt
+// and capping at maxDelay. It is a pure function with no side effects, designed
+// for exhaustive table-driven testing independent of error classification or Clock.
+func calculateBackoff(base time.Duration, attempt int) time.Duration {
+	const maxDelay = 2 * time.Minute
+
+	if base >= maxDelay {
+		return maxDelay
+	}
+
+	delay := base
+	for i := 0; i < attempt; i++ {
+		if delay >= maxDelay/2 {
+			return maxDelay
+		}
+		delay *= 2
+		if delay >= maxDelay {
+			return maxDelay
+		}
+	}
+	return delay
+}
+
 func (p *DefaultRetryPolicy) ShouldRetry(c clock.Clock, err error, attempt int, hasSeenRateLimit bool) (time.Duration, bool) {
 	if attempt >= p.MaxRetries {
 		return 0, false
@@ -114,29 +137,9 @@ func (p *DefaultRetryPolicy) ShouldRetry(c clock.Clock, err error, attempt int, 
 			base = p.RateLimitBackoff
 		}
 
-		const maxDelay = 2 * time.Minute // Enforce an architectural ceiling
+		delay := calculateBackoff(base, attempt)
 
-		delay := base
-
-		// 1. Initial cap in case base > maxDelay
-		if delay >= maxDelay {
-			delay = maxDelay
-		} else {
-			// 2. Safely double the delay, breaking early to prevent int64 overflow
-			for i := 0; i < attempt; i++ {
-				if delay >= maxDelay/2 {
-					delay = maxDelay
-					break
-				}
-				delay *= 2
-				if delay >= maxDelay {
-					delay = maxDelay
-					break
-				}
-			}
-		}
-
-		// 3. Apply Jitter
+		// Apply Jitter
 		finalDelay := time.Duration(c.Jitter(float64(delay)))
 
 		return finalDelay, true

--- a/internal/agent/orchestrator/retry_test.go
+++ b/internal/agent/orchestrator/retry_test.go
@@ -136,3 +136,91 @@ func TestDefaultRetryPolicy_OverflowSafety(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateBackoff(t *testing.T) {
+	const maxDelay = 2 * time.Minute
+
+	tests := []struct {
+		name      string
+		base      time.Duration
+		attempt   int
+		wantDelay time.Duration
+	}{
+		{
+			name:      "zero attempt returns base",
+			base:      2 * time.Second,
+			attempt:   0,
+			wantDelay: 2 * time.Second,
+		},
+		{
+			name:      "single doubling",
+			base:      2 * time.Second,
+			attempt:   1,
+			wantDelay: 4 * time.Second,
+		},
+		{
+			name:      "double doubling",
+			base:      2 * time.Second,
+			attempt:   2,
+			wantDelay: 8 * time.Second,
+		},
+		{
+			name:      "triple doubling",
+			base:      2 * time.Second,
+			attempt:   3,
+			wantDelay: 16 * time.Second,
+		},
+		{
+			name:      "max delay ceiling hit via large attempt",
+			base:      2 * time.Second,
+			attempt:   10, // 2^10 * 2s = 2048s > 2m
+			wantDelay: maxDelay,
+		},
+		{
+			name:      "base exceeds maxDelay from start",
+			base:      5 * time.Minute,
+			attempt:   0,
+			wantDelay: maxDelay,
+		},
+		{
+			name:      "base exceeds maxDelay with attempt > 0",
+			base:      5 * time.Minute,
+			attempt:   3,
+			wantDelay: maxDelay,
+		},
+		{
+			name:      "overflow safety — extreme attempt 63",
+			base:      2 * time.Second,
+			attempt:   63,
+			wantDelay: maxDelay,
+		},
+		{
+			name:      "rate-limit base single doubling",
+			base:      10 * time.Second,
+			attempt:   1,
+			wantDelay: 20 * time.Second,
+		},
+		{
+			name:      "rate-limit base hits ceiling",
+			base:      10 * time.Second,
+			attempt:   10, // 10s * 2^10 = 10240s > 2m
+			wantDelay: maxDelay,
+		},
+		{
+			name:      "zero base duration",
+			base:      0,
+			attempt:   5,
+			wantDelay: 0, // 0 doubled stays 0, never hits maxDelay cap
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calculateBackoff(tt.base, tt.attempt)
+			if got != tt.wantDelay {
+				t.Errorf("calculateBackoff(%v, %d) = %v; want %v",
+					tt.base, tt.attempt, got, tt.wantDelay)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Decompose `DefaultRetryPolicy.ShouldRetry` by extracting the exponential backoff math into a package-level pure function `calculateBackoff`.

## Problem

`ShouldRetry` had cyclomatic complexity of **9** — one change away from crossing the threshold of 10. The backoff math (delay doubling, capping at max) was tightly coupled to error classification logic.

## Solution

- Extract `calculateBackoff(base, attempt)` as a pure function — no Clock dependency, no side effects, independently testable
- Add `TestCalculateBackoff` with 11 table-driven cases
- Fix orphaned `// 3.` comment to `// Apply Jitter`

## Results

| Metric | Before | After |
|---|---|---|
| `ShouldRetry` complexity | 9 | **5** |
| `calculateBackoff` complexity | — | **5** |
| Linter | 0 | 0 |
| Race tests | pass | pass |

Closes #184