### PR TITLE
test(events): cover subscriberLoop closed-channel and Listen idempotency paths (#289)

### DIFF
--- a/internal/domain/events/event_bus_pubsub_test.go
+++ b/internal/domain/events/event_bus_pubsub_test.go
@@ -121,3 +121,62 @@ func TestStartSubscriberLoopLocked_PanicRecovery(t *testing.T) {
 		t.Errorf("expected 'event Type() panic' in log, got: %s", output)
 	}
 }
+
+// TestSubscriberLoop_ClosedChannel exercises the !ok (closed-channel) return
+// path in subscriberLoop. When a subscriber's channel is closed externally,
+// the worker observes a zero-value Event with ok=false and returns nil.
+//
+// Synchronization is deterministic via workerWG: close(w.ch) causes the
+// worker to exit the for-select loop, fire defer workerWG.Done(), and
+// unblock workerWG.Wait().
+func TestSubscriberLoop_ClosedChannel(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := NewSimpleEventBus(ctx, WithAsync(true), WithQueueSize(1))
+
+	// Start Listen in a background goroutine and wait for full initialization.
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		_ = bus.Listen(ctx)
+	}()
+	bus.WaitStarted()
+
+	// Subscribe a no-op global subscriber to create an active worker goroutine.
+	bus.SubscribeGlobal(&funcSubscriber{f: func(ctx context.Context, e Event) {}})
+
+	// Retrieve the wrapper for the subscriber we just added.
+	bus.mu.RLock()
+	if len(bus.globalSubscribers) == 0 {
+		bus.mu.RUnlock()
+		t.Fatal("expected at least one global subscriber")
+	}
+	w := bus.globalSubscribers[0]
+	bus.mu.RUnlock()
+
+	// Close the subscriber's channel. The worker goroutine currently blocked
+	// on <-w.ch will receive a zero-value with ok=false and return nil.
+	close(w.ch)
+
+	// Wait for the worker to exit. workerWG.Wait() returns only after
+	// subscriberLoop's defer workerWG.Done() fires.
+	workerDone := make(chan struct{})
+	go func() {
+		bus.workerWG.Wait()
+		close(workerDone)
+	}()
+
+	select {
+	case <-workerDone:
+		// Worker exited via the closed-channel path — success.
+	case <-time.After(2 * time.Second):
+		t.Fatal("worker did not exit after channel close — closed-channel path was not exercised")
+	}
+
+	// Clean shutdown: cancel the listen context and wait for Listen to return.
+	cancel()
+	<-listenDone
+}

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -938,6 +938,37 @@ func TestSimpleEventBus_ListenDefensive(t *testing.T) {
 			t.Errorf("expected ErrBusClosed, got %v", err)
 		}
 	})
+
+	t.Run("AlreadyRunning", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		bus := events.NewSimpleEventBus(ctx, events.WithAsync(true))
+		eventstest.CleanupBus(t, bus)
+
+		// Start the first Listen in a background goroutine and wait for
+		// full initialization. After WaitStarted returns, b.running is
+		// guaranteed true under the lock.
+		listenDone := make(chan struct{})
+		go func() {
+			defer close(listenDone)
+			_ = bus.Listen(ctx)
+		}()
+		bus.WaitStarted()
+
+		// Call Listen a second time on an already-running bus.
+		// This exercises the early-return path:
+		//   if b.running { b.mu.Unlock(); return nil }
+		err := bus.Listen(ctx)
+		if err != nil {
+			t.Errorf("expected nil on re-entrant Listen to already-running bus, got %v", err)
+		}
+
+		// Clean shutdown: cancel the context and wait for the first Listen
+		// goroutine to return.
+		cancel()
+		<-listenDone
+	})
 }
 
 func TestSimpleEventBus_NilAndClosedSubscriptions(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #289.

Adds two deterministic tests for the remaining uncovered error paths in `SimpleEventBus`:

### 1. `TestSubscriberLoop_ClosedChannel` (white-box)
- Closes a subscriber's channel and verifies the worker exits via `workerWG.Wait()`
- Covers the `!ok` return path — no `time.Sleep`, fully channel/WaitGroup synchronized
- Coverage: `subscriberLoop` 92.9% → **100.0%**

### 2. `AlreadyRunning` subtest in `TestSimpleEventBus_ListenDefensive` (black-box)
- Calls `Listen` on an already-running bus and asserts `nil` return
- Uses `WaitStarted()` for deterministic sync
- Covers the `b.running` early-return idempotency path
- Coverage: `Listen` 88.6% → **94.3%**

## Verification
- `go test -race -count=10 ./internal/domain/events/...` — **PASS**
- No regressions in existing event bus tests
- Overall package coverage: 96.1% → **98.5%**