### PR TITLE
refactor: three-phase optimistic reload for FileConfigWatcher.Refresh (#197)

### DIFF
--- a/internal/agent/session/config_watcher.go
+++ b/internal/agent/session/config_watcher.go
@@ -181,12 +181,15 @@ func (cw *FileConfigWatcher) Refresh(model string) {
 	newSessCfg, sessInfo, sessChanged := cw.loadSessionOutsideLock(snap, mainChanged)
 
 	// Phase 3: Apply mutations to in-memory cache only. No I/O.
+	// Guard each mutation with a ModTime comparison to prevent
+	// stale overwrites: if a concurrent Refresh already applied
+	// a newer version, we must not overwrite it with older data.
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
-	if mainChanged {
+	if mainChanged && !mainInfo.ModTime().Before(cw.lastMainMod) {
 		cw.applyMainConfig(newMainCfg, mainInfo, model)
 	}
-	if sessChanged {
+	if sessChanged && !sessInfo.ModTime().Before(cw.lastSessionMod) {
 		cw.applySessionLimits(newSessCfg)
 		cw.lastSessionMod = sessInfo.ModTime()
 	}

--- a/internal/agent/session/config_watcher.go
+++ b/internal/agent/session/config_watcher.go
@@ -90,6 +90,17 @@ type ConfigWatcher interface {
 	SyncToStrategy(cs *sessctx.Strategy)
 }
 
+// reloadSnapshot captures the mutable comparison state needed to decide
+// whether to reload files. It is populated under RLock (Phase 1) so that
+// all blocking I/O (Phase 2) can run without holding any mutex.
+type reloadSnapshot struct {
+	mainPath       string
+	sessionPath    string
+	lastMainMod    time.Time
+	lastSessionMod time.Time
+	lastModel      string
+}
+
 // fileConfigWatcher monitors configuration files for changes and caches values.
 type FileConfigWatcher struct {
 	mu                   sync.RWMutex
@@ -140,31 +151,82 @@ func (cw *FileConfigWatcher) SetPaths(main, session string) {
 	cw.sessionPath = session
 }
 
+// snapshotReloadState returns a stack-local copy of the watcher's mutable
+// comparison fields. Caller must NOT hold any lock; this method acquires
+// and releases RLock internally.
+func (cw *FileConfigWatcher) snapshotReloadState() reloadSnapshot {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+	return reloadSnapshot{
+		mainPath:       cw.mainPath,
+		sessionPath:    cw.sessionPath,
+		lastMainMod:    cw.lastMainMod,
+		lastSessionMod: cw.lastSessionMod,
+		lastModel:      cw.lastModel,
+	}
+}
+
 // Refresh checks for file changes and updates cached values if necessary.
+// It uses three phases to avoid holding the write lock across disk I/O:
+//  1. RLock snapshot of comparison state
+//  2. All blocking I/O without any lock
+//  3. Write lock only for in-memory mutations
 func (cw *FileConfigWatcher) Refresh(model string) {
+	// Phase 1: Snapshot mutable comparison state under RLock.
+	snap := cw.snapshotReloadState()
+
+	// Phase 2: All blocking I/O. No lock held.
+	// Safe because Loader/SessionLoader/FS are immutable after construction.
+	newMainCfg, mainInfo, mainChanged := cw.loadMainOutsideLock(snap, model)
+	newSessCfg, sessInfo, sessChanged := cw.loadSessionOutsideLock(snap, mainChanged)
+
+	// Phase 3: Apply mutations to in-memory cache only. No I/O.
 	cw.mu.Lock()
 	defer cw.mu.Unlock()
+	if mainChanged {
+		cw.applyMainConfig(newMainCfg, mainInfo, model)
+	}
+	if sessChanged {
+		cw.applySessionLimits(newSessCfg)
+		cw.lastSessionMod = sessInfo.ModTime()
+	}
+}
 
-	changed := cw.updateFromMain(model)
-	cw.updateFromSession(changed)
+// loadMainOutsideLock performs all blocking I/O needed to reload the main
+// configuration file. It must NOT hold any mutex. It returns the parsed
+// config, the os.FileInfo from Stat, and whether the file was actually
+// reloaded. If no reload is needed, it returns (nil, nil, false).
+func (cw *FileConfigWatcher) loadMainOutsideLock(snap reloadSnapshot, model string) (*config.Config, os.FileInfo, bool) {
+	ok, info := cw.shouldReloadMain(snap, model)
+	if !ok {
+		return nil, nil, false
+	}
+
+	cfg, err := cw.Loader.Load(snap.mainPath)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	return cfg, info, true
 }
 
 // shouldReloadMain checks whether the main configuration file needs to be
-// re-read. It returns (false, nil) when the reload can be skipped because
-// the path is empty, the file cannot be stat'd, neither the modification
-// time nor the model have changed, or the Loader is nil.
-// Otherwise it returns (true, info) where info is the os.FileInfo from Stat.
-func (cw *FileConfigWatcher) shouldReloadMain(model string) (bool, os.FileInfo) {
-	if cw.mainPath == "" {
+// re-read using a snapshot captured under RLock. It returns (false, nil) when
+// the reload can be skipped because the path is empty, the file cannot be
+// stat'd, neither the modification time nor the model have changed, or the
+// Loader is nil. Otherwise it returns (true, info) where info is the
+// os.FileInfo from Stat.
+func (cw *FileConfigWatcher) shouldReloadMain(snap reloadSnapshot, model string) (bool, os.FileInfo) {
+	if snap.mainPath == "" {
 		return false, nil
 	}
 
-	info, err := cw.FS.Stat(cw.mainPath)
+	info, err := cw.FS.Stat(snap.mainPath)
 	if err != nil {
 		return false, nil
 	}
 
-	if !info.ModTime().After(cw.lastMainMod) && model == cw.lastModel {
+	if !info.ModTime().After(snap.lastMainMod) && model == snap.lastModel {
 		return false, nil
 	}
 
@@ -173,6 +235,40 @@ func (cw *FileConfigWatcher) shouldReloadMain(model string) (bool, os.FileInfo) 
 	}
 
 	return true, info
+}
+
+// loadSessionOutsideLock performs all blocking I/O needed to reload the
+// session configuration file. It must NOT hold any mutex. It returns the
+// parsed session config, the os.FileInfo from Stat, and whether the file
+// was actually reloaded. If no reload is needed, it returns (nil, nil, false).
+func (cw *FileConfigWatcher) loadSessionOutsideLock(snap reloadSnapshot, forceUpdate bool) (*config.SessionConfig, os.FileInfo, bool) {
+	if snap.sessionPath == "" {
+		return nil, nil, false
+	}
+
+	info, err := cw.FS.Stat(snap.sessionPath)
+	if err != nil {
+		return nil, nil, false
+	}
+
+	if !info.ModTime().After(snap.lastSessionMod) && !forceUpdate {
+		return nil, nil, false
+	}
+
+	if cw.SessionLoader == nil {
+		return nil, nil, false
+	}
+
+	sessCfg, err := cw.SessionLoader.LoadSession(snap.sessionPath)
+	if err != nil {
+		cw.logSessionLoadErrorNoLock(err, snap.sessionPath)
+		return nil, nil, false
+	}
+	if sessCfg == nil {
+		return nil, nil, false
+	}
+
+	return sessCfg, info, true
 }
 
 // applyMainConfig updates the watcher's cached state from a successfully
@@ -188,52 +284,6 @@ func (cw *FileConfigWatcher) applyMainConfig(cfg *config.Config, info os.FileInf
 	cw.contextWindow = resolveContextWindow(cfg, model, cw.defaultWindow)
 }
 
-func (cw *FileConfigWatcher) updateFromMain(model string) bool {
-	ok, info := cw.shouldReloadMain(model)
-	if !ok {
-		return false
-	}
-
-	cfg, err := cw.Loader.Load(cw.mainPath)
-	if err != nil {
-		return false
-	}
-
-	cw.applyMainConfig(cfg, info, model)
-	return true
-}
-
-func (cw *FileConfigWatcher) updateFromSession(forceUpdate bool) {
-	if cw.sessionPath == "" {
-		return
-	}
-
-	info, err := cw.FS.Stat(cw.sessionPath)
-	if err != nil {
-		return
-	}
-
-	if info.ModTime().After(cw.lastSessionMod) || forceUpdate {
-		cw.lastSessionMod = info.ModTime()
-		cw.loadSessionConfig()
-	}
-}
-
-func (cw *FileConfigWatcher) loadSessionConfig() {
-	if cw.SessionLoader == nil {
-		return
-	}
-	sessCfg, err := cw.SessionLoader.LoadSession(cw.sessionPath)
-	if err != nil {
-		cw.logSessionLoadError(err)
-		return
-	}
-	if sessCfg == nil {
-		return
-	}
-	cw.applySessionLimits(sessCfg)
-}
-
 // applySessionLimits applies non-nil session config overrides to the watcher's
 // cached limits. The caller must hold cw.mu (write lock).
 func (cw *FileConfigWatcher) applySessionLimits(cfg *config.SessionConfig) {
@@ -245,6 +295,14 @@ func (cw *FileConfigWatcher) applySessionLimits(cfg *config.SessionConfig) {
 	}
 	if cfg.MaxHistoryTurns != nil {
 		cw.maxHistoryTurns = *cfg.MaxHistoryTurns
+	}
+}
+
+// logSessionLoadErrorNoLock logs a session load error without reading
+// cw.sessionPath from the watcher. It is safe to call outside the mutex.
+func (cw *FileConfigWatcher) logSessionLoadErrorNoLock(err error, sessionPath string) {
+	if !os.IsNotExist(err) && cw.logger != nil {
+		cw.logger.Warn("Failed to load session config", "path", sessionPath, "error", err)
 	}
 }
 

--- a/internal/agent/session/config_watcher_internal_test.go
+++ b/internal/agent/session/config_watcher_internal_test.go
@@ -123,9 +123,10 @@ func TestShouldReloadMain(t *testing.T) {
 				fcw.Refresh("gpt-5")
 			}
 
-			ok, info := fcw.shouldReloadMain(tt.model)
+			snap := fcw.snapshotReloadState()
+			ok, info := fcw.shouldReloadMain(snap, tt.model)
 			if ok != tt.wantOK {
-				t.Errorf("shouldReloadMain(%q) = (%v, %v); want ok=%v", tt.model, ok, info, tt.wantOK)
+				t.Errorf("shouldReloadMain(snap, %q) = (%v, %v); want ok=%v", tt.model, ok, info, tt.wantOK)
 			}
 		})
 	}

--- a/internal/agent/session/config_watcher_test.go
+++ b/internal/agent/session/config_watcher_test.go
@@ -59,6 +59,68 @@ func (l *testSessionLoader) toIntPtr(val interface{}) *int {
 	return nil
 }
 
+// sleepingFileStat simulates slow disk I/O by sleeping before returning.
+type sleepingFileStat struct {
+	delay   time.Duration
+	modTime time.Time
+}
+
+func (s sleepingFileStat) Stat(name string) (os.FileInfo, error) {
+	time.Sleep(s.delay)
+	return stubFileInfo{modTime: s.modTime}, nil
+}
+
+// sleepingConfigLoader simulates slow config loading.
+type sleepingConfigLoader struct {
+	delay time.Duration
+}
+
+func (l sleepingConfigLoader) Load(path string) (*config.Config, error) {
+	time.Sleep(l.delay)
+	return &config.Config{
+		MaxHistoryTokens: 500,
+		MaxToolTurns:     10,
+		MaxHistoryTurns:  20,
+	}, nil
+}
+
+// TestFileConfigWatcher_ConcurrentRefreshAndRead proves that GetLimits
+// is NOT blocked by Refresh's disk I/O. A slow FS (200ms Stat) must not
+// delay concurrent readers beyond ~50ms. This test FAILS on the old
+// lock-across-I/O design and PASSES after the three-phase refactor.
+func TestFileConfigWatcher_ConcurrentRefreshAndRead(t *testing.T) {
+	fcw := session.NewFileConfigWatcher(nil, nil, 100, 10, 20, nil)
+	cw := fcw.(*session.FileConfigWatcher)
+
+	// Simulate slow disk: 200ms Stat + 100ms Load = 300ms total I/O.
+	futureTime := time.Now().Add(time.Hour)
+	cw.FS = sleepingFileStat{delay: 200 * time.Millisecond, modTime: futureTime}
+	cw.Loader = sleepingConfigLoader{delay: 100 * time.Millisecond}
+	cw.SetPaths("/fake/main.yaml", "")
+
+	// Barrier to synchronize goroutines.
+	start := make(chan struct{})
+
+	// Spawn Refresh in a goroutine. It will spend ~300ms in Phase 2 I/O.
+	go func() {
+		<-start
+		cw.Refresh("gpt-5")
+	}()
+
+	// Wait for Refresh to be mid-I/O, then measure GetLimits latency.
+	close(start)
+	time.Sleep(50 * time.Millisecond) // Let Refresh enter Phase 2 I/O.
+
+	// Measure GetLimits: must return quickly (not blocked behind Refresh's I/O).
+	deadline := time.Now().Add(50 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		cw.GetLimits()
+	}
+
+	// If we reach here, GetLimits wasn't blocked for 300ms.
+	// The test passes trivially — the absence of timeout is the assertion.
+}
+
 func TestConfigWatcher_Refresh(t *testing.T) {
 	tmpDir := t.TempDir()
 	sessionPath := filepath.Join(tmpDir, "session.json")

--- a/internal/agent/session/config_watcher_test.go
+++ b/internal/agent/session/config_watcher_test.go
@@ -107,18 +107,18 @@ func TestFileConfigWatcher_ConcurrentRefreshAndRead(t *testing.T) {
 		cw.Refresh("gpt-5")
 	}()
 
-	// Wait for Refresh to be mid-I/O, then measure GetLimits latency.
+	// Let Refresh enter Phase 2 I/O, then measure GetLimits latency.
 	close(start)
-	time.Sleep(50 * time.Millisecond) // Let Refresh enter Phase 2 I/O.
+	time.Sleep(50 * time.Millisecond) // Refresh is now mid-I/O.
 
-	// Measure GetLimits: must return quickly (not blocked behind Refresh's I/O).
-	deadline := time.Now().Add(50 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		cw.GetLimits()
+	// Measure: GetLimits must NOT block behind Refresh's disk I/O.
+	before := time.Now()
+	cw.GetLimits()
+	elapsed := time.Since(before)
+
+	if elapsed >= 100*time.Millisecond {
+		t.Fatalf("GetLimits blocked for %v, expected < 100ms (Refresh I/O takes 300ms)", elapsed)
 	}
-
-	// If we reach here, GetLimits wasn't blocked for 300ms.
-	// The test passes trivially — the absence of timeout is the assertion.
 }
 
 func TestConfigWatcher_Refresh(t *testing.T) {


### PR DESCRIPTION
## Summary

Decouples disk I/O from the write lock in `FileConfigWatcher.Refresh` by splitting into three phases:

1. **Phase 1 (RLock)**: Snapshot mutable comparison state to stack (race-free)
2. **Phase 2 (no lock)**: All blocking I/O — `Stat`, `Load`, `LoadSession`
3. **Phase 3 (Lock)**: Write lock for in-memory mutations only

## Problem

`Refresh` held `cw.mu.Lock()` across up to **four** synchronous disk I/O operations, blocking all concurrent readers (`GetLimits`, `SyncToStrategy`, `GetContextWindow`) on the chat hot path (`agent.go:217`).

## Solution

- Added `reloadSnapshot` struct + `snapshotReloadState()` for Phase 1
- Added `loadMainOutsideLock` and `loadSessionOutsideLock` for Phase 2
- Rewrote `Refresh` to orchestrate three phases; removed `updateFromMain`, `updateFromSession`, `loadSessionConfig`
- Preserves `forceUpdate` contract via `mainChanged` boolean across phases
- Added `TestFileConfigWatcher_ConcurrentRefreshAndRead` liveness guard

## Verification

- [x] `go test -race ./internal/agent/session/...` — PASS
- [x] `go test -race ./internal/agent/...` — PASS
- [x] `go test -count=10 -race ./internal/agent/session/...` — zero flakes
- [x] `go vet ./internal/agent/session/...` — clean
- [x] `ConfigWatcher` interface unchanged — zero call-site changes

Closes #197