### PR TITLE
test(di): close coverage gaps in Bootstrapper and sessionDeps getters

### DIFF
--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/factory"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
@@ -543,6 +544,7 @@ func TestSessionDeps_Getters(t *testing.T) {
 		tracker:         tracker,
 		pricingData:     pData,
 		sessionProvider: sessionProvider,
+		health:          factory.NewHealthCheckManager(nil),
 		clientFactory: func() (llm.ExtendedClient, error) {
 			return client, nil
 		},
@@ -563,6 +565,7 @@ func TestSessionDeps_Getters(t *testing.T) {
 	assert.Equal(t, pData, deps.GetPricingData())
 	assert.NotNil(t, deps.GetClient())
 	assert.Equal(t, sessionProvider, deps.GetSessionProvider())
+	assert.NotNil(t, deps.GetHealthManager())
 }
 
 type mockKVStore struct {
@@ -1089,4 +1092,16 @@ func TestBypassConfirmationPriority(t *testing.T) {
 			mockKV.AssertExpectations(t)
 		})
 	}
+}
+
+func TestBootstrapper_Getters(t *testing.T) {
+	tempDir := t.TempDir()
+	sm := new(mockConfigurableSecurityManager)
+	setupDefaultSMExpectations(sm)
+
+	b := NewBootstrapper(tempDir, sm, "1.0.0", io.Discard, io.Discard, nil, nil, nil)
+
+	assert.NotNil(t, b.GetHistoryBrowser())
+	assert.NotNil(t, b.GetUIRenderer())
+	assert.NotNil(t, b.GetHistoryRenderer())
 }


### PR DESCRIPTION
Closes #278

## Summary
Four getter methods on `container.go` were at 0% test coverage:

| Method | Before | After |
|--------|--------|-------|
| `GetHealthManager` (sessionDeps) | 0.0% | **100.0%** |
| `GetHistoryBrowser` (Bootstrapper) | 0.0% | **100.0%** |
| `GetUIRenderer` (Bootstrapper) | 0.0% | **100.0%** |
| `GetHistoryRenderer` (Bootstrapper) | 0.0% | **100.0%** |

## Changes
- Extended `TestSessionDeps_Getters` with `health` field + assertion
- Added `TestBootstrapper_Getters` for three Bootstrapper UI delegation getters

Package coverage: **90.8% → 92.4%**