### PR TITLE
test(clock): add coverage for Since, NewTicker, and realTicker.C (fixes #266)

### DIFF
--- a/internal/pkg/clock/clock_test.go
+++ b/internal/pkg/clock/clock_test.go
@@ -50,3 +50,55 @@ func TestRealClock_Jitter(t *testing.T) {
 		}
 	}
 }
+
+// TestRealClock_Since verifies that RealClock.Since returns a non-negative duration
+// that is at least as long as a known sleep interval.
+func TestRealClock_Since(t *testing.T) {
+	t.Parallel()
+	c := RealClock{}
+	t0 := c.Now()
+	c.Sleep(10 * time.Millisecond)
+	d := c.Since(t0)
+
+	if d < 0 {
+		t.Errorf("RealClock.Since() = %v, want non-negative", d)
+	}
+	if d < 10*time.Millisecond {
+		t.Errorf("RealClock.Since() = %v, want at least 10ms", d)
+	}
+}
+
+// TestRealTicker_C verifies that realTicker.C returns a non-nil channel and that
+// repeated calls return the same underlying channel.
+func TestRealTicker_C(t *testing.T) {
+	c := RealClock{}
+	tk := c.NewTicker(time.Hour)
+	t.Cleanup(tk.Stop)
+
+	ch1 := tk.C()
+	ch2 := tk.C()
+
+	if ch1 == nil {
+		t.Error("realTicker.C() returned nil channel")
+	}
+	if ch1 != ch2 {
+		t.Error("realTicker.C() returned different channels across calls — expected same channel")
+	}
+}
+
+// TestRealClock_NewTicker verifies that RealClock.NewTicker returns a Ticker
+// whose channel fires at least once within a timeout window.
+func TestRealClock_NewTicker(t *testing.T) {
+	c := RealClock{}
+	tk := c.NewTicker(10 * time.Millisecond)
+	t.Cleanup(tk.Stop)
+
+	select {
+	case tick := <-tk.C():
+		if tick.IsZero() {
+			t.Error("NewTicker channel delivered zero time")
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("NewTicker did not fire within 200ms timeout")
+	}
+}


### PR DESCRIPTION
## Summary

Adds three tests to `internal/pkg/clock`, raising package coverage from 57.1% to 100%.

### New Tests

| Test | Function Covered | What It Verifies |
|---|---|---|
| `TestRealClock_Since` | `Since` | Non-negative duration after sleep |
| `TestRealTicker_C` | `realTicker.C` | Channel identity (non-nil, same across calls) |
| `TestRealClock_NewTicker` | `NewTicker` | Ticker fires within 200ms timeout |

### Verification

- `go test -race -count=3 ./internal/pkg/clock/` — **PASS**
- `go tool cover -func` — **100%** (7/7 functions)
- No goroutine leaks (all tickers stopped via `t.Cleanup`)
- Zero production code changes

Fixes #266