### PR TITLE
fix: simplify unreachable rows.Close() error path in event_store

### DIFF
--- a/internal/agent/repository/event_store.go
+++ b/internal/agent/repository/event_store.go
@@ -39,10 +39,11 @@ func (r *eventStore) getSessionEvents(ctx context.Context, eventIDs []string) (e
 		return nil, fmt.Errorf("querying session events: %w", err)
 	}
 	defer func() {
-		if closeErr := rows.Close(); closeErr != nil {
-			if err == nil {
-				err = fmt.Errorf("closing event rows: %w", closeErr)
-			}
+		if closeErr := rows.Close(); closeErr != nil && err == nil {
+			// Defensive only: database/sql surfaces driver Close errors
+			// via rows.Err() inside parseSessionEvents before this defer
+			// evaluates, so this branch is unreachable in practice.
+			err = fmt.Errorf("closing event rows: %w", closeErr)
 		}
 	}()
 

--- a/internal/agent/repository/event_store_error_test.go
+++ b/internal/agent/repository/event_store_error_test.go
@@ -108,23 +108,6 @@ func TestGetSessionEvents_CloseError(t *testing.T) {
 	assert.Nil(t, events)
 }
 
-func TestGetSessionEvents_CloseErrorWhenParseSucceeds(t *testing.T) {
-	// The err==nil branch at lines 43-45 in event_store.go is unreachable
-	// with standard database/sql: after rows.Next() returns false, the
-	// driver's Close() is called automatically and any error is surfaced
-	// through rows.Err() before our deferred rows.Close() runs.  This means
-	// parseSessionEvents always sees the close error via rows.Err(), making
-	// err non-nil when the defer evaluates it.
-	//
-	// The existing TestGetSessionEvents_CloseError verifies that close
-	// errors ARE propagated — just through the rows.Err() path rather
-	// than the deferred err==nil path.
-	//
-	// This test exists as documentation; the real coverage for close-error
-	// propagation is in TestGetSessionEvents_CloseError.
-	t.Skip("err==nil close-error branch unreachable with database/sql semantics")
-}
-
 // TestGetSessionEvents_CloseErrorPropagationPath proves that close errors
 // ARE propagated to the caller — they just flow through the rows.Err() path
 // inside parseSessionEvents rather than the err==nil defer branch.


### PR DESCRIPTION
## Summary

The `err==nil` branch inside the deferred `rows.Close()` at `event_store.go:43-45` is architecturally unreachable with standard `database/sql` semantics. Driver Close errors surface via `rows.Err()` inside `parseSessionEvents` before the defer evaluates, making the branch dead code.

## Changes

- **`event_store.go`** — Collapsed nested `if err == nil` into a single guard clause with an explanatory comment documenting the `database/sql` semantics.
- **`event_store_error_test.go`** — Removed `TestGetSessionEvents_CloseErrorWhenParseSucceeds` (permanently skipped). Its documentation now lives as the inline comment. `TestGetSessionEvents_CloseErrorPropagationPath` remains as the authoritative test proving close errors reach the caller.

## Verification

- `go vet` — clean
- `go test ./internal/agent/repository/...` — 7/7 PASS, zero skips

Closes #272