### PR TITLE
refactor: consolidate SimpleEventBus worker initialization into startSubscriberLoop

### DIFF
--- a/internal/domain/events/event_bus_lifecycle.go
+++ b/internal/domain/events/event_bus_lifecycle.go
@@ -5,7 +5,6 @@ package events
 
 import (
 	"context"
-	"log/slog"
 	"runtime/debug"
 )
 
@@ -193,18 +192,7 @@ func (b *SimpleEventBus) Listen(ctx context.Context) error {
 	wrappers = append(wrappers, b.globalSubscribers...)
 
 	for _, w := range wrappers {
-		w := w
-		b.workerWG.Add(1)
-		go func() {
-			defer func() {
-				if r := recover(); r != nil {
-					b.getLogger().ErrorContext(listenCtx, "panic in event bus subscriber loop",
-						slog.Any("error", r),
-						slog.String("stack", string(debug.Stack())))
-				}
-			}()
-			_ = b.subscriberLoop(listenCtx, w)
-		}()
+		b.startSubscriberLoop(w)
 	}
 
 	// Signal that the listener is fully initialized

--- a/internal/domain/events/event_bus_pubsub.go
+++ b/internal/domain/events/event_bus_pubsub.go
@@ -280,16 +280,17 @@ func (b *SimpleEventBus) SubscribeSubscriber(eventType string, sub Subscriber) {
 // startSubscriberLoop starts the background worker loop for a given subscriber.
 // It assumes b.mu is held by the caller.
 func (b *SimpleEventBus) startSubscriberLoop(w *subscriberWrapper) {
+	ctx := b.listenCtx
 	b.workerWG.Add(1)
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				b.getLogger().ErrorContext(b.listenCtx, "panic in dynamic event bus subscriber loop",
+				b.getLogger().ErrorContext(ctx, "panic in event bus subscriber loop",
 					slog.Any("error", r),
 					slog.String("stack", string(debug.Stack())))
 			}
 		}()
-		_ = b.subscriberLoop(b.listenCtx, w)
+		_ = b.subscriberLoop(ctx, w)
 	}()
 }
 

--- a/internal/domain/events/event_bus_pubsub_test.go
+++ b/internal/domain/events/event_bus_pubsub_test.go
@@ -41,7 +41,7 @@ type hookHandler struct {
 
 func (h *hookHandler) Handle(ctx context.Context, r slog.Record) error {
 	err := h.Handler.Handle(ctx, r)
-	if strings.Contains(r.Message, "panic in dynamic event bus subscriber loop") {
+	if strings.Contains(r.Message, "panic in event bus subscriber loop") {
 		select {
 		case <-h.onPanicMsg:
 			// already closed
@@ -114,8 +114,8 @@ func TestStartSubscriberLoop_PanicRecovery(t *testing.T) {
 
 	// Verify the panic was logged by startSubscriberLoop's recover().
 	output := buf.String()
-	if !strings.Contains(output, "panic in dynamic event bus subscriber loop") {
-		t.Errorf("expected 'panic in dynamic event bus subscriber loop' in log, got: %s", output)
+	if !strings.Contains(output, "panic in event bus subscriber loop") {
+		t.Errorf("expected 'panic in event bus subscriber loop' in log, got: %s", output)
 	}
 	if !strings.Contains(output, "event Type() panic") {
 		t.Errorf("expected 'event Type() panic' in log, got: %s", output)


### PR DESCRIPTION
## Summary

Closes #286 — eliminates DRY violation where worker-spawning boilerplate (`workerWG.Add`, goroutine, panic recovery, `subscriberLoop` call) was duplicated in both `Listen` and `startSubscriberLoop`.

## Changes

| File | Change |
|---|---|
| `event_bus_lifecycle.go` | Replaced 14-line inline worker-spawn block in `Listen` with `b.startSubscriberLoop(w)`; removed unused `log/slog` import |
| `event_bus_pubsub.go` | Captured `b.listenCtx` into local `ctx` before goroutine spawn to fix latent data race; unified log message |
| `event_bus_pubsub_test.go` | Updated 2 assertions + 1 error message to match unified log string |

## Architecture

- `startSubscriberLoop` is now the **single source of truth** for spawning subscriber worker goroutines.
- Every worker gets consistent panic recovery behavior regardless of whether it was started at `Listen` time or added dynamically.
- Context capture is race-free: `b.listenCtx` is snapshotted into a stack-local before the goroutine launches, eliminating the write-after-read race with `Listen`'s shutdown path.

## Verification

```
go build ./internal/domain/events/...   → PASS
go test -race ./internal/domain/events/... → PASS (2.282s)
go vet ./internal/domain/events/...     → PASS
```