### PR TITLE
fix: log SelectSkills error instead of silently discarding (#203)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -134,7 +134,7 @@ func (a *agent) initComponents() error {
 		Summarizer: a.summarizer,
 		Estimator:  strategy,
 		Events:     a.events,
-		Extras:     []ports.ContextTransformer{session.NewSkillInjector(a.skillSelector)},
+		Extras:     []ports.ContextTransformer{session.NewSkillInjector(a.skillSelector, a.logger)},
 	}
 
 	a.ctxManager = sessctx.NewManager(strategy, a.hManager, a.events, factory,

--- a/internal/agent/session/skill_injector.go
+++ b/internal/agent/session/skill_injector.go
@@ -16,14 +16,15 @@ import (
 // skillInjector dynamically selects and injects Go development skills into the context.
 type skillInjector struct {
 	Selector skills.SkillSelector
+	Logger   ports.Logger
 }
 
 // NewSkillInjector creates a ports.ContextTransformer that injects skills
 // into the context. It exists as a constructor so the session/ package can
 // inject skill selection into the session/context pipeline without the
 // context/ sub-package importing domain/skills.
-func NewSkillInjector(selector skills.SkillSelector) ports.ContextTransformer {
-	return &skillInjector{Selector: selector}
+func NewSkillInjector(selector skills.SkillSelector, logger ports.Logger) ports.ContextTransformer {
+	return &skillInjector{Selector: selector, Logger: logger}
 }
 
 func (t *skillInjector) Transform(ctx context.Context, req *ports.ContextRequest) error {
@@ -35,6 +36,9 @@ func (t *skillInjector) Transform(ctx context.Context, req *ports.ContextRequest
 
 	selected, err := t.Selector.SelectSkills(ctx, strings.TrimSpace(taskDescription))
 	if err != nil {
+		if t.Logger != nil {
+			t.Logger.Warn("skill selection failed; proceeding without injected skills", "error", err)
+		}
 		return nil
 	}
 

--- a/internal/agent/session/skill_injector_test.go
+++ b/internal/agent/session/skill_injector_test.go
@@ -5,6 +5,7 @@ package session
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -105,6 +106,27 @@ func TestSkillInjector_Transform(t *testing.T) {
 			},
 			validate: func(t *testing.T, req *ports.ContextRequest) {
 				// Success if it doesn't panic
+			},
+		},
+		{
+			name: "SelectSkillsErrorIsLoggedAndSwallowed",
+			selector: &mockSkillSelector{
+				err: errors.New("selector unavailable"),
+			},
+			req: &ports.ContextRequest{
+				History: []*llm.Content{
+					{Role: "user", Parts: []*llm.Part{{Text: "how do I test in Go?"}}},
+				},
+			},
+			validate: func(t *testing.T, req *ports.ContextRequest) {
+				// Transform must NOT return an error — the failure is logged, not propagated.
+				// History must remain unchanged (no injection, no mutation).
+				if len(req.History) != 1 {
+					t.Errorf("expected history unchanged (1 entry), got %d", len(req.History))
+				}
+				if req.PersistHistory {
+					t.Error("expected PersistHistory to remain false when skill selection fails")
+				}
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Fixes #203 — `skillInjector.Transform` silently swallowed errors from `SelectSkills`, making skill selection failures completely invisible to operators and the agent.

## Root Cause

The `skillInjector` had no `ports.Logger` dependency. When `SelectSkills` returned an error (I/O failure, selector state corruption, etc.), it was silently discarded — no log, no event, no degradation signal. The agent proceeded without injected skills, degrading response quality with zero observability.

## Changes

| File | Change |
|---|---|
| `skill_injector.go` | Added `Logger` field, updated constructor, log at `Warn` on error (nil-safe) |
| `agent.go` | Pass `a.logger` to `NewSkillInjector` |
| `skill_injector_test.go` | New test case: `SelectSkillsErrorIsLoggedAndSwallowed` |

## Architecture Decision

**Error is logged, not propagated.** `skillInjector` is a quality-enhancing transformer (priority 10), not a correctness-critical one. Returning the error would halt the entire canonical context pipeline and prevent the LLM call — a denial-of-service for an otherwise operational agent. The correct degradation is: log the warning and proceed without skill injection.

## Verification

- `go build ./internal/agent/...` — clean
- `go test ./internal/agent/...` — all 8 packages pass
- New error-path test passes: `go test -run TestSkillInjector_Transform/SelectSkillsErrorIsLoggedAndSwallowed ./internal/agent/session/...`