### PR TITLE
events: rename startSubscriberLoop → startSubscriberLoopLocked

### DIFF
--- a/internal/domain/events/event_bus_lifecycle.go
+++ b/internal/domain/events/event_bus_lifecycle.go
@@ -192,7 +192,7 @@ func (b *SimpleEventBus) Listen(ctx context.Context) error {
 	wrappers = append(wrappers, b.globalSubscribers...)
 
 	for _, w := range wrappers {
-		b.startSubscriberLoop(w)
+		b.startSubscriberLoopLocked(w)
 	}
 
 	// Signal that the listener is fully initialized

--- a/internal/domain/events/event_bus_pubsub.go
+++ b/internal/domain/events/event_bus_pubsub.go
@@ -231,7 +231,7 @@ func (b *SimpleEventBus) Subscribe(sub func(context.Context, Event)) {
 	b.globalSubscribers = append(b.globalSubscribers, w)
 
 	if b.running && b.asyncDispatch {
-		b.startSubscriberLoop(w)
+		b.startSubscriberLoopLocked(w)
 	}
 }
 
@@ -252,7 +252,7 @@ func (b *SimpleEventBus) SubscribeGlobal(sub Subscriber) {
 	b.globalSubscribers = append(b.globalSubscribers, w)
 
 	if b.running && b.asyncDispatch {
-		b.startSubscriberLoop(w)
+		b.startSubscriberLoopLocked(w)
 	}
 }
 
@@ -273,13 +273,13 @@ func (b *SimpleEventBus) SubscribeSubscriber(eventType string, sub Subscriber) {
 	b.subscribers[eventType] = append(b.subscribers[eventType], w)
 
 	if b.running && b.asyncDispatch {
-		b.startSubscriberLoop(w)
+		b.startSubscriberLoopLocked(w)
 	}
 }
 
-// startSubscriberLoop starts the background worker loop for a given subscriber.
+// startSubscriberLoopLocked starts the background worker loop for a given subscriber.
 // It assumes b.mu is held by the caller.
-func (b *SimpleEventBus) startSubscriberLoop(w *subscriberWrapper) {
+func (b *SimpleEventBus) startSubscriberLoopLocked(w *subscriberWrapper) {
 	ctx := b.listenCtx
 	b.workerWG.Add(1)
 	go func() {

--- a/internal/domain/events/event_bus_pubsub_test.go
+++ b/internal/domain/events/event_bus_pubsub_test.go
@@ -26,7 +26,7 @@ func (s *panicSubscriber) Handle(ctx context.Context, e Event) error {
 // With Fix 1 (cached event.Type()), notifySubscriber calls Type() before
 // sub.Handle, so the panic happens there; the recover catches it and returns
 // an error. subscriberLoop then calls event.Type() again in its error-logging
-// path, triggering a second panic that propagates to startSubscriberLoop's recover.
+// path, triggering a second panic that propagates to startSubscriberLoopLocked's recover.
 type panickingTypeEvent struct{}
 
 func (e panickingTypeEvent) Type() string { panic("event Type() panic") }
@@ -52,16 +52,16 @@ func (h *hookHandler) Handle(ctx context.Context, r slog.Record) error {
 	return err
 }
 
-// TestStartSubscriberLoop_PanicRecovery exercises the recover() path in
-// startSubscriberLoop where a panic escapes both notifySubscriber's recovery
-// and subscriberLoop, reaching the startSubscriberLoop safety net.
+// TestStartSubscriberLoopLocked_PanicRecovery exercises the recover() path in
+// startSubscriberLoopLocked where a panic escapes both notifySubscriber's recovery
+// and subscriberLoop, reaching the startSubscriberLoopLocked safety net.
 //
 // The chain works as follows:
 //  1. notifySubscriber calls event.Type() (cached before defer) → panics
 //  2. notifySubscriber's recover catches it, returns an error
 //  3. subscriberLoop calls event.Type() again for error logging → second panic
-//  4. second panic escapes subscriberLoop → caught by startSubscriberLoop's recover
-func TestStartSubscriberLoop_PanicRecovery(t *testing.T) {
+//  4. second panic escapes subscriberLoop → caught by startSubscriberLoopLocked's recover
+func TestStartSubscriberLoopLocked_PanicRecovery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -78,7 +78,7 @@ func TestStartSubscriberLoop_PanicRecovery(t *testing.T) {
 	)
 
 	// Start Listen in background so the bus is "running".
-	// This is required for startSubscriberLoop to be called by SubscribeGlobal.
+	// This is required for startSubscriberLoopLocked to be called by SubscribeGlobal.
 	listenDone := make(chan struct{})
 	go func() {
 		defer close(listenDone)
@@ -87,32 +87,32 @@ func TestStartSubscriberLoop_PanicRecovery(t *testing.T) {
 	bus.WaitStarted()
 
 	// Dynamically subscribe a subscriber that panics on Handle.
-	// Because the bus is already running, SubscribeGlobal calls startSubscriberLoop.
+	// Because the bus is already running, SubscribeGlobal calls startSubscriberLoopLocked.
 	bus.SubscribeGlobal(&panicSubscriber{msg: "dynamic panic boom"})
 
 	// Send a panickingTypeEvent directly to the subscriber's channel,
 	// bypassing Publish (which would panic on event.Type()).
 	// This triggers the chain: notifySubscriber calls event.Type() → panics →
 	// recover returns error → subscriberLoop calls event.Type() for logging →
-	// second panic → startSubscriberLoop catches.
+	// second panic → startSubscriberLoopLocked catches.
 	bus.mu.RLock()
 	w := bus.globalSubscribers[0]
 	bus.mu.RUnlock()
 	w.ch <- panickingTypeEvent{}
 
-	// Wait for startSubscriberLoop's recover to log the panic.
+	// Wait for startSubscriberLoopLocked's recover to log the panic.
 	select {
 	case <-panicCaught:
 		// Good — the recover fired and logged the expected message.
 	case <-time.After(2 * time.Second):
-		t.Fatal("timed out waiting for startSubscriberLoop panic recovery log")
+		t.Fatal("timed out waiting for startSubscriberLoopLocked panic recovery log")
 	}
 
 	// Shutdown cleanly.
 	cancel()
 	<-listenDone
 
-	// Verify the panic was logged by startSubscriberLoop's recover().
+	// Verify the panic was logged by startSubscriberLoopLocked's recover().
 	output := buf.String()
 	if !strings.Contains(output, "panic in event bus subscriber loop") {
 		t.Errorf("expected 'panic in event bus subscriber loop' in log, got: %s", output)


### PR DESCRIPTION
## Summary

Surfaces the lock-required contract at every call site by renaming `startSubscriberLoop` → `startSubscriberLoopLocked`, following Go's idiomatic `*Locked` suffix convention.

## Changes

| File | Change |
|------|--------|
| `event_bus_pubsub.go` | Renamed definition + 3 call sites; updated doc comment |
| `event_bus_lifecycle.go` | 1 call site in `Listen()` |
| `event_bus_pubsub_test.go` | Renamed test function + 10 comment/string references |

## Verification

- ✅ `go test -race ./internal/domain/events/...` — pass
- ✅ `go vet ./internal/domain/events/...` — clean
- ✅ Zero residual references to old name
- ✅ Pure naming hygiene — no behavioral change

Closes #292