### PR TITLE
refactor(auth): remove getToken from Authenticator interface (ADR-033)

### DIFF
--- a/docs/adr/2026-05-narrow-authenticator-interface.md
+++ b/docs/adr/2026-05-narrow-authenticator-interface.md
@@ -1,6 +1,6 @@
 # ADR-033: Narrow the `auth.Authenticator` Interface (Remove `getToken`)
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-05-10
 - **Deciders:** @thptcnec (Architect)
 

--- a/docs/adr/2026-05-narrow-authenticator-interface.md
+++ b/docs/adr/2026-05-narrow-authenticator-interface.md
@@ -1,0 +1,60 @@
+# ADR-033: Narrow the `auth.Authenticator` Interface (Remove `getToken`)
+
+- **Status:** Proposed
+- **Date:** 2026-05-10
+- **Deciders:** @thptcnec (Architect)
+
+## Context
+
+The `auth.Authenticator` interface in `internal/infrastructure/auth/auth.go` contains an unexported method:
+
+```go
+type Authenticator interface {
+    getToken(ctx context.Context) (string, error)  // unexported
+    Invalidate()
+    Apply(ctx context.Context, req *Request) error
+}
+```
+
+Because `getToken` is unexported, **no package outside `auth` can implement `Authenticator`**. This seals consumer packages (gemini, openai, anthropic, llm) out of their own abstraction, forcing them to depend on `auth`'s concrete types (`BearerAuth`, `APIKeyAuth`, etc.) — the root cause of the test-literal coupling identified in issues #298 and #299.
+
+AST-based analysis (`find_usages`) confirms that `getToken` has **zero cross-package callers**: all 22 references are confined to `auth.go` (internal `Apply` dispatch) and `auth_test.go` (same-package tests). `Apply()` is the only method any consumer ever invokes.
+
+Two paths were evaluated:
+
+### Option A — Export `getToken` as `GetToken`
+
+- Rename `getToken` → `GetToken` on the interface and all 6 implementations.
+- **Rejected because:** forces every implementation to expose token retrieval as a public API, even though `Apply()` is the only behavior consumers need. Creates 6 new public methods to maintain, and introduces a security concern (consumers could bypass `Apply`'s header-injection logic to leak tokens).
+
+### Option B — Remove `getToken` from the interface
+
+- Interface shrinks to:
+  ```go
+  type Authenticator interface {
+      Invalidate()
+      Apply(ctx context.Context, req *Request) error
+  }
+  ```
+- `getToken` remains a private method on each concrete type — no behavior change.
+- All 6 concrete types (`VertexAuth`, `APIKeyAuth`, `BearerAuth`, `AnthropicAuth`, `ServiceAccountAuth`, `noOpAuth`) are unaffected: their `Apply()` methods call their own `getToken` via receiver-bound dispatch, not via the interface vtable.
+
+## Decision
+
+**Option B: Remove `getToken` from the `Authenticator` interface.**
+
+The `getToken` method is an internal helper of each concrete type's `Apply()` method. It has no business on the public contract. The narrowed interface honors the Interface Segregation Principle — consumers see only the two methods they actually use (`Apply`, `Invalidate`).
+
+## Consequences
+
+### Positive
+- Third-party auth schemes (corporate SSO, mTLS bridge, etc.) can now live in their own packages by implementing the `Authenticator` interface — no dependency on `auth`'s concrete types.
+- Consumer packages (gemini, openai, anthropic, llm) can define local test doubles for `Authenticator` without importing `auth.BearerAuth` or any other concrete type.
+- Interface surface area shrinks from 3 methods to 2 — both consumed.
+- Zero behavior change: `getToken` remains private on all 6 concrete types.
+
+### Negative
+- Minimal. The interface contract becomes slightly less self-documenting — one must read a concrete type to understand that `Apply` internally uses a token-fetching helper. Mitigated by the fact that `Apply`'s behavior (inject credentials into request headers) is obvious from its signature and doc comment.
+
+### Neutral
+- The `errorAuthenticator` in `provider_health_test.go` (which already implements only `Invalidate` + `Apply`) requires no change.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,6 +34,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-030** | Release Branch Synchronization Policy | 2026-05 | Accepted | [2026-05-release-branch-synchronization-policy.md](2026-05-release-branch-synchronization-policy.md) |
 | **ADR-031** | Caller Cancellation Priority in Dual-Context Enqueue | 2026-05 | Accepted | [2026-05-caller-cancellation-priority.md](2026-05-caller-cancellation-priority.md) |
 | **ADR-032** | Test-Hook Policy for Unexported Concrete Types | 2026-05 | Accepted | [2026-05-test-hook-policy.md](2026-05-test-hook-policy.md) |
+| **ADR-033** | Narrow the `auth.Authenticator` Interface (Remove `getToken`) | 2026-05 | Proposed | [2026-05-narrow-authenticator-interface.md](2026-05-narrow-authenticator-interface.md) |
 
 ## How to Create a New ADR
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,7 +34,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-030** | Release Branch Synchronization Policy | 2026-05 | Accepted | [2026-05-release-branch-synchronization-policy.md](2026-05-release-branch-synchronization-policy.md) |
 | **ADR-031** | Caller Cancellation Priority in Dual-Context Enqueue | 2026-05 | Accepted | [2026-05-caller-cancellation-priority.md](2026-05-caller-cancellation-priority.md) |
 | **ADR-032** | Test-Hook Policy for Unexported Concrete Types | 2026-05 | Accepted | [2026-05-test-hook-policy.md](2026-05-test-hook-policy.md) |
-| **ADR-033** | Narrow the `auth.Authenticator` Interface (Remove `getToken`) | 2026-05 | Proposed | [2026-05-narrow-authenticator-interface.md](2026-05-narrow-authenticator-interface.md) |
+| **ADR-033** | Narrow the `auth.Authenticator` Interface (Remove `getToken`) | 2026-05 | Accepted | [2026-05-narrow-authenticator-interface.md](2026-05-narrow-authenticator-interface.md) |
 
 ## How to Create a New ADR
 

--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -22,7 +22,6 @@ import (
 
 // Authenticator defines the interface for injecting credentials into API requests.
 type Authenticator interface {
-	getToken(ctx context.Context) (string, error)
 	Invalidate()
 	Apply(ctx context.Context, req *Request) error
 }

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -24,6 +24,22 @@ import (
 	"google.golang.org/genai"
 )
 
+// stubAuthenticator is a local test double for auth.Authenticator.
+// It proves that consumer packages can now implement the interface
+// without importing any auth concrete type (ADR-033).
+type stubAuthenticator struct {
+	token string
+}
+
+func (s *stubAuthenticator) Invalidate() {}
+
+func (s *stubAuthenticator) Apply(_ context.Context, req *auth.Request) error {
+	if s.token != "" {
+		req.Headers["Authorization"] = "Bearer " + s.token
+	}
+	return nil
+}
+
 func validateAuthOnly(t *testing.T, r *http.Request) {
 	if r.Header.Get("Authorization") != "Bearer test-token" {
 		t.Errorf("expected bearer token, got '%s'", r.Header.Get("Authorization"))
@@ -766,6 +782,24 @@ func TestGemini_ResetConnections_ThreadSafety(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestNewClient_WithLocalStubAuthenticator verifies that a consumer-defined
+// test double (not importing any auth concrete type) satisfies
+// auth.Authenticator and correctly injects credentials.
+func TestNewClient_WithLocalStubAuthenticator(t *testing.T) {
+	stub := &stubAuthenticator{token: "local-stub-token"}
+
+	client, err := NewClient("https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models", "gemini-2.0-flash", stub, WithTimeout(30*time.Second))
+	if err != nil {
+		t.Fatalf("NewClient with local stub authenticator: %v", err)
+	}
+	if client == nil {
+		t.Fatal("expected non-nil client")
+	}
+	if client.authenticator != stub {
+		t.Fatal("client did not retain the stub authenticator")
+	}
 }
 
 func TestNewClient_Options(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #300.

Removes the unexported `getToken` method from the `auth.Authenticator` interface, following **Option B** from [ADR-033](docs/adr/2026-05-narrow-authenticator-interface.md).

## Problem

The `Authenticator` interface contained an unexported `getToken` method, sealing consumer packages (gemini, openai, anthropic) out of the interface contract. This forced all ~80 test sites to depend on `auth` concrete types (`BearerAuth`, `AnthropicAuth`, etc.) — the root cause of #298.

AST analysis confirms `getToken` has **zero cross-package callers**. `Apply()` is the only method any consumer invokes.

## Change

- **1 line removed** from `auth.Authenticator` interface declaration
- All 6 concrete types retain their private `getToken` methods — zero behavior change
- `gemini_test.go` demonstrates a local `stubAuthenticator` test double that satisfies the interface without importing any `auth.*Auth` concrete type

## Verification

| Check | Result |
|---|---|
| `go vet ./...` | ✅ Clean |
| `go test -race -count=1 ./...` | ✅ 61/61 PASS |
| `golangci-lint run` | ✅ Clean |
| `make check-full` | ✅ All gates green |
| `govulncheck` | ✅ 0 vulns |
| Coverage | `auth` 97.9%, `gemini` 93.2% |

## Files Changed

| File | Delta |
|---|---|
| `internal/infrastructure/auth/auth.go` | −1 line |
| `internal/infrastructure/llm/gemini/gemini_test.go` | +34 lines |
| `docs/adr/2026-05-narrow-authenticator-interface.md` | +60 lines (new) |
| `docs/adr/README.md` | +1 line |