### PR TITLE
test(gemini): add error-path coverage for initSDK (#324)

### DIFF
--- a/internal/infrastructure/llm/gemini/backend.go
+++ b/internal/infrastructure/llm/gemini/backend.go
@@ -58,7 +58,12 @@ func (c *Client) initSDK(timeout time.Duration) error {
 		HTTPClient: httpClient,
 	}
 
-	sdkClient, err := genai.NewClient(ctx, clientConfig)
+	newClient := c.newGenaiClient
+	if newClient == nil {
+		newClient = genai.NewClient
+	}
+
+	sdkClient, err := newClient(ctx, clientConfig)
 	if err != nil {
 		return fmt.Errorf("failed to create genai client: %w", err)
 	}

--- a/internal/infrastructure/llm/gemini/backend_test.go
+++ b/internal/infrastructure/llm/gemini/backend_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package gemini
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+	"google.golang.org/genai"
+)
+
+// failingAuthenticator is a test double that always fails Apply.
+type failingAuthenticator struct {
+	err error
+}
+
+func (f *failingAuthenticator) Invalidate() {}
+
+func (f *failingAuthenticator) Apply(_ context.Context, _ *auth.Request) error {
+	return f.err
+}
+
+func TestInitSDK_PrepareAuthHeaderError(t *testing.T) {
+	sentinel := errors.New("stub auth failure")
+
+	c := &Client{
+		apiURL:        "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models",
+		model:         "test-model",
+		authenticator: &failingAuthenticator{err: sentinel},
+		headers:       nil,
+	}
+
+	err := c.initSDK(30 * time.Second)
+
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to prepare auth headers") {
+		t.Errorf("expected error to contain %q, got %q", "failed to prepare auth headers", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), sentinel.Error()) {
+		t.Errorf("expected error to contain %q, got %q", sentinel.Error(), err.Error())
+	}
+}
+
+func TestInitSDK_GenaiNewClientError(t *testing.T) {
+	sentinel := errors.New("sdk init explosion")
+
+	c := &Client{
+		apiURL:        "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models",
+		model:         "test-model",
+		authenticator: &failingAuthenticator{err: nil}, // succeeds: nil error
+		headers:       nil,
+		newGenaiClient: func(ctx context.Context, cfg *genai.ClientConfig) (*genai.Client, error) {
+			return nil, sentinel
+		},
+	}
+
+	err := c.initSDK(30 * time.Second)
+
+	if err == nil {
+		t.Fatal("expected non-nil error, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to create genai client") {
+		t.Errorf("expected error to contain %q, got %q", "failed to create genai client", err.Error())
+	}
+
+	if !strings.Contains(err.Error(), sentinel.Error()) {
+		t.Errorf("expected error to contain %q, got %q", sentinel.Error(), err.Error())
+	}
+}

--- a/internal/infrastructure/llm/gemini/backend_test.go
+++ b/internal/infrastructure/llm/gemini/backend_test.go
@@ -45,8 +45,8 @@ func TestInitSDK_PrepareAuthHeaderError(t *testing.T) {
 		t.Errorf("expected error to contain %q, got %q", "failed to prepare auth headers", err.Error())
 	}
 
-	if !strings.Contains(err.Error(), sentinel.Error()) {
-		t.Errorf("expected error to contain %q, got %q", sentinel.Error(), err.Error())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected error to wrap sentinel %q, got %v", sentinel.Error(), err)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestInitSDK_GenaiNewClientError(t *testing.T) {
 		t.Errorf("expected error to contain %q, got %q", "failed to create genai client", err.Error())
 	}
 
-	if !strings.Contains(err.Error(), sentinel.Error()) {
-		t.Errorf("expected error to contain %q, got %q", sentinel.Error(), err.Error())
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected error to wrap sentinel %q, got %v", sentinel.Error(), err)
 	}
 }

--- a/internal/infrastructure/llm/gemini/gemini.go
+++ b/internal/infrastructure/llm/gemini/gemini.go
@@ -22,6 +22,7 @@ import (
 type Client struct {
 	mu                sync.RWMutex
 	sdkClient         *genai.Client
+	newGenaiClient    func(context.Context, *genai.ClientConfig) (*genai.Client, error)
 	authenticator     auth.Authenticator
 	apiURL            string
 	model             string


### PR DESCRIPTION
## Summary

Closes #324 — adds test coverage for 2 previously untested error-handling branches in `initSDK`.

## Changes

### New file: `backend_test.go`
- **`failingAuthenticator`** — reusable test double implementing `auth.Authenticator`
- **`TestInitSDK_PrepareAuthHeaderError`** — asserts `"failed to prepare auth headers"` wrapping
- **`TestInitSDK_GenaiNewClientError`** — asserts `"failed to create genai client"` wrapping

### Modified: `gemini.go`
- Added unexported `newGenaiClient` function field to `Client` struct as an architectural seam

### Modified: `backend.go`
- Replaced direct `genai.NewClient` call with nil-coalescing fallback using the new field

## Coverage Impact

| Function | Before | After |
|----------|--------|-------|
| `initSDK` | 93.1% | **96.9%** |
| Package total | 93.2% | **93.5%** |

Residual 3.1% gap is the unreachable `else` branch of `http.DefaultTransport.(*http.Transport)` — a defensive guard, not a target of this PR.

## Verification

- ✅ `go test ./...` — all 57 packages PASS
- ✅ `go vet ./internal/infrastructure/llm/gemini/...` — 0 issues
- ✅ Both error wrapping prefixes asserted