### PR TITLE
refactor(tests): migrate ADO tests to toolstest.MockSecurityManager

### DIFF
--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -1041,7 +1041,7 @@ func TestGetBuildChanges(t *testing.T) {
 
 func TestAdoTools_DetailedErrors(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	commonArgs := map[string]interface{}{
 		"organization": "myorg",
@@ -2222,7 +2222,7 @@ func TestCreatePipeline(t *testing.T) {
 			}))
 			t.Cleanup(server.Close)
 
-			sm := &mockSecurityManager{approved: tt.approved}
+			sm := &toolstest.MockSecurityManager{AllowAll: tt.approved, ConfirmFunc: func(ctx context.Context, msg string) (bool, error) { return tt.approved, nil }}
 			m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 			// Pre-populate cache to test invalidation
@@ -2244,7 +2244,7 @@ func TestCreatePipeline(t *testing.T) {
 			assert.Equal(t, tt.wantPipelineID, result.PipelineID)
 			assert.Equal(t, tt.wantName, result.Name)
 			assert.Equal(t, tt.expectPost, postCalled, "POST call mismatch")
-			assert.Equal(t, tt.expectConfirm, sm.confirmCalled, "Confirm call mismatch")
+			assert.Equal(t, tt.expectConfirm, sm.ConfirmCalled, "Confirm call mismatch")
 
 			if tt.name == "Success" {
 				_, exists := m.pipelineCache.Load(cacheKey)
@@ -2294,7 +2294,7 @@ func TestAdoRunPipeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		sm := &mockSecurityManager{approved: true}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		// Branch is the raw user-facing name; _ref_name is the formatted ADO ref.
@@ -2314,12 +2314,12 @@ func TestAdoRunPipeline(t *testing.T) {
 		assert.Equal(t, 101, result.RunID)
 		assert.Equal(t, "https://dev.azure.com/myorg/myproj/_build/results?buildId=101", result.WebURL)
 		// Confirmation prompt should show the raw branch, not the formatted ref.
-		assert.Contains(t, sm.lastConfirmText, "branch: feature")
-		assert.NotContains(t, sm.lastConfirmText, "branch: refs/heads/feature")
+		assert.Contains(t, sm.LastConfirmText, "branch: feature")
+		assert.NotContains(t, sm.LastConfirmText, "branch: refs/heads/feature")
 	})
 
 	t.Run("Cancelled", func(t *testing.T) {
-		sm := &mockSecurityManager{approved: false}
+		sm := &toolstest.MockSecurityManager{ConfirmFunc: func(ctx context.Context, msg string) (bool, error) { return false, nil }}
 		m := NewADOManager(sm)
 
 		args := map[string]interface{}{
@@ -2359,7 +2359,7 @@ func TestAdoRunPipeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		sm := &mockSecurityManager{approved: true}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		// No _ref_name: exercises the defensive fallback path.
@@ -2385,7 +2385,7 @@ func TestAdoRunPipeline(t *testing.T) {
 		}))
 		t.Cleanup(server.Close)
 
-		sm := &mockSecurityManager{approved: false} // decline so no HTTP body assertion needed
+		sm := &toolstest.MockSecurityManager{ConfirmFunc: func(ctx context.Context, msg string) (bool, error) { return false, nil }} // decline so no HTTP body assertion needed
 		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 
 		args := map[string]interface{}{
@@ -2400,38 +2400,10 @@ func TestAdoRunPipeline(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, result.Cancelled)
 
-		assert.Contains(t, sm.lastConfirmText, "branch: main",
+		assert.Contains(t, sm.LastConfirmText, "branch: main",
 			"confirmation prompt should display the raw branch name")
-		assert.NotContains(t, sm.lastConfirmText, "branch: refs/heads/main",
+		assert.NotContains(t, sm.LastConfirmText, "branch: refs/heads/main",
 			"confirmation prompt must not display the fully qualified ref")
 	})
 }
 
-type mockSecurityManager struct {
-	approved        bool
-	err             error
-	confirmCalled   bool
-	lastConfirmText string
-}
-
-func (m *mockSecurityManager) IsPathSafe(path string) (string, error) { return path, nil }
-func (m *mockSecurityManager) IsPathWritable(path string) (string, error) {
-	return path, nil
-}
-func (m *mockSecurityManager) Authorize(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
-	return m.approved, m.err
-}
-func (m *mockSecurityManager) LogAudit(action string, args ...any) {}
-func (m *mockSecurityManager) TerminalLock()                       {}
-func (m *mockSecurityManager) TerminalUnlock()                     {}
-func (m *mockSecurityManager) Prompt(message string)               {}
-func (m *mockSecurityManager) Warn(message string)                 {}
-func (m *mockSecurityManager) Confirm(ctx context.Context, message string) (bool, error) {
-	m.confirmCalled = true
-	m.lastConfirmText = message
-	return m.approved, m.err
-}
-func (m *mockSecurityManager) ReadLine(ctx context.Context) (string, error) { return "", nil }
-func (m *mockSecurityManager) IsCommandAllowed(command string) bool         { return true }
-func (m *mockSecurityManager) IsBypassActive() bool                         { return false }
-func (m *mockSecurityManager) Close() error                                 { return nil }

--- a/internal/tools/integrations/ado/handler_test.go
+++ b/internal/tools/integrations/ado/handler_test.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -27,11 +29,16 @@ func noopHeartbeat() chan<- struct{} {
 
 // setupADOServer creates an httptest server, registers cleanup, and returns
 // an AdoManager pointed at it with an already-approved or rejected security confirmer.
-func setupADOServer(t *testing.T, handler http.HandlerFunc, approved bool) *AdoManager {
+func setupADOServer(t *testing.T, handler http.HandlerFunc, confirmFunc func(context.Context, string) (bool, error)) *AdoManager {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
-	return NewADOManager(&mockSecurityManager{approved: approved}, WithBaseURL(server.URL), WithToken("test-pat"))
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	if confirmFunc != nil {
+		sm.ConfirmFunc = confirmFunc
+		sm.AllowAll = false
+	}
+	return NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
 }
 
 // ============================================================================
@@ -45,7 +52,7 @@ func TestNewGetBuildTimelineHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/build/builds/1/timeline")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"records":[{"id":"1","name":"Task 1"}]}`))
-		}, true)
+		}, nil)
 
 		handler := newGetBuildTimelineHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -60,7 +67,7 @@ func TestNewGetBuildTimelineHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}, true)
+		}, nil)
 
 		handler := newGetBuildTimelineHandler(m)
 		_, err := handler(context.Background(), map[string]interface{}{
@@ -79,7 +86,7 @@ func TestNewGetTaskLogHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/build/builds/1/logs/5")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("build output\n"))
-		}, true)
+		}, nil)
 
 		handler := newGetTaskLogHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -94,7 +101,7 @@ func TestNewGetTaskLogHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
-		}, true)
+		}, nil)
 
 		handler := newGetTaskLogHandler(m)
 		_, err := handler(context.Background(), map[string]interface{}{
@@ -113,7 +120,7 @@ func TestNewGetBuildChangesHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/build/builds/1/changes")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":"abc","message":"feat: add"}]}`))
-		}, true)
+		}, nil)
 
 		handler := newGetBuildChangesHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -128,7 +135,7 @@ func TestNewGetBuildChangesHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
-		}, true)
+		}, nil)
 
 		handler := newGetBuildChangesHandler(m)
 		_, err := handler(context.Background(), map[string]interface{}{
@@ -151,7 +158,7 @@ func TestNewListPipelinesHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/_apis/pipelines")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":1,"name":"my-pipeline"}]}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newListPipelinesHandler(m, f)
@@ -168,7 +175,7 @@ func TestNewListPipelinesHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newListPipelinesHandler(m, f)
@@ -188,7 +195,7 @@ func TestNewGetPipelineRunHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/runs/101")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":101,"name":"run1","state":"completed","result":"succeeded","createdDate":"d","url":"u"}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineRunHandler(m, f)
@@ -205,7 +212,7 @@ func TestNewGetPipelineRunHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineRunHandler(m, f)
@@ -225,7 +232,7 @@ func TestNewGetPipelineDefinitionHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/_apis/pipelines/123")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":123,"name":"test-pipeline"}`))
-		}, true)
+		}, nil)
 
 		handler := newGetPipelineDefinitionHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -240,7 +247,7 @@ func TestNewGetPipelineDefinitionHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
-		}, true)
+		}, nil)
 
 		handler := newGetPipelineDefinitionHandler(m)
 		_, err := handler(context.Background(), map[string]interface{}{
@@ -259,7 +266,7 @@ func TestNewListPipelineRunsHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/_apis/build/builds")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":101,"buildNumber":"r1","status":"completed","result":"succeeded","queueTime":"t","repository":{"name":"repo"}}]}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newListPipelineRunsHandler(m, f)
@@ -276,7 +283,7 @@ func TestNewListPipelineRunsHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newListPipelineRunsHandler(m, f)
@@ -297,7 +304,7 @@ func TestNewGetPipelineLogsHandler(t *testing.T) {
 			assert.NotContains(t, r.URL.Path, "/logs/")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":1,"lineCount":10}]}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineLogsHandler(m, f)
@@ -317,7 +324,7 @@ func TestNewGetPipelineLogsHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/logs/5")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("log content here"))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineLogsHandler(m, f)
@@ -333,7 +340,7 @@ func TestNewGetPipelineLogsHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineLogsHandler(m, f)
@@ -353,7 +360,7 @@ func TestNewCreatePipelineHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/_apis/pipelines")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":99,"name":"my-pipe"}]}`))
-		}, true)
+		}, nil)
 
 		handler := newCreatePipelineHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -369,7 +376,7 @@ func TestNewCreatePipelineHandler(t *testing.T) {
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"value":[{"id":1,"name":"other"}]}`))
-		}, false)
+		}, func(ctx context.Context, msg string) (bool, error) { return false, nil })
 
 		handler := newCreatePipelineHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -393,7 +400,7 @@ func TestNewCreatePipelineHandler(t *testing.T) {
 				_, _ = w.Write([]byte(`{"id":200}`))
 				return
 			}
-		}, true)
+		}, nil)
 
 		handler := newCreatePipelineHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -414,7 +421,7 @@ func TestNewRunPipelineHandler(t *testing.T) {
 			assert.Contains(t, r.URL.Path, "/_apis/pipelines/1/runs")
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":303,"_links":{"web":{"href":"https://dev.azure.com/x"}}}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newRunPipelineHandler(m, f)
@@ -429,7 +436,7 @@ func TestNewRunPipelineHandler(t *testing.T) {
 
 	t.Run("Cancelled", func(t *testing.T) {
 		t.Parallel()
-		m := NewADOManager(&mockSecurityManager{approved: false}, WithToken("test-pat"))
+		m := NewADOManager(&toolstest.MockSecurityManager{ConfirmFunc: func(ctx context.Context, msg string) (bool, error) { return false, nil }}, WithToken("test-pat"))
 		f := newPipelineFormatter()
 		handler := newRunPipelineHandler(m, f)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -454,7 +461,7 @@ func TestNewRunPipelineHandler(t *testing.T) {
 
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":404,"_links":{"web":{"href":"https://dev.azure.com/x"}}}`))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newRunPipelineHandler(m, f)
@@ -489,7 +496,7 @@ func TestNewUpdateBuildDefinitionVariablesHandler(t *testing.T) {
 				_, _ = w.Write([]byte(`{}`))
 				return
 			}
-		}, true)
+		}, nil)
 
 		handler := newUpdateBuildDefinitionVariablesHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -512,7 +519,7 @@ func TestNewUpdateBuildDefinitionVariablesHandler(t *testing.T) {
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte(`{"id":123,"variables":{}}`))
-		}, false)
+		}, func(ctx context.Context, msg string) (bool, error) { return false, nil })
 
 		handler := newUpdateBuildDefinitionVariablesHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -532,7 +539,7 @@ func TestNewUpdateBuildDefinitionVariablesHandler(t *testing.T) {
 		t.Parallel()
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusInternalServerError)
-		}, true)
+		}, nil)
 
 		handler := newUpdateBuildDefinitionVariablesHandler(m)
 		_, err := handler(context.Background(), map[string]interface{}{
@@ -559,7 +566,7 @@ func TestHandlerNilHeartbeat(t *testing.T) {
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("output"))
-		}, true)
+		}, nil)
 
 		handler := newGetTaskLogHandler(m)
 		result, err := handler(context.Background(), map[string]interface{}{
@@ -575,7 +582,7 @@ func TestHandlerNilHeartbeat(t *testing.T) {
 		m := setupADOServer(t, func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write([]byte("log data"))
-		}, true)
+		}, nil)
 
 		f := newPipelineFormatter()
 		handler := newGetPipelineLogsHandler(m, f)

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -10,12 +10,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAdoManager_ExecuteCreatePipeline_Errors(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	tests := []struct {
 		name           string
@@ -80,7 +82,7 @@ func TestAdoManager_ExecuteCreatePipeline_Errors(t *testing.T) {
 
 func TestAdoManager_ExecuteRequest_NetworkError(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	// We use a client that points to a non-existent port or closed server
 	m := NewADOManager(sm,
@@ -96,7 +98,7 @@ func TestAdoManager_ExecuteRequest_NetworkError(t *testing.T) {
 }
 
 func TestAdoManager_ExecuteRequest_AuthMissing(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	m := NewADOManager(sm)
 
@@ -109,7 +111,7 @@ func TestAdoManager_ExecuteRequest_AuthMissing(t *testing.T) {
 
 func TestAdoManager_GetPipelineRun_Errors(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	tests := []struct {
 		name           string
@@ -162,7 +164,7 @@ func TestAdoManager_GetPipelineRun_Errors(t *testing.T) {
 }
 
 func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Fetch Pipelines Failure", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -191,7 +193,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 }
 
 func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Malformed JSON Response", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -220,7 +222,7 @@ func TestAdoManager_ExecuteRunPipeline_Errors(t *testing.T) {
 }
 
 func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -258,7 +260,7 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 }
 
 func TestAdoManager_ListPipelineRuns_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -296,7 +298,7 @@ func TestAdoManager_ListPipelineRuns_Errors(t *testing.T) {
 }
 
 func TestAdoManager_ListPipelineLogs_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -347,7 +349,7 @@ func TestAdoManager_ListPipelineLogs_Errors(t *testing.T) {
 }
 
 func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -408,7 +410,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 }
 
 func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -446,7 +448,7 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 }
 
 func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -488,7 +490,7 @@ func TestAdoManager_AdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 }
 
 func TestAdoManager_GetPipelineDefinition_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -526,7 +528,7 @@ func TestAdoManager_GetPipelineDefinition_Errors(t *testing.T) {
 }
 
 func TestAdoManager_UpdateBuildDefinitionVariables_Errors(t *testing.T) {
-	sm := &mockSecurityManager{approved: true}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 	t.Run("Missing Parameters", func(t *testing.T) {
 		m := NewADOManager(sm)
@@ -608,7 +610,7 @@ func TestAdoManager_UpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		}))
 		t.Cleanup(ts.Close)
 
-		deniedSM := &mockSecurityManager{approved: false}
+		deniedSM := &toolstest.MockSecurityManager{ConfirmFunc: func(ctx context.Context, msg string) (bool, error) { return false, nil }}
 		m := NewADOManager(deniedSM, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		args := map[string]interface{}{
 			"organization":  "o",

--- a/internal/tools/integrations/ado/registry_test.go
+++ b/internal/tools/integrations/ado/registry_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -256,7 +258,7 @@ func TestRegisterRepository(t *testing.T) {
 func TestRegister(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		r := &mockRegistry{}
-		sm := &mockSecurityManager{approved: true}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
 
 		// No AZURE_PAT_ALL env — Register should still succeed (token is optional
 		// at registration time; the handlers check it at execution time).
@@ -276,7 +278,7 @@ func TestRegister(t *testing.T) {
 		// on the second call.
 		r := &failingRegistry{maxCalls: 1}
 
-		sm := &mockSecurityManager{approved: true}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
 		err := Register(r, sm, nil)
 
 		assert.Error(t, err)

--- a/internal/tools/toolstest/mock_security_manager.go
+++ b/internal/tools/toolstest/mock_security_manager.go
@@ -22,6 +22,9 @@ type MockSecurityManager struct {
 	AuthorizeFunc   func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error)
 	IsSafeFunc      func(path string) (string, error)
 	IsWritableFunc  func(path string) (string, error)
+	ConfirmFunc     func(ctx context.Context, message string) (bool, error)
+	ConfirmCalled   bool
+	LastConfirmText string
 	Interactor      security.UserInteractor
 }
 
@@ -62,6 +65,11 @@ func (m *MockSecurityManager) Prompt(message string)               {}
 func (m *MockSecurityManager) Warn(message string)                 {}
 
 func (m *MockSecurityManager) Confirm(ctx context.Context, message string) (bool, error) {
+	m.ConfirmCalled = true
+	m.LastConfirmText = message
+	if m.ConfirmFunc != nil {
+		return m.ConfirmFunc(ctx, message)
+	}
 	if m.Interactor != nil {
 		return m.Interactor.Confirm(ctx, message)
 	}


### PR DESCRIPTION
Closes #211.

Per ADR-021, cross-package test dependencies should leverage their designated double packages. The ADO integration package used a local `mockSecurityManager` struct that duplicated functionality from `internal/tools/toolstest.MockSecurityManager`.

### Changes Made:
1. **Extended `toolstest.MockSecurityManager`**:
   - Added `ConfirmCalled` and `LastConfirmText` to track `Confirm()` invocations.
   - Added `ConfirmFunc` for optional override of the `Confirm()` return value.
2. **Migrated ADO Tests**:
   - Replaced `&mockSecurityManager{}` with `&toolstest.MockSecurityManager{}` across `azure_devops_test.go`, `handler_test.go`, `negative_test.go`, and `registry_test.go`.
   - Updated the `setupADOServer` helper in `handler_test.go` to utilize `ConfirmFunc`.
   - Removed the local definition of `mockSecurityManager`.
3. **Validated Functionality**:
   - Ensured all tests pass and logic is intact without local duplications.