### PR TITLE
test: add mechanical delegation tests for agentinternal bridge (#216)

### DIFF
--- a/internal/agent/agentinternal/accessor_test.go
+++ b/internal/agent/agentinternal/accessor_test.go
@@ -1,0 +1,653 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agentinternal
+
+import (
+	"context"
+	"log/slog"
+	"reflect"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent"
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
+	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockInternalAccessor is a mock of agent.InternalAccessor used by
+// white-box tests of the agentinternal delegation chain. It mirrors
+// the testify/mock pattern established by mockSessionLifecycleManager.
+type mockInternalAccessor struct {
+	mock.Mock
+}
+
+func (m *mockInternalAccessor) ApplyConfig(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+func (m *mockInternalAccessor) AsChatter() ports.Chatter {
+	return m.Called().Get(0).(ports.Chatter)
+}
+
+func (m *mockInternalAccessor) GetTrackerForInternalUse() domain_pricing.CostTracker {
+	return m.Called().Get(0).(domain_pricing.CostTracker)
+}
+
+func (m *mockInternalAccessor) GetCtxManagerForInternalUse() *sessctx.Manager {
+	return m.Called().Get(0).(*sessctx.Manager)
+}
+
+func (m *mockInternalAccessor) GetEventsForInternalUse() events.EventBus {
+	return m.Called().Get(0).(events.EventBus)
+}
+
+func (m *mockInternalAccessor) GetConfigWatcherForInternalUse() session.ConfigWatcher {
+	return m.Called().Get(0).(session.ConfigWatcher)
+}
+
+func (m *mockInternalAccessor) GetRuntimeSnapshotForInternalUse() struct {
+	ProviderName     string
+	Model            string
+	Mode             string
+	PricingOverrides map[string]domain_pricing.ModelPricing
+	Limits           events.Limits
+} {
+	return m.Called().Get(0).(struct {
+		ProviderName     string
+		Model            string
+		Mode             string
+		PricingOverrides map[string]domain_pricing.ModelPricing
+		Limits           events.Limits
+	})
+}
+
+func (m *mockInternalAccessor) SetEventsForInternalUse(bus events.EventBus) {
+	m.Called(bus)
+}
+
+func (m *mockInternalAccessor) SetConfigWatcherForInternalUse(cw session.ConfigWatcher) {
+	m.Called(cw)
+}
+
+func (m *mockInternalAccessor) SetCtxManagerForInternalUse(cm *sessctx.Manager) {
+	m.Called(cm)
+}
+
+func (m *mockInternalAccessor) SetLoggerForInternalUse(l ports.Logger) {
+	m.Called(l)
+}
+
+func (m *mockInternalAccessor) SetTrackerForInternalUse(t domain_pricing.CostTracker) {
+	m.Called(t)
+}
+
+func (m *mockInternalAccessor) SetRuntimeConfigForInternalUse(
+	providerName, model, mode string,
+	pricingOverrides map[string]domain_pricing.ModelPricing,
+	limits events.Limits,
+) {
+	m.Called(providerName, model, mode, pricingOverrides, limits)
+}
+
+var _ agent.InternalAccessor = (*mockInternalAccessor)(nil)
+
+// TestAsAgentInternal verifies the constructor that wraps a
+// ports.Chatter into an *AgentInternal. It must return nil for a
+// nil input and a valid, non-nil *AgentInternal for a bare agent.
+func TestAsAgentInternal(t *testing.T) {
+	t.Run("nil chatter", func(t *testing.T) {
+		result := AsAgentInternal(nil)
+		if result != nil {
+			t.Errorf("AsAgentInternal(nil) = %v; want nil", result)
+		}
+	})
+
+	t.Run("bare agent", func(t *testing.T) {
+		bare := agent.NewBareForInternalUse()
+		chatter := bare.AsChatter()
+		result := AsAgentInternal(chatter)
+		if result == nil {
+			t.Fatal("AsAgentInternal(bare agent) returned nil")
+		}
+		if result.raw == nil {
+			t.Fatal("AsAgentInternal(bare agent).raw is nil")
+		}
+	})
+}
+
+// TestNewBareAgent verifies that NewBareAgent returns a non-nil
+// *AgentInternal with a non-nil underlying raw accessor.
+func TestNewBareAgent(t *testing.T) {
+	a := NewBareAgent()
+	if a == nil {
+		t.Fatal("NewBareAgent() returned nil")
+	}
+	if a.raw == nil {
+		t.Fatal("NewBareAgent().raw is nil")
+	}
+}
+
+// mockCostTracker is a mock of domain_pricing.CostTracker for use in
+// getter delegation tests. It follows the testify/mock pattern used
+// by mockInternalAccessor and mockSessionLifecycleManager.
+type mockCostTracker struct {
+	mock.Mock
+}
+
+func (m *mockCostTracker) GetTotalCost(ctx context.Context) float64 {
+	return m.Called(ctx).Get(0).(float64)
+}
+
+func (m *mockCostTracker) GetDailyCost(ctx context.Context) float64 {
+	return m.Called(ctx).Get(0).(float64)
+}
+
+func (m *mockCostTracker) GetStats(ctx context.Context) (domain_pricing.UsageStats, float64) {
+	args := m.Called(ctx)
+	return args.Get(0).(domain_pricing.UsageStats), args.Get(1).(float64)
+}
+
+func (m *mockCostTracker) Accumulate(mt llm.Metrics) {
+	m.Called(mt)
+}
+
+func (m *mockCostTracker) AccumulateAndReturn(mt llm.Metrics) float64 {
+	return m.Called(mt).Get(0).(float64)
+}
+
+func (m *mockCostTracker) Warmup() {
+	m.Called()
+}
+
+var _ domain_pricing.CostTracker = (*mockCostTracker)(nil)
+
+// shutdowner is a minimal interface for types that support graceful
+// shutdown. It is used to clean up event buses created during tests.
+type shutdowner interface {
+	Shutdown(ctx context.Context) error
+}
+
+// TestAgentInternal_Getters verifies that each read-only accessor on
+// *AgentInternal correctly delegates to the corresponding
+// *ForInternalUse bridge method on the underlying InternalAccessor.
+// Each sub-test injects a concrete value into a mock, calls the
+// accessor, and asserts the returned value is identical.
+func TestAgentInternal_Getters(t *testing.T) {
+	tests := []struct {
+		name   string
+		setup  func(mock *mockInternalAccessor) any
+		call   func(ai *AgentInternal) any
+		assert func(t *testing.T, got, want any)
+	}{
+		{
+			name: "GetCtxManager",
+			setup: func(mock *mockInternalAccessor) any {
+				mgr := &sessctx.Manager{}
+				mock.On("GetCtxManagerForInternalUse").Return(mgr)
+				return mgr
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.GetCtxManager()
+			},
+			assert: assertPointerEqual,
+		},
+		{
+			name: "GetEvents",
+			setup: func(mock *mockInternalAccessor) any {
+				bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+				mock.On("GetEventsForInternalUse").Return(bus)
+				return bus
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.GetEvents()
+			},
+			assert: assertPointerEqual,
+		},
+		{
+			name: "GetConfigWatcher",
+			setup: func(mock *mockInternalAccessor) any {
+				cw := session.NewNoOpConfigWatcher(1000, 10, 5)
+				mock.On("GetConfigWatcherForInternalUse").Return(cw)
+				return cw
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.GetConfigWatcher()
+			},
+			assert: assertPointerEqual,
+		},
+		{
+			name: "GetTracker",
+			setup: func(mock *mockInternalAccessor) any {
+				tr := &mockCostTracker{}
+				mock.On("GetTrackerForInternalUse").Return(tr)
+				return tr
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.GetTracker()
+			},
+			assert: assertPointerEqual,
+		},
+		{
+			name: "GetRuntimeConfig",
+			setup: func(mock *mockInternalAccessor) any {
+				snap := struct {
+					ProviderName     string
+					Model            string
+					Mode             string
+					PricingOverrides map[string]domain_pricing.ModelPricing
+					Limits           events.Limits
+				}{
+					ProviderName: "test-provider",
+					Model:        "test-model",
+					Mode:         "test-mode",
+					PricingOverrides: map[string]domain_pricing.ModelPricing{
+						"test-model": {Hit: 0.01},
+					},
+					Limits: events.Limits{
+						MaxHistoryTokens: 2000,
+						MaxToolTurns:     20,
+						MaxHistoryTurns:  10,
+					},
+				}
+				mock.On("GetRuntimeSnapshotForInternalUse").Return(snap)
+				return RuntimeSnapshot{
+					ProviderName: "test-provider",
+					Model:        "test-model",
+					Mode:         "test-mode",
+					PricingOverrides: map[string]domain_pricing.ModelPricing{
+						"test-model": {Hit: 0.01},
+					},
+					Limits: events.Limits{
+						MaxHistoryTokens: 2000,
+						MaxToolTurns:     20,
+						MaxHistoryTurns:  10,
+					},
+				}
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.GetRuntimeConfig()
+			},
+			assert: func(t *testing.T, got, want any) {
+				t.Helper()
+				if !reflect.DeepEqual(got, want) {
+					t.Errorf("GetRuntimeConfig() = %+v; want %+v", got, want)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := new(mockInternalAccessor)
+			want := tt.setup(mock)
+			ai := &AgentInternal{raw: mock}
+
+			// Shut down any event bus created during setup.
+			if s, ok := want.(shutdowner); ok {
+				t.Cleanup(func() { _ = s.Shutdown(context.Background()) })
+			}
+
+			got := tt.call(ai)
+			tt.assert(t, got, want)
+			mock.AssertExpectations(t)
+		})
+	}
+}
+
+// assertPointerEqual is a helper that uses pointer equality (==) to
+// verify that a getter returned the exact same value injected into
+// the mock. It is appropriate for pointer and interface types where
+// identity matters.
+func assertPointerEqual(t *testing.T, got, want any) {
+	t.Helper()
+	if got != want {
+		t.Errorf("got %v; want %v", got, want)
+	}
+}
+
+// TestAgentInternal_Setters verifies that each *ForTest mutator on
+// *AgentInternal correctly delegates to the corresponding
+// Set*ForInternalUse bridge method on the underlying InternalAccessor.
+// Each sub-test sets up a mock expectation with the exact argument,
+// invokes the mutator, and asserts the expectation was satisfied.
+func TestAgentInternal_Setters(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(mock *mockInternalAccessor) any
+		call  func(ai *AgentInternal, val any)
+	}{
+		{
+			name: "SetEventsForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+				mock.On("SetEventsForInternalUse", bus).Return()
+				return bus
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetEventsForTest(val.(events.EventBus))
+			},
+		},
+		{
+			name: "SetConfigWatcherForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				cw := session.NewNoOpConfigWatcher(1000, 10, 5)
+				mock.On("SetConfigWatcherForInternalUse", cw).Return()
+				return cw
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetConfigWatcherForTest(val.(session.ConfigWatcher))
+			},
+		},
+		{
+			name: "SetCtxManagerForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				mgr := &sessctx.Manager{}
+				mock.On("SetCtxManagerForInternalUse", mgr).Return()
+				return mgr
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetCtxManagerForTest(val.(*sessctx.Manager))
+			},
+		},
+		{
+			name: "SetLoggerForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				l := slog.Default()
+				mock.On("SetLoggerForInternalUse", l).Return()
+				return l
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetLoggerForTest(val.(ports.Logger))
+			},
+		},
+		{
+			name: "SetTrackerForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				tr := &mockCostTracker{}
+				mock.On("SetTrackerForInternalUse", tr).Return()
+				return tr
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetTrackerForTest(val.(domain_pricing.CostTracker))
+			},
+		},
+		{
+			name: "SetRuntimeConfigForTest",
+			setup: func(mock *mockInternalAccessor) any {
+				snap := RuntimeSnapshot{
+					ProviderName: "p",
+					Model:        "m",
+					Mode:         "md",
+					PricingOverrides: map[string]domain_pricing.ModelPricing{
+						"x": {},
+					},
+					Limits: events.Limits{MaxHistoryTokens: 100},
+				}
+				mock.On("SetRuntimeConfigForInternalUse",
+					snap.ProviderName, snap.Model, snap.Mode,
+					snap.PricingOverrides, snap.Limits,
+				).Return()
+				return snap
+			},
+			call: func(ai *AgentInternal, val any) {
+				ai.SetRuntimeConfigForTest(val.(RuntimeSnapshot))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := new(mockInternalAccessor)
+			val := tt.setup(mock)
+			ai := &AgentInternal{raw: mock}
+
+			// Shut down any event bus created during setup.
+			if s, ok := val.(shutdowner); ok {
+				t.Cleanup(func() { _ = s.Shutdown(context.Background()) })
+			}
+
+			tt.call(ai, val)
+			mock.AssertExpectations(t)
+		})
+	}
+}
+
+// mockChatter is a mock of ports.Chatter used by action delegation
+// tests that need to verify Chat and Shutdown pass through the
+// AsChatter bridge correctly.
+type mockChatter struct {
+	mock.Mock
+}
+
+func (m *mockChatter) Chat(ctx context.Context, sess *ports.Session, prompt string) error {
+	return m.Called(ctx, sess, prompt).Error(0)
+}
+
+func (m *mockChatter) Shutdown(ctx context.Context) error {
+	return m.Called(ctx).Error(0)
+}
+
+func (m *mockChatter) SetLimits(ctx context.Context, toolTurns, historyTokens, historyTurns int) error {
+	return m.Called(ctx, toolTurns, historyTokens, historyTurns).Error(0)
+}
+
+func (m *mockChatter) Subscribe(sub func(context.Context, events.Event)) {
+	m.Called(sub)
+}
+
+var _ ports.Chatter = (*mockChatter)(nil)
+
+// TestAgentInternal_Actions verifies that the three action methods —
+// ApplyConfig, Chat, and Shutdown — correctly delegate to the
+// underlying InternalAccessor bridge and propagate errors.
+func TestAgentInternal_Actions(t *testing.T) {
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter)
+		call    func(ai *AgentInternal) error
+		wantErr bool
+	}{
+		{
+			name: "ApplyConfig/success",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("ApplyConfig", mock.Anything).Return(nil)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.ApplyConfig(context.Background())
+			},
+			wantErr: false,
+		},
+		{
+			name: "ApplyConfig/error",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("ApplyConfig", mock.Anything).Return(assert.AnError)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.ApplyConfig(context.Background())
+			},
+			wantErr: true,
+		},
+		{
+			name: "Chat/success",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("AsChatter").Return(mockCh)
+				mockCh.On("Chat", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.Chat(context.Background(), &ports.Session{}, "test prompt")
+			},
+			wantErr: false,
+		},
+		{
+			name: "Chat/error",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("AsChatter").Return(mockCh)
+				mockCh.On("Chat", mock.Anything, mock.Anything, mock.Anything).Return(assert.AnError)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.Chat(context.Background(), &ports.Session{}, "test prompt")
+			},
+			wantErr: true,
+		},
+		{
+			name: "Shutdown/success",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("AsChatter").Return(mockCh)
+				mockCh.On("Shutdown", mock.Anything).Return(nil)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.Shutdown(context.Background())
+			},
+			wantErr: false,
+		},
+		{
+			name: "Shutdown/error",
+			setup: func(t *testing.T, mockRaw *mockInternalAccessor, mockCh *mockChatter) {
+				mockRaw.On("AsChatter").Return(mockCh)
+				mockCh.On("Shutdown", mock.Anything).Return(assert.AnError)
+			},
+			call: func(ai *AgentInternal) error {
+				return ai.Shutdown(context.Background())
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRaw := new(mockInternalAccessor)
+			mockCh := new(mockChatter)
+
+			tt.setup(t, mockRaw, mockCh)
+
+			ai := &AgentInternal{raw: mockRaw}
+			err := tt.call(ai)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			mockRaw.AssertExpectations(t)
+			mockCh.AssertExpectations(t)
+		})
+	}
+}
+
+// TestMockSessionLifecycleManager verifies that the testify-based
+// mockSessionLifecycleManager (defined in accessor.go) behaves correctly
+// with the standard .On(...).Return(...) pattern. In particular, it
+// exercises the nil-guarded type assertions in BuildSessionDependencies
+// to ensure they don't panic when testify returns nil values.
+func TestMockSessionLifecycleManager(t *testing.T) {
+	t.Run("BuildSessionDependencies/all non-nil", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+
+		deps := &agenttest.MockServiceSessionDependencies{}
+		hm := &agenttest.MockHistoryManager{}
+		cleanup := func(ctx context.Context) error { return nil }
+
+		m.On("BuildSessionDependencies",
+			mock.Anything,
+			mock.AnythingOfType("*config.Config"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("bool"),
+			mock.Anything,
+		).Return(deps, hm, cleanup, nil)
+
+		gotDeps, gotHM, gotCleanup, err := m.BuildSessionDependencies(
+			context.Background(),
+			&config.Config{},
+			"/some/path",
+			true,
+			nil, // CapturerInteractor — nil is fine with mock.Anything
+		)
+
+		assert.NoError(t, err)
+		assert.Same(t, deps, gotDeps, "SessionDependencies should be the same pointer")
+		assert.Same(t, hm, gotHM, "HistoryManager should be the same pointer")
+		assert.NotNil(t, gotCleanup, "cleanup function should be non-nil")
+		m.AssertExpectations(t)
+	})
+
+	t.Run("BuildSessionDependencies/nil deps and hm", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+
+		cleanup := func(ctx context.Context) error { return nil }
+
+		m.On("BuildSessionDependencies",
+			mock.Anything,
+			mock.AnythingOfType("*config.Config"),
+			mock.AnythingOfType("string"),
+			mock.AnythingOfType("bool"),
+			mock.Anything,
+		).Return(nil, nil, cleanup, nil)
+
+		gotDeps, gotHM, gotCleanup, err := m.BuildSessionDependencies(
+			context.Background(),
+			&config.Config{},
+			"/some/path",
+			false,
+			nil,
+		)
+
+		// The nil guards in BuildSessionDependencies must prevent panics
+		// and leave the returned interface values as nil.
+		assert.NoError(t, err)
+		assert.Nil(t, gotDeps, "nil guard: deps should be nil")
+		assert.Nil(t, gotHM, "nil guard: hm should be nil")
+		assert.NotNil(t, gotCleanup, "cleanup function should be non-nil")
+		m.AssertExpectations(t)
+	})
+
+	t.Run("FinalizeSession/success", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+
+		m.On("FinalizeSession",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(nil)
+
+		err := m.FinalizeSession(
+			context.Background(),
+			&agenttest.MockHistoryManager{},
+			&agenttest.MockServiceSessionDependencies{},
+			&config.Config{},
+		)
+
+		assert.NoError(t, err)
+		m.AssertExpectations(t)
+	})
+
+	t.Run("FinalizeSession/error", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+
+		m.On("FinalizeSession",
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+			mock.Anything,
+		).Return(assert.AnError)
+
+		err := m.FinalizeSession(
+			context.Background(),
+			&agenttest.MockHistoryManager{},
+			&agenttest.MockServiceSessionDependencies{},
+			&config.Config{},
+		)
+
+		assert.Error(t, err)
+		m.AssertExpectations(t)
+	})
+}

--- a/internal/agent/agentinternal/doc.go
+++ b/internal/agent/agentinternal/doc.go
@@ -9,11 +9,14 @@
 // in internal/agent/ (package agent_test) and tests/integration/agent/,
 // which collectively cover all 18 exported symbols.
 //
-// This package is intentionally excluded from unit test coverage
-// metrics (see the test-coverage target in the top-level Makefile).
-// Writing mock-based unit tests for pure delegation methods would
-// test Go's method dispatch, not project logic, and would create
-// maintenance burden with zero value.
+// This package includes mechanical delegation tests in accessor_test.go
+// that verify interface conformance between AgentInternal wrappers and
+// the underlying InternalAccessor bridge. The tests use testify mocks
+// (mockInternalAccessor, mockChatter, mockCostTracker) and serve as a
+// regression safety net: a renamed field, a removed interface method,
+// or a signature mismatch in the delegation chain is caught immediately
+// rather than surfacing as a confusing nil-pointer panic in downstream
+// integration tests.
 //
 // See: docs/adr/2026-04-test-only-access-via-agentinternal-bridge.md
 // See: https://github.com/gosharplite/tell-me-go/issues/138

--- a/internal/agent/internal_bridge_test.go
+++ b/internal/agent/internal_bridge_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	"github.com/stretchr/testify/mock"
+)
+
+// mockCostTracker is a minimal mock of domain_pricing.CostTracker used
+// by bridge tests that only need a concrete value to inject/extract
+// — no method expectations are set.
+type mockCostTracker struct {
+	mock.Mock
+}
+
+func (m *mockCostTracker) GetTotalCost(ctx context.Context) float64 {
+	return m.Called(ctx).Get(0).(float64)
+}
+
+func (m *mockCostTracker) GetDailyCost(ctx context.Context) float64 {
+	return m.Called(ctx).Get(0).(float64)
+}
+
+func (m *mockCostTracker) GetStats(ctx context.Context) (domain_pricing.UsageStats, float64) {
+	args := m.Called(ctx)
+	return args.Get(0).(domain_pricing.UsageStats), args.Get(1).(float64)
+}
+
+func (m *mockCostTracker) Accumulate(mt llm.Metrics) {
+	m.Called(mt)
+}
+
+func (m *mockCostTracker) AccumulateAndReturn(mt llm.Metrics) float64 {
+	return m.Called(mt).Get(0).(float64)
+}
+
+func (m *mockCostTracker) Warmup() {
+	m.Called()
+}
+
+var _ domain_pricing.CostTracker = (*mockCostTracker)(nil)
+
+// TestInternalBridge_GettersAndSetters verifies that the five orphan
+// bridge methods on *agent — GetTrackerForInternalUse,
+// GetEventsForInternalUse, GetConfigWatcherForInternalUse,
+// SetLoggerForInternalUse, and SetTrackerForInternalUse — correctly
+// read from or write to the corresponding unexported fields.
+//
+// These five methods have no transitive coverage path today: they are
+// not exercised by agentinternal tests (which use mocks), nor by
+// applyconfig_failpath_test.go. A signature mismatch or a renamed
+// field would go undetected without this test.
+func TestInternalBridge_GettersAndSetters(t *testing.T) {
+	t.Run("Getter/GetTrackerForInternalUse", func(t *testing.T) {
+		a := &agent{}
+		tracker := &mockCostTracker{}
+		a.tracker = tracker
+
+		got := a.GetTrackerForInternalUse()
+		if got != tracker {
+			t.Errorf("GetTrackerForInternalUse() = %v; want %v", got, tracker)
+		}
+	})
+
+	t.Run("Getter/GetEventsForInternalUse", func(t *testing.T) {
+		a := &agent{}
+		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+		t.Cleanup(func() { _ = bus.Shutdown(context.Background()) })
+		a.events = bus
+
+		got := a.GetEventsForInternalUse()
+		if got != bus {
+			t.Errorf("GetEventsForInternalUse() = %v; want %v", got, bus)
+		}
+	})
+
+	t.Run("Getter/GetConfigWatcherForInternalUse", func(t *testing.T) {
+		a := &agent{}
+		cw := session.NewNoOpConfigWatcher(1000, 10, 5)
+		a.configWatcher = cw
+
+		got := a.GetConfigWatcherForInternalUse()
+		if got != cw {
+			t.Errorf("GetConfigWatcherForInternalUse() = %v; want %v", got, cw)
+		}
+	})
+
+	t.Run("Setter/SetLoggerForInternalUse", func(t *testing.T) {
+		a := &agent{}
+		logger := slog.Default()
+
+		a.SetLoggerForInternalUse(logger)
+		if a.logger != logger {
+			t.Errorf("after SetLoggerForInternalUse, a.logger = %v; want %v", a.logger, logger)
+		}
+	})
+
+	t.Run("Setter/SetTrackerForInternalUse", func(t *testing.T) {
+		a := &agent{}
+		tracker := &mockCostTracker{}
+
+		a.SetTrackerForInternalUse(tracker)
+		if a.tracker != tracker {
+			t.Errorf("after SetTrackerForInternalUse, a.tracker = %v; want %v", a.tracker, tracker)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Closes #216.

Adds mechanical delegation tests for the two-layer test-only bridge (ADR-022):
- **`accessor_test.go`** — 23 subtests covering all 18 exported functions in `agentinternal`
- **`internal_bridge_test.go`** — 5 subtests covering orphan bridge methods
- **`doc.go`** — updated to reflect new coverage policy

## Changes

| File | Status | Lines |
|------|--------|-------|
| `internal/agent/agentinternal/accessor_test.go` | New | ~670 |
| `internal/agent/internal_bridge_test.go` | New | ~100 |
| `internal/agent/agentinternal/doc.go` | Modified | 5 removed, 7 added |

## Verification

| Metric | Before | After |
|--------|--------|-------|
| `agentinternal` coverage | 0.0% | **100.0%** |
| `go test -race ./internal/agent/...` | — | clean |
| Production code modified | — | **0 files** |

## Test structure

```
accessor_test.go:
  TestAsAgentInternal          (2 cases: nil, bare agent)
  TestNewBareAgent             (1 case)
  TestAgentInternal_Getters    (5 getters: CtxManager, Events, ConfigWatcher, Tracker, RuntimeConfig)
  TestAgentInternal_Setters    (6 setters: Events, ConfigWatcher, CtxManager, Logger, Tracker, RuntimeConfig)
  TestAgentInternal_Actions    (6 cases: ApplyConfigx2, Chatx2, Shutdownx2)
  TestMockSessionLifecycleManager (4 cases: BuildSessionDepsx2, FinalizeSessionx2)

internal_bridge_test.go:
  TestInternalBridge_GettersAndSetters (5 bridge methods)
```
