### PR TITLE
refactor(test): replace manual assertion trees with testify/assert in god tests

### DIFF
--- a/internal/agent/session/context/context_transformers_test.go
+++ b/internal/agent/session/context/context_transformers_test.go
@@ -1565,7 +1565,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := propagator.Transform(ctx, tt.inputReq)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantPersist, tt.inputReq.PersistHistory)
 			if tt.validateResult != nil {
 				tt.validateResult(t, tt.inputReq)

--- a/internal/agent/session/context/context_transformers_test.go
+++ b/internal/agent/session/context/context_transformers_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1469,9 +1470,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 			validateResult: func(t *testing.T, req *ports.ContextRequest) {
 				modelMsg := req.History[1]
 				fcPart := modelMsg.Parts[1]
-				if string(fcPart.ThoughtSignature) != "sig-123" {
-					t.Errorf("expected thought signature 'sig-123', got '%s'", fcPart.ThoughtSignature)
-				}
+				assert.Equal(t, "sig-123", string(fcPart.ThoughtSignature))
 			},
 		},
 		{
@@ -1490,9 +1489,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 			wantPersist: false,
 			validateResult: func(t *testing.T, req *ports.ContextRequest) {
 				fcPart := req.History[0].Parts[1]
-				if len(fcPart.ThoughtSignature) != 0 {
-					t.Errorf("expected empty thought signature, got '%s'", fcPart.ThoughtSignature)
-				}
+				assert.Empty(t, fcPart.ThoughtSignature)
 			},
 		},
 		{
@@ -1518,9 +1515,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 			wantPersist: false,
 			validateResult: func(t *testing.T, req *ports.ContextRequest) {
 				fcPart := req.History[0].Parts[1]
-				if len(fcPart.ThoughtSignature) != 0 {
-					t.Errorf("expected empty thought signature, got '%s'", fcPart.ThoughtSignature)
-				}
+				assert.Empty(t, fcPart.ThoughtSignature)
 			},
 		},
 		{
@@ -1542,9 +1537,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 			wantPersist: false,
 			validateResult: func(t *testing.T, req *ports.ContextRequest) {
 				fcPart := req.History[0].Parts[1]
-				if string(fcPart.ThoughtSignature) != "existing-sig" {
-					t.Errorf("expected existing thought signature 'existing-sig', got '%s'", fcPart.ThoughtSignature)
-				}
+				assert.Equal(t, "existing-sig", string(fcPart.ThoughtSignature))
 			},
 		},
 		{
@@ -1564,9 +1557,7 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 			wantPersist: true,
 			validateResult: func(t *testing.T, req *ports.ContextRequest) {
 				fcPart := req.History[0].Parts[2]
-				if string(fcPart.ThoughtSignature) != "sig-1" {
-					t.Errorf("expected first thought signature 'sig-1', got '%s'", fcPart.ThoughtSignature)
-				}
+				assert.Equal(t, "sig-1", string(fcPart.ThoughtSignature))
 			},
 		},
 	}
@@ -1574,12 +1565,8 @@ func TestThoughtSignaturePropagator_Transform(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := propagator.Transform(ctx, tt.inputReq)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if tt.inputReq.PersistHistory != tt.wantPersist {
-				t.Errorf("PersistHistory = %v, want %v", tt.inputReq.PersistHistory, tt.wantPersist)
-			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPersist, tt.inputReq.PersistHistory)
 			if tt.validateResult != nil {
 				tt.validateResult(t, tt.inputReq)
 			}

--- a/internal/agent/session/skill_injector_test.go
+++ b/internal/agent/session/skill_injector_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/skills"
@@ -74,7 +75,7 @@ func TestSkillInjector_Transform(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, req *ports.ContextRequest) {
-				assert.Len(t, req.History, 2)
+				require.Len(t, req.History, 2)
 				assert.Equal(t, "system", req.History[0].Role)
 				assert.True(t, req.History[0].Pinned, "expected injected system message to be pinned")
 				injectedText := req.History[0].Parts[0].Text
@@ -140,7 +141,7 @@ func TestSkillInjector_Transform(t *testing.T) {
 				assert.Len(t, req.History, 1, "expected history unchanged")
 				assert.False(t, req.PersistHistory, "expected PersistHistory to remain false when skill selection fails")
 				// Verify the warning was logged.
-				assert.Len(t, errLogger.warns, 1)
+				require.Len(t, errLogger.warns, 1)
 				assert.Equal(t, "skill selection failed; proceeding without injected skills", errLogger.warns[0].msg)
 			},
 		},

--- a/internal/agent/session/skill_injector_test.go
+++ b/internal/agent/session/skill_injector_test.go
@@ -6,9 +6,9 @@ package session
 import (
 	"context"
 	"errors"
-	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/skills"
@@ -74,22 +74,12 @@ func TestSkillInjector_Transform(t *testing.T) {
 				},
 			},
 			validate: func(t *testing.T, req *ports.ContextRequest) {
-				if len(req.History) != 2 {
-					t.Fatalf("expected 2 history entries, got %d", len(req.History))
-				}
-				if req.History[0].Role != "system" {
-					t.Errorf("expected first message to be system, got %q", req.History[0].Role)
-				}
-				if !req.History[0].Pinned {
-					t.Error("expected injected system message to be pinned")
-				}
+				assert.Len(t, req.History, 2)
+				assert.Equal(t, "system", req.History[0].Role)
+				assert.True(t, req.History[0].Pinned, "expected injected system message to be pinned")
 				injectedText := req.History[0].Parts[0].Text
-				if !strings.Contains(injectedText, "test-skill") {
-					t.Errorf("expected injected text to contain skill name, got %q", injectedText)
-				}
-				if !strings.Contains(injectedText, "Use testing.") {
-					t.Errorf("expected injected text to contain skill content, got %q", injectedText)
-				}
+				assert.Contains(t, injectedText, "test-skill")
+				assert.Contains(t, injectedText, "Use testing.")
 			},
 		},
 		{
@@ -147,19 +137,11 @@ func TestSkillInjector_Transform(t *testing.T) {
 			validate: func(t *testing.T, req *ports.ContextRequest) {
 				// Transform must NOT return an error — the failure is logged, not propagated.
 				// History must remain unchanged (no injection, no mutation).
-				if len(req.History) != 1 {
-					t.Errorf("expected history unchanged (1 entry), got %d", len(req.History))
-				}
-				if req.PersistHistory {
-					t.Error("expected PersistHistory to remain false when skill selection fails")
-				}
+				assert.Len(t, req.History, 1, "expected history unchanged")
+				assert.False(t, req.PersistHistory, "expected PersistHistory to remain false when skill selection fails")
 				// Verify the warning was logged.
-				if len(errLogger.warns) != 1 {
-					t.Fatalf("expected 1 warning call, got %d", len(errLogger.warns))
-				}
-				if errLogger.warns[0].msg != "skill selection failed; proceeding without injected skills" {
-					t.Errorf("unexpected warning message: %q", errLogger.warns[0].msg)
-				}
+				assert.Len(t, errLogger.warns, 1)
+				assert.Equal(t, "skill selection failed; proceeding without injected skills", errLogger.warns[0].msg)
 			},
 		},
 	}


### PR DESCRIPTION
Closes #261

## Summary

Replaced manual `if`/`t.Fatalf`/`t.Errorf` assertion trees in table-driven test validate closures with `github.com/stretchr/testify/assert` calls — a pattern already established in 17 other test files in the `session/` package.

## Changes

| File | Function | Complexity Before | Complexity After |
|------|----------|-------------------|------------------|
| `skill_injector_test.go` | `TestSkillInjector_Transform` | 13 | 4 |
| `context_transformers_test.go` | `TestThoughtSignaturePropagator_Transform` | 10 | 3 |

## Verification

- `go test ./internal/agent/session/... -race` — PASS
- Full package complexity scan — no function exceeds threshold of 10
- Purely mechanical migration, zero behavioral changes