### PR TITLE
fix(ui): replace time.Sleep with deterministic test hook in MidFlight tests (#236)

### DIFF
--- a/internal/agent/session/ui/event_queue.go
+++ b/internal/agent/session/ui/event_queue.go
@@ -27,6 +27,12 @@ type eventQueue struct {
 	logger    ports.Logger
 	isClosed  atomic.Bool
 	closeOnce sync.Once
+
+	// beforeBlockingSendHook is nil in production. Tests can set it to a
+	// signal channel to deterministically observe when enqueueCritical has
+	// passed both pre-guards and is about to enter the blocking select.
+	// See ADR-011 §3 Rule 2 for the pattern this enables.
+	beforeBlockingSendHook func() //nolint:unused // test hook
 }
 
 // newEventQueue creates a new eventQueue with the given capacity.
@@ -72,6 +78,13 @@ func (eq *eventQueue) enqueueCritical(ctx context.Context, e events.Event) error
 	if err := eq.loopCtx.Err(); err != nil {
 		return eq.wrapActorDead(err)
 	}
+
+	// Test hook: signals that the goroutine has passed all pre-guards and
+	// is about to enter the blocking select. Nil in production (no cost).
+	if eq.beforeBlockingSendHook != nil {
+		eq.beforeBlockingSendHook()
+	}
+
 	select {
 	case eq.ch <- e:
 		return nil

--- a/internal/agent/session/ui/event_queue_test.go
+++ b/internal/agent/session/ui/event_queue_test.go
@@ -5,6 +5,7 @@ package ui
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -100,7 +101,8 @@ func TestEventQueue_EnqueueCritical_MidFlightCallerCancel(t *testing.T) {
 	f.FillQueue(events.TurnStatusEvent{})
 
 	inSelect := make(chan struct{})
-	f.bridge.SetBeforeBlockingSendHook(func() { close(inSelect) })
+	var once sync.Once
+	f.bridge.SetBeforeBlockingSendHook(func() { once.Do(func() { close(inSelect) }) })
 
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -132,7 +134,8 @@ func TestEventQueue_EnqueueCritical_MidFlightActorDeath(t *testing.T) {
 	f.FillQueue(events.TurnStatusEvent{})
 
 	inSelect := make(chan struct{})
-	f.bridge.SetBeforeBlockingSendHook(func() { close(inSelect) })
+	var once sync.Once
+	f.bridge.SetBeforeBlockingSendHook(func() { once.Do(func() { close(inSelect) }) })
 
 	done := make(chan struct{})
 	go func() {

--- a/internal/agent/session/ui/event_queue_test.go
+++ b/internal/agent/session/ui/event_queue_test.go
@@ -99,21 +99,19 @@ func TestEventQueue_EnqueueCritical_MidFlightCallerCancel(t *testing.T) {
 	f.BlockLoop(t)
 	f.FillQueue(events.TurnStatusEvent{})
 
+	inSelect := make(chan struct{})
+	f.bridge.SetBeforeBlockingSendHook(func() { close(inSelect) })
+
 	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan struct{})
-	started := make(chan struct{})
 	go func() {
-		close(started)
 		_ = f.bridge.HandleEvent(ctx, events.TurnStatusEvent{})
 		close(done)
 	}()
 
-	<-started
-	// Give the goroutine time to pass HandleEvent's guard and the pre-guards
-	time.Sleep(10 * time.Millisecond)
-
-	cancel() // mid-flight caller cancellation
+	<-inSelect // deterministic: goroutine has passed both pre-guards, now in select
+	cancel()   // mid-flight caller cancellation — guaranteed to hit <-ctx.Done()
 
 	select {
 	case <-done:
@@ -133,19 +131,17 @@ func TestEventQueue_EnqueueCritical_MidFlightActorDeath(t *testing.T) {
 	f.BlockLoop(t)
 	f.FillQueue(events.TurnStatusEvent{})
 
+	inSelect := make(chan struct{})
+	f.bridge.SetBeforeBlockingSendHook(func() { close(inSelect) })
+
 	done := make(chan struct{})
-	started := make(chan struct{})
 	go func() {
-		close(started)
 		_ = f.bridge.HandleEvent(context.Background(), events.TurnStatusEvent{})
 		close(done)
 	}()
 
-	<-started
-	// Give the goroutine time to pass HandleEvent's guard and the pre-guards
-	time.Sleep(10 * time.Millisecond)
-
-	f.bridge.KillActor() // mid-flight actor death
+	<-inSelect   // deterministic: goroutine has passed both pre-guards, now in select
+	f.bridge.KillActor() // mid-flight actor death — guaranteed to hit <-eq.loopCtx.Done()
 
 	select {
 	case <-done:

--- a/internal/agent/session/ui/export_test.go
+++ b/internal/agent/session/ui/export_test.go
@@ -21,3 +21,13 @@ func SyncBridge(t *testing.T, b *Bridge, m interface {
 func (b *Bridge) Wg() *sync.WaitGroup {
 	return &b.wg
 }
+
+// SetBeforeBlockingSendHook installs a callback fired by enqueueCritical
+// after the pre-guards (caller cancellation, actor death) but before the
+// blocking select. Tests use this to deterministically observe when a
+// goroutine is inside the select, replacing time.Sleep-based flaky sync.
+//
+// The hook is nil by default and has zero overhead in production.
+func (b *Bridge) SetBeforeBlockingSendHook(fn func()) {
+	b.queue.beforeBlockingSendHook = fn
+}


### PR DESCRIPTION
## Summary

Eliminates the last two ADR-011 §3 Rule 1 violations in `internal/agent/session/ui/` by replacing `time.Sleep(10ms)` synchronization with a deterministic `beforeBlockingSendHook` callback.

## Changes

| File | Change |
|---|---|
| `event_queue.go` | Add `beforeBlockingSendHook func()` field + nil-check between pre-guards and `select` |
| `export_test.go` | Add `SetBeforeBlockingSendHook(*Bridge)` setter (follows `Wg()` / `SyncBridge` convention) |
| `event_queue_test.go` | Replace `started` channel + `time.Sleep(10ms)` with `inSelect` channel + hook |

## Problem

The two MidFlight tests (`CallerCancel` / `ActorDeath`) used `time.Sleep(10ms)` to wait for the goroutine to reach the blocking `select`. When the sleep was too short (CI load, GC pause), `cancel()` fired before the goroutine entered the `select` — the pre-guard caught it instead, the test still passed, but the intended `<-ctx.Done()` / `<-loopCtx.Done()` arm was never exercised. **False green.**

## Solution

A `beforeBlockingSendHook` fires after the pre-guards but before the `select`. Tests close an `inSelect` channel at that exact point, then trigger cancellation — **deterministically** hitting the correct `select` arm.

Zero production cost: the hook is `nil` by default; the branch predictor eliminates the nil-check.

## Verification

```
time.Sleep count in test file:      0
-race -count=100 MidFlight tests:   200/200 (2.2s)
Full package -race:                 PASS
golangci-lint:                      PASS
```

## ADR Compliance

- **ADR-011 §3 Rule 1**: No `time.Sleep` for synchronization ✅
- **ADR-011 §3 Rule 2**: Positive Synchronization via Mock Callbacks ✅

Closes #236.