### PR TITLE
test: add Logger warning assertion to skill injector error fallback path

### DIFF
--- a/internal/agent/session/skill_injector_test.go
+++ b/internal/agent/session/skill_injector_test.go
@@ -45,7 +45,10 @@ func (m *mockLogger) Debug(msg string, args ...any) {}
 func TestSkillInjector_Transform(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
-
+	// errLogger is intentionally shared via closure capture by exactly ONE test case
+	// ("SelectSkillsErrorIsLoggedAndSwallowed"). No other case sets logger to a non-nil
+	// value, so no data race exists. Do not reuse errLogger in additional cases without
+	// scoping it per-test or making mockLogger thread-safe.
 	errLogger := &mockLogger{}
 
 	tests := []struct {

--- a/internal/agent/session/skill_injector_test.go
+++ b/internal/agent/session/skill_injector_test.go
@@ -23,14 +23,36 @@ func (m *mockSkillSelector) SelectSkills(ctx context.Context, taskDescription st
 	return m.selected, m.err
 }
 
+// mockLogger records Warn calls for assertion in tests.
+type mockLogger struct {
+	warns []struct {
+		msg  string
+		args []any
+	}
+}
+
+func (m *mockLogger) Warn(msg string, args ...any) {
+	m.warns = append(m.warns, struct {
+		msg  string
+		args []any
+	}{msg, args})
+}
+
+func (m *mockLogger) Error(msg string, args ...any) {}
+func (m *mockLogger) Info(msg string, args ...any)  {}
+func (m *mockLogger) Debug(msg string, args ...any) {}
+
 func TestSkillInjector_Transform(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+
+	errLogger := &mockLogger{}
 
 	tests := []struct {
 		name     string
 		selector skills.SkillSelector
 		req      *ports.ContextRequest
+		logger   ports.Logger
 		validate func(t *testing.T, req *ports.ContextRequest)
 	}{
 		{
@@ -118,6 +140,7 @@ func TestSkillInjector_Transform(t *testing.T) {
 					{Role: "user", Parts: []*llm.Part{{Text: "how do I test in Go?"}}},
 				},
 			},
+			logger: errLogger,
 			validate: func(t *testing.T, req *ports.ContextRequest) {
 				// Transform must NOT return an error — the failure is logged, not propagated.
 				// History must remain unchanged (no injection, no mutation).
@@ -127,6 +150,13 @@ func TestSkillInjector_Transform(t *testing.T) {
 				if req.PersistHistory {
 					t.Error("expected PersistHistory to remain false when skill selection fails")
 				}
+				// Verify the warning was logged.
+				if len(errLogger.warns) != 1 {
+					t.Fatalf("expected 1 warning call, got %d", len(errLogger.warns))
+				}
+				if errLogger.warns[0].msg != "skill selection failed; proceeding without injected skills" {
+					t.Errorf("unexpected warning message: %q", errLogger.warns[0].msg)
+				}
 			},
 		},
 	}
@@ -135,7 +165,7 @@ func TestSkillInjector_Transform(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			injector := &skillInjector{Selector: tt.selector}
+			injector := &skillInjector{Selector: tt.selector, Logger: tt.logger}
 			err := injector.Transform(ctx, tt.req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary
Closes #221

Adds test coverage for the Logger warning path in `skillInjector.Transform` when `SelectSkills` fails with an error and a Logger is present.

## Before
The `SelectSkillsErrorIsLoggedAndSwallowed` test case verified graceful degradation (no error returned, history unchanged), but did **not** assert the warning was logged — because the injector was constructed without a Logger (`nil`), skipping the `if t.Logger != nil` branch.

## Changes
1. Added `mockLogger` struct that records `Warn` calls
2. Added optional `logger ports.Logger` field to the test table struct (zero-value `nil` preserves existing behavior)
3. Wired `mockLogger` into the error test case and asserted:
   - Exactly 1 `Warn` call
   - Correct warning message: `"skill selection failed; proceeding without injected skills"`

## Verification
- `go build ./...` ✅
- `go test ./internal/agent/session/...` ✅ PASS
- Coverage: 96.1% (package)