### PR TITLE
fix: replace filepath.Rel with strings.HasPrefix in isInSearchPath

### DIFF
--- a/internal/tools/analysis/index_search.go
+++ b/internal/tools/analysis/index_search.go
@@ -98,11 +98,12 @@ func (idx *indexer) isInSearchPath(targetPath, filePath string) bool {
 	if targetPath == filePath {
 		return true
 	}
-	rel, err := filepath.Rel(targetPath, filePath)
-	if err != nil {
-		return false
+	if strings.HasPrefix(filePath, targetPath) {
+		if len(filePath) > len(targetPath) && filePath[len(targetPath)] == filepath.Separator {
+			return true
+		}
 	}
-	return !strings.HasPrefix(rel, "..")
+	return false
 }
 
 func (idx *indexer) matchesQuery(sym symbolLocation, query string, exportedOnly bool) bool {

--- a/internal/tools/analysis/index_search.go
+++ b/internal/tools/analysis/index_search.go
@@ -99,6 +99,13 @@ func (idx *indexer) isInSearchPath(targetPath, filePath string) bool {
 		return true
 	}
 	if strings.HasPrefix(filePath, targetPath) {
+		// If targetPath is a root directory (e.g., "/" or "C:\"),
+		// it already ends in a separator.
+		if targetPath[len(targetPath)-1] == filepath.Separator {
+			return true
+		}
+		// Otherwise, require a separator at the boundary to prevent
+		// partial matches (e.g., /foo matching /foobar).
 		if len(filePath) > len(targetPath) && filePath[len(targetPath)] == filepath.Separator {
 			return true
 		}
@@ -135,15 +142,8 @@ func (idx *indexer) GetUsages(ctx context.Context, symbol string, path string, h
 	}
 
 	for _, loc := range usages {
-		// Optimized path check instead of filepath.Rel
-		if loc.Path == searchPath {
+		if idx.isInSearchPath(searchPath, loc.Path) {
 			results = append(results, loc)
-			continue
-		}
-		if strings.HasPrefix(loc.Path, searchPath) {
-			if len(loc.Path) > len(searchPath) && loc.Path[len(searchPath)] == filepath.Separator {
-				results = append(results, loc)
-			}
 		}
 	}
 

--- a/internal/tools/analysis/index_search.go
+++ b/internal/tools/analysis/index_search.go
@@ -99,6 +99,10 @@ func (idx *indexer) isInSearchPath(targetPath, filePath string) bool {
 		return true
 	}
 	if strings.HasPrefix(filePath, targetPath) {
+		// Empty target matches everything (filepath.Rel semantics).
+		if len(targetPath) == 0 {
+			return true
+		}
 		// If targetPath is a root directory (e.g., "/" or "C:\"),
 		// it already ends in a separator.
 		if targetPath[len(targetPath)-1] == filepath.Separator {

--- a/internal/tools/analysis/index_search_test.go
+++ b/internal/tools/analysis/index_search_test.go
@@ -1,0 +1,42 @@
+package analysis
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestIsInSearchPath(t *testing.T) {
+	t.Parallel()
+
+	idx := &indexer{} // isInSearchPath is a pure function, no fields needed
+
+	winRoot := filepath.FromSlash("C:/")
+	winChild := filepath.FromSlash("C:/a")
+	winFile := filepath.FromSlash("C:/a/b.go")
+	winSibling := filepath.FromSlash("C:/foobar.go")
+
+	tests := []struct {
+		name         string
+		target, file string
+		want         bool
+	}{
+		{"exact match", "/a/b.go", "/a/b.go", true},
+		{"child in subdirectory", "/a", "/a/b.go", true},
+		{"sibling prefix rejected", "/foo", "/foobar.go", false},
+		{"root directory", "/", "/a/b.go", true},
+		{"empty target matches all", "", "/a/b.go", true},
+		{"unrelated path", "/x", "/y/b.go", false},
+		{"Win root", winRoot, winFile, true},
+		{"Win child", winChild, winFile, true},
+		{"Win sibling rejected", winChild, winSibling, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := idx.isInSearchPath(tt.target, tt.file)
+			if got != tt.want {
+				t.Errorf("isInSearchPath(%q, %q) = %v; want %v", tt.target, tt.file, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`TestIndexer_Scaling` fails on CI: `SearchSymbols took 126ms` (threshold: 100ms). Passes locally at ~4ms.

## Root Cause

`SearchSymbols.isInSearchPath` used `filepath.Rel` for every file path in the in-memory index, but `GetUsages` in the same file already uses an optimized `strings.HasPrefix` approach for the identical sub-path containment check. `filepath.Rel` is **116× slower** (calls `filepath.Clean` twice, allocates).

On CI, this combines with `filepath.Abs(".")` at the top of `SearchSymbols` (which calls `os.Getwd()` — slow on network-mounted CI filesystems) to push total time over the 100ms threshold.

## Fix

Replaced `isInSearchPath` body with the same `strings.HasPrefix` + separator guard pattern already used by `GetUsages`. The `symbolsByPath` keys are absolute paths (set by `harvester.toLocation` via `filepath.Abs` in `processFile`), so the prefix check is semantically equivalent.

**Before:** `SearchSymbols took 126ms` (failing)
**After:** `SearchSymbols took 78µs` (passing)

Closes #295