### PR TITLE
feat: safely remove TokenGatekeeper nil-guard by enforcing constructor (fixes #199)

### DIFF
--- a/internal/agent/session/context/context_manager_table_test.go
+++ b/internal/agent/session/context/context_manager_table_test.go
@@ -23,10 +23,11 @@ func TestTokenGatekeeper_Table(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tg := &TokenGatekeeper{
-				MaxTokens: tt.maxTokens,
-				Estimator: &agenttest.MockTokenCounter{Tokens: tt.tokens},
-			}
+			tg := newTokenGatekeeper(
+				&agenttest.MockTokenCounter{Tokens: tt.tokens},
+				nil,
+				withMaxTokens(tt.maxTokens),
+			)
 			req := &request{
 				History: []*llm.Content{{Role: "user"}},
 			}

--- a/internal/agent/session/context/context_transformers_test.go
+++ b/internal/agent/session/context/context_transformers_test.go
@@ -210,10 +210,11 @@ func TestTokenGatekeeper_Transform(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("Under limit", func(t *testing.T) {
-		tg := &TokenGatekeeper{
-			MaxTokens: 1000,
-			Estimator: &agenttest.MockTokenCounter{Tokens: 500},
-		}
+		tg := newTokenGatekeeper(
+			&agenttest.MockTokenCounter{Tokens: 500},
+			nil,
+			withMaxTokens(1000),
+		)
 		req := &request{History: []*llm.Content{{Role: "user"}}}
 		err := tg.Transform(ctx, req)
 		require.NoError(t, err)
@@ -221,15 +222,15 @@ func TestTokenGatekeeper_Transform(t *testing.T) {
 	})
 
 	t.Run("Exceeds limit after summarization", func(t *testing.T) {
-		tg := &TokenGatekeeper{
-			MaxTokens: 1000,
-			Estimator: &agenttest.MockTokenCounter{Tokens: 1100}, // Always returns 1100
-			Summarizer: &agenttest.MockSummarizer{
+		tg := newTokenGatekeeper(
+			&agenttest.MockTokenCounter{Tokens: 1100},
+			&agenttest.MockSummarizer{
 				SummarizeFn: func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 					return "summary", &llm.Metrics{}, nil
 				},
 			},
-		}
+			withMaxTokens(1000),
+		)
 		// 10 messages to allow summarization trigger (>= 10)
 		h := make([]*llm.Content, 10)
 		for i := range h {
@@ -241,15 +242,15 @@ func TestTokenGatekeeper_Transform(t *testing.T) {
 	})
 
 	t.Run("Summarization failure", func(t *testing.T) {
-		tg := &TokenGatekeeper{
-			MaxTokens: 2000,
-			Estimator: &agenttest.MockTokenCounter{Tokens: 950},
-			Summarizer: &agenttest.MockSummarizer{
+		tg := newTokenGatekeeper(
+			&agenttest.MockTokenCounter{Tokens: 950},
+			&agenttest.MockSummarizer{
 				SummarizeFn: func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 					return "", nil, errors.New("summarize error")
 				},
 			},
-		}
+			withMaxTokens(2000),
+		)
 		h := make([]*llm.Content, 10)
 		for i := range h {
 			h[i] = &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "msg"}}}
@@ -313,16 +314,16 @@ func (m *dynamicMockEstimator) EstimateTokens(contents []*llm.Content) int {
 func TestTokenGatekeeper_AutoSummarize_PinnedAware(t *testing.T) {
 	ctx := context.Background()
 	summarizerCalled := false
-	tg := &TokenGatekeeper{
-		MaxTokens: 10000,
-		Estimator: &dynamicMockEstimator{tokens: 9500},
-		Summarizer: &agenttest.MockSummarizer{
+	tg := newTokenGatekeeper(
+		&dynamicMockEstimator{tokens: 9500},
+		&agenttest.MockSummarizer{
 			SummarizeFn: func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 				summarizerCalled = true
 				return "summary", &llm.Metrics{}, nil
 			},
 		},
-	}
+		withMaxTokens(10000),
+	)
 
 	h := generateMessageHistory(20)
 	// Pin turns 0 and 1 (indices 0-3)
@@ -375,15 +376,15 @@ func TestWarningInjector_Transform_Clogged(t *testing.T) {
 
 func TestTokenGatekeeper_SetsSummarizationAttempted(t *testing.T) {
 	ctx := context.Background()
-	tg := &TokenGatekeeper{
-		MaxTokens: 10000,
-		Estimator: &dynamicMockEstimator{tokens: 9500},
-		Summarizer: &agenttest.MockSummarizer{
+	tg := newTokenGatekeeper(
+		&dynamicMockEstimator{tokens: 9500},
+		&agenttest.MockSummarizer{
 			SummarizeFn: func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 				return "summary", &llm.Metrics{}, nil
 			},
 		},
-	}
+		withMaxTokens(10000),
+	)
 	h := make([]*llm.Content, 10)
 	for i := range h {
 		h[i] = &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "msg"}}}
@@ -396,10 +397,11 @@ func TestTokenGatekeeper_SetsSummarizationAttempted(t *testing.T) {
 
 func TestTokenGatekeeper_AutoSummarize_BlockedByPins(t *testing.T) {
 	ctx := context.Background()
-	tg := &TokenGatekeeper{
-		MaxTokens: 2000,
-		Estimator: &agenttest.MockTokenCounter{Tokens: 1900}, // > 90%
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{Tokens: 1900},
+		nil,
+		withMaxTokens(2000),
+	)
 
 	// Create history where all messages are pinned
 	h := make([]*llm.Content, 20)
@@ -468,10 +470,11 @@ func TestTokenGatekeeper_SafetyBuffer_Boundary(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tg := &TokenGatekeeper{
-				MaxTokens: tt.maxTokens,
-				Estimator: &agenttest.MockTokenCounter{Tokens: tt.tokens},
-			}
+			tg := newTokenGatekeeper(
+				&agenttest.MockTokenCounter{Tokens: tt.tokens},
+				nil,
+				withMaxTokens(tt.maxTokens),
+			)
 			req := &request{History: []*llm.Content{{Role: "user"}}}
 			err := tg.Transform(ctx, req)
 			if tt.wantErr {
@@ -520,10 +523,11 @@ func TestTokenGatekeeper_SystemContextBuffer_Boundary(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("10 percent cap", func(t *testing.T) {
-		tg := &TokenGatekeeper{
-			MaxTokens: 1000,
-			Estimator: &agenttest.MockTokenCounter{Tokens: 901},
-		}
+		tg := newTokenGatekeeper(
+			&agenttest.MockTokenCounter{Tokens: 901},
+			nil,
+			withMaxTokens(1000),
+		)
 		req := &request{History: []*llm.Content{{Role: "user"}}}
 		err := tg.Transform(ctx, req)
 		require.ErrorIs(t, err, llm.ErrContextLimitExceeded, "expected ErrContextLimitExceeded for 901 tokens (limit 900)")
@@ -534,10 +538,11 @@ func TestTokenGatekeeper_SystemContextBuffer_Boundary(t *testing.T) {
 	})
 
 	t.Run("Capped by SystemContextBuffer", func(t *testing.T) {
-		tg := &TokenGatekeeper{
-			MaxTokens: 10000,
-			Estimator: &agenttest.MockTokenCounter{Tokens: 9001},
-		}
+		tg := newTokenGatekeeper(
+			&agenttest.MockTokenCounter{Tokens: 9001},
+			nil,
+			withMaxTokens(10000),
+		)
 		req := &request{History: []*llm.Content{{Role: "user"}}}
 		err := tg.Transform(ctx, req)
 		require.ErrorIs(t, err, llm.ErrContextLimitExceeded, "expected ErrContextLimitExceeded for 9001 tokens (limit 9000)")
@@ -797,7 +802,7 @@ func TestIsToolCall_Helper(t *testing.T) {
 }
 
 func TestFindSummarizableRange_Helper(t *testing.T) {
-	tg := &TokenGatekeeper{}
+	tg := newTokenGatekeeper(nil, nil)
 
 	t.Run("No pins", func(t *testing.T) {
 		history := generateMessageHistory(20)
@@ -952,10 +957,11 @@ func setupTestPipeline(maxTokens int) (*contextPipeline, *Strategy) {
 
 	pipeline := NewContextPipeline(
 		&HistoryPruner{Policy: &SlidingWindowPolicy{MaxTurns: 10}},
-		&TokenGatekeeper{
-			MaxTokens: maxTokens,
-			Estimator: strategy,
-		},
+		newTokenGatekeeper(
+			strategy,
+			nil,
+			withMaxTokens(maxTokens),
+		),
 		&WarningInjector{Strategy: strategy},
 		&TransientMerger{},
 	)

--- a/internal/agent/session/context/coverage_expansion_test.go
+++ b/internal/agent/session/context/coverage_expansion_test.go
@@ -109,10 +109,12 @@ func (m *mockExpEventBus) WaitStarted()                                      {}
 
 func TestTokenGatekeeper_ValidateHardLimits_Boundaries(t *testing.T) {
 	bus := &mockExpEventBus{}
-	tg := &TokenGatekeeper{
-		MaxTokens: 5000, // Buffer will be 500 (10% of 5000)
-		Events:    bus,
-	}
+	tg := newTokenGatekeeper(
+		nil,
+		nil,
+		withMaxTokens(5000),
+		withEvents(bus),
+	)
 	// limit = 5000 - 500 = 4500
 
 	tests := []struct {
@@ -187,7 +189,7 @@ func TestTokenGatekeeper_LocateCandidateBlock_EdgeCases(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			start, count := tg.locateCandidateBlock(context.Background(), tt.turns, tt.target, tg.CandidateSelector)
+			start, count := tg.locateCandidateBlock(context.Background(), tt.turns, tt.target, tg.candidateSelector)
 			assert.Equal(t, tt.expectedStart, start)
 			assert.Equal(t, tt.expectedCount, count)
 		})
@@ -200,7 +202,7 @@ func TestCompositePruningPolicy_Name_Coverage(t *testing.T) {
 }
 
 func TestTokenGatekeeper_FindSummarizableRange_ErrorPath(t *testing.T) {
-	tg := &TokenGatekeeper{}
+	tg := newTokenGatekeeper(nil, nil)
 	// History with no summarizable blocks (all pinned)
 	history := []*llm.Content{
 		{Role: "user", Pinned: true},
@@ -212,10 +214,12 @@ func TestTokenGatekeeper_FindSummarizableRange_ErrorPath(t *testing.T) {
 
 func TestTokenGatekeeper_HandleSafetyPressure_EdgeCases(t *testing.T) {
 	bus := &mockExpEventBus{}
-	tg := &TokenGatekeeper{
-		MaxTokens: 1000,
-		Events:    bus,
-	}
+	tg := newTokenGatekeeper(
+		nil,
+		nil,
+		withMaxTokens(1000),
+		withEvents(bus),
+	)
 
 	// Case 1: MaxTokens <= 0
 	tg.MaxTokens = 0

--- a/internal/agent/session/context/error_coverage_test.go
+++ b/internal/agent/session/context/error_coverage_test.go
@@ -49,10 +49,10 @@ func TestContextManager_ValidateSubset_Cancelled(t *testing.T) {
 }
 
 func TestTokenGatekeeper_AutoSummarize_GroupTurnsError(t *testing.T) {
-	tg := &TokenGatekeeper{
-		Estimator:  &agenttest.MockTokenCounter{},
-		Summarizer: &agenttest.MockSummarizer{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		&agenttest.MockSummarizer{},
+	)
 
 	// Trigger invalid payload via groupTurns failing
 	history := []*llm.Content{
@@ -197,10 +197,11 @@ func TestContextManager_FinalizeSummarization_PrunedError(t *testing.T) {
 
 func TestTokenGatekeeper_TriggerSummarization_EventError(t *testing.T) {
 	mockBus := &mockFailingEventBus{err: errors.New("event error")}
-	tg := &TokenGatekeeper{
-		Events:    mockBus,
-		Estimator: &agenttest.MockTokenCounter{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		nil,
+		withEvents(mockBus),
+	)
 
 	req := &ports.ContextRequest{
 		Metadata: ports.ContextMetadata{},
@@ -212,10 +213,10 @@ func TestTokenGatekeeper_TriggerSummarization_EventError(t *testing.T) {
 }
 
 func TestTokenGatekeeper_TriggerSummarization_MaintenanceBlocked(t *testing.T) {
-	tg := &TokenGatekeeper{
-		Estimator:  &agenttest.MockTokenCounter{},
-		Summarizer: &agenttest.MockSummarizer{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		&agenttest.MockSummarizer{},
+	)
 	tg.Summarizer.(*agenttest.MockSummarizer).SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 		return "", nil, errors.New("summarize error")
 	})
@@ -339,13 +340,13 @@ func TestTokenGatekeeper_LocateCandidateBlock_Cancelled(t *testing.T) {
 		turns[i] = []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "u"}}}}
 	}
 
-	start, num := tg.locateCandidateBlock(ctx, turns, 10, tg.CandidateSelector)
+	start, num := tg.locateCandidateBlock(ctx, turns, 10, tg.candidateSelector)
 	require.Equal(t, -1, start)
 	require.Equal(t, 0, num)
 }
 
 func TestTokenGatekeeper_TriggerSummarization_AlreadyAttempted(t *testing.T) {
-	tg := &TokenGatekeeper{}
+	tg := newTokenGatekeeper(nil, nil)
 	req := &ports.ContextRequest{
 		Metadata: ports.ContextMetadata{SummarizationAttempted: true},
 	}
@@ -355,10 +356,10 @@ func TestTokenGatekeeper_TriggerSummarization_AlreadyAttempted(t *testing.T) {
 }
 
 func TestTokenGatekeeper_TriggerSummarization_OtherError(t *testing.T) {
-	tg := &TokenGatekeeper{
-		Estimator:  &agenttest.MockTokenCounter{},
-		Summarizer: &agenttest.MockSummarizer{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		&agenttest.MockSummarizer{},
+	)
 	tg.Summarizer.(*agenttest.MockSummarizer).SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 		return "", nil, errors.New("other error")
 	})
@@ -384,10 +385,10 @@ func TestTokenGatekeeper_TriggerSummarization_OtherError(t *testing.T) {
 }
 
 func TestTokenGatekeeper_TriggerSummarization_NilEvents(t *testing.T) {
-	tg := &TokenGatekeeper{
-		Estimator:  &agenttest.MockTokenCounter{},
-		Summarizer: &agenttest.MockSummarizer{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		&agenttest.MockSummarizer{},
+	)
 	tg.Summarizer.(*agenttest.MockSummarizer).SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 		return "summary", nil, nil
 	})
@@ -411,9 +412,10 @@ func TestTokenGatekeeper_TriggerSummarization_NilEvents(t *testing.T) {
 }
 
 func TestTokenGatekeeper_TriggerSummarization_InvalidPayload(t *testing.T) {
-	tg := &TokenGatekeeper{
-		Estimator: &agenttest.MockTokenCounter{},
-	}
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{},
+		nil,
+	)
 
 	history := make([]*llm.Content, 12)
 	for i := range history {
@@ -435,7 +437,7 @@ func TestTokenGatekeeper_TriggerSummarization_InvalidPayload(t *testing.T) {
 // return immediately without panicking (covers the untested branch at
 // gatekeeper.go:172).
 func TestTokenGatekeeper_PublishSystemEvent_NilEventBus(t *testing.T) {
-	tg := &TokenGatekeeper{Events: nil}
+	tg := newTokenGatekeeper(nil, nil)
 	// Must not panic
 	tg.publishSystemEvent(context.Background(), "test message", "info")
 }
@@ -445,10 +447,12 @@ func TestTokenGatekeeper_PublishSystemEvent_NilEventBus(t *testing.T) {
 // via getLogger().Error (covers the error-logging branch at gatekeeper.go:180-183).
 func TestTokenGatekeeper_PublishSystemEvent_SafePublishError(t *testing.T) {
 	logger := &agenttest.MockPortsLogger{}
-	tg := &TokenGatekeeper{
-		Events: &mockFailingEventBus{err: errors.New("publish boom")},
-		Logger: logger,
-	}
+	tg := newTokenGatekeeper(
+		nil,
+		nil,
+		withEvents(&mockFailingEventBus{err: errors.New("publish boom")}),
+		withLogger(logger),
+	)
 	tg.publishSystemEvent(context.Background(), "test message", "info")
 
 	require.GreaterOrEqual(t, len(logger.Errors), 1)
@@ -460,10 +464,12 @@ func TestTokenGatekeeper_PublishSystemEvent_SafePublishError(t *testing.T) {
 // and NOT logged (covers the resilience branch at gatekeeper.go:179-180).
 func TestTokenGatekeeper_PublishSystemEvent_ErrBusNotInitialized(t *testing.T) {
 	logger := &agenttest.MockPortsLogger{}
-	tg := &TokenGatekeeper{
-		Events: &mockFailingEventBus{err: events.ErrBusNotInitialized},
-		Logger: logger,
-	}
+	tg := newTokenGatekeeper(
+		nil,
+		nil,
+		withEvents(&mockFailingEventBus{err: events.ErrBusNotInitialized}),
+		withLogger(logger),
+	)
 	tg.publishSystemEvent(context.Background(), "test message", "info")
 
 	require.Empty(t, logger.Errors, "ErrBusNotInitialized should be silently swallowed, not logged")

--- a/internal/agent/session/context/gatekeeper.go
+++ b/internal/agent/session/context/gatekeeper.go
@@ -27,17 +27,62 @@ type TokenGatekeeper struct {
 	Summarizer        ports.Summarizer
 	Events            events.EventBus
 	Logger            ports.Logger
-	CandidateSelector CandidateSelector
+	candidateSelector CandidateSelector
 }
 
 // gatekeeperOption configures an optional setting on TokenGatekeeper.
 type gatekeeperOption func(*TokenGatekeeper)
 
+// GatekeeperOption is the public alias for gatekeeperOption, allowing
+// external packages to configure a TokenGatekeeper via NewTokenGatekeeper.
+type GatekeeperOption = gatekeeperOption
+
 // withCandidateSelector sets a custom candidate selection strategy.
 func withCandidateSelector(sel CandidateSelector) gatekeeperOption {
 	return func(tg *TokenGatekeeper) {
-		tg.CandidateSelector = sel
+		tg.candidateSelector = sel
 	}
+}
+
+// withMaxTokens sets the maximum token budget for the gatekeeper.
+func withMaxTokens(n int) gatekeeperOption {
+	return func(tg *TokenGatekeeper) {
+		tg.MaxTokens = n
+	}
+}
+
+// withEvents sets the event bus for publishing gatekeeper lifecycle events.
+func withEvents(bus events.EventBus) gatekeeperOption {
+	return func(tg *TokenGatekeeper) {
+		tg.Events = bus
+	}
+}
+
+// withLogger sets the structured logger for the gatekeeper.
+func withLogger(l ports.Logger) gatekeeperOption {
+	return func(tg *TokenGatekeeper) {
+		tg.Logger = l
+	}
+}
+
+// WithCandidateSelector is the public wrapper for withCandidateSelector.
+func WithCandidateSelector(sel CandidateSelector) GatekeeperOption {
+	return withCandidateSelector(sel)
+}
+
+// WithMaxTokens is the public wrapper for withMaxTokens.
+func WithMaxTokens(n int) GatekeeperOption {
+	return withMaxTokens(n)
+}
+
+// WithEvents is the public wrapper for withEvents.
+func WithEvents(bus events.EventBus) GatekeeperOption {
+	return withEvents(bus)
+}
+
+// WithGatekeeperLogger is the public wrapper for withLogger.
+func WithGatekeeperLogger(l ports.Logger) GatekeeperOption {
+	return withLogger(l)
 }
 
 // newTokenGatekeeper creates a TokenGatekeeper with sensible defaults.
@@ -47,12 +92,19 @@ func newTokenGatekeeper(estimator TokenEstimator, summarizer ports.Summarizer, o
 	tg := &TokenGatekeeper{
 		Estimator:         estimator,
 		Summarizer:        summarizer,
-		CandidateSelector: &contiguousUnpinnedSelector{},
+		candidateSelector: &contiguousUnpinnedSelector{},
 	}
 	for _, opt := range opts {
 		opt(tg)
 	}
 	return tg
+}
+
+// NewTokenGatekeeper creates a TokenGatekeeper with sensible defaults.
+// Required dependencies (estimator, summarizer) are explicit parameters;
+// optional settings are configured via GatekeeperOption functions.
+func NewTokenGatekeeper(estimator TokenEstimator, summarizer ports.Summarizer, opts ...GatekeeperOption) *TokenGatekeeper {
+	return newTokenGatekeeper(estimator, summarizer, opts...)
 }
 
 // hardLimitPolicy encapsulates the context-window buffer reservation
@@ -284,10 +336,7 @@ func (t *TokenGatekeeper) findSummarizableRange(ctx context.Context, history []*
 		return 0, 0, 0, err
 	}
 
-	selector := t.CandidateSelector
-	if selector == nil {
-		selector = &contiguousUnpinnedSelector{}
-	}
+	selector := t.candidateSelector
 	minViable := selector.MinViableBlock()
 
 	// We want to summarize about 50% of the history, but at least minViable turns.

--- a/internal/agent/session/context/gatekeeper_domain_test.go
+++ b/internal/agent/session/context/gatekeeper_domain_test.go
@@ -49,9 +49,10 @@ func TestTokenGatekeeper_DomainBoundaryValidation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gatekeeper := &TokenGatekeeper{
-				Estimator: &agenttest.MockTokenCounter{Tokens: 10},
-			}
+			gatekeeper := newTokenGatekeeper(
+				&agenttest.MockTokenCounter{Tokens: 10},
+				nil,
+			)
 
 			req := &ports.ContextRequest{
 				History:  tt.history,

--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -53,11 +53,11 @@ func TestGatekeeper_ErrorHandling(t *testing.T) {
 		req.History[i] = &llm.Content{Role: role, Parts: []*llm.Part{{Text: "msg"}}}
 	}
 
-	gatekeeper := &sessctx.TokenGatekeeper{
-		MaxTokens:  100,
-		Estimator:  &agenttest.MockEstimator{},
-		Summarizer: &mockFailingSummarizer{},
-	}
+	gatekeeper := sessctx.NewTokenGatekeeper(
+		&agenttest.MockEstimator{},
+		&mockFailingSummarizer{},
+		sessctx.WithMaxTokens(100),
+	)
 	gatekeeper.Estimator.(*agenttest.MockEstimator).SetTokens(95)
 
 	err := gatekeeper.Transform(ctx, req)
@@ -214,11 +214,12 @@ func TestTokenGatekeeper_NilSummarizer(t *testing.T) {
 		req.History[i] = &llm.Content{Role: role, Parts: []*llm.Part{{Text: "msg"}}}
 	}
 
-	gatekeeper := &sessctx.TokenGatekeeper{
-		MaxTokens: 100000,
-		Estimator: &agenttest.MockEstimator{},
-		// Summarizer intentionally nil — tests the nil-guard path
-	}
+	gatekeeper := sessctx.NewTokenGatekeeper(
+		&agenttest.MockEstimator{},
+		nil,
+		sessctx.WithMaxTokens(100000),
+	)
+	// Summarizer intentionally nil — tests the nil-guard path
 	// 95% tokens triggers safety pressure (90% threshold) but stays under
 	// the hard limit (MaxTokens - reserved = 100000 - min(1000, 10000) = 99000)
 	gatekeeper.Estimator.(*agenttest.MockEstimator).SetTokens(95000)
@@ -239,11 +240,12 @@ func TestTokenGatekeeper_EventPublish_Errors(t *testing.T) {
 	counter.SetTokens(950)
 	strategy := sessctx.NewStrategy(counter)
 
-	gatekeeper := &sessctx.TokenGatekeeper{
-		MaxTokens: 1000,
-		Estimator: strategy,
-		Events:    mockBus,
-	}
+	gatekeeper := sessctx.NewTokenGatekeeper(
+		strategy,
+		nil,
+		sessctx.WithMaxTokens(1000),
+		sessctx.WithEvents(mockBus),
+	)
 
 	// We need a large payload to trigger the token limit warning
 	largeText := ""
@@ -267,10 +269,11 @@ func TestTokenGatekeeper_FindSummarizableRange_ContextCancellation(t *testing.T)
 	tc := &agenttest.MockTokenCounter{}
 	strategy := sessctx.NewStrategy(tc)
 
-	gatekeeper := &sessctx.TokenGatekeeper{
-		MaxTokens: 10,
-		Estimator: strategy,
-	}
+	gatekeeper := sessctx.NewTokenGatekeeper(
+		strategy,
+		nil,
+		sessctx.WithMaxTokens(10),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately

--- a/internal/agent/session/context/gatekeeper_test.go
+++ b/internal/agent/session/context/gatekeeper_test.go
@@ -106,11 +106,13 @@ func TestTokenGatekeeper_ValidateHardLimits(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tg := &TokenGatekeeper{
-				MaxTokens: tt.maxTokens,
-				Events:    tt.bus,
-				Logger:    tt.logger,
-			}
+			tg := newTokenGatekeeper(
+				nil,
+				nil,
+				withMaxTokens(tt.maxTokens),
+				withEvents(tt.bus),
+				withLogger(tt.logger),
+			)
 
 			ctx := context.Background()
 			err := tg.validateHardLimits(ctx, nil, tt.tokens)

--- a/internal/agent/session/context/group_turns_error_test.go
+++ b/internal/agent/session/context/group_turns_error_test.go
@@ -50,15 +50,15 @@ func TestHistoryPruner_GroupTurnsErrorPropagation(t *testing.T) {
 
 func TestTokenGatekeeper_GroupTurnsErrorPropagation(t *testing.T) {
 	ctx := context.Background()
-	tg := &TokenGatekeeper{
-		MaxTokens: 1000,
-		Estimator: &agenttest.MockTokenCounter{Tokens: 1100}, // Trigger autoSummarize
-		Summarizer: &agenttest.MockSummarizer{
+	tg := newTokenGatekeeper(
+		&agenttest.MockTokenCounter{Tokens: 1100},
+		&agenttest.MockSummarizer{
 			SummarizeFn: func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
 				return "summary", &llm.Metrics{}, nil
 			},
 		},
-	}
+		withMaxTokens(1000),
+	)
 
 	// 10 messages to allow autoSummarize to proceed to findSummarizableRange
 	history := make([]*llm.Content, 10)

--- a/internal/agent/session/context/pipeline_factory.go
+++ b/internal/agent/session/context/pipeline_factory.go
@@ -74,13 +74,13 @@ func (f *Factory) BuildStandardPipeline(limits events.Limits, extras ...ports.Co
 	}
 
 	transformers = append(transformers,
-		&TokenGatekeeper{
-			MaxTokens:  limits.MaxHistoryTokens,
-			Estimator:  f.Estimator.(TokenEstimator),
-			Summarizer: f.Summarizer,
-			Events:     f.Events,
-			Logger:     f.Logger,
-		},
+		newTokenGatekeeper(
+			f.Estimator.(TokenEstimator),
+			f.Summarizer,
+			withMaxTokens(limits.MaxHistoryTokens),
+			withEvents(f.Events),
+			withLogger(f.Logger),
+		),
 		&emptyTurnFilter{},
 		&WarningInjector{
 			Strategy: f.Estimator.(*Strategy),

--- a/tests/integration/agent/session/context_manager_robustness_test.go
+++ b/tests/integration/agent/session/context_manager_robustness_test.go
@@ -48,12 +48,12 @@ func TestContextManager_Prepare_SafetyInjection(t *testing.T) {
 		&sessctx.HistoryPruner{
 			Policy: &sessctx.SlidingWindowPolicy{MaxTurns: 20},
 		},
-		&sessctx.TokenGatekeeper{
-			MaxTokens:  1000,
-			Estimator:  strategy,
-			Summarizer: cm.Summarizer,
-			Events:     cm.Events,
-		},
+		sessctx.NewTokenGatekeeper(
+			strategy,
+			cm.Summarizer,
+			sessctx.WithMaxTokens(1000),
+			sessctx.WithEvents(cm.Events),
+		),
 		&sessctx.WarningInjector{
 			Strategy: strategy,
 		},


### PR DESCRIPTION
## Summary

Closes #199 (supersedes #190).

Removes the defensive nil-guard in `findSummarizableRange` by closing the production constructor-bypass gap in `pipeline_factory.go`.

## Problem

`pipeline_factory.go:77` created a raw `&TokenGatekeeper{...}` struct literal without setting `CandidateSelector`, leaving it nil. The nil-guard in `findSummarizableRange` was the only thing preventing a production panic. Issue #190 proposed removing the nil-guard without first fixing the factory — which would have shipped an NPE on every pipeline build.

## Solution (7 ordered steps)

| Step | Description |
|:--:|---|
| A | Add `withMaxTokens`, `withEvents`, `withLogger` functional options |
| B | Export `GatekeeperOption` type alias + `With*` public wrappers |
| C | Export `NewTokenGatekeeper` constructor |
| D | Fix `pipeline_factory.go` to use constructor instead of raw literal |
| E | Migrate all 33 test sites (internal + external + integration) |
| F | Remove nil-guard from `findSummarizableRange` |
| G | Unexport `CandidateSelector` → `candidateSelector` (compiler-enforced invariant) |

## Verification

- Zero `&TokenGatekeeper{...}` literals remain outside the constructor
- `go test -race ./...` passes
- Both external packages compile against the new API
- `candidateSelector` is always non-nil — guaranteed by the constructor, sealed by the compiler

## Files Changed

11 files, +217 / −145