### PR TITLE
feat(agent): add coverage for service.go defensive guards (#222)

### DIFF
--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -204,7 +204,11 @@ func (s *chatService) GetToolNames(ctx context.Context, reg tools.Registry) ([]s
 // StreamTurnsLog resolves the turns log path for the current mode and streams it to the provided writer.
 func (s *chatService) StreamTurnsLog(ctx context.Context, cfg *domain_config.Config, out io.Writer) (err error) {
 	paths := persistence.ResolvePaths(s.HomeDir, cfg.Mode)
-	// Coverage: defensive guard — ResolvePaths always produces a non-empty TurnsLogPath for all valid modes.
+	// Coverage: defensive guard — ResolvePaths always produces a non-empty TurnsLogPath
+	// for all valid modes (empty/invalid modes fall back to "default"). This guard is
+	// unreachable through the public API but serves as a safety net against future
+	// regressions in path resolution. See TestChatService_StreamTurnsLog_EmptyPath
+	// for verification of the empty-mode fallback behavior.
 	if paths.TurnsLogPath == "" {
 		return errors.New("turns log path not available")
 	}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -685,6 +685,37 @@ func TestRunDiagnostics(t *testing.T) {
 			},
 		},
 		{
+			name:       "JSON marshal error",
+			jsonOutput: true,
+			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *agenttest.MockServiceSessionDependencies, bus *agenttest.MockServiceEventBus, hcm *mockHealthCheckManager, uir *mockUIRendererForDiag) {
+				cfg := &config.Config{Mode: "assistant"}
+				cleanup := func(context.Context) error { return nil }
+				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+
+				deps.On("GetEventBus").Return(bus)
+				deps.On("GetHealthManager").Return(hcm)
+				bus.On("Shutdown", mock.Anything).Return(nil)
+
+				// Construct a report with an un-marshalable Details field.
+				// json.MarshalIndent cannot serialize a channel, so the defensive
+				// guard at service.go:258-260 is exercised.
+				unmarshalableReport := &ports.HealthReport{
+					OverallStatus: ports.StatusHealthy,
+					Components: map[ports.Component]ports.ComponentReport{
+						ports.CompPersistence: {
+							Component: ports.CompPersistence,
+							Status:    ports.StatusHealthy,
+							Message:   "OK",
+							Details:   make(chan int),
+						},
+					},
+				}
+				hcm.On("CheckAll", mock.Anything).Return(unmarshalableReport, nil)
+			},
+			wantErr: true,
+			errMsg:  "failed to serialize health report",
+		},
+		{
 			name: "build deps error",
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *agenttest.MockServiceSessionDependencies, bus *agenttest.MockServiceEventBus, hcm *mockHealthCheckManager, uir *mockUIRendererForDiag) {
 				cfg := &config.Config{Mode: "assistant"}


### PR DESCRIPTION
## Summary

Closes #222 — adds test coverage for two untested defensive guards in `internal/agent/service.go`.

## Changes

### Guard \#1 — `StreamTurnsLog` empty path (lines 208–210)
- **Verdict:** Unreachable through the public API — `ResolvePaths` always produces a non-empty path.
- **Action:** Expanded the comment to document the empty-mode fallback behavior and reference the existing `TestChatService_StreamTurnsLog_EmptyPath` test.

### Guard \#2 — `RunDiagnostics` JSON marshal error (lines 258–260)
- **Verdict:** Testable via mock — `ComponentReport.Details` is typed `any`, so injecting a channel triggers `json.MarshalIndent` failure.
- **Action:** Added `"JSON marshal error"` test case using `Details: make(chan int)`.

## Files Changed
| File | Delta | Purpose |
|------|-------|---------|
| `internal/agent/service.go` | +4/−1 | Expanded Guard \#1 comment |
| `internal/agent/service_test.go` | +32/−0 | Added Guard \#2 test case |

## Verification
- Full `go test ./internal/agent/...` — all 8 packages pass
- No production logic changed; both guards remain as defensive safety nets