### PR TITLE
docs(adr): define test-hook policy for unexported concrete types (ADR-032)

### DIFF
--- a/docs/adr/2026-05-test-hook-policy.md
+++ b/docs/adr/2026-05-test-hook-policy.md
@@ -1,0 +1,76 @@
+# ADR-032: Test-Hook Policy for Unexported Concrete Types
+
+## Status
+Accepted
+
+## Context
+
+PR [#245](https://github.com/gosharplite/tell-me-go/pull/245) surfaced a disagreement about
+`beforeBlockingSendHook` — a nil-in-production `func()` field on the unexported `eventQueue` struct,
+used for deterministic test synchronization. The reviewer flagged it as a Clean Architecture
+violation; the architect assessed it as a pragmatic Go pattern. The debate (fully documented in
+[PR #245 comments](https://github.com/gosharplite/tell-me-go/pull/245#issuecomment-4402652177))
+revealed there is **no documented policy** on when test hooks embedded in production structs are
+acceptable vs. when interface mocking should be used.
+
+This creates:
+
+1. **Inconsistent reviews** — the same pattern may be approved or rejected based on reviewer.
+2. **Precedent risk** — without clear criteria, hooks proliferate unchecked, creating God Objects
+   that accumulate testing artifacts.
+3. **ADR-011 ambiguity** — ADR-011 §3 Rule 2 mandates "Positive Synchronization via Mock
+   Callbacks" but does not address unexported concrete types that have no interface boundary
+   to mock.
+
+## Decision
+
+### Decision Criteria
+
+A nil-in-production `func()` test hook is **acceptable** when **all** of the following are true:
+
+| # | Criterion | Rationale |
+|---|-----------|-----------|
+| 1 | **Unexported concrete type** | The type is not part of any package's public API. No interface boundary exists that could be mocked. |
+| 2 | **No interface to mock** | The synchronization point is on an unexported method of a concrete type. `testify/mock` is impossible because there is no interface to implement. |
+| 3 | **`time.Sleep` is the only alternative** | Without the hook, the test must use arbitrary sleeps — violating ADR-011 Rule 1 and introducing flakiness. |
+| 4 | **Nil `func()` — zero overhead** | The hook field is a single function pointer. The production path executes one nil-check branch. Zero allocations. |
+| 5 | **Single synchronization point** | The hook observes one well-defined state transition, not broad behavioral verification. Broad verification belongs with interface mocks. |
+| 6 | **Documented** | The field carries a `// Test hook: nil in production` comment and a reference to this ADR. |
+
+A hook that violates any criterion **must** use an alternative mechanism:
+
+- **Exported type or interface exists** → Interface mock (ADR-011 Rule 2).
+- **Broad behavioral verification** → Interface mock.
+- **Multiple hooks accumulating on one struct** → Re-evaluate the struct's responsibilities; consider decomposition.
+- **Hook has side effects beyond observation** → Forbidden. Hooks are observation-only.
+
+### Rationale
+
+The decisive factor is the **interface boundary limitation**. ADR-011 Rule 2 requires
+`testify/mock`'s `.Run()` callbacks, but `.Run()` requires an interface to mock. When the target
+is an unexported concrete type with no interface, the mock pathway is simply unavailable.
+
+The Go standard library uses the same pattern sparingly: `net/http` maintains unexported test
+hooks (e.g., `testHookServerServe`) for internal synchronization points that are unreachable
+through the public API. This ADR applies the same discipline: permitted, documented, and tracked.
+
+### Registry Requirement
+
+Every authorized test hook **must** be registered in Appendix A of this ADR. Adding a hook
+requires amending this ADR — making proliferation visible and forcing a conscious architectural
+decision each time.
+
+## Consequences
+
+- **Positive**: Eliminates inconsistent review outcomes for test hooks.
+- **Positive**: Contains God Object risk through mandatory registry and strict criteria.
+- **Positive**: Preserves ADR-011's zero-`time.Sleep` guarantee for all synchronization scenarios,
+  including those unreachable through interface mocking.
+- **Negative**: Slight process overhead — each new hook requires an ADR amendment.
+  Accepted because new hooks should be rare.
+
+## Appendix A — Authorized Test Hook Registry
+
+| # | Struct | Field | File | Purpose | Since |
+|---|--------|-------|------|---------|-------|
+| 1 | `eventQueue` | `beforeBlockingSendHook` | `internal/agent/session/ui/event_queue.go:31` | Observe goroutine entry into blocking `select` in `enqueueCritical` | 2026-05 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,6 +32,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-028** | Delegate Registration Logic to Integration Sub-Packages | 2026-05 | Accepted | [2026-05-subpackage-registration-pattern.md](2026-05-subpackage-registration-pattern.md) |
 | **ADR-029** | Fallible `Reconfigure` Delegate Chain in Agent Hot-Reload | 2026-05 | Accepted | [2026-05-fallible-reconfigure-delegate-chain.md](2026-05-fallible-reconfigure-delegate-chain.md) |
 | **ADR-030** | Release Branch Synchronization Policy | 2026-05 | Accepted | [2026-05-release-branch-synchronization-policy.md](2026-05-release-branch-synchronization-policy.md) |
+| **ADR-032** | Test-Hook Policy for Unexported Concrete Types | 2026-05 | Accepted | [2026-05-test-hook-policy.md](2026-05-test-hook-policy.md) |
 
 ## How to Create a New ADR
 

--- a/internal/agent/session/ui/event_queue.go
+++ b/internal/agent/session/ui/event_queue.go
@@ -31,7 +31,7 @@ type eventQueue struct {
 	// beforeBlockingSendHook is nil in production. Tests can set it to a
 	// signal channel to deterministically observe when enqueueCritical has
 	// passed both pre-guards and is about to enter the blocking select.
-	// See ADR-011 §3 Rule 2 for the pattern this enables.
+	// See ADR-032 for the test-hook policy and Appendix A for registration.
 	beforeBlockingSendHook func() //nolint:unused // test hook
 }
 


### PR DESCRIPTION
Closes #246.

## Summary

Adds ADR-032 establishing clear criteria for when nil-in-production `func()` test hooks are acceptable on unexported concrete types vs. when interface mocking must be used.

## Background

PR [#245](https://github.com/gosharplite/tell-me-go/pull/245) surfaced a disagreement about `beforeBlockingSendHook` — the reviewer flagged it as a Clean Architecture violation; the architect assessed it as a pragmatic Go pattern. The debate revealed no documented policy existed. This ADR closes that gap.

## Changes

| File | Change |
|------|--------|
| `docs/adr/2026-05-test-hook-policy.md` | New ADR with 6 criteria, rationale, and Appendix A registry |
| `docs/adr/README.md` | Register ADR-032 in index |
| `internal/agent/session/ui/event_queue.go` | Update hook comment: ADR-011 → ADR-032 |

## ADR-032 Key Points

- **6 criteria** must ALL be met for a test hook to be acceptable (unexported type, no interface to mock, `time.Sleep` is the only alternative, nil func() zero overhead, single sync point, documented)
- **Appendix A** — mandatory registry of all authorized hooks (seeded with `eventQueue.beforeBlockingSendHook`)
- Hooks violating any criterion → interface mock required instead