### PR TITLE
refactor(anthropic): split client_test.go and extract assertion helpers

### DIFF
--- a/internal/infrastructure/llm/anthropic/client_messages_test.go
+++ b/internal/infrastructure/llm/anthropic/client_messages_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+func TestExtendedThinking(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := messagesResponse{
+			Content: []contentBlock{
+				{
+					Type:     "thinking",
+					Thinking: "Logic trace...",
+				},
+				{
+					Type: "text",
+					Text: "The answer is 42",
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "claude-3-7-sonnet", &auth.AnthropicAuth{APIKey: "key"})
+	resp, _, _ := client.SendChat(context.Background(), nil, nil, nil)
+
+	var thought, text string
+	for _, p := range resp.Parts {
+		if p.IsThought {
+			thought += p.Text
+		} else if p.Text != "" {
+			text += p.Text
+		}
+	}
+
+	if thought != "Logic trace..." {
+		t.Errorf("expected thought 'Logic trace...', got %q", thought)
+	}
+	if text != "The answer is 42" {
+		t.Errorf("expected text 'The answer is 42', got %q", text)
+	}
+}
+
+func TestThinkingBudget(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req messagesRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		if req.Thinking == nil || req.Thinking.Budget != 2048 || req.Thinking.Type != "enabled" {
+			t.Errorf("unexpected thinking config: %+v", req.Thinking)
+		}
+		if req.MaxTokens <= 2048 {
+			t.Errorf("expected max_tokens > 2048, got %d", req.MaxTokens)
+		}
+
+		resp := messagesResponse{}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "claude-3-7", &auth.AnthropicAuth{APIKey: "key"}, WithThinkingBudget(2048))
+	_, _, _ = client.SendChat(context.Background(), nil, nil, nil)
+}
+
+func TestAnthropic_SystemContent(t *testing.T) {
+	client := NewClient("", "claude-3", nil, WithPersona("Initial Persona"))
+	history := []*llm.Content{
+		{
+			Role:  "system",
+			Parts: []*llm.Part{{Text: "Additional instructions"}},
+		},
+	}
+	system, _, _ := client.toAnthropicMessages(history)
+	if !strings.Contains(system, "Initial Persona") || !strings.Contains(system, "Additional instructions") {
+		t.Errorf("expected merged system content, got %q", system)
+	}
+}
+
+func TestAnthropic_AppendOrMergeMessage(t *testing.T) {
+	client := &client{}
+	messages := []message{
+		{Role: "user", Content: []contentBlock{{Type: "text", Text: "Hi"}}},
+	}
+
+	// Test merging
+	blocks := []contentBlock{{Type: "text", Text: " there"}}
+	merged := client.appendOrMergeMessage(messages, "user", blocks)
+
+	if len(merged) != 1 || len(merged[0].Content) != 2 {
+		t.Errorf("expected 1 merged message with 2 blocks, got %d messages and %d blocks", len(merged), len(merged[0].Content))
+	}
+}
+
+func TestTransientPartsSupport(t *testing.T) {
+	c := &client{}
+	history := &llm.Content{
+		Role: "user",
+		Parts: []*llm.Part{
+			{Text: "Permanent part"},
+		},
+		TransientParts: []*llm.Part{
+			{Text: "Transient part"},
+		},
+	}
+
+	role, blocks, err := c.convertToAnthropicBlocks(history)
+	if err != nil {
+		t.Fatalf("convertToAnthropicBlocks failed: %v", err)
+	}
+
+	if role != "user" {
+		t.Errorf("expected role user, got %s", role)
+	}
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+
+	if blocks[0].Text != "Permanent part" {
+		t.Errorf("expected first block text 'Permanent part', got %q", blocks[0].Text)
+	}
+	if blocks[1].Text != "Transient part" {
+		t.Errorf("expected second block text 'Transient part', got %q", blocks[1].Text)
+	}
+}
+
+func TestThinkingTokens_AlwaysZero_PerWireContract(t *testing.T) {
+	// Pins issue #72: Anthropic's Messages API does not expose a
+	// separate reasoning-token field. Even if a future API revision
+	// introduces one with a different JSON name, this client must
+	// not silently start reporting it without a deliberate change.
+	// See ADR-023 for the broader "displayed numbers come from the
+	// wire" principle this test protects.
+	raw := []byte(`{
+        "id":"msg_test",
+        "role":"assistant",
+        "stop_reason":"end_turn",
+        "content":[
+            {"type":"thinking","thinking":"Let me reason about this carefully...","signature":"sig_x"},
+            {"type":"text","text":"The answer is 42."}
+        ],
+        "usage":{
+            "input_tokens":1000,
+            "output_tokens":750,
+            "cache_read_input_tokens":0,
+            "cache_creation_input_tokens":0
+        }
+    }`)
+	var resp messagesResponse
+	if err := json.Unmarshal(raw, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	c := &client{model: "claude-opus-4", logger: &ports.NoOpLogger{}, baseURL: "https://api.anthropic.com/v1"}
+	content, metrics, err := c.fromAnthropicResponse(&resp, 1.0)
+	if err != nil {
+		t.Fatalf("fromAnthropicResponse: %v", err)
+	}
+
+	// Wire-correct invariants:
+	if metrics.ThinkingTokens != 0 {
+		t.Errorf("ThinkingTokens must be 0 for Anthropic (no wire field); got %d", metrics.ThinkingTokens)
+	}
+	if metrics.ResponseTokens != 750 {
+		t.Errorf("ResponseTokens must equal raw output_tokens=750 (includes thinking); got %d", metrics.ResponseTokens)
+	}
+
+	// Reasoning *content* must still be parsed into a thought Part —
+	// this is the user's only signal that thinking actually fired.
+	var sawThought bool
+	for _, p := range content.Parts {
+		if p.IsThought && p.Text != "" {
+			sawThought = true
+		}
+	}
+	if !sawThought {
+		t.Error("expected at least one IsThought Part with non-empty Text")
+	}
+}
+
+func TestPartToContentBlock(t *testing.T) {
+	c := &client{logger: &ports.NoOpLogger{}}
+
+	tests := []struct {
+		name        string
+		part        *llm.Part
+		role        string
+		wantType    string
+		wantOk      bool
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name: "FunctionCall - valid",
+			part: &llm.Part{
+				FunctionCall: &llm.FunctionCall{
+					ID:   "call_1",
+					Name: "my_tool",
+					Args: map[string]interface{}{"foo": "bar"},
+				},
+			},
+			role:     "assistant",
+			wantType: "tool_use",
+			wantOk:   true,
+			wantErr:  false,
+		},
+		{
+			name: "FunctionCall - missing ID",
+			part: &llm.Part{
+				FunctionCall: &llm.FunctionCall{
+					Name: "my_tool",
+				},
+			},
+			role:        "assistant",
+			wantOk:      false,
+			wantErr:     true,
+			errContains: "missing ID for tool call",
+		},
+		{
+			name: "FunctionCall - nil Args",
+			part: &llm.Part{
+				FunctionCall: &llm.FunctionCall{
+					ID:   "call_1",
+					Name: "my_tool",
+				},
+			},
+			role:     "assistant",
+			wantType: "tool_use",
+			wantOk:   true,
+			wantErr:  false,
+		},
+		{
+			name: "FunctionResponse - valid",
+			part: &llm.Part{
+				FunctionResponse: &llm.FunctionResponse{
+					ID:       "call_1",
+					Name:     "my_tool",
+					Response: map[string]interface{}{"result": "success"},
+				},
+			},
+			role:     "user",
+			wantType: "tool_result",
+			wantOk:   true,
+			wantErr:  false,
+		},
+		{
+			name: "FunctionResponse - missing ID",
+			part: &llm.Part{
+				FunctionResponse: &llm.FunctionResponse{
+					Name:     "my_tool",
+					Response: map[string]interface{}{"result": "success"},
+				},
+			},
+			role:        "user",
+			wantOk:      false,
+			wantErr:     true,
+			errContains: "missing ID for tool response",
+		},
+		{
+			name: "Thinking - assistant role",
+			part: &llm.Part{
+				IsThought:        true,
+				Text:             "thinking...",
+				ThoughtSignature: []byte("sig"),
+			},
+			role:     "assistant",
+			wantType: "thinking",
+			wantOk:   true,
+			wantErr:  false,
+		},
+		{
+			name: "Text block",
+			part: &llm.Part{
+				Text: "hello",
+			},
+			role:     "user",
+			wantType: "text",
+			wantOk:   true,
+			wantErr:  false,
+		},
+		{
+			name:    "Empty part",
+			part:    &llm.Part{},
+			role:    "user",
+			wantOk:  false,
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok, err := c.partToContentBlock(tt.part, tt.role)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if ok != tt.wantOk {
+				t.Errorf("expected ok=%v, got ok=%v", tt.wantOk, ok)
+			}
+
+			if tt.wantOk && got.Type != tt.wantType {
+				t.Errorf("expected type %q, got %q", tt.wantType, got.Type)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -10,14 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"reflect"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 	llmerr "github.com/gosharplite/tell-me-go/internal/infrastructure/llm/llmerr"
 )
@@ -154,300 +152,6 @@ func testHistoryProcessing(t *testing.T) {
 	}
 }
 
-func TestExtendedThinking(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		resp := messagesResponse{
-			Content: []contentBlock{
-				{
-					Type:     "thinking",
-					Thinking: "Logic trace...",
-				},
-				{
-					Type: "text",
-					Text: "The answer is 42",
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "claude-3-7-sonnet", &auth.AnthropicAuth{APIKey: "key"})
-	resp, _, _ := client.SendChat(context.Background(), nil, nil, nil)
-
-	var thought, text string
-	for _, p := range resp.Parts {
-		if p.IsThought {
-			thought += p.Text
-		} else if p.Text != "" {
-			text += p.Text
-		}
-	}
-
-	if thought != "Logic trace..." {
-		t.Errorf("expected thought 'Logic trace...', got %q", thought)
-	}
-	if text != "The answer is 42" {
-		t.Errorf("expected text 'The answer is 42', got %q", text)
-	}
-}
-
-func TestToolCalling(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req messagesRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-
-		// Check if it's the second call (with tool result)
-		if len(req.Messages) == 3 && req.Messages[2].Content[0].Type == "tool_result" {
-			lastMsg := req.Messages[2]
-			block := lastMsg.Content[0]
-			expectedContent := "London: 15C"
-			if block.ToolUseID != "toolu_123" || block.Content != expectedContent {
-				t.Errorf("unexpected tool result block: %+v", block)
-			}
-
-			resp := messagesResponse{
-				Content: []contentBlock{{Type: "text", Text: "It is 15C in London."}},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-			return
-		}
-
-		// Initial call
-		resp := messagesResponse{
-			Content: []contentBlock{
-				{
-					Type:  "tool_use",
-					ID:    "toolu_123",
-					Name:  "get_weather",
-					Input: map[string]interface{}{"location": "London"},
-				},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"})
-
-	// 1. Initial call
-	history := []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "Weather in London?"}}}}
-	resp, _, err := client.SendChat(context.Background(), history, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp.Parts[0].FunctionCall.ID != "toolu_123" {
-		t.Errorf("expected tool use ID toolu_123, got %s", resp.Parts[0].FunctionCall.ID)
-	}
-
-	// 2. Respond with tool result
-	history = append(history, resp)
-	history = append(history, &llm.Content{
-		Role: "tool",
-		Parts: []*llm.Part{
-			{
-				FunctionResponse: &llm.FunctionResponse{
-					ID:       "toolu_123",
-					Name:     "get_weather",
-					Response: map[string]interface{}{"result": "London: 15C"},
-				},
-			},
-		},
-	})
-
-	resp2, _, err := client.SendChat(context.Background(), history, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if resp2.Parts[0].Text != "It is 15C in London." {
-		t.Errorf("unexpected final response: %s", resp2.Parts[0].Text)
-	}
-}
-
-func TestThinkingBudget(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req messagesRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-
-		if req.Thinking == nil || req.Thinking.Budget != 2048 || req.Thinking.Type != "enabled" {
-			t.Errorf("unexpected thinking config: %+v", req.Thinking)
-		}
-		if req.MaxTokens <= 2048 {
-			t.Errorf("expected max_tokens > 2048, got %d", req.MaxTokens)
-		}
-
-		resp := messagesResponse{}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "claude-3-7", &auth.AnthropicAuth{APIKey: "key"}, WithThinkingBudget(2048))
-	_, _, _ = client.SendChat(context.Background(), nil, nil, nil)
-}
-
-func TestToAnthropicSchema(t *testing.T) {
-	tests := []struct {
-		name     string
-		schema   *tools.Schema
-		expected map[string]interface{}
-	}{
-		{
-			name: "Simple string",
-			schema: &tools.Schema{
-				Type:        "STRING",
-				Description: "A string",
-			},
-			expected: map[string]interface{}{
-				"type":        "string",
-				"description": "A string",
-			},
-		},
-		{
-			name: "Object with properties",
-			schema: &tools.Schema{
-				Type: "OBJECT",
-				Properties: map[string]*tools.Schema{
-					"name": {Type: "STRING"},
-				},
-				Required: []string{"name"},
-			},
-			expected: map[string]interface{}{
-				"type": "object",
-				"properties": map[string]interface{}{
-					"name": map[string]interface{}{"type": "string"},
-				},
-				"required": []string{"name"},
-			},
-		},
-		{
-			name: "Empty object (should not have properties or required)",
-			schema: &tools.Schema{
-				Type:       "OBJECT",
-				Properties: map[string]*tools.Schema{},
-				Required:   []string{},
-			},
-			expected: map[string]interface{}{
-				"type": "object",
-			},
-		},
-		{
-			name: "Array with items",
-			schema: &tools.Schema{
-				Type: "ARRAY",
-				Items: &tools.Schema{
-					Type: "STRING",
-				},
-			},
-			expected: map[string]interface{}{
-				"type": "array",
-				"items": map[string]interface{}{
-					"type": "string",
-				},
-			},
-		},
-		{
-			name: "Non-array with items (items should be omitted)",
-			schema: &tools.Schema{
-				Type: "STRING",
-				Items: &tools.Schema{
-					Type: "STRING",
-				},
-			},
-			expected: map[string]interface{}{
-				"type": "string",
-			},
-		},
-		{
-			name: "Enum",
-			schema: &tools.Schema{
-				Type: "STRING",
-				Enum: []string{"red", "green", "blue"},
-			},
-			expected: map[string]interface{}{
-				"type": "string",
-				"enum": []string{"red", "green", "blue"},
-			},
-		},
-		{
-			name: "Empty enum",
-			schema: &tools.Schema{
-				Type: "STRING",
-				Enum: []string{},
-			},
-			expected: map[string]interface{}{
-				"type": "string",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := toAnthropicSchema(tt.schema)
-
-			// Use JSON marshal/unmarshal to compare maps to avoid type issues with nested interfaces
-			gotJSON, _ := json.Marshal(got)
-			expJSON, _ := json.Marshal(tt.expected)
-
-			var gotMap, expMap map[string]interface{}
-			_ = json.Unmarshal(gotJSON, &gotMap)
-			_ = json.Unmarshal(expJSON, &expMap)
-
-			if !reflect.DeepEqual(gotMap, expMap) {
-				t.Errorf("toAnthropicSchema() = %v, want %v", gotMap, expMap)
-			}
-		})
-	}
-}
-
-func TestToAnthropicTools(t *testing.T) {
-	client := &client{}
-	decls := []*tools.ToolDeclaration{
-		{
-			Name:        "parameterless_tool",
-			Description: "A tool with no parameters",
-			Parameters:  nil,
-		},
-		{
-			Name:        "parameterized_tool",
-			Description: "A tool with parameters",
-			Parameters: &tools.Schema{
-				Type: "OBJECT",
-				Properties: map[string]*tools.Schema{
-					"arg": {Type: "STRING"},
-				},
-			},
-		},
-	}
-
-	anthropicTools := client.toAnthropicTools(decls)
-
-	if len(anthropicTools) != 2 {
-		t.Fatalf("expected 2 tools, got %d", len(anthropicTools))
-	}
-
-	// Check parameterless tool
-	if anthropicTools[0].Name != "parameterless_tool" {
-		t.Errorf("expected name parameterless_tool, got %s", anthropicTools[0].Name)
-	}
-	expectedSchema := map[string]interface{}{
-		"type":       "object",
-		"properties": map[string]interface{}{},
-	}
-	if !reflect.DeepEqual(anthropicTools[0].InputSchema, expectedSchema) {
-		t.Errorf("expected schema %+v, got %+v", expectedSchema, anthropicTools[0].InputSchema)
-	}
-
-	// Check parameterized tool
-	if anthropicTools[1].Name != "parameterized_tool" {
-		t.Errorf("expected name parameterized_tool, got %s", anthropicTools[1].Name)
-	}
-	if anthropicTools[1].InputSchema == nil {
-		t.Error("expected parameterized tool to have a schema, got nil")
-	}
-}
-
 func TestSendChat_Errors(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -545,6 +249,36 @@ func (readFailureRoundTripper) RoundTrip(*http.Request) (*http.Response, error) 
 	}, nil
 }
 
+// assertPrepareRequestError verifies that prepareAnthropicRequest returns
+// an error containing wantErr and a nil *messagesRequest for the given
+// history. This mirrors the assertNilDepRequired pattern from f8430bce.
+func assertPrepareRequestError(t *testing.T, c *client, history []*llm.Content, wantErr string) {
+	t.Helper()
+	req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), wantErr) {
+		t.Errorf("expected error containing %q, got %q", wantErr, err.Error())
+	}
+	if req != nil {
+		t.Error("expected nil request on error, got non-nil")
+	}
+}
+
+// assertPrepareRequestSuccess verifies that prepareAnthropicRequest succeeds
+// and returns a non-nil *messagesRequest for the given history.
+func assertPrepareRequestSuccess(t *testing.T, c *client, history []*llm.Content) {
+	t.Helper()
+	req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if req == nil {
+		t.Error("expected non-nil request on success")
+	}
+}
+
 func TestPrepareRequest_ToAnthropicMessagesError(t *testing.T) {
 	// prepareAnthropicRequest is called before any network request. These
 	// sub-cases verify that conversion errors in toAnthropicMessages /
@@ -559,17 +293,7 @@ func TestPrepareRequest_ToAnthropicMessagesError(t *testing.T) {
 				FunctionCall: &llm.FunctionCall{Name: "foo", ID: ""},
 			}},
 		}}
-		req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "missing ID for tool call") {
-			t.Errorf("expected error containing %q, got %q", "missing ID for tool call", err.Error())
-		}
-		if req != nil {
-			t.Error("expected nil request on error, got non-nil")
-		}
+		assertPrepareRequestError(t, c, history, "missing ID for tool call")
 	})
 
 	t.Run("malformed FunctionCall in TransientParts", func(t *testing.T) {
@@ -579,17 +303,7 @@ func TestPrepareRequest_ToAnthropicMessagesError(t *testing.T) {
 				FunctionCall: &llm.FunctionCall{Name: "bar", ID: ""},
 			}},
 		}}
-		req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "missing ID for tool call") {
-			t.Errorf("expected error containing %q, got %q", "missing ID for tool call", err.Error())
-		}
-		if req != nil {
-			t.Error("expected nil request on error, got non-nil")
-		}
+		assertPrepareRequestError(t, c, history, "missing ID for tool call")
 	})
 
 	t.Run("malformed FunctionResponse", func(t *testing.T) {
@@ -599,17 +313,7 @@ func TestPrepareRequest_ToAnthropicMessagesError(t *testing.T) {
 				FunctionResponse: &llm.FunctionResponse{Name: "baz", ID: ""},
 			}},
 		}}
-		req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
-
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "missing ID for tool response") {
-			t.Errorf("expected error containing %q, got %q", "missing ID for tool response", err.Error())
-		}
-		if req != nil {
-			t.Error("expected nil request on error, got non-nil")
-		}
+		assertPrepareRequestError(t, c, history, "missing ID for tool response")
 	})
 
 	t.Run("no error with valid history", func(t *testing.T) {
@@ -617,14 +321,7 @@ func TestPrepareRequest_ToAnthropicMessagesError(t *testing.T) {
 			Role:  "user",
 			Parts: []*llm.Part{{Text: "hello"}},
 		}}
-		req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
-
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if req == nil {
-			t.Error("expected non-nil request on success")
-		}
+		assertPrepareRequestSuccess(t, c, history)
 	})
 }
 
@@ -651,35 +348,6 @@ func TestSendChat_Timeout(t *testing.T) {
 	}
 }
 
-func TestAnthropic_SystemContent(t *testing.T) {
-	client := NewClient("", "claude-3", nil, WithPersona("Initial Persona"))
-	history := []*llm.Content{
-		{
-			Role:  "system",
-			Parts: []*llm.Part{{Text: "Additional instructions"}},
-		},
-	}
-	system, _, _ := client.toAnthropicMessages(history)
-	if !strings.Contains(system, "Initial Persona") || !strings.Contains(system, "Additional instructions") {
-		t.Errorf("expected merged system content, got %q", system)
-	}
-}
-
-func TestAnthropic_AppendOrMergeMessage(t *testing.T) {
-	client := &client{}
-	messages := []message{
-		{Role: "user", Content: []contentBlock{{Type: "text", Text: "Hi"}}},
-	}
-
-	// Test merging
-	blocks := []contentBlock{{Type: "text", Text: " there"}}
-	merged := client.appendOrMergeMessage(messages, "user", blocks)
-
-	if len(merged) != 1 || len(merged[0].Content) != 2 {
-		t.Errorf("expected 1 merged message with 2 blocks, got %d messages and %d blocks", len(merged), len(merged[0].Content))
-	}
-}
-
 func TestAnthropic_GenerateImages_NotImplemented(t *testing.T) {
 	client := NewClient("", "", nil)
 	_, err := client.GenerateImages(context.Background(), "", "", "")
@@ -692,51 +360,6 @@ func TestAnthropic_RefreshAuth(t *testing.T) {
 	auth := &auth.AnthropicAuth{APIKey: "old"}
 	client := NewClient("", "", auth)
 	_ = client.RefreshAuth()
-}
-
-func TestPromptCaching(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("anthropic-beta") != "prompt-caching-2024-07-31" {
-			t.Errorf("expected beta header, got %s", r.Header.Get("anthropic-beta"))
-		}
-
-		var req messagesRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-
-		systemBlocks, ok := req.System.([]interface{})
-		if !ok || len(systemBlocks) != 1 {
-			t.Errorf("expected 1 system block, got %v", req.System)
-		} else {
-			block := systemBlocks[0].(map[string]interface{})
-			if block["type"] != "text" || block["text"] != "You are a helpful assistant" {
-				t.Errorf("unexpected system block text: %v", block["text"])
-			}
-			cache, ok := block["cache_control"].(map[string]interface{})
-			if !ok || cache["type"] != "ephemeral" {
-				t.Errorf("expected ephemeral cache control, got %v", block["cache_control"])
-			}
-		}
-
-		resp := messagesResponse{
-			Usage: usage{
-				InputTokens:          100,
-				CacheReadInputTokens: 80,
-				OutputTokens:         50,
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"}, WithPersona("You are a helpful assistant"))
-	_, metrics, err := client.SendChat(context.Background(), nil, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if metrics.CachedTokens != 80 {
-		t.Errorf("expected 80 cached tokens, got %d", metrics.CachedTokens)
-	}
 }
 
 func TestAnthropic_InternalErrors(t *testing.T) {
@@ -830,535 +453,5 @@ func TestNewClient_Options(t *testing.T) {
 	}
 	if _, ok := c.logger.(*ports.NoOpLogger); !ok {
 		t.Error("expected logger to be NoOpLogger")
-	}
-}
-
-// assertVertexURLPath checks that the Vertex AI URL path ends with
-// the rawPredict suffix for the correct model.
-func assertVertexURLPath(t *testing.T, r *http.Request) {
-	t.Helper()
-	if !strings.HasSuffix(r.URL.Path, "/claude-3-5-sonnet-v1:rawPredict") {
-		t.Errorf("expected path to end with /claude-3-5-sonnet-v1:rawPredict, got %s", r.URL.Path)
-	}
-}
-
-// assertVertexNoAnthropicVersionHeader checks that Vertex does NOT send
-// an anthropic-version header (that header is Anthropic-direct only).
-func assertVertexNoAnthropicVersionHeader(t *testing.T, r *http.Request) {
-	t.Helper()
-	if v := r.Header.Get("anthropic-version"); v != "" {
-		t.Errorf("expected NO anthropic-version header for Vertex, got %s", v)
-	}
-}
-
-// assertVertexNoAnthropicBetaHeader checks that Vertex does NOT send
-// an anthropic-beta header (that header is Anthropic-direct only).
-func assertVertexNoAnthropicBetaHeader(t *testing.T, r *http.Request) {
-	t.Helper()
-	if v := r.Header.Get("anthropic-beta"); v != "" {
-		t.Errorf("expected NO anthropic-beta header for Vertex, got %s", v)
-	}
-}
-
-// assertVertexModelOmittedFromBody checks that the model field is omitted
-// from the JSON body (Vertex infers the model from the URL path).
-func assertVertexModelOmittedFromBody(t *testing.T, req messagesRequest) {
-	t.Helper()
-	if req.Model != "" {
-		t.Errorf("expected model to be omitted from JSON body for Vertex, got %s", req.Model)
-	}
-}
-
-// assertVertexAnthropicVersionInBody checks that anthropic_version is
-// set to the Vertex-specific value inside the JSON body.
-func assertVertexAnthropicVersionInBody(t *testing.T, req messagesRequest) {
-	t.Helper()
-	if req.AnthropicVersion != "vertex-2023-10-16" {
-		t.Errorf("expected anthropic_version vertex-2023-10-16 in JSON body, got %s", req.AnthropicVersion)
-	}
-}
-
-// assertVertexCacheControlInSystemBlock checks that ephemeral cache_control
-// is present in the first system block. When there are no system blocks
-// the check is a no-op.
-func assertVertexCacheControlInSystemBlock(t *testing.T, req messagesRequest) {
-	t.Helper()
-	sys, ok := req.System.([]interface{})
-	if !ok || len(sys) == 0 {
-		return // no system blocks; nothing to check
-	}
-	block := sys[0].(map[string]interface{})
-	cache, ok := block["cache_control"].(map[string]interface{})
-	if !ok || cache["type"] != "ephemeral" {
-		t.Errorf("expected ephemeral cache_control in system block for Vertex, got %v", block["cache_control"])
-	}
-}
-
-// vertexAIHandler returns an http.Handler that asserts Vertex AI wire-format
-// invariants and returns a fixed success response. Each invariant failure is
-// reported via t.Errorf without short-circuiting so the test collects all
-// failures in a single run.
-func vertexAIHandler(t *testing.T) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		assertVertexURLPath(t, r)
-		assertVertexNoAnthropicVersionHeader(t, r)
-		assertVertexNoAnthropicBetaHeader(t, r)
-
-		var req messagesRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("failed to decode request body: %v", err)
-			return
-		}
-
-		assertVertexCacheControlInSystemBlock(t, req)
-		assertVertexModelOmittedFromBody(t, req)
-		assertVertexAnthropicVersionInBody(t, req)
-
-		resp := messagesResponse{
-			ID:   "msg_vertex_123",
-			Role: "assistant",
-			Content: []contentBlock{
-				{Type: "text", Text: "Hello from Vertex Claude"},
-			},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}
-}
-
-func TestVertexAI_Support(t *testing.T) {
-	vertexBaseURL := "/aiplatform.googleapis.com/v1"
-	model := "claude-3-5-sonnet-v1"
-
-	tests := []struct {
-		name     string
-		system   []*llm.Content // system instructions to inject cache_control
-		wantText string
-	}{
-		{
-			name:     "basic Vertex call",
-			system:   nil,
-			wantText: "Hello from Vertex Claude",
-		},
-		{
-			name: "Vertex with system (cache_control)",
-			system: []*llm.Content{
-				{Role: "system", Parts: []*llm.Part{{Text: "You are helpful"}}},
-			},
-			wantText: "Hello from Vertex Claude",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(vertexAIHandler(t))
-			defer server.Close()
-
-			client := NewClient(
-				server.URL+vertexBaseURL,
-				model,
-				&auth.AnthropicAuth{APIKey: "test-key"},
-			)
-
-			resp, _, err := client.SendChat(context.Background(), tt.system, nil, nil)
-			if err != nil {
-				t.Fatalf("SendChat failed: %v", err)
-			}
-
-			if len(resp.Parts) == 0 || resp.Parts[0].Text != tt.wantText {
-				t.Errorf("unexpected response content: got %+v, want text %q", resp.Parts, tt.wantText)
-			}
-		})
-	}
-}
-
-func TestAnthropic_TrafficTypeDetection(t *testing.T) {
-	t.Run("Reflected Intent (Header Fallback)", func(t *testing.T) {
-		headers := map[string]string{
-			"X-Vertex-AI-LLM-Shared-Request-Type": "priority",
-		}
-		c := NewClient("", "claude-3", nil, WithHeaders(headers))
-
-		resp := &messagesResponse{
-			Usage: usage{InputTokens: 10, OutputTokens: 20},
-		}
-
-		_, metrics, err := c.fromAnthropicResponse(resp, 1.0)
-		if err != nil {
-			t.Fatalf("fromAnthropicResponse failed: %v", err)
-		}
-
-		if metrics.TrafficType != "ON_DEMAND_PRIORITY" {
-			t.Errorf("expected TrafficType ON_DEMAND_PRIORITY, got %q", metrics.TrafficType)
-		}
-	})
-
-	t.Run("Source of Truth (Server Metadata)", func(t *testing.T) {
-		c := NewClient("", "claude-3", nil) // No headers
-
-		resp := &messagesResponse{
-			Usage: usage{
-				InputTokens:  10,
-				OutputTokens: 20,
-				ExtraProperties: &extraProperties{
-					Google: &googleProperties{
-						TrafficType: "ON_DEMAND_PRIORITY",
-					},
-				},
-			},
-		}
-
-		_, metrics, err := c.fromAnthropicResponse(resp, 1.0)
-		if err != nil {
-			t.Fatalf("fromAnthropicResponse failed: %v", err)
-		}
-
-		if metrics.TrafficType != "ON_DEMAND_PRIORITY" {
-			t.Errorf("expected TrafficType ON_DEMAND_PRIORITY, got %q", metrics.TrafficType)
-		}
-	})
-}
-
-func TestHistoryCaching(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req messagesRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Errorf("failed to decode request body: %v", err)
-			return
-		}
-
-		if len(req.Messages) != 2 {
-			t.Fatalf("expected 2 messages in history, got %d", len(req.Messages))
-		}
-
-		// The last message's last block should have cache_control
-		lastMsg := req.Messages[len(req.Messages)-1]
-		lastBlock := lastMsg.Content[len(lastMsg.Content)-1]
-		if lastBlock.CacheControl == nil || lastBlock.CacheControl.Type != "ephemeral" {
-			t.Errorf("expected ephemeral cache control on last history block, got %+v", lastBlock.CacheControl)
-		}
-
-		// The first message's last block should NOT have cache_control (it's not the last turn)
-		firstMsg := req.Messages[0]
-		firstBlock := firstMsg.Content[len(firstMsg.Content)-1]
-		if firstBlock.CacheControl != nil {
-			t.Errorf("expected NO cache control on first history block, got %+v", firstBlock.CacheControl)
-		}
-
-		resp := messagesResponse{
-			Content: []contentBlock{{Type: "text", Text: "OK"}},
-		}
-		_ = json.NewEncoder(w).Encode(resp)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"})
-	history := []*llm.Content{
-		{
-			Role:  "user",
-			Parts: []*llm.Part{{Text: "Message 1"}},
-		},
-		{
-			Role:  "assistant",
-			Parts: []*llm.Part{{Text: "Response 1"}},
-		},
-	}
-	_, _, err := client.SendChat(context.Background(), history, nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestMetricsMapping(t *testing.T) {
-	t.Run("Native Anthropic (Total InputTokens)", func(t *testing.T) {
-		c := &client{model: "claude-3-5-sonnet", logger: &ports.NoOpLogger{}, baseURL: "https://api.anthropic.com/v1"}
-		resp := &messagesResponse{
-			Usage: usage{
-				InputTokens:              1500, // Total (1000 hits + 500 misses)
-				OutputTokens:             500,
-				CacheReadInputTokens:     1000,
-				CacheCreationInputTokens: 200,
-			},
-		}
-
-		_, metrics, err := c.fromAnthropicResponse(resp, 2.5)
-		if err != nil {
-			t.Fatalf("fromAnthropicResponse failed: %v", err)
-		}
-
-		assertMetricsMapping(t, metrics, 1500, 1000, 200)
-	})
-
-	t.Run("Vertex AI (Incremental InputTokens)", func(t *testing.T) {
-		c := &client{model: "claude-3-5-sonnet", logger: &ports.NoOpLogger{}, baseURL: "https://us-central1-aiplatform.googleapis.com/v1"}
-		resp := &messagesResponse{
-			Usage: usage{
-				InputTokens:              500, // Incremental (misses only)
-				OutputTokens:             500,
-				CacheReadInputTokens:     1000,
-				CacheCreationInputTokens: 200,
-			},
-		}
-
-		_, metrics, err := c.fromAnthropicResponse(resp, 2.5)
-		if err != nil {
-			t.Fatalf("fromAnthropicResponse failed: %v", err)
-		}
-
-		// PromptTokens should be normalized to Total (500 delta + 1000 cache_read + 200 cache_creation = 1700)
-		assertMetricsMapping(t, metrics, 1700, 1000, 200)
-	})
-}
-
-// assertMetricsMapping asserts the four metrics fields that every
-// Anthropic response must set.
-//
-// Pins issue #72: Anthropic does not separately report reasoning
-// tokens on the wire. The client must always set ThinkingTokens=0 so
-// the pricing layer's
-//
-//	OutputCost = ResponseTokens × Comp + ThinkingTokens × Thinking
-//
-// reduces to ResponseTokens × Comp (wire-correct: Anthropic rolls
-// reasoning into output_tokens at the standard rate).
-// See ADR-023.
-func assertMetricsMapping(t *testing.T, m *llm.Metrics, wantPrompt, wantCached, wantCacheWrite int32) {
-	t.Helper()
-	if m.PromptTokens != wantPrompt {
-		t.Errorf("expected PromptTokens %d, got %d", wantPrompt, m.PromptTokens)
-	}
-	if m.CachedTokens != wantCached {
-		t.Errorf("expected CachedTokens %d, got %d", wantCached, m.CachedTokens)
-	}
-	if m.CacheWriteTokens != wantCacheWrite {
-		t.Errorf("expected CacheWriteTokens %d, got %d", wantCacheWrite, m.CacheWriteTokens)
-	}
-	if m.ThinkingTokens != 0 {
-		t.Errorf("Anthropic must always report ThinkingTokens=0; got %d", m.ThinkingTokens)
-	}
-}
-
-func TestTransientPartsSupport(t *testing.T) {
-	c := &client{}
-	history := &llm.Content{
-		Role: "user",
-		Parts: []*llm.Part{
-			{Text: "Permanent part"},
-		},
-		TransientParts: []*llm.Part{
-			{Text: "Transient part"},
-		},
-	}
-
-	role, blocks, err := c.convertToAnthropicBlocks(history)
-	if err != nil {
-		t.Fatalf("convertToAnthropicBlocks failed: %v", err)
-	}
-
-	if role != "user" {
-		t.Errorf("expected role user, got %s", role)
-	}
-
-	if len(blocks) != 2 {
-		t.Fatalf("expected 2 blocks, got %d", len(blocks))
-	}
-
-	if blocks[0].Text != "Permanent part" {
-		t.Errorf("expected first block text 'Permanent part', got %q", blocks[0].Text)
-	}
-	if blocks[1].Text != "Transient part" {
-		t.Errorf("expected second block text 'Transient part', got %q", blocks[1].Text)
-	}
-}
-
-func TestThinkingTokens_AlwaysZero_PerWireContract(t *testing.T) {
-	// Pins issue #72: Anthropic's Messages API does not expose a
-	// separate reasoning-token field. Even if a future API revision
-	// introduces one with a different JSON name, this client must
-	// not silently start reporting it without a deliberate change.
-	// See ADR-023 for the broader "displayed numbers come from the
-	// wire" principle this test protects.
-	raw := []byte(`{
-        "id":"msg_test",
-        "role":"assistant",
-        "stop_reason":"end_turn",
-        "content":[
-            {"type":"thinking","thinking":"Let me reason about this carefully...","signature":"sig_x"},
-            {"type":"text","text":"The answer is 42."}
-        ],
-        "usage":{
-            "input_tokens":1000,
-            "output_tokens":750,
-            "cache_read_input_tokens":0,
-            "cache_creation_input_tokens":0
-        }
-    }`)
-	var resp messagesResponse
-	if err := json.Unmarshal(raw, &resp); err != nil {
-		t.Fatalf("decode: %v", err)
-	}
-
-	c := &client{model: "claude-opus-4", logger: &ports.NoOpLogger{}, baseURL: "https://api.anthropic.com/v1"}
-	content, metrics, err := c.fromAnthropicResponse(&resp, 1.0)
-	if err != nil {
-		t.Fatalf("fromAnthropicResponse: %v", err)
-	}
-
-	// Wire-correct invariants:
-	if metrics.ThinkingTokens != 0 {
-		t.Errorf("ThinkingTokens must be 0 for Anthropic (no wire field); got %d", metrics.ThinkingTokens)
-	}
-	if metrics.ResponseTokens != 750 {
-		t.Errorf("ResponseTokens must equal raw output_tokens=750 (includes thinking); got %d", metrics.ResponseTokens)
-	}
-
-	// Reasoning *content* must still be parsed into a thought Part —
-	// this is the user's only signal that thinking actually fired.
-	var sawThought bool
-	for _, p := range content.Parts {
-		if p.IsThought && p.Text != "" {
-			sawThought = true
-		}
-	}
-	if !sawThought {
-		t.Error("expected at least one IsThought Part with non-empty Text")
-	}
-}
-
-func TestPartToContentBlock(t *testing.T) {
-	c := &client{logger: &ports.NoOpLogger{}}
-
-	tests := []struct {
-		name        string
-		part        *llm.Part
-		role        string
-		wantType    string
-		wantOk      bool
-		wantErr     bool
-		errContains string
-	}{
-		{
-			name: "FunctionCall - valid",
-			part: &llm.Part{
-				FunctionCall: &llm.FunctionCall{
-					ID:   "call_1",
-					Name: "my_tool",
-					Args: map[string]interface{}{"foo": "bar"},
-				},
-			},
-			role:     "assistant",
-			wantType: "tool_use",
-			wantOk:   true,
-			wantErr:  false,
-		},
-		{
-			name: "FunctionCall - missing ID",
-			part: &llm.Part{
-				FunctionCall: &llm.FunctionCall{
-					Name: "my_tool",
-				},
-			},
-			role:        "assistant",
-			wantOk:      false,
-			wantErr:     true,
-			errContains: "missing ID for tool call",
-		},
-		{
-			name: "FunctionCall - nil Args",
-			part: &llm.Part{
-				FunctionCall: &llm.FunctionCall{
-					ID:   "call_1",
-					Name: "my_tool",
-				},
-			},
-			role:     "assistant",
-			wantType: "tool_use",
-			wantOk:   true,
-			wantErr:  false,
-		},
-		{
-			name: "FunctionResponse - valid",
-			part: &llm.Part{
-				FunctionResponse: &llm.FunctionResponse{
-					ID:       "call_1",
-					Name:     "my_tool",
-					Response: map[string]interface{}{"result": "success"},
-				},
-			},
-			role:     "user",
-			wantType: "tool_result",
-			wantOk:   true,
-			wantErr:  false,
-		},
-		{
-			name: "FunctionResponse - missing ID",
-			part: &llm.Part{
-				FunctionResponse: &llm.FunctionResponse{
-					Name:     "my_tool",
-					Response: map[string]interface{}{"result": "success"},
-				},
-			},
-			role:        "user",
-			wantOk:      false,
-			wantErr:     true,
-			errContains: "missing ID for tool response",
-		},
-		{
-			name: "Thinking - assistant role",
-			part: &llm.Part{
-				IsThought:        true,
-				Text:             "thinking...",
-				ThoughtSignature: []byte("sig"),
-			},
-			role:     "assistant",
-			wantType: "thinking",
-			wantOk:   true,
-			wantErr:  false,
-		},
-		{
-			name: "Text block",
-			part: &llm.Part{
-				Text: "hello",
-			},
-			role:     "user",
-			wantType: "text",
-			wantOk:   true,
-			wantErr:  false,
-		},
-		{
-			name:    "Empty part",
-			part:    &llm.Part{},
-			role:    "user",
-			wantOk:  false,
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, ok, err := c.partToContentBlock(tt.part, tt.role)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if ok != tt.wantOk {
-				t.Errorf("expected ok=%v, got ok=%v", tt.wantOk, ok)
-			}
-
-			if tt.wantOk && got.Type != tt.wantType {
-				t.Errorf("expected type %q, got %q", tt.wantType, got.Type)
-			}
-		})
 	}
 }

--- a/internal/infrastructure/llm/anthropic/client_tools_test.go
+++ b/internal/infrastructure/llm/anthropic/client_tools_test.go
@@ -1,0 +1,252 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+func TestToolCalling(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req messagesRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		// Check if it's the second call (with tool result)
+		if len(req.Messages) == 3 && req.Messages[2].Content[0].Type == "tool_result" {
+			lastMsg := req.Messages[2]
+			block := lastMsg.Content[0]
+			expectedContent := "London: 15C"
+			if block.ToolUseID != "toolu_123" || block.Content != expectedContent {
+				t.Errorf("unexpected tool result block: %+v", block)
+			}
+
+			resp := messagesResponse{
+				Content: []contentBlock{{Type: "text", Text: "It is 15C in London."}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		// Initial call
+		resp := messagesResponse{
+			Content: []contentBlock{
+				{
+					Type:  "tool_use",
+					ID:    "toolu_123",
+					Name:  "get_weather",
+					Input: map[string]interface{}{"location": "London"},
+				},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"})
+
+	// 1. Initial call
+	history := []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "Weather in London?"}}}}
+	resp, _, err := client.SendChat(context.Background(), history, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Parts[0].FunctionCall.ID != "toolu_123" {
+		t.Errorf("expected tool use ID toolu_123, got %s", resp.Parts[0].FunctionCall.ID)
+	}
+
+	// 2. Respond with tool result
+	history = append(history, resp)
+	history = append(history, &llm.Content{
+		Role: "tool",
+		Parts: []*llm.Part{
+			{
+				FunctionResponse: &llm.FunctionResponse{
+					ID:       "toolu_123",
+					Name:     "get_weather",
+					Response: map[string]interface{}{"result": "London: 15C"},
+				},
+			},
+		},
+	})
+
+	resp2, _, err := client.SendChat(context.Background(), history, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp2.Parts[0].Text != "It is 15C in London." {
+		t.Errorf("unexpected final response: %s", resp2.Parts[0].Text)
+	}
+}
+
+func TestToAnthropicSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		schema   *tools.Schema
+		expected map[string]interface{}
+	}{
+		{
+			name: "Simple string",
+			schema: &tools.Schema{
+				Type:        "STRING",
+				Description: "A string",
+			},
+			expected: map[string]interface{}{
+				"type":        "string",
+				"description": "A string",
+			},
+		},
+		{
+			name: "Object with properties",
+			schema: &tools.Schema{
+				Type: "OBJECT",
+				Properties: map[string]*tools.Schema{
+					"name": {Type: "STRING"},
+				},
+				Required: []string{"name"},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"name": map[string]interface{}{"type": "string"},
+				},
+				"required": []string{"name"},
+			},
+		},
+		{
+			name: "Empty object (should not have properties or required)",
+			schema: &tools.Schema{
+				Type:       "OBJECT",
+				Properties: map[string]*tools.Schema{},
+				Required:   []string{},
+			},
+			expected: map[string]interface{}{
+				"type": "object",
+			},
+		},
+		{
+			name: "Array with items",
+			schema: &tools.Schema{
+				Type: "ARRAY",
+				Items: &tools.Schema{
+					Type: "STRING",
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "array",
+				"items": map[string]interface{}{
+					"type": "string",
+				},
+			},
+		},
+		{
+			name: "Non-array with items (items should be omitted)",
+			schema: &tools.Schema{
+				Type: "STRING",
+				Items: &tools.Schema{
+					Type: "STRING",
+				},
+			},
+			expected: map[string]interface{}{
+				"type": "string",
+			},
+		},
+		{
+			name: "Enum",
+			schema: &tools.Schema{
+				Type: "STRING",
+				Enum: []string{"red", "green", "blue"},
+			},
+			expected: map[string]interface{}{
+				"type": "string",
+				"enum": []string{"red", "green", "blue"},
+			},
+		},
+		{
+			name: "Empty enum",
+			schema: &tools.Schema{
+				Type: "STRING",
+				Enum: []string{},
+			},
+			expected: map[string]interface{}{
+				"type": "string",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toAnthropicSchema(tt.schema)
+
+			// Use JSON marshal/unmarshal to compare maps to avoid type issues with nested interfaces
+			gotJSON, _ := json.Marshal(got)
+			expJSON, _ := json.Marshal(tt.expected)
+
+			var gotMap, expMap map[string]interface{}
+			_ = json.Unmarshal(gotJSON, &gotMap)
+			_ = json.Unmarshal(expJSON, &expMap)
+
+			if !reflect.DeepEqual(gotMap, expMap) {
+				t.Errorf("toAnthropicSchema() = %v, want %v", gotMap, expMap)
+			}
+		})
+	}
+}
+
+func TestToAnthropicTools(t *testing.T) {
+	client := &client{}
+	decls := []*tools.ToolDeclaration{
+		{
+			Name:        "parameterless_tool",
+			Description: "A tool with no parameters",
+			Parameters:  nil,
+		},
+		{
+			Name:        "parameterized_tool",
+			Description: "A tool with parameters",
+			Parameters: &tools.Schema{
+				Type: "OBJECT",
+				Properties: map[string]*tools.Schema{
+					"arg": {Type: "STRING"},
+				},
+			},
+		},
+	}
+
+	anthropicTools := client.toAnthropicTools(decls)
+
+	if len(anthropicTools) != 2 {
+		t.Fatalf("expected 2 tools, got %d", len(anthropicTools))
+	}
+
+	// Check parameterless tool
+	if anthropicTools[0].Name != "parameterless_tool" {
+		t.Errorf("expected name parameterless_tool, got %s", anthropicTools[0].Name)
+	}
+	expectedSchema := map[string]interface{}{
+		"type":       "object",
+		"properties": map[string]interface{}{},
+	}
+	if !reflect.DeepEqual(anthropicTools[0].InputSchema, expectedSchema) {
+		t.Errorf("expected schema %+v, got %+v", expectedSchema, anthropicTools[0].InputSchema)
+	}
+
+	// Check parameterized tool
+	if anthropicTools[1].Name != "parameterized_tool" {
+		t.Errorf("expected name parameterized_tool, got %s", anthropicTools[1].Name)
+	}
+	if anthropicTools[1].InputSchema == nil {
+		t.Error("expected parameterized tool to have a schema, got nil")
+	}
+}

--- a/internal/infrastructure/llm/anthropic/client_vertex_test.go
+++ b/internal/infrastructure/llm/anthropic/client_vertex_test.go
@@ -1,0 +1,367 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package anthropic
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+// assertVertexURLPath checks that the Vertex AI URL path ends with
+// the rawPredict suffix for the correct model.
+func assertVertexURLPath(t *testing.T, r *http.Request) {
+	t.Helper()
+	if !strings.HasSuffix(r.URL.Path, "/claude-3-5-sonnet-v1:rawPredict") {
+		t.Errorf("expected path to end with /claude-3-5-sonnet-v1:rawPredict, got %s", r.URL.Path)
+	}
+}
+
+// assertVertexNoAnthropicVersionHeader checks that Vertex does NOT send
+// an anthropic-version header (that header is Anthropic-direct only).
+func assertVertexNoAnthropicVersionHeader(t *testing.T, r *http.Request) {
+	t.Helper()
+	if v := r.Header.Get("anthropic-version"); v != "" {
+		t.Errorf("expected NO anthropic-version header for Vertex, got %s", v)
+	}
+}
+
+// assertVertexNoAnthropicBetaHeader checks that Vertex does NOT send
+// an anthropic-beta header (that header is Anthropic-direct only).
+func assertVertexNoAnthropicBetaHeader(t *testing.T, r *http.Request) {
+	t.Helper()
+	if v := r.Header.Get("anthropic-beta"); v != "" {
+		t.Errorf("expected NO anthropic-beta header for Vertex, got %s", v)
+	}
+}
+
+// assertVertexModelOmittedFromBody checks that the model field is omitted
+// from the JSON body (Vertex infers the model from the URL path).
+func assertVertexModelOmittedFromBody(t *testing.T, req messagesRequest) {
+	t.Helper()
+	if req.Model != "" {
+		t.Errorf("expected model to be omitted from JSON body for Vertex, got %s", req.Model)
+	}
+}
+
+// assertVertexAnthropicVersionInBody checks that anthropic_version is
+// set to the Vertex-specific value inside the JSON body.
+func assertVertexAnthropicVersionInBody(t *testing.T, req messagesRequest) {
+	t.Helper()
+	if req.AnthropicVersion != "vertex-2023-10-16" {
+		t.Errorf("expected anthropic_version vertex-2023-10-16 in JSON body, got %s", req.AnthropicVersion)
+	}
+}
+
+// assertVertexCacheControlInSystemBlock checks that ephemeral cache_control
+// is present in the first system block. When there are no system blocks
+// the check is a no-op.
+func assertVertexCacheControlInSystemBlock(t *testing.T, req messagesRequest) {
+	t.Helper()
+	sys, ok := req.System.([]interface{})
+	if !ok || len(sys) == 0 {
+		return // no system blocks; nothing to check
+	}
+	block := sys[0].(map[string]interface{})
+	cache, ok := block["cache_control"].(map[string]interface{})
+	if !ok || cache["type"] != "ephemeral" {
+		t.Errorf("expected ephemeral cache_control in system block for Vertex, got %v", block["cache_control"])
+	}
+}
+
+// vertexAIHandler returns an http.Handler that asserts Vertex AI wire-format
+// invariants and returns a fixed success response. Each invariant failure is
+// reported via t.Errorf without short-circuiting so the test collects all
+// failures in a single run.
+func vertexAIHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		assertVertexURLPath(t, r)
+		assertVertexNoAnthropicVersionHeader(t, r)
+		assertVertexNoAnthropicBetaHeader(t, r)
+
+		var req messagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+			return
+		}
+
+		assertVertexCacheControlInSystemBlock(t, req)
+		assertVertexModelOmittedFromBody(t, req)
+		assertVertexAnthropicVersionInBody(t, req)
+
+		resp := messagesResponse{
+			ID:   "msg_vertex_123",
+			Role: "assistant",
+			Content: []contentBlock{
+				{Type: "text", Text: "Hello from Vertex Claude"},
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+func TestVertexAI_Support(t *testing.T) {
+	vertexBaseURL := "/aiplatform.googleapis.com/v1"
+	model := "claude-3-5-sonnet-v1"
+
+	tests := []struct {
+		name     string
+		system   []*llm.Content // system instructions to inject cache_control
+		wantText string
+	}{
+		{
+			name:     "basic Vertex call",
+			system:   nil,
+			wantText: "Hello from Vertex Claude",
+		},
+		{
+			name: "Vertex with system (cache_control)",
+			system: []*llm.Content{
+				{Role: "system", Parts: []*llm.Part{{Text: "You are helpful"}}},
+			},
+			wantText: "Hello from Vertex Claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(vertexAIHandler(t))
+			defer server.Close()
+
+			client := NewClient(
+				server.URL+vertexBaseURL,
+				model,
+				&auth.AnthropicAuth{APIKey: "test-key"},
+			)
+
+			resp, _, err := client.SendChat(context.Background(), tt.system, nil, nil)
+			if err != nil {
+				t.Fatalf("SendChat failed: %v", err)
+			}
+
+			if len(resp.Parts) == 0 || resp.Parts[0].Text != tt.wantText {
+				t.Errorf("unexpected response content: got %+v, want text %q", resp.Parts, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestAnthropic_TrafficTypeDetection(t *testing.T) {
+	t.Run("Reflected Intent (Header Fallback)", func(t *testing.T) {
+		headers := map[string]string{
+			"X-Vertex-AI-LLM-Shared-Request-Type": "priority",
+		}
+		c := NewClient("", "claude-3", nil, WithHeaders(headers))
+
+		resp := &messagesResponse{
+			Usage: usage{InputTokens: 10, OutputTokens: 20},
+		}
+
+		_, metrics, err := c.fromAnthropicResponse(resp, 1.0)
+		if err != nil {
+			t.Fatalf("fromAnthropicResponse failed: %v", err)
+		}
+
+		if metrics.TrafficType != "ON_DEMAND_PRIORITY" {
+			t.Errorf("expected TrafficType ON_DEMAND_PRIORITY, got %q", metrics.TrafficType)
+		}
+	})
+
+	t.Run("Source of Truth (Server Metadata)", func(t *testing.T) {
+		c := NewClient("", "claude-3", nil) // No headers
+
+		resp := &messagesResponse{
+			Usage: usage{
+				InputTokens:  10,
+				OutputTokens: 20,
+				ExtraProperties: &extraProperties{
+					Google: &googleProperties{
+						TrafficType: "ON_DEMAND_PRIORITY",
+					},
+				},
+			},
+		}
+
+		_, metrics, err := c.fromAnthropicResponse(resp, 1.0)
+		if err != nil {
+			t.Fatalf("fromAnthropicResponse failed: %v", err)
+		}
+
+		if metrics.TrafficType != "ON_DEMAND_PRIORITY" {
+			t.Errorf("expected TrafficType ON_DEMAND_PRIORITY, got %q", metrics.TrafficType)
+		}
+	})
+}
+
+func TestHistoryCaching(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req messagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+			return
+		}
+
+		if len(req.Messages) != 2 {
+			t.Fatalf("expected 2 messages in history, got %d", len(req.Messages))
+		}
+
+		// The last message's last block should have cache_control
+		lastMsg := req.Messages[len(req.Messages)-1]
+		lastBlock := lastMsg.Content[len(lastMsg.Content)-1]
+		if lastBlock.CacheControl == nil || lastBlock.CacheControl.Type != "ephemeral" {
+			t.Errorf("expected ephemeral cache control on last history block, got %+v", lastBlock.CacheControl)
+		}
+
+		// The first message's last block should NOT have cache_control (it's not the last turn)
+		firstMsg := req.Messages[0]
+		firstBlock := firstMsg.Content[len(firstMsg.Content)-1]
+		if firstBlock.CacheControl != nil {
+			t.Errorf("expected NO cache control on first history block, got %+v", firstBlock.CacheControl)
+		}
+
+		resp := messagesResponse{
+			Content: []contentBlock{{Type: "text", Text: "OK"}},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"})
+	history := []*llm.Content{
+		{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: "Message 1"}},
+		},
+		{
+			Role:  "assistant",
+			Parts: []*llm.Part{{Text: "Response 1"}},
+		},
+	}
+	_, _, err := client.SendChat(context.Background(), history, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMetricsMapping(t *testing.T) {
+	t.Run("Native Anthropic (Total InputTokens)", func(t *testing.T) {
+		c := &client{model: "claude-3-5-sonnet", logger: &ports.NoOpLogger{}, baseURL: "https://api.anthropic.com/v1"}
+		resp := &messagesResponse{
+			Usage: usage{
+				InputTokens:              1500, // Total (1000 hits + 500 misses)
+				OutputTokens:             500,
+				CacheReadInputTokens:     1000,
+				CacheCreationInputTokens: 200,
+			},
+		}
+
+		_, metrics, err := c.fromAnthropicResponse(resp, 2.5)
+		if err != nil {
+			t.Fatalf("fromAnthropicResponse failed: %v", err)
+		}
+
+		assertMetricsMapping(t, metrics, 1500, 1000, 200)
+	})
+
+	t.Run("Vertex AI (Incremental InputTokens)", func(t *testing.T) {
+		c := &client{model: "claude-3-5-sonnet", logger: &ports.NoOpLogger{}, baseURL: "https://us-central1-aiplatform.googleapis.com/v1"}
+		resp := &messagesResponse{
+			Usage: usage{
+				InputTokens:              500, // Incremental (misses only)
+				OutputTokens:             500,
+				CacheReadInputTokens:     1000,
+				CacheCreationInputTokens: 200,
+			},
+		}
+
+		_, metrics, err := c.fromAnthropicResponse(resp, 2.5)
+		if err != nil {
+			t.Fatalf("fromAnthropicResponse failed: %v", err)
+		}
+
+		// PromptTokens should be normalized to Total (500 delta + 1000 cache_read + 200 cache_creation = 1700)
+		assertMetricsMapping(t, metrics, 1700, 1000, 200)
+	})
+}
+
+// assertMetricsMapping asserts the four metrics fields that every
+// Anthropic response must set.
+//
+// Pins issue #72: Anthropic does not separately report reasoning
+// tokens on the wire. The client must always set ThinkingTokens=0 so
+// the pricing layer's
+//
+//	OutputCost = ResponseTokens × Comp + ThinkingTokens × Thinking
+//
+// reduces to ResponseTokens × Comp (wire-correct: Anthropic rolls
+// reasoning into output_tokens at the standard rate).
+// See ADR-023.
+func assertMetricsMapping(t *testing.T, m *llm.Metrics, wantPrompt, wantCached, wantCacheWrite int32) {
+	t.Helper()
+	if m.PromptTokens != wantPrompt {
+		t.Errorf("expected PromptTokens %d, got %d", wantPrompt, m.PromptTokens)
+	}
+	if m.CachedTokens != wantCached {
+		t.Errorf("expected CachedTokens %d, got %d", wantCached, m.CachedTokens)
+	}
+	if m.CacheWriteTokens != wantCacheWrite {
+		t.Errorf("expected CacheWriteTokens %d, got %d", wantCacheWrite, m.CacheWriteTokens)
+	}
+	if m.ThinkingTokens != 0 {
+		t.Errorf("Anthropic must always report ThinkingTokens=0; got %d", m.ThinkingTokens)
+	}
+}
+
+func TestPromptCaching(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("anthropic-beta") != "prompt-caching-2024-07-31" {
+			t.Errorf("expected beta header, got %s", r.Header.Get("anthropic-beta"))
+		}
+
+		var req messagesRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		systemBlocks, ok := req.System.([]interface{})
+		if !ok || len(systemBlocks) != 1 {
+			t.Errorf("expected 1 system block, got %v", req.System)
+		} else {
+			block := systemBlocks[0].(map[string]interface{})
+			if block["type"] != "text" || block["text"] != "You are a helpful assistant" {
+				t.Errorf("unexpected system block text: %v", block["text"])
+			}
+			cache, ok := block["cache_control"].(map[string]interface{})
+			if !ok || cache["type"] != "ephemeral" {
+				t.Errorf("expected ephemeral cache control, got %v", block["cache_control"])
+			}
+		}
+
+		resp := messagesResponse{
+			Usage: usage{
+				InputTokens:          100,
+				CacheReadInputTokens: 80,
+				OutputTokens:         50,
+			},
+		}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "claude-3-5", &auth.AnthropicAuth{APIKey: "key"}, WithPersona("You are a helpful assistant"))
+	_, metrics, err := client.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if metrics.CachedTokens != 80 {
+		t.Errorf("expected 80 cached tokens, got %d", metrics.CachedTokens)
+	}
+}


### PR DESCRIPTION
## Summary

Split the ~1,250-line monolithic `client_test.go` into four focused test files and extract assertion helpers, following the pattern established in `f8430bce`.

## Changes

- **Extract helpers**: `assertPrepareRequestError` + `assertPrepareRequestSuccess` mirroring the `assertNilDepRequired` pattern
- **Split into 4 files**:
  - `client_test.go` (457 lines): core send/error/timeout/auth/options
  - `client_messages_test.go` (330 lines): thinking, system, messages, transient parts, partToContentBlock
  - `client_vertex_test.go` (367 lines): Vertex AI assertions, traffic type, caching, metrics
  - `client_tools_test.go` (252 lines): tool schema conversion, tool calling

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Max test complexity | 12 | 1 |
| Complexity alerts | 1 | 0 |
| Files >1,000 lines | 1 | 0 |
| Project health | 1 alert | ALL GREEN |

Closes #326