### PR TITLE
fix(ui): replace racy started channel with beforeBlockingSendHook in TestEventQueue_EnqueueEvent_CriticalBlocking

### DIFF
--- a/internal/agent/session/ui/event_queue_test.go
+++ b/internal/agent/session/ui/event_queue_test.go
@@ -211,14 +211,16 @@ func TestEventQueue_EnqueueEvent_CriticalBlocking(t *testing.T) {
 	defer cancel2()
 
 	done := make(chan struct{})
-	started := make(chan struct{})
+	inSelect := make(chan struct{})
+	var once sync.Once
+	q.beforeBlockingSendHook = func() { once.Do(func() { close(inSelect) }) }
+
 	go func() {
-		close(started)
 		defer close(done)
 		_ = q.enqueueEvent(ctx, events.ResponseEvent{})
 	}()
 
-	<-started
+	<-inSelect // deterministic: goroutine is past pre-guards, now in blocking select
 
 	// Prove that done does not receive a value prematurely
 	select {


### PR DESCRIPTION
## Summary

Closes #243

Fixes a race condition in `TestEventQueue_EnqueueEvent_CriticalBlocking` where the `close(started)` / `<-started` channel pair does not guarantee the goroutine has reached the blocking `select` before `cancel2()` fires. If cancellation wins the race, the test exercises the pre-guard (`ctx.Err()`) rather than the mid-flight `<-ctx.Done()` in the `select` — a false positive.

## Fix

Replaces the `started` channel pair with the deterministic `beforeBlockingSendHook` + `inSelect` channel pattern, already proven in `TestEventQueue_EnqueueCritical_MidFlightCallerCancel`. The hook fires inside `enqueueCritical` **after** both pre-guards (`ctx.Err()` and `loopCtx.Err()`), guaranteeing the goroutine is inside the blocking `select` before the main goroutine calls `cancel2()`.

## Verification

```
go test -race -count=50 ./internal/agent/session/ui/... -run TestEventQueue_EnqueueEvent_CriticalBlocking
# PASS — zero flakes
```

## Diff

-3 lines, +5 lines — minimal, deterministic, zero test latency.