### PR TITLE
[ENHANCEMENT] Add in-process golden-path E2E test: Config → Chat → Shutdown

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -28,6 +28,21 @@ var binPath string
 var projectRoot string
 
 func TestMain(m *testing.M) {
+	// testing.Short() panics in TestMain if flag.Parse() hasn't run yet.
+	// Check os.Args directly to decide whether to skip the binary build.
+	shortMode := false
+	for _, a := range os.Args {
+		if a == "-test.short" || a == "-test.short=true" {
+			shortMode = true
+			break
+		}
+	}
+	if shortMode {
+		// In-process tests don't need the compiled binary.
+		code := m.Run()
+		os.Exit(code)
+	}
+
 	// Build the binary once for all E2E tests
 	tempDir, err := os.MkdirTemp("", "tell-me-go-e2e")
 	if err != nil {

--- a/tests/e2e/golden_path_test.go
+++ b/tests/e2e/golden_path_test.go
@@ -47,10 +47,11 @@ func (m *goldenPathMockClient) RefreshAuth() error { return nil }
 func TestGoldenPath_ConfigToShutdown(t *testing.T) {
 	// Step 1 — Setup
 	homeDir := t.TempDir()
-	sm := security.NewSecurityManager(nil)
+	sm := security.NewSecurityManager(security.NoOpInteractor)
 	defer sm.Close()
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
+	// Step 2 — Create bootstrapper with mock LLM client
 	bootstrapper := di.NewBootstrapper(homeDir, sm, "test-version", io.Discard, io.Discard, logger, nil,
 		func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 			return &goldenPathMockClient{}, nil

--- a/tests/e2e/golden_path_test.go
+++ b/tests/e2e/golden_path_test.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/di"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
+)
+
+// goldenPathMockClient is a minimal ExtendedClient that returns a simple
+// text response with no tool calls — the golden path.
+type goldenPathMockClient struct{}
+
+func (m *goldenPathMockClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return &llm.Content{
+		Role:  "model",
+		Parts: []*llm.Part{{Text: "Hello from golden-path mock!"}},
+	}, &llm.Metrics{PromptTokens: 5, ResponseTokens: 3}, nil
+}
+
+func (m *goldenPathMockClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return m.SendChat(ctx, input, tools, resolver)
+}
+
+func (m *goldenPathMockClient) GenerateImages(ctx context.Context, model, prompt, mimeType string) ([][]byte, error) {
+	return nil, nil
+}
+
+func (m *goldenPathMockClient) RefreshAuth() error { return nil }
+
+// TestGoldenPath_ConfigToShutdown exercises the full vertical:
+// DI bootstrap → agent init → chat → graceful shutdown.
+// It runs in-process under -short and -race.
+func TestGoldenPath_ConfigToShutdown(t *testing.T) {
+	// Step 1 — Setup
+	homeDir := t.TempDir()
+	sm := security.NewSecurityManager(nil)
+	defer sm.Close()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	bootstrapper := di.NewBootstrapper(homeDir, sm, "test-version", io.Discard, io.Discard, logger, nil,
+		func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+			return &goldenPathMockClient{}, nil
+		},
+	)
+
+	// Step 3 — Build session dependencies
+	cfg := &config.Config{
+		Mode:  "assistant",
+		Model: "test-model",
+		Models: map[string]config.ModelConfig{
+			"test-model": {Pricing: pricing.ModelPricing{Comp: 0.01}},
+		},
+	}
+
+	ctx := context.Background()
+	deps, hManager, cleanup, err := bootstrapper.BuildSessionDependencies(ctx, cfg, "", false, nil)
+	if err != nil {
+		t.Fatalf("BuildSessionDependencies failed: %v", err)
+	}
+	defer func() { _ = cleanup(ctx) }()
+
+	// Step 4 — Create agent via factory
+	factory := bootstrapper.GetAgentFactory()
+	chatter, err := factory(ctx, deps, ports.ChatterConfig{
+		ProviderName: "test-provider",
+		Model:        "test-model",
+		Mode:         "assistant",
+	})
+	if err != nil {
+		t.Fatalf("AgentFactory failed: %v", err)
+	}
+
+	// Step 5 — Execute Chat (golden path)
+	sess := ports.NewSession("golden-path", hManager)
+	if err := chatter.Chat(ctx, sess, "Hello, golden path!"); err != nil {
+		t.Fatalf("Chat failed: %v", err)
+	}
+
+	// Step 6 — Assert 2 messages in history (user + model)
+	contents, histErr := hManager.GetWindow(ctx, 0, -1)
+	if histErr != nil {
+		t.Fatalf("GetWindow failed: %v", histErr)
+	}
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 messages in history (user + model), got %d", len(contents))
+	}
+	if len(contents[1].Parts) == 0 || contents[1].Parts[0].Text != "Hello from golden-path mock!" {
+		t.Errorf("unexpected model response: %+v", contents[1])
+	}
+
+	// Step 7 — Graceful shutdown
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := chatter.Shutdown(shutdownCtx); err != nil {
+		t.Fatalf("Shutdown failed: %v", err)
+	}
+}

--- a/tests/e2e/pipe_redirection_test.go
+++ b/tests/e2e/pipe_redirection_test.go
@@ -16,6 +16,9 @@ import (
 
 func TestPipeCommandsTool(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
 	// 1. Setup Mock Server
 
 	echoCmd := "echo"
@@ -81,6 +84,9 @@ func TestPipeCommandsTool(t *testing.T) {
 
 func TestExecuteCommandWithRedirection(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
 	// 1. Setup Mock Server
 
 	echoCmd := "echo"
@@ -147,6 +153,9 @@ func TestExecuteCommandWithRedirection(t *testing.T) {
 
 func TestPipeCommandsWithRedirectionAndAppend(t *testing.T) {
 	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
 	homeDir := t.TempDir()
 	outFile := filepath.Join(homeDir, "piped_out.txt")
 


### PR DESCRIPTION
## Scope

Closes #305 — adds a single in-process E2E test that exercises the full vertical: **DI bootstrap → agent init → chat → graceful shutdown**.

## Changes

| File | Change |
|------|--------|
| `tests/e2e/e2e_test.go` | Gate `TestMain` binary build behind `!testing.Short()` via `os.Args` check |
| `tests/e2e/golden_path_test.go` | **New** — `TestGoldenPath_ConfigToShutdown` (in-process, runs under `-short`) |
| `tests/e2e/pipe_redirection_test.go` | Add `testing.Short()` skip guards to 3 tests |

## Test Plan

The golden-path test uses:
- `Bootstrapper.BuildSessionDependencies()` for DI wiring
- A mock `ExtendedClient` returning a simple text response (no tool calls)
- Asserts: no error from `Chat()`, 2 messages in history, clean `Shutdown()`

### Verification

```
go test -short -race -count=1 ./tests/e2e/... → PASS (1.2s)
```

## Out of Scope

- Tool execution pipeline (covered by `TestMultiTurnToolOrchestration`)
- Session persistence round-trip
- CLI flag parsing / stdin piping