### PR TITLE
refactor: reduce cyclomatic complexity of findCycles and generateMermaidDiagram

### DIFF
--- a/internal/tools/analysis/mermaid.go
+++ b/internal/tools/analysis/mermaid.go
@@ -127,42 +127,54 @@ func renderStyles(sb *strings.Builder, pkgs []string, cycleEdgeIndices []string)
 	}
 }
 
-func findCycles(graph map[string][]string) [][]string {
-	var cycles [][]string
-	visited := make(map[string]bool)
-	onStack := make(map[string]bool)
-	var path []string
+type cycleDetector struct {
+	graph   map[string][]string
+	visited map[string]bool
+	onStack map[string]bool
+	path    []string
+	cycles  [][]string
+}
 
-	var dfs func(string)
-	dfs = func(u string) {
-		visited[u] = true
-		onStack[u] = true
-		path = append(path, u)
+func (d *cycleDetector) dfs(u string) {
+	d.visited[u] = true
+	d.onStack[u] = true
+	d.path = append(d.path, u)
 
-		deps := graph[u]
-		// Sort deps for deterministic cycle detection if multiple exist
-		sort.Strings(deps)
-		for _, v := range deps {
-			if !visited[v] {
-				dfs(v)
-			} else if onStack[v] {
-				cycleStart := -1
-				for i, node := range path {
-					if node == v {
-						cycleStart = i
-						break
-					}
-				}
-				if cycleStart != -1 {
-					cycle := append([]string{}, path[cycleStart:]...)
-					cycle = append(cycle, v)
-					cycles = append(cycles, cycle)
-				}
+	deps := d.graph[u]
+	// Sort deps for deterministic cycle detection if multiple exist
+	sort.Strings(deps)
+	for _, v := range deps {
+		if !d.visited[v] {
+			d.dfs(v)
+		} else if d.onStack[v] {
+			cycle := d.buildCycle(v)
+			if cycle != nil {
+				d.cycles = append(d.cycles, cycle)
 			}
 		}
+	}
 
-		onStack[u] = false
-		path = path[:len(path)-1]
+	d.onStack[u] = false
+	d.path = d.path[:len(d.path)-1]
+}
+
+func (d *cycleDetector) buildCycle(v string) []string {
+	for i, node := range d.path {
+		if node == v {
+			cycle := make([]string, len(d.path)-i+1)
+			copy(cycle, d.path[i:])
+			cycle[len(cycle)-1] = v
+			return cycle
+		}
+	}
+	return nil
+}
+
+func findCycles(graph map[string][]string) [][]string {
+	d := &cycleDetector{
+		graph:   graph,
+		visited: make(map[string]bool),
+		onStack: make(map[string]bool),
 	}
 
 	nodes := make([]string, 0, len(graph))
@@ -172,9 +184,9 @@ func findCycles(graph map[string][]string) [][]string {
 	sort.Strings(nodes)
 
 	for _, n := range nodes {
-		if !visited[n] {
-			dfs(n)
+		if !d.visited[n] {
+			d.dfs(n)
 		}
 	}
-	return cycles
+	return d.cycles
 }

--- a/internal/tools/analysis/mermaid_tool.go
+++ b/internal/tools/analysis/mermaid_tool.go
@@ -5,38 +5,60 @@ package analysis
 
 import (
 	"context"
+	"errors"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-// generateMermaidDiagram transforms a dependency map into a Mermaid.js diagram.
-// It is registered as a tool.
-func generateMermaidDiagram(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	rawGraph, ok := args["graph"]
-	if !ok {
-		return tools.ToolResult{Text: "Error: missing 'graph' argument"}, nil
+// coerceGraphMap converts a map[string]interface{} to map[string][]string
+// by coercing each value that is []string or []interface{}.
+func coerceGraphMap(m map[string]interface{}) map[string][]string {
+	graph := make(map[string][]string)
+	for k, v := range m {
+		switch deps := v.(type) {
+		case []string:
+			graph[k] = deps
+		case []interface{}:
+			for _, d := range deps {
+				if s, ok := d.(string); ok {
+					graph[k] = append(graph[k], s)
+				}
+			}
+		}
+	}
+	return graph
+}
+
+// normalizeGraphArg coerces the raw graph argument into a map[string][]string.
+// It handles three cases:
+//   - nil: returns an error about the missing graph argument
+//   - map[string][]string: returned as-is
+//   - map[string]interface{}: delegated to coerceGraphMap
+//   - anything else: returns a type error
+func normalizeGraphArg(rawGraph interface{}) (map[string][]string, error) {
+	if rawGraph == nil {
+		return nil, errors.New("missing 'graph' argument")
 	}
 
-	graph := make(map[string][]string)
+	var graph map[string][]string
 	switch m := rawGraph.(type) {
 	case map[string][]string:
 		graph = m
 	case map[string]interface{}:
-		for k, v := range m {
-			switch deps := v.(type) {
-			case []string:
-				graph[k] = deps
-			case []interface{}:
-				for _, d := range deps {
-					if s, ok := d.(string); ok {
-						graph[k] = append(graph[k], s)
-					}
-				}
-			}
-		}
+		graph = coerceGraphMap(m)
 	default:
-		return tools.ToolResult{Text: "Error: 'graph' argument must be a map of string to string list"}, nil
+		return nil, errors.New("'graph' argument must be a map of string to string list")
 	}
 
+	return graph, nil
+}
+
+// generateMermaidDiagram transforms a dependency map into a Mermaid.js diagram.
+// It is registered as a tool.
+func generateMermaidDiagram(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	graph, err := normalizeGraphArg(args["graph"])
+	if err != nil {
+		return tools.ToolResult{Text: "Error: " + err.Error()}, nil
+	}
 	return tools.ToolResult{Text: generateMermaid(graph)}, nil
 }


### PR DESCRIPTION
Closes #207

## Summary
Reduces cyclomatic complexity of two production functions from 10 to well under the threshold of 7:

| Function | Before | After |
|---|---|---|
| `generateMermaidDiagram` | 10 | **2** |
| `findCycles` | 10 | **4** |

## Changes

### `mermaid_tool.go`
- Extracted `normalizeGraphArg` – isolates type-coercion logic (complexity 5)
- Extracted `coerceGraphMap` – handles `map[string]interface{}` coercion (complexity 6)
- `generateMermaidDiagram` is now a 3-line delegation function (complexity 2)

### `mermaid.go`
- Introduced `cycleDetector` struct – mirrors the existing `circularDetector` pattern from `architecture.go`
- Extracted `dfs` as a method on `cycleDetector` (complexity 5)
- Extracted `buildCycle` from the inline cycle-finding loop (complexity 3)
- `findCycles` is now a thin wrapper (complexity 4)

## Verification
- All existing tests pass
- `go vet` clean
- No behavioral changes – purely structural refactoring