### PR TITLE
refactor: reduce cyclomatic complexity below threshold 10 (fixes #201)

### DIFF
--- a/internal/tools/analysis/harvest.go
+++ b/internal/tools/analysis/harvest.go
@@ -116,26 +116,31 @@ func (a *defaultDeadCodeAnalyzer) harvestPackageSymbols(pkg *packages.Package, s
 	}
 }
 
+// isEligibleForHarvest reports whether obj qualifies as a harvestable
+// declaration. It excludes nil objects, unexported symbols, the init
+// function, Go test functions, and declarations residing in
+// export_test.go files (which are test-API surface by convention).
+func (a *defaultDeadCodeAnalyzer) isEligibleForHarvest(obj types.Object, fset *token.FileSet) bool {
+	if obj == nil || obj.Pkg() == nil {
+		return false
+	}
+	if !obj.Exported() || obj.Name() == "init" {
+		return false
+	}
+	if a.isTestSymbol(obj.Name()) {
+		return false
+	}
+	if isExportTestFile(fset, obj.Pos()) {
+		return false
+	}
+	return true
+}
+
 // harvestObjectSymbols inspects a single types.Object and registers it (and its
 // exported methods) in the scanState if it qualifies as an exported, non-test,
 // non-export_test symbol.
 func (a *defaultDeadCodeAnalyzer) harvestObjectSymbols(obj types.Object, fset *token.FileSet, state *scanState) {
-	if obj == nil || obj.Pkg() == nil {
-		return
-	}
-	if !obj.Exported() || obj.Name() == "init" {
-		return
-	}
-
-	// Exclude Go test functions from being reported as technical debt.
-	if a.isTestSymbol(obj.Name()) {
-		return
-	}
-
-	// Suppress declarations that live in `export_test.go` files — these
-	// are by convention test-API surface, not production code. See
-	// isExportTestFile for full rationale.
-	if isExportTestFile(fset, obj.Pos()) {
+	if !a.isEligibleForHarvest(obj, fset) {
 		return
 	}
 

--- a/internal/tools/analysis/refactor_manager.go
+++ b/internal/tools/analysis/refactor_manager.go
@@ -69,6 +69,27 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 	return tools.ToolResult{Text: fmt.Sprintf("Successfully moved %s from %s to %s", plan.Symbol, plan.SrcFile, plan.DstFile)}, nil
 }
 
+// loadGoFilesForRename discovers all Go source files in resolvedDir, loads
+// them into a new transaction, and returns the file list and transaction.
+// Callers own the responsibility of adding transforms and committing.
+func (m *refactorManager) loadGoFilesForRename(resolvedDir string) ([]string, *transaction, error) {
+	goFiles, err := filepath.Glob(filepath.Join(resolvedDir, "*.go"))
+	if err != nil {
+		return nil, nil, fmt.Errorf("glob %s: %w", resolvedDir, err)
+	}
+	if len(goFiles) == 0 {
+		return nil, nil, fmt.Errorf("no .go files found in %s", resolvedDir)
+	}
+
+	tx := newTransaction()
+	for _, f := range goFiles {
+		if _, err := tx.LoadFile(f); err != nil {
+			return nil, nil, fmt.Errorf("load %s: %w", filepath.Base(f), err)
+		}
+	}
+	return goFiles, tx, nil
+}
+
 func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		OldName string `json:"old_name"`
@@ -89,21 +110,10 @@ func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]inte
 		return tools.ToolResult{}, err
 	}
 
-	// Find all Go source files in the target directory.
-	goFiles, err := filepath.Glob(filepath.Join(resolvedDir, "*.go"))
+	// Discover and load all Go source files into a transaction.
+	goFiles, tx, err := m.loadGoFilesForRename(resolvedDir)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("glob %s: %w", resolvedDir, err)
-	}
-	if len(goFiles) == 0 {
-		return tools.ToolResult{}, fmt.Errorf("no .go files found in %s", resolvedDir)
-	}
-
-	// Load all files into a transaction and apply the rename.
-	tx := newTransaction()
-	for _, f := range goFiles {
-		if _, err := tx.LoadFile(f); err != nil {
-			return tools.ToolResult{}, fmt.Errorf("load %s: %w", filepath.Base(f), err)
-		}
+		return tools.ToolResult{}, err
 	}
 
 	plan := &renamePlan{OldName: params.OldName, NewName: params.NewName}

--- a/internal/tools/analysis/sequence.go
+++ b/internal/tools/analysis/sequence.go
@@ -391,7 +391,12 @@ func (a *defaultSequenceAnalyzer) exprToString(expr ast.Expr) string {
 	}
 }
 
-func (a *defaultSequenceAnalyzer) findStartPackage(symbol string, allPkgs []*packages.Package) (*packages.Package, string) {
+// findByPrefix attempts to locate a package by matching the symbol against
+// each package's full import path as a prefix (e.g., "github.com/foo/bar.Baz"
+// matches package "github.com/foo/bar"). When multiple packages match, the
+// one with the longest import path wins. Returns the matched package and the
+// remaining portion of the symbol after the package path, or nil if no match.
+func (a *defaultSequenceAnalyzer) findByPrefix(symbol string, allPkgs []*packages.Package) (*packages.Package, string) {
 	var startPkg *packages.Package
 	var remaining string
 	for _, p := range allPkgs {
@@ -402,21 +407,38 @@ func (a *defaultSequenceAnalyzer) findStartPackage(symbol string, allPkgs []*pac
 			}
 		}
 	}
+	return startPkg, remaining
+}
 
-	if startPkg == nil {
-		lastDot := strings.LastIndex(symbol, ".")
-		if lastDot != -1 {
-			pkgPath := symbol[:lastDot]
-			remaining = symbol[lastDot+1:]
-			for _, p := range allPkgs {
-				if strings.HasSuffix(p.PkgPath, pkgPath) || p.PkgPath == pkgPath {
-					startPkg = p
-					break
-				}
-			}
+// findBySuffix is the fallback when findByPrefix fails. It takes the portion
+// of the symbol before the last dot as a candidate package path, then searches
+// for a package whose import path either equals that candidate or has it as a
+// suffix. Returns the matched package and the symbol portion after the last dot,
+// or nil if no match.
+func (a *defaultSequenceAnalyzer) findBySuffix(symbol string, allPkgs []*packages.Package) (*packages.Package, string) {
+	lastDot := strings.LastIndex(symbol, ".")
+	if lastDot == -1 {
+		return nil, ""
+	}
+	pkgPath := symbol[:lastDot]
+	remaining := symbol[lastDot+1:]
+	for _, p := range allPkgs {
+		if strings.HasSuffix(p.PkgPath, pkgPath) || p.PkgPath == pkgPath {
+			return p, remaining
 		}
 	}
-	return startPkg, remaining
+	return nil, ""
+}
+
+// findStartPackage resolves a symbol string to its containing package using
+// a two-phase strategy: first a prefix match against full import paths, then
+// a suffix/equality fallback. Returns the package and the remaining symbol
+// portion (function name with optional receiver), or nil if unresolved.
+func (a *defaultSequenceAnalyzer) findStartPackage(symbol string, allPkgs []*packages.Package) (*packages.Package, string) {
+	if pkg, rem := a.findByPrefix(symbol, allPkgs); pkg != nil {
+		return pkg, rem
+	}
+	return a.findBySuffix(symbol, allPkgs)
 }
 
 func (a *defaultSequenceAnalyzer) resolveStartFunc(pkg *packages.Package, remaining string) (*ast.FuncDecl, error) {


### PR DESCRIPTION
## Summary

Extract private helpers from three production functions that exceeded the cyclomatic complexity threshold of 10.

| Function | File | Before | After |
|----------|------|--------|-------|
| `harvestObjectSymbols` | harvest.go | 10 | **5** |
| `findStartPackage` | sequence.go | 10 | **2** |
| `RenameSymbol` | refactor_manager.go | 11 | **8** |

## Approach

Behavior-preserving Extract Method refactoring only:
- **harvest.go**: Extracted `isEligibleForHarvest` predicate to consolidate four guard clauses
- **sequence.go**: Extracted `findByPrefix` + `findBySuffix` to separate two-phase search
- **refactor_manager.go**: Extracted `loadGoFilesForRename` to isolate file I/O orchestration

## Verification

- `go test ./internal/tools/analysis/...` — **PASS**
- `golangci-lint run` — **0 issues**
- Zero test changes required
- Closes #201