### PR TITLE
fix(auth): add nil guard in getTokenFromGcloud and swap test sites to BearerAuth

### DIFF
--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -53,6 +53,9 @@ func NewVertexAuth() *VertexAuth {
 }
 
 func (a *VertexAuth) getTokenFromGcloud() ([]byte, error) {
+	if a.tokenCmdFunc == nil {
+		return nil, fmt.Errorf("tokenCmdFunc not wired; use NewVertexAuth() to construct VertexAuth")
+	}
 	return a.tokenCmdFunc()
 }
 

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -598,3 +598,23 @@ func TestNewVertexAuth_DefaultTokenCmdFunc(t *testing.T) {
 		t.Fatal("NewVertexAuth must wire a default tokenCmdFunc")
 	}
 }
+
+// TestVertexAuth_NilTokenCmdFunc_ReturnsError verifies that calling getToken()
+// on a bare &VertexAuth{} without a wired tokenCmdFunc returns a descriptive error
+// instead of panicking. This guards against future test code that constructs
+// VertexAuth without using NewVertexAuth() or presetting Token.
+func TestVertexAuth_NilTokenCmdFunc_ReturnsError(t *testing.T) {
+	auth := &VertexAuth{
+		CacheDir: t.TempDir(), // isolate from any stale cached token on disk
+	}
+	// No Token set, no tokenCmdFunc wired — should hit the nil guard
+
+	_, err := auth.getToken(context.Background())
+
+	if err == nil {
+		t.Fatal("expected error for nil tokenCmdFunc, got nil")
+	}
+	if !strings.Contains(err.Error(), "NewVertexAuth") {
+		t.Errorf("error should mention NewVertexAuth, got: %v", err)
+	}
+}

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -141,7 +141,7 @@ func runSendChatTest(t *testing.T, tt sendChatTestCase) {
 	t.Cleanup(server.Close)
 
 	apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-	authenticator := &auth.VertexAuth{Token: "test-token"}
+	authenticator := &auth.BearerAuth{Token: "test-token"}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
 	client, err := NewClient(
@@ -193,7 +193,7 @@ func TestRefreshAuth(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-	authenticator := &auth.VertexAuth{Token: "test-token"}
+	authenticator := &auth.BearerAuth{Token: "test-token"}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
 	client, _ := NewClient(apiURL, "test-model", authenticator, WithEventBus(bus), WithTimeout(5*time.Second))
@@ -262,7 +262,7 @@ func runGenerateImagesTest(t *testing.T, tt generateImagesTestCase) {
 	apiURL := "http://localhost/v1" // Trigger GeminiAPI backend with v1
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
-	client, err := NewClient(apiURL, "test-model", &auth.VertexAuth{Token: "test"}, WithEventBus(bus), WithTimeout(5*time.Second))
+	client, err := NewClient(apiURL, "test-model", &auth.BearerAuth{Token: "test"}, WithEventBus(bus), WithTimeout(5*time.Second))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -664,7 +664,7 @@ func TestGemini_EdgeCase_DetermineBackend_MockURL(t *testing.T) {
 }
 
 func TestGemini_ModelQualification(t *testing.T) {
-	authenticator := &auth.VertexAuth{Token: "test-token"}
+	authenticator := &auth.BearerAuth{Token: "test-token"}
 
 	t.Run("Qualify short model name", func(t *testing.T) {
 		apiURL := "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/us-central1/publishers/deepseek-ai/models"

--- a/internal/infrastructure/llm/gemini/truncation_test.go
+++ b/internal/infrastructure/llm/gemini/truncation_test.go
@@ -69,7 +69,7 @@ func (s *truncationTestSetup) build(t *testing.T) *Client {
 	t.Cleanup(server.Close)
 
 	apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-	authenticator := &auth.VertexAuth{Token: "test-token"}
+	authenticator := &auth.BearerAuth{Token: "test-token"}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
 
@@ -107,7 +107,7 @@ func TestGemini_DefaultMaxOutputTokens_IsGenerous(t *testing.T) {
 	t.Parallel()
 
 	apiURL := "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-	c, err := NewClient(apiURL, "gemini-1.5-flash", &auth.VertexAuth{Token: "t"})
+	c, err := NewClient(apiURL, "gemini-1.5-flash", &auth.BearerAuth{Token: "t"})
 	if err != nil {
 		t.Fatalf("NewClient failed: %v", err)
 	}
@@ -133,7 +133,7 @@ func TestGemini_WithMaxOutputTokens_Override(t *testing.T) {
 	const override = 32000
 	apiURL := "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
 	c, err := NewClient(apiURL, "gemini-1.5-flash",
-		&auth.VertexAuth{Token: "t"},
+		&auth.BearerAuth{Token: "t"},
 		WithMaxOutputTokens(override),
 	)
 	if err != nil {
@@ -160,7 +160,7 @@ func TestGemini_WithMaxOutputTokens_ZeroFallsBackToDefault(t *testing.T) {
 
 	apiURL := "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
 	c, err := NewClient(apiURL, "gemini-1.5-flash",
-		&auth.VertexAuth{Token: "t"},
+		&auth.BearerAuth{Token: "t"},
 		WithMaxOutputTokens(0),
 	)
 	if err != nil {

--- a/internal/infrastructure/llm/search_test.go
+++ b/internal/infrastructure/llm/search_test.go
@@ -85,7 +85,7 @@ func TestSearchToolSelection(t *testing.T) {
 
 			bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 			eventstest.CleanupBus(t, bus)
-			client, err := gemini.NewClient(tt.apiURL, "model", &auth.VertexAuth{Token: "test"}, gemini.WithSearch(true), gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+			client, err := gemini.NewClient(tt.apiURL, "model", &auth.BearerAuth{Token: "test"}, gemini.WithSearch(true), gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 			if err != nil {
 				t.Fatalf("failed to create client: %v", err)
 			}

--- a/tests/integration/agent/session/auto_summarize_test.go
+++ b/tests/integration/agent/session/auto_summarize_test.go
@@ -58,7 +58,7 @@ func TestContextManager_AutoSummarizeTrigger(t *testing.T) {
 	defer server.Close()
 
 	apiURL := server.URL + "/v1/projects/p/locations/l/publishers/google/models/aiplatform.googleapis.com"
-	client, err := gemini.NewClient(apiURL, "test-model", &auth.VertexAuth{Token: "test"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+	client, err := gemini.NewClient(apiURL, "test-model", &auth.BearerAuth{Token: "test"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}
@@ -174,7 +174,7 @@ func setupAutoSummarizeTest(t *testing.T) (ports.HistoryManager, *sessctx.Manage
 	}))
 
 	apiURL := server.URL + "/v1/projects/p/locations/l/publishers/google/models/aiplatform.googleapis.com"
-	client, _ := gemini.NewClient(apiURL, "test", &auth.VertexAuth{Token: "t"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+	client, _ := gemini.NewClient(apiURL, "test", &auth.BearerAuth{Token: "t"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 
 	strategy := sessctx.NewStrategy(sessctx.NewHeuristicTokenCounter(reg))
 	gw := llm.NewResilientClient(client)
@@ -236,7 +236,7 @@ func TestContextManager_AutoSummarizeWithSystemInstructions(t *testing.T) {
 
 	apiURL := server.URL + "/v1/projects/p/locations/l/publishers/google/models/aiplatform.googleapis.com"
 	// Set initial system instructions
-	client, _ := gemini.NewClient(apiURL, "test", &auth.VertexAuth{Token: "t"}, gemini.WithSystemInstruction("Initial System Instruction"), gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+	client, _ := gemini.NewClient(apiURL, "test", &auth.BearerAuth{Token: "t"}, gemini.WithSystemInstruction("Initial System Instruction"), gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 
 	strategy := sessctx.NewStrategy(sessctx.NewHeuristicTokenCounter(reg))
 	gw := llm.NewResilientClient(client)
@@ -323,7 +323,7 @@ func TestToolInjectedTokenBudgetPressure(t *testing.T) {
 	defer server.Close()
 
 	apiURL := server.URL + "/v1/projects/p/locations/l/publishers/google/models/aiplatform.googleapis.com"
-	client, _ := gemini.NewClient(apiURL, "test", &auth.VertexAuth{Token: "t"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+	client, _ := gemini.NewClient(apiURL, "test", &auth.BearerAuth{Token: "t"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 
 	strategy := sessctx.NewStrategy(sessctx.NewHeuristicTokenCounter(reg))
 	gw := llm.NewResilientClient(client)

--- a/tests/integration/agent/session/summarize_test.go
+++ b/tests/integration/agent/session/summarize_test.go
@@ -154,7 +154,7 @@ func setupTestClient(t *testing.T, url string) *gemini.Client {
 	apiURL := url + "/v1/projects/p/locations/l/publishers/google/models/aiplatform.googleapis.com"
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
-	client, err := gemini.NewClient(apiURL, "test-model", &auth.VertexAuth{Token: "test"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
+	client, err := gemini.NewClient(apiURL, "test-model", &auth.BearerAuth{Token: "test"}, gemini.WithEventBus(bus), gemini.WithTimeout(5*time.Second))
 	if err != nil {
 		t.Fatalf("failed to create client: %v", err)
 	}


### PR DESCRIPTION
## Summary

Defense-in-depth fix for **[#298](https://github.com/gosharplite/tell-me-go/issues/298) — Migrate bare `&auth.VertexAuth{}` test literals**.

### What changed

**Layer 1 — Nil guard (P0):** `getTokenFromGcloud()` now returns a descriptive `fmt.Errorf` when `tokenCmdFunc` is nil instead of nil-deref panicking. This protects all future code regardless of call site.

**Layer 2 — Test decoupling (P1):** 13 bare `&auth.VertexAuth{Token: "..."}` struct literals across 5 test files replaced with `&auth.BearerAuth{Token: "..."}`. The LLM-client tests only need a static-token `Authenticator`; they never exercise `VertexAuth`'s gcloud/cache/refresh machinery. Switching to the lighter `BearerAuth` (no mutex, no disk cache, no `exec.Command`, no `tokenCmdFunc`) decouples these tests from the auth subsystem entirely and makes the nil-`tokenCmdFunc` failure mode unreachable from this call path.

**Layer 3 — Nil guard test:** `TestVertexAuth_NilTokenCmdFunc_ReturnsError` verifies the guard with `t.TempDir()` isolation to prevent stale-cache false-passes.

### Why BearerAuth over the issue's proposed NewVertexAuth() approach

`VertexAuth.Apply()` and `BearerAuth.Apply()` produce identical output:
```go
req.Headers["Authorization"] = "Bearer " + token
```

All 13 tests only need a static Bearer token injected into headers. Using `BearerAuth` eliminates the failure mode at the architectural level rather than just guarding against it — there is no `tokenCmdFunc` to forget to wire.

### Files changed (7 + 0 skipped)

| File | Change |
|------|--------|
| `internal/infrastructure/auth/auth.go` | +3 lines nil guard |
| `internal/infrastructure/auth/auth_test.go` | +20 lines new test |
| `internal/infrastructure/llm/gemini/gemini_test.go` | 4 sites: `VertexAuth` → `BearerAuth` |
| `internal/infrastructure/llm/gemini/truncation_test.go` | 4 sites: `VertexAuth` → `BearerAuth` |
| `internal/infrastructure/llm/search_test.go` | 1 site: `VertexAuth` → `BearerAuth` |
| `tests/integration/agent/session/auto_summarize_test.go` | 4 sites: `VertexAuth` → `BearerAuth` |
| `tests/integration/agent/session/summarize_test.go` | 1 site: `VertexAuth` → `BearerAuth` |
| `internal/infrastructure/llm/resilient_client_test.go` | **Skipped** — `reflect.TypeOf` type assertion |

### Verification

- `go build ./...` ✅
- `go test -race -count=1 ./internal/infrastructure/auth/...` ✅
- `go test -race -count=1 ./internal/infrastructure/llm/...` ✅ (5 packages)
- `go test -race -count=1 ./tests/integration/agent/session/...` ✅
- Zero bare `&auth.VertexAuth{` remain outside the exempted `reflect.TypeOf` ✅

Closes #298
