### PR TITLE
refactor: centralize path ignore logic into WorkspacePolicy service (#331)

### DIFF
--- a/internal/application/suggestions/service.go
+++ b/internal/application/suggestions/service.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/pkg/matcher"
 )
 
@@ -30,10 +31,11 @@ type multiSourceSuggestionService struct {
 	stateMu   sync.RWMutex
 	closing   bool
 	logger    io.Writer
+	policy    services.WorkspacePolicy
 }
 
 // NewMultiSourceSuggestionService creates a new suggestion service and pre-loads the history.
-func NewMultiSourceSuggestionService(ctx context.Context, fs persistence.FileSystem, tracker ports.PromptTracker, recentHistory []string, logger io.Writer) (ports.SuggestionService, error) {
+func NewMultiSourceSuggestionService(ctx context.Context, fs persistence.FileSystem, tracker ports.PromptTracker, recentHistory []string, logger io.Writer, policy services.WorkspacePolicy) (ports.SuggestionService, error) {
 	if logger == nil {
 		logger = io.Discard
 	}
@@ -43,6 +45,7 @@ func NewMultiSourceSuggestionService(ctx context.Context, fs persistence.FileSys
 		tracker: tracker,
 		fs:      fs,
 		logger:  logger,
+		policy:  policy,
 	}
 
 	// 1. Pre-load Global Top Prompts
@@ -222,7 +225,7 @@ func (s *multiSourceSuggestionService) scanFiles(ctx context.Context, query stri
 func (s *multiSourceSuggestionService) processEntriesBatch(entries []os.DirEntry, dir string, fileQuery string, currentResults []string) []string {
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() && isIgnoredDir(name) {
+		if entry.IsDir() && s.policy.ShouldIgnoreDir(name) {
 			continue
 		}
 
@@ -265,15 +268,4 @@ func (s *multiSourceSuggestionService) mergeSuggestions(s1, s2 []string, limit i
 		return merged[:limit]
 	}
 	return merged
-}
-
-func isIgnoredDir(name string) bool {
-	// 1. Explicitly ignored common dependency/build directories
-	switch name {
-	case ".git", "node_modules", "vendor", "bin", "obj":
-		return true
-	}
-
-	// 2. Ignore hidden directories
-	return strings.HasPrefix(name, ".")
 }

--- a/internal/application/suggestions/service_test.go
+++ b/internal/application/suggestions/service_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/application/suggestions"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 type mockPromptTracker struct {
@@ -65,7 +66,7 @@ func TestMultiSourceSuggestionService_GetSuggestions(t *testing.T) {
 	}
 
 	fs := persistence.NewMockFileSystem()
-	service, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, []string{"hello", "world"}, io.Discard)
+	service, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, []string{"hello", "world"}, io.Discard, infra_persistence.NewWorkspacePolicy())
 	if err != nil {
 		t.Fatalf("failed to create service: %v", err)
 	}
@@ -113,7 +114,7 @@ func TestMultiSourceSuggestionService_GetSuggestions(t *testing.T) {
 func TestMultiSourceSuggestionService_ContextCancellation(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Create many files in mock FS to make scan potentially slow (though mock is fast)
 	tmpDir := "/tmp/test"
@@ -133,7 +134,7 @@ func TestMultiSourceSuggestionService_ContextCancellation(t *testing.T) {
 func TestMultiSourceSuggestionService_FileSystemSearch(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Create some test files in mock FS
 	tmpDir := "/tmp/test"
@@ -177,7 +178,7 @@ func TestMultiSourceSuggestionService_RecordPrompt(t *testing.T) {
 		appended: appended,
 	}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	prompt := "new-unique-prompt"
 	err := service.RecordPrompt(context.Background(), prompt)
@@ -270,7 +271,7 @@ func TestMultiSourceSuggestionService_MergeSuggestions(t *testing.T) {
 func TestSuggestionService_ScanFiles_CancelledContext(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Create some files in mock FS
 	tmpDir := "/tmp/test"
@@ -301,7 +302,7 @@ func TestSuggestionService_ScanFiles_CancelledContext(t *testing.T) {
 func TestSuggestionService_ScanFiles_InvalidDir(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Call GetSuggestions with a path that definitely doesn't exist in mock FS
 	invalidPath := "/non-existent-dir/file"
@@ -330,7 +331,7 @@ func TestSuggestionService_LoadTopNFails(t *testing.T) {
 	tracker := &errorPromptTracker{}
 	fs := persistence.NewMockFileSystem()
 	// This should log to stderr but not return an error
-	service, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 	if err != nil {
 		t.Fatalf("NewMultiSourceSuggestionService should not fail when tracker fails to load: %v", err)
 	}
@@ -342,7 +343,7 @@ func TestSuggestionService_LoadTopNFails(t *testing.T) {
 func TestSuggestionService_RecordPrompt_EmptyPath(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	err := service.RecordPrompt(context.Background(), "")
 	if err != nil {
@@ -358,7 +359,7 @@ func TestSuggestionService_RecordPrompt_EmptyPath(t *testing.T) {
 func TestMultiSourceSuggestionService_ScanFiles_ExclusionsAndLimit(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	tmpDir := "/tmp/test"
 
@@ -501,7 +502,7 @@ func assertSuggestionsMatch(t *testing.T, got, expected []string) {
 func TestMultiSourceSuggestionService_RecordPrompt_MRU(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// 1. Record multiple prompts
 	prompts := []string{"p1", "p2", "p3"}
@@ -546,7 +547,7 @@ func TestMultiSourceSuggestionService_Close_WaitsForBackgroundTasks(t *testing.T
 		appended: appended,
 	}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Record a prompt
 	prompt := "close-test-prompt"
@@ -576,7 +577,7 @@ func TestNewMultiSourceSuggestionService_NilLogger(t *testing.T) {
 		}
 	}()
 
-	_, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, nil)
+	_, err := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, nil, infra_persistence.NewWorkspacePolicy())
 	if err != nil {
 		t.Fatalf("NewMultiSourceSuggestionService failed: %v", err)
 	}
@@ -587,7 +588,7 @@ func TestRecordPrompt_NilLogger(t *testing.T) {
 	failTracker := &failingAppendTracker{}
 	fs := persistence.NewMockFileSystem()
 
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, failTracker, nil, nil)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, failTracker, nil, nil, infra_persistence.NewWorkspacePolicy())
 
 	_ = service.RecordPrompt(context.Background(), "test")
 
@@ -632,7 +633,7 @@ func TestMultiSourceSuggestionService_Close_ImmediateCancellation(t *testing.T) 
 func TestRecordPrompt_AfterClose(t *testing.T) {
 	tracker := &mockPromptTracker{}
 	fs := persistence.NewMockFileSystem()
-	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard)
+	service, _ := suggestions.NewMultiSourceSuggestionService(context.Background(), fs, tracker, nil, io.Discard, infra_persistence.NewWorkspacePolicy())
 
 	// Call Close on the service
 	err := service.Close(context.Background())

--- a/internal/domain/services/workspace_policy.go
+++ b/internal/domain/services/workspace_policy.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package services
+
+// WorkspacePolicy centralizes filesystem filtering rules so that every tool and
+// service in the application agrees on which directories and paths to skip.
+type WorkspacePolicy interface {
+	// ShouldIgnoreDir reports whether a directory entry (by name only, not full
+	// path) should be excluded from traversal. Callers that walk directory trees
+	// should skip the entry and, if the entry is a directory, skip its children.
+	ShouldIgnoreDir(name string) bool
+
+	// ShouldIgnorePath reports whether a full path should be excluded. This is
+	// used when the caller already has the resolved path (e.g. secret scanning)
+	// and needs to check every path component against the policy.
+	ShouldIgnorePath(path string) bool
+}

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/exec"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/factory"
@@ -55,6 +56,7 @@ type Bootstrapper struct {
 	Stderr            io.Writer
 	Logger            *slog.Logger
 	FileSystem        infra_persistence.FileSystem
+	WorkspacePolicy   services.WorkspacePolicy
 	ClientFactory     func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error)
 	RegisterAllTools  func(params infra_tools.ToolRegistrationParams) error
 	RegisterMetrics   func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error
@@ -88,6 +90,10 @@ func NewBootstrapper(homeDir string, sm ConfigurableSecurityManager, version str
 		NewSessionState:  infra_persistence.NewSessionState,
 	}
 
+	if b.WorkspacePolicy == nil {
+		b.WorkspacePolicy = infra_persistence.NewWorkspacePolicy()
+	}
+
 	b.sessionFactory = newSessionFactory(homeDir, fs, sm, stdout, stderr, logger,
 		func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error {
 			return b.RotateSession(ctx, fs, stdout, paths, retentionDays, logger)
@@ -106,7 +112,7 @@ func NewBootstrapper(homeDir string, sm ConfigurableSecurityManager, version str
 	b.historyFactory = newHistoryFactory(homeDir, fs)
 	b.uiFactory = newUIFactory(sm, stdout, stderr, logger)
 	b.chatFactory = newChatFactory(homeDir, version, stdout, stderr, sm, fs, b, b.uiFactory)
-	b.suggestionFactory = newSuggestionFactory(homeDir, fs, stderr, logger)
+	b.suggestionFactory = newSuggestionFactory(homeDir, fs, stderr, logger, b.WorkspacePolicy)
 	return b
 }
 
@@ -155,6 +161,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		logger:           telemetry.NewSlogLogger(b.Logger),
 		turnsLogger:      turnsLogger,
 		sessionProvider:  sessionProvider,
+		workspacePolicy:  b.WorkspacePolicy,
 		clientFactory:    clientFactory,
 	}
 
@@ -200,6 +207,7 @@ type sessionDeps struct {
 	logger           ports.Logger
 	turnsLogger      ports.TurnsLogger
 	sessionProvider  ports.SessionProvider
+	workspacePolicy  services.WorkspacePolicy
 	health           ports.HealthCheckManager
 
 	initOnce      sync.Once
@@ -282,6 +290,9 @@ func (d *sessionDeps) GetTurnsLogger() ports.TurnsLogger    { return d.turnsLogg
 func (d *sessionDeps) GetPaths() *persistence.Paths         { return d.paths }
 func (d *sessionDeps) GetSessionProvider() ports.SessionProvider {
 	return d.sessionProvider
+}
+func (d *sessionDeps) GetWorkspacePolicy() services.WorkspacePolicy {
+	return d.workspacePolicy
 }
 func (d *sessionDeps) GetPricingOverrides() map[string]pricing.ModelPricing {
 	return d.pricingOverrides

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -101,7 +101,7 @@ func NewBootstrapper(homeDir string, sm ConfigurableSecurityManager, version str
 		func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error) {
 			return b.NewSessionState(ctx, modeDir)
 		})
-	b.toolchainFactory = newToolchainFactory(homeDir, fs, sm,
+	b.toolchainFactory = newToolchainFactory(homeDir, fs, sm, b.WorkspacePolicy,
 		func(params infra_tools.ToolRegistrationParams) error {
 			return b.RegisterAllTools(params)
 		},

--- a/internal/infrastructure/di/factory_error_test.go
+++ b/internal/infrastructure/di/factory_error_test.go
@@ -236,7 +236,7 @@ func TestBuildRegistry_FailurePaths(t *testing.T) {
 				sm.On("RegisterPolicyTools", mock.Anything, mock.Anything).Return(nil).Maybe()
 			}
 
-			factory := newToolchainFactory(tempDir, nil, sm, nil, nil).(*defaultToolchainFactory)
+			factory := newToolchainFactory(tempDir, nil, sm, nil, nil, nil).(*defaultToolchainFactory)
 			if tt.setup != nil {
 				tt.setup(factory)
 			}

--- a/internal/infrastructure/di/suggestion_factory.go
+++ b/internal/infrastructure/di/suggestion_factory.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/application/suggestions"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
@@ -19,18 +20,20 @@ type suggestionFactory interface {
 }
 
 type defaultSuggestionFactory struct {
-	HomeDir    string
-	FileSystem infra_persistence.FileSystem
-	Stderr     io.Writer
-	Logger     *slog.Logger
+	HomeDir         string
+	FileSystem      infra_persistence.FileSystem
+	Stderr          io.Writer
+	Logger          *slog.Logger
+	WorkspacePolicy services.WorkspacePolicy
 }
 
-func newSuggestionFactory(homeDir string, fs infra_persistence.FileSystem, stderr io.Writer, logger *slog.Logger) suggestionFactory {
+func newSuggestionFactory(homeDir string, fs infra_persistence.FileSystem, stderr io.Writer, logger *slog.Logger, wp services.WorkspacePolicy) suggestionFactory {
 	return &defaultSuggestionFactory{
-		HomeDir:    homeDir,
-		FileSystem: fs,
-		Stderr:     stderr,
-		Logger:     logger,
+		HomeDir:         homeDir,
+		FileSystem:      fs,
+		Stderr:          stderr,
+		Logger:          logger,
+		WorkspacePolicy: wp,
 	}
 }
 
@@ -41,5 +44,5 @@ func (f *defaultSuggestionFactory) BuildSuggestionService(ctx stdctx.Context, re
 		tracker = history.NewNoOpTracker()
 	}
 
-	return suggestions.NewMultiSourceSuggestionService(ctx, infra_persistence.NewDomainFS(f.FileSystem), tracker, recentHistory, f.Stderr)
+	return suggestions.NewMultiSourceSuggestionService(ctx, infra_persistence.NewDomainFS(f.FileSystem), tracker, recentHistory, f.Stderr, f.WorkspacePolicy)
 }

--- a/internal/infrastructure/di/toolchain_factory.go
+++ b/internal/infrastructure/di/toolchain_factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/exec"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
@@ -39,15 +40,17 @@ type defaultToolchainFactory struct {
 	HomeDir          string
 	FileSystem       infra_persistence.FileSystem
 	SM               ConfigurableSecurityManager
+	WorkspacePolicy  services.WorkspacePolicy
 	RegisterAllTools func(params infra_tools.ToolRegistrationParams) error
 	RegisterMetrics  func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error
 }
 
-func newToolchainFactory(homeDir string, fs infra_persistence.FileSystem, sm ConfigurableSecurityManager, registerAll func(params infra_tools.ToolRegistrationParams) error, registerMetrics func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error) toolchainFactory {
+func newToolchainFactory(homeDir string, fs infra_persistence.FileSystem, sm ConfigurableSecurityManager, wp services.WorkspacePolicy, registerAll func(params infra_tools.ToolRegistrationParams) error, registerMetrics func(r tools.Registry, sm security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]pricing.ModelPricing, kvStore ports.KVStore) error) toolchainFactory {
 	return &defaultToolchainFactory{
 		HomeDir:          homeDir,
 		FileSystem:       fs,
 		SM:               sm,
+		WorkspacePolicy:  wp,
 		RegisterAllTools: registerAll,
 		RegisterMetrics:  registerMetrics,
 	}
@@ -72,6 +75,7 @@ func (f *defaultToolchainFactory) BuildRegistry(params toolchainParams) (tools.R
 		EventBus:         params.Bus,
 		FileSystem:       infra_persistence.NewDomainFS(f.FileSystem),
 		HealthManager:    params.HealthManager,
+		WorkspacePolicy:  f.WorkspacePolicy,
 	}
 
 	if err := f.RegisterAllTools(regParams); err != nil {

--- a/internal/infrastructure/persistence/workspace_policy.go
+++ b/internal/infrastructure/persistence/workspace_policy.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package persistence
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
+)
+
+// Ensure defaultWorkspacePolicy satisfies the domain interface at compile time.
+var _ services.WorkspacePolicy = (*defaultWorkspacePolicy)(nil)
+
+// defaultWorkspacePolicy is the standard implementation of WorkspacePolicy.
+// It uses the union of all ignore rules that were previously duplicated across
+// the codebase (tools, suggestions, release scanning). It is safe for concurrent
+// use because it has no mutable state.
+type defaultWorkspacePolicy struct{}
+
+// NewWorkspacePolicy returns a new defaultWorkspacePolicy.
+func NewWorkspacePolicy() *defaultWorkspacePolicy {
+	return &defaultWorkspacePolicy{}
+}
+
+// ignoredDirNames is the canonical set of directory names that every walker and
+// scanner in the application must skip. It is the union of all previously
+// hardcoded lists.
+var ignoredDirNames = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"vendor":       true,
+	"bin":          true,
+	"obj":          true,
+	"output":       true,
+	"dist":         true,
+	"testdata":     true,
+	"configs":      true,
+}
+
+// ignoredExtensions lists file suffixes that the path-level policy should skip
+// (used by secret scanning and other full-path checks).
+var ignoredExtensions = []string{
+	"_test.go",
+	".md",
+	".json",
+	".golden",
+}
+
+// ShouldIgnoreDir reports whether the directory name should be skipped. It
+// matches the explicit set of known noise directories and also any hidden
+// directory (name starts with '.').
+func (p *defaultWorkspacePolicy) ShouldIgnoreDir(name string) bool {
+	if ignoredDirNames[name] {
+		return true
+	}
+	// Hidden directories (e.g. .terraform, .vscode) — but "." itself is not ignored.
+	return len(name) > 1 && name[0] == '.'
+}
+
+// ShouldIgnorePath reports whether the full path should be skipped. It checks
+// every path component against the directory policy and also checks the leaf
+// file against the ignored extensions list.
+func (p *defaultWorkspacePolicy) ShouldIgnorePath(path string) bool {
+	normalized := filepath.ToSlash(filepath.Clean(path))
+	parts := strings.Split(normalized, "/")
+	for _, part := range parts {
+		if p.ShouldIgnoreDir(part) {
+			return true
+		}
+	}
+	// Check file extension exclusions on the leaf.
+	leaf := parts[len(parts)-1]
+	for _, ext := range ignoredExtensions {
+		if strings.HasSuffix(leaf, ext) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/infrastructure/persistence/workspace_policy.go
+++ b/internal/infrastructure/persistence/workspace_policy.go
@@ -20,7 +20,7 @@ var _ services.WorkspacePolicy = (*defaultWorkspacePolicy)(nil)
 type defaultWorkspacePolicy struct{}
 
 // NewWorkspacePolicy returns a new defaultWorkspacePolicy.
-func NewWorkspacePolicy() *defaultWorkspacePolicy {
+func NewWorkspacePolicy() services.WorkspacePolicy {
 	return &defaultWorkspacePolicy{}
 }
 

--- a/internal/tools/analysis/dependency.go
+++ b/internal/tools/analysis/dependency.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/tools/go/packages"
@@ -23,15 +24,17 @@ type defaultDependencyAnalyzer struct {
 	Runner    AnalysisGoRunner
 	SP        domain_security.PolicyEvaluator
 	Events    events.EventBus
+	Policy    services.WorkspacePolicy
 	modPrefix string
 	modMu     sync.Mutex
 }
 
-func newDependencyAnalyzer(runner AnalysisGoRunner, sp domain_security.PolicyEvaluator, bus events.EventBus) *defaultDependencyAnalyzer {
+func newDependencyAnalyzer(runner AnalysisGoRunner, sp domain_security.PolicyEvaluator, bus events.EventBus, wp services.WorkspacePolicy) *defaultDependencyAnalyzer {
 	return &defaultDependencyAnalyzer{
 		Runner: runner,
 		SP:     sp,
 		Events: bus,
+		Policy: wp,
 	}
 }
 
@@ -138,11 +141,6 @@ func (a *defaultDependencyAnalyzer) startHeartbeat(hb chan<- struct{}, done <-ch
 	}
 }
 
-// isSkippedDir reports whether the named directory should be excluded from package scanning.
-func isSkippedDir(name string) bool {
-	return name == "vendor" || (len(name) > 1 && name[0] == '.')
-}
-
 // containsGoFiles reports whether the directory at path contains at least one .go file.
 func containsGoFiles(path string) (bool, error) {
 	files, err := os.ReadDir(path)
@@ -166,7 +164,7 @@ func (a *defaultDependencyAnalyzer) listInternalPackages(root string) ([]string,
 		if !info.IsDir() {
 			return nil
 		}
-		if isSkippedDir(info.Name()) {
+		if a.Policy.ShouldIgnoreDir(info.Name()) {
 			return filepath.SkipDir
 		}
 		hasGo, err := containsGoFiles(path)

--- a/internal/tools/analysis/dependency_test.go
+++ b/internal/tools/analysis/dependency_test.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 func TestDependencyAnalyzer_GetPackageGraph(t *testing.T) {
@@ -36,7 +38,7 @@ func TestDependencyAnalyzer_GetPackageGraph(t *testing.T) {
 		},
 	}
 
-	analyzer := newDependencyAnalyzer(mockRunner, &mockSecurityProvider{}, nil)
+	analyzer := newDependencyAnalyzer(mockRunner, &mockSecurityProvider{}, nil, infra_persistence.NewWorkspacePolicy())
 
 	// Set workdir to tmpDir so that go list -m works
 	// In a real scenario, the tool would run in the project root.

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
@@ -143,7 +144,7 @@ func TestHealthManager_GetCodeHealth(t *testing.T) {
 	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem())
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
 	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
 
 	ctx := context.Background()
@@ -176,7 +177,7 @@ func TestHealthManager_GetCodeHealth_Cancelled(t *testing.T) {
 	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem())
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
 	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/tools/analysis/info.go
+++ b/internal/tools/analysis/info.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
@@ -29,20 +30,13 @@ type infoManager struct {
 	FS     persistence.FileSystem
 	Events events.EventBus
 	Runner AnalysisGoRunner
+	Policy services.WorkspacePolicy
 }
 
 type projectStats struct {
 	fileCounts map[string]int
 	packages   map[string]bool
 	totalLOC   int
-}
-
-func (m *infoManager) isIgnoredDir(name string, isDir bool) bool {
-	if !isDir {
-		return false
-	}
-	// Skip hidden directories, testdata, vendor, and node_modules
-	return name != "." && (strings.HasPrefix(name, ".") || name == "testdata" || name == "vendor" || name == "node_modules")
 }
 
 func (m *infoManager) isTargetSourceFile(name string, isDir bool) bool {
@@ -98,7 +92,7 @@ func (m *infoManager) makeWalkFunc(ctx context.Context, stats *projectStats, hb 
 
 		name := info.Name()
 		isDir := info.IsDir()
-		if m.isIgnoredDir(name, isDir) {
+		if isDir && m.Policy.ShouldIgnoreDir(name) {
 			return filepath.SkipDir
 		}
 

--- a/internal/tools/analysis/info_test.go
+++ b/internal/tools/analysis/info_test.go
@@ -7,10 +7,11 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 func TestInfoManager_RenderProjectSummary(t *testing.T) {
-	m := &infoManager{}
+	m := &infoManager{Policy: infra_persistence.NewWorkspacePolicy()}
 
 	modInfo := "module example.com/test\ngo 1.21\n"
 	fileCounts := map[string]int{
@@ -46,7 +47,7 @@ func TestInfoManager_RenderProjectSummary(t *testing.T) {
 
 func TestInfoManager_ExtractGenericSkeleton(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
-	m := &infoManager{FS: fs}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	tests := []struct {
@@ -101,7 +102,7 @@ function test() {
 
 func TestInfoManager_ResolveModuleInfo(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
-	m := &infoManager{FS: fs}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	tests := []struct {
@@ -137,7 +138,7 @@ func TestInfoManager_ResolveModuleInfo(t *testing.T) {
 
 func TestInfoManager_CollectFileStats(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
-	m := &infoManager{FS: fs}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	// Setup mock files
@@ -176,7 +177,7 @@ func TestInfoManager_CollectFileStats(t *testing.T) {
 
 func TestInfoManager_GetProjectSummary(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
-	m := &infoManager{FS: fs}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	_ = fs.WriteFile(ctx, "go.mod", []byte("module example.com/test\ngo 1.25\n"), 0644)
@@ -197,7 +198,7 @@ func TestInfoManager_GetProjectSummary(t *testing.T) {
 
 func TestInfoManager_CollectFileStats_EdgeCases(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
-	m := &infoManager{FS: fs}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	t.Run("empty directory", func(t *testing.T) {
@@ -243,7 +244,7 @@ func TestInfoManager_GoDoc(t *testing.T) {
 			return []byte("GoDoc output"), nil
 		},
 	}
-	m := &infoManager{Runner: runner}
+	m := &infoManager{Runner: runner, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	args := map[string]interface{}{

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
@@ -78,19 +79,19 @@ type analysisManager struct {
 	Events events.EventBus
 }
 
-func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem) *analysisManager {
+func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy) *analysisManager {
 	runner := toolchain.NewGoRunner(executor)
 	m := &analysisManager{
 		Complexity: newComplexityAnalyzer(cache, sp),
-		Dependency: newDependencyAnalyzer(runner, sp, bus),
+		Dependency: newDependencyAnalyzer(runner, sp, bus, wp),
 		Sequence:   newSequenceAnalyzer(executor, sp, idx),
 		Change:     newChangeAnalyzer(cache, executor),
 		Types:      newTypeManager(idx, cache, sp),
 		DeadCode:   newDeadCodeAnalyzer(sp, idx),
 
 		Refactor: newRefactorManager(sp),
-		Info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner},
-		Search:   &searchManager{SP: sp, FS: fs},
+		Info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp},
+		Search:   &searchManager{SP: sp, FS: fs, Policy: wp},
 		Arch:     &architectureManager{SP: sp, Runner: runner, idx: idx},
 		Events:   bus,
 	}

--- a/internal/tools/analysis/manager_test.go
+++ b/internal/tools/analysis/manager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 )
 
@@ -24,7 +25,7 @@ func setupAnalysisManager(t *testing.T) (*analysisManager, string) {
 	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 
-	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem())
+	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
 	return m, tmpDir
 }
 

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -9,14 +9,15 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
 // Register adds all consolidated analysis tools to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem) (tools.ToolFunc, error) {
+func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy) (tools.ToolFunc, error) {
 	idx, _ := newIndexer(".")
 	cache := newASTCache(".")
-	m := newAnalysisManager(idx, cache, sm, bus, executor, fs)
+	m := newAnalysisManager(idx, cache, sm, bus, executor, fs, wp)
 
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration

--- a/internal/tools/analysis/search.go
+++ b/internal/tools/analysis/search.go
@@ -11,13 +11,15 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/workspace"
 )
 
 type searchManager struct {
-	SP security.PathValidator
-	FS persistence.FileSystem
+	SP     security.PathValidator
+	FS     persistence.FileSystem
+	Policy services.WorkspacePolicy
 }
 
 var todoRegex = regexp.MustCompile(`(?i)(TODO|FIXME|BUG):?.*`)
@@ -26,7 +28,7 @@ func (m *searchManager) executeSearch(ctx context.Context, path string, hb chan<
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resChan, errChan := workspace.ConcurrentSearch(ctx, m.SP, m.FS, path, hb, matchFunc)
+	resChan, errChan := workspace.ConcurrentSearch(ctx, m.SP, m.FS, path, hb, matchFunc, m.Policy)
 
 	var results []string
 	truncated := false

--- a/internal/tools/analysis/search_test.go
+++ b/internal/tools/analysis/search_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +107,7 @@ func TestListTodos(t *testing.T) {
 func setupTodoWorkspace(t *testing.T, files map[string]string) (*searchManager, string) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	fs := persistence.NewMockFileSystem()
-	m := &searchManager{SP: sm, FS: fs}
+	m := &searchManager{SP: sm, FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 	tempDir := "/mock/todo-test"
 	sm.RegisterSafePath(tempDir)
@@ -126,7 +127,7 @@ func TestSearchUsagesGlobally(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	fs := persistence.NewMockFileSystem()
-	m := &searchManager{SP: sm, FS: fs}
+	m := &searchManager{SP: sm, FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	tempDir := "/mock/usages"
@@ -178,7 +179,7 @@ func TestSearchManager_Errors(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: false}
 	fs := persistence.NewMockFileSystem()
-	m := &searchManager{SP: sm, FS: fs}
+	m := &searchManager{SP: sm, FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	// Setup for success case

--- a/internal/tools/developer/registration.go
+++ b/internal/tools/developer/registration.go
@@ -8,12 +8,13 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
 
 // Register adds all development workflow and release tools to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, archVerify tools.ToolFunc) error {
+func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, archVerify tools.ToolFunc) error {
 	runner := toolchain.NewGoRunner(exec)
 	dev := newDevManager(sm, validator, runner)
 
@@ -100,6 +101,7 @@ func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandEx
 		sm:           sm,
 		fs:           fs,
 		runner:       runner,
+		policy:       wp,
 		archVerifier: archVerify,
 	}
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{

--- a/internal/tools/developer/registration_test.go
+++ b/internal/tools/developer/registration_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 )
@@ -73,7 +74,7 @@ func TestRegister(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
 	exec := &mockToolchainExecutor{}
 
-	if err := Register(registry, sm, exec, validator, fs, nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 

--- a/internal/tools/developer/release.go
+++ b/internal/tools/developer/release.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
@@ -33,6 +34,7 @@ type releaseManager struct {
 	sm           domain_security.PathValidator
 	fs           persistence.FileSystem
 	runner       releaseGoRunner
+	policy       services.WorkspacePolicy
 	archVerifier tools.ToolFunc
 }
 
@@ -53,7 +55,7 @@ func (m *releaseManager) verifyReleaseReadiness(ctx context.Context, _ map[strin
 	}
 
 	pipeline := []readinessCheck{
-		&secretScanner{root: root, fs: m.fs},
+		&secretScanner{root: root, fs: m.fs, policy: m.policy},
 		&dependencyChecker{root: root, fs: m.fs},
 		&linterChecker{runner: m.runner},
 		&architectureChecker{verifier: m.archVerifier},
@@ -160,8 +162,9 @@ func (a *scanAccumulator) addFindings(matches []string) {
 
 // secretScanner implementation
 type secretScanner struct {
-	root string
-	fs   persistence.FileSystem
+	root   string
+	fs     persistence.FileSystem
+	policy services.WorkspacePolicy
 }
 
 func (s *secretScanner) Name() string { return "Security Scan" }
@@ -230,20 +233,7 @@ func (s *secretScanner) scanContent(content []byte, path string, patterns []*reg
 }
 
 func (s *secretScanner) isIgnored(path string) bool {
-	p := filepath.ToSlash(filepath.Clean(path))
-	// Check for common ignored directories in any part of the path
-	parts := strings.Split(p, "/")
-	for _, part := range parts {
-		// Added "configs" to the exclusion list to prevent false positives from environment variable placeholders
-		if part == ".git" || part == "vendor" || part == "node_modules" || part == "configs" {
-			return true
-		}
-	}
-
-	return strings.HasSuffix(p, "_test.go") ||
-		strings.HasSuffix(p, ".md") ||
-		strings.HasSuffix(p, ".json") ||
-		strings.HasSuffix(p, ".golden")
+	return s.policy.ShouldIgnorePath(path)
 }
 
 // dependencyChecker implementation

--- a/internal/tools/developer/release_test.go
+++ b/internal/tools/developer/release_test.go
@@ -176,7 +176,7 @@ func TestVerifyReleaseReadiness_Failures(t *testing.T) {
 			tt.setupFiles(fs)
 			runner := tt.setupRunner()
 			m := &releaseManager{
-		policy: infra_persistence.NewWorkspacePolicy(),
+				policy: infra_persistence.NewWorkspacePolicy(),
 				sm:     sm,
 				fs:     fs,
 				runner: runner,
@@ -252,7 +252,7 @@ func TestLinterChecker_Fallbacks(t *testing.T) {
 			_ = fs.WriteFile(ctx, root+"/go.mod", []byte("module test"), 0644)
 			runner := tt.setupRunner()
 			m := &releaseManager{
-		policy: infra_persistence.NewWorkspacePolicy(),
+				policy: infra_persistence.NewWorkspacePolicy(),
 				sm:     sm,
 				fs:     fs,
 				runner: runner,
@@ -273,7 +273,7 @@ func TestVerifyReleaseReadiness_Parallelism(t *testing.T) {
 
 	m := &releaseManager{
 		policy: infra_persistence.NewWorkspacePolicy(),
-		sm: sm,
+		sm:     sm,
 	}
 
 	t.Run("Default", func(t *testing.T) {

--- a/internal/tools/developer/release_test.go
+++ b/internal/tools/developer/release_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
@@ -70,6 +71,7 @@ func TestVerifyReleaseReadiness_Success(t *testing.T) {
 	runner := &mockReleaseRunner{}
 
 	m := &releaseManager{
+		policy: infra_persistence.NewWorkspacePolicy(),
 		sm:     sm,
 		fs:     fs,
 		runner: runner,
@@ -174,6 +176,7 @@ func TestVerifyReleaseReadiness_Failures(t *testing.T) {
 			tt.setupFiles(fs)
 			runner := tt.setupRunner()
 			m := &releaseManager{
+		policy: infra_persistence.NewWorkspacePolicy(),
 				sm:     sm,
 				fs:     fs,
 				runner: runner,
@@ -249,6 +252,7 @@ func TestLinterChecker_Fallbacks(t *testing.T) {
 			_ = fs.WriteFile(ctx, root+"/go.mod", []byte("module test"), 0644)
 			runner := tt.setupRunner()
 			m := &releaseManager{
+		policy: infra_persistence.NewWorkspacePolicy(),
 				sm:     sm,
 				fs:     fs,
 				runner: runner,
@@ -268,6 +272,7 @@ func TestVerifyReleaseReadiness_Parallelism(t *testing.T) {
 	sm.RegisterSafePath(".")
 
 	m := &releaseManager{
+		policy: infra_persistence.NewWorkspacePolicy(),
 		sm: sm,
 	}
 
@@ -302,7 +307,7 @@ func TestVerifyReleaseReadiness_Parallelism(t *testing.T) {
 }
 
 func TestSecretScanner_IsIgnored(t *testing.T) {
-	s := &secretScanner{}
+	s := &secretScanner{policy: infra_persistence.NewWorkspacePolicy()}
 	tests := []struct {
 		path   string
 		ignore bool

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -6,6 +6,8 @@
 package tools
 
 import (
+	"fmt"
+
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -42,6 +44,9 @@ type ToolRegistrationParams struct {
 
 // RegisterAll registers all available tools into the registry.
 func RegisterAll(params ToolRegistrationParams) error {
+	if params.WorkspacePolicy == nil {
+		return fmt.Errorf("RegisterAll: WorkspacePolicy is required and must not be nil")
+	}
 	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager); err != nil {
 		return err
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/analysis"
 	"github.com/gosharplite/tell-me-go/internal/tools/developer"
@@ -35,12 +36,13 @@ type ToolRegistrationParams struct {
 	AssetsDir        string
 	EventBus         events.EventBus
 	FileSystem       persistence.FileSystem
+	WorkspacePolicy  services.WorkspacePolicy
 	HealthManager    ports.HealthCheckManager
 }
 
 // RegisterAll registers all available tools into the registry.
 func RegisterAll(params ToolRegistrationParams) error {
-	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.HealthManager); err != nil {
+	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager); err != nil {
 		return err
 	}
 	if params.SessionProvider != nil {
@@ -48,11 +50,11 @@ func RegisterAll(params ToolRegistrationParams) error {
 			return err
 		}
 	}
-	archVerify, err := analysis.Register(params.Registry, params.SecurityManager, params.EventBus, params.CommandExecutor, params.FileSystem)
+	archVerify, err := analysis.Register(params.Registry, params.SecurityManager, params.EventBus, params.CommandExecutor, params.FileSystem, params.WorkspacePolicy)
 	if err != nil {
 		return err
 	}
-	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, archVerify); err != nil {
+	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify); err != nil {
 		return err
 	}
 	if err := integrations.RegisterAll(params.Registry, params.FileSystem, params.SecurityManager, params.Client, params.AssetsDir); err != nil {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domaintools "github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/tools"
@@ -45,6 +46,7 @@ func TestNewToolRegistry(t *testing.T) {
 		Mode:            "mode",
 		AssetsDir:       t.TempDir(),
 		FileSystem:      persistencetest.NewPlainOSFileSystem(),
+		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 	}); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
@@ -69,6 +71,7 @@ func TestRegisterAll_WithSessionProvider(t *testing.T) {
 		Mode:            "mode",
 		AssetsDir:       t.TempDir(),
 		FileSystem:      persistencetest.NewPlainOSFileSystem(),
+		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 	}); err != nil {
 		t.Fatalf("RegisterAll with SessionProvider failed: %v", err)
 	}
@@ -87,6 +90,7 @@ func TestToolExecution(t *testing.T) {
 		Mode:            "mode",
 		AssetsDir:       t.TempDir(),
 		FileSystem:      persistencetest.NewPlainOSFileSystem(),
+		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 	}); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
@@ -112,6 +116,7 @@ func TestGenerateMermaidDiagram(t *testing.T) {
 		Mode:            "mode",
 		AssetsDir:       t.TempDir(),
 		FileSystem:      persistencetest.NewPlainOSFileSystem(),
+		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 	}); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
@@ -229,8 +234,9 @@ func TestRegisterAll_Errors(t *testing.T) {
 			t.Parallel()
 			mockReg := &MockRegistry{failAfter: tt.failAfter}
 			params := tools.ToolRegistrationParams{
-				HealthManager: nil,
-				Registry:      mockReg,
+				HealthManager:   nil,
+				Registry:        mockReg,
+				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 			}
 			if tt.setup != nil {
 				tt.setup(&params)

--- a/internal/tools/workspace/concurrent_search_test.go
+++ b/internal/tools/workspace/concurrent_search_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 type searchMockFile struct {
@@ -192,7 +193,7 @@ func testConcurrentSearchTable(t *testing.T) {
 
 			resChan, errChan := ConcurrentSearch(ctx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 				return "", strings.Contains(line, tt.query)
-			})
+			}, infra_persistence.NewWorkspacePolicy())
 
 			var results []string
 			for res := range resChan {
@@ -231,7 +232,7 @@ func testConcurrentSearchBinaryLarge(t *testing.T) {
 
 	resChan, errChan := ConcurrentSearch(ctx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 		return "", strings.Contains(line, "todo")
-	})
+	}, infra_persistence.NewWorkspacePolicy())
 
 	var results []string
 	for res := range resChan {
@@ -262,7 +263,7 @@ func testConcurrentSearchCancellation(t *testing.T) {
 
 	_, errChan := ConcurrentSearch(cancelCtx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 		return "", true
-	})
+	}, infra_persistence.NewWorkspacePolicy())
 
 	err := <-errChan
 	if err != context.Canceled {
@@ -281,7 +282,7 @@ func testConcurrentSearchRace(t *testing.T) {
 				defer wg.Done()
 				resChan, _ := ConcurrentSearch(ctx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 					return "", true
-				})
+				}, infra_persistence.NewWorkspacePolicy())
 				for range resChan {
 				}
 			}()

--- a/internal/tools/workspace/git_test.go
+++ b/internal/tools/workspace/git_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"

--- a/internal/tools/workspace/git_test.go
+++ b/internal/tools/workspace/git_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
@@ -176,7 +177,7 @@ func TestGitTools(t *testing.T) {
 			}
 
 			reg := registry.New()
-			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), nil); err != nil {
+			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
 				t.Fatalf("Register failed: %v", err)
 			}
 
@@ -276,7 +277,7 @@ func TestGitDestructiveActions(t *testing.T) {
 			}
 
 			reg := registry.New()
-			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), nil); err != nil {
+			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
 				t.Fatalf("Register failed: %v", err)
 			}
 
@@ -314,7 +315,7 @@ func TestGitBlameSafety(t *testing.T) {
 	}
 
 	reg := registry.New()
-	if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), nil); err != nil {
+	if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 

--- a/internal/tools/workspace/reader.go
+++ b/internal/tools/workspace/reader.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
@@ -25,6 +26,7 @@ type fileReader struct {
 	sm       domain_security.PathValidator
 	fs       persistence.FileSystem
 	executor commandExecutor
+	policy   services.WorkspacePolicy
 }
 
 func (r *fileReader) listFiles(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -265,7 +267,7 @@ func (r *fileReader) findFile(ctx context.Context, args map[string]interface{}, 
 		return nil
 	}
 
-	if err := walkAndProcess(ctx, r.sm, r.fs, params.Path, hb, processor); err != nil {
+	if err := walkAndProcess(ctx, r.sm, r.fs, params.Path, hb, processor, r.policy); err != nil {
 		return tools.ToolResult{}, err
 	}
 

--- a/internal/tools/workspace/reader_test.go
+++ b/internal/tools/workspace/reader_test.go
@@ -12,6 +12,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
@@ -28,7 +29,7 @@ func TestListFiles(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	t.Run("list root", func(t *testing.T) {
@@ -58,7 +59,7 @@ func TestReadFile(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{path}, "reason": "testing"}, nil)
@@ -80,7 +81,7 @@ func TestGetTree(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	t.Run("basic tree", func(t *testing.T) {
@@ -110,7 +111,7 @@ func TestFindFile(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	t.Run("find .go files", func(t *testing.T) {
@@ -169,6 +170,7 @@ func TestGetFileDiff(t *testing.T) {
 	r := &fileReader{
 		sm:       sm,
 		fs:       persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
 		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
 	}
 	ctx := context.Background()
@@ -204,7 +206,7 @@ func TestReadFile_Truncation(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{path}, "reason": "testing"}, nil)
@@ -228,7 +230,7 @@ func TestReadFile_Binary(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{path}, "reason": "testing"}, nil)
@@ -251,6 +253,7 @@ func TestGetFileDiff_Errors(t *testing.T) {
 	r := &fileReader{
 		sm:       sm,
 		fs:       persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
 		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
 	}
 	ctx := context.Background()
@@ -290,7 +293,7 @@ func TestReadFiles(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	tests := []struct {
@@ -365,7 +368,7 @@ func TestReadFile_UTF8Truncation(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{path}, "reason": "testing"}, nil)
@@ -403,7 +406,7 @@ func TestReadFiles_UTF8Truncation(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{path}, "reason": "testing"}, nil)
@@ -436,7 +439,7 @@ func TestReadFile_Directory(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{subDir}, "reason": "testing"}, nil)
@@ -456,7 +459,7 @@ func TestReadFiles_Directory(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{subDir}, "reason": "testing"}, nil)
@@ -470,7 +473,7 @@ func TestReadFiles_Directory(t *testing.T) {
 
 func TestReadFiles_Limit(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	// More than 50 files

--- a/internal/tools/workspace/reader_test.go
+++ b/internal/tools/workspace/reader_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"unicode/utf8"
 
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
@@ -170,7 +170,7 @@ func TestGetFileDiff(t *testing.T) {
 	r := &fileReader{
 		sm:       sm,
 		fs:       persistencetest.NewPlainOSFileSystem(),
-		policy: infra_persistence.NewWorkspacePolicy(),
+		policy:   infra_persistence.NewWorkspacePolicy(),
 		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
 	}
 	ctx := context.Background()
@@ -253,7 +253,7 @@ func TestGetFileDiff_Errors(t *testing.T) {
 	r := &fileReader{
 		sm:       sm,
 		fs:       persistencetest.NewPlainOSFileSystem(),
-		policy: infra_persistence.NewWorkspacePolicy(),
+		policy:   infra_persistence.NewWorkspacePolicy(),
 		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
 	}
 	ctx := context.Background()

--- a/internal/tools/workspace/registration.go
+++ b/internal/tools/workspace/registration.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
@@ -19,8 +20,8 @@ type fileSystemManager struct {
 }
 
 // Register adds all workspace-related tools (file, git, system) to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, health ports.HealthCheckManager) error {
-	if err := registerFiles(r, sm, fs, exec); err != nil {
+func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, health ports.HealthCheckManager) error {
+	if err := registerFiles(r, sm, fs, exec, wp); err != nil {
 		return err
 	}
 	if err := registerSystem(r, sm, validator, health); err != nil {
@@ -32,7 +33,7 @@ func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandEx
 	return nil
 }
 
-func registerFiles(r tools.Registry, sm domain_security.Manager, fs persistence.FileSystem, exec tools.CommandExecutor) error {
+func registerFiles(r tools.Registry, sm domain_security.Manager, fs persistence.FileSystem, exec tools.CommandExecutor, wp services.WorkspacePolicy) error {
 	bm := newBackupManager(sm, fs, 10)
 
 	// Inject the executor into the reader if it matches the internal commandExecutor interface.
@@ -43,9 +44,9 @@ func registerFiles(r tools.Registry, sm domain_security.Manager, fs persistence.
 	}
 
 	m := &fileSystemManager{
-		reader: &fileReader{sm: sm, fs: fs, executor: internalExec},
+		reader: &fileReader{sm: sm, fs: fs, executor: internalExec, policy: wp},
 		writer: &fileWriter{sm: sm, bm: bm, fs: fs},
-		search: &fileSearcher{sm: sm, fs: fs},
+		search: &fileSearcher{sm: sm, fs: fs, policy: wp},
 	}
 
 	type toolSpec struct {

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +60,7 @@ func TestRegister(t *testing.T) {
 	validator := &toolstest.MockCommandValidator{}
 	fs := persistencetest.NewPlainOSFileSystem()
 
-	if err := Register(registry, sm, exec, validator, fs, nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
@@ -103,7 +104,7 @@ func TestRegister(t *testing.T) {
 	t.Run("check_system_health", func(t *testing.T) {
 		reg := &mockToolRegistry{}
 		mockHealth := &mockHealthCheckManager{}
-		if err := Register(reg, sm, exec, validator, fs, mockHealth); err != nil {
+		if err := Register(reg, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), mockHealth); err != nil {
 			t.Fatalf("Register failed: %v", err)
 		}
 		found := false

--- a/internal/tools/workspace/search.go
+++ b/internal/tools/workspace/search.go
@@ -12,12 +12,14 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
 type fileSearcher struct {
-	sm domain_security.PathValidator
-	fs persistence.FileSystem
+	sm     domain_security.PathValidator
+	fs     persistence.FileSystem
+	policy services.WorkspacePolicy
 }
 
 // defPatterns defines regex patterns for detecting definitions in supported languages.
@@ -56,7 +58,7 @@ func (s *fileSearcher) searchFiles(ctx context.Context, args map[string]interfac
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resChan, errChan := ConcurrentSearch(ctx, s.sm, s.fs, path, hb, matcher)
+	resChan, errChan := ConcurrentSearch(ctx, s.sm, s.fs, path, hb, matcher, s.policy)
 	results, truncated := s.collectSearchResults(resChan, cancel)
 
 	if err := s.checkConcurrentSearchError(errChan); err != nil {
@@ -120,7 +122,7 @@ func (s *fileSearcher) grepDefinitions(ctx context.Context, args map[string]inte
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	resChan, errChan := ConcurrentSearch(ctx, s.sm, s.fs, path, hb, matcher)
+	resChan, errChan := ConcurrentSearch(ctx, s.sm, s.fs, path, hb, matcher, s.policy)
 	results, truncated := s.collectSearchResults(resChan, cancel)
 
 	if err := s.checkConcurrentSearchError(errChan); err != nil {

--- a/internal/tools/workspace/search_bench_test.go
+++ b/internal/tools/workspace/search_bench_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 )
 
@@ -29,7 +30,7 @@ func BenchmarkConcurrentSearch_FullProject(b *testing.B) {
 		ctx, cancel := context.WithCancel(ctx)
 		resChan, errChan := ConcurrentSearch(ctx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 			return "", strings.Contains(line, "func ")
-		})
+		}, infra_persistence.NewWorkspacePolicy())
 
 		var results []string
 		for res := range resChan {
@@ -64,7 +65,7 @@ func BenchmarkConcurrentSearch_EarlyStop(b *testing.B) {
 		ctx, cancel := context.WithCancel(ctx)
 		resChan, errChan := ConcurrentSearch(ctx, sp, fs, ".", nil, func(_, line string) (string, bool) {
 			return "", strings.Contains(line, "func ")
-		})
+		}, infra_persistence.NewWorkspacePolicy())
 
 		var results []string
 		for res := range resChan {

--- a/internal/tools/workspace/search_test.go
+++ b/internal/tools/workspace/search_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -36,7 +37,7 @@ func TestSearchFiles_SkipsBinary(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 
 	ctx := context.Background()
 	args := map[string]interface{}{
@@ -132,7 +133,7 @@ func testGrepFunctions(t *testing.T) {
 		"script.js": "function jsFunc() {}\nconst arrow = () => {}",
 		"main.go":   "func main() {}",
 	})
-	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs}
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs, policy: infra_persistence.NewWorkspacePolicy()}
 	res, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": root, "reason": "testing"}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -150,7 +151,7 @@ func testGrepStructs(t *testing.T) {
 		"data.go": "type User struct {\n    ID int\n}",
 		"app.py":  "class App:\n    pass",
 	})
-	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs}
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs, policy: infra_persistence.NewWorkspacePolicy()}
 	res, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": root, "reason": "testing"}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -165,7 +166,7 @@ func testGrepInterfaces(t *testing.T) {
 	fs, root := setupGrepTest(t, map[string]string{
 		"service.go": "type Service interface {\n    Run()\n}",
 	})
-	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs}
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs, policy: infra_persistence.NewWorkspacePolicy()}
 	res, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": root, "reason": "testing"}, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -179,7 +180,7 @@ func testGrepComplexPatterns(t *testing.T) {
 	fs, root := setupGrepTest(t, map[string]string{
 		"script.py": "def my_func():\n    pass\nclass MyClass:\n    pass",
 	})
-	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs}
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs, policy: infra_persistence.NewWorkspacePolicy()}
 
 	t.Run("with query", func(t *testing.T) {
 		res, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": root, "query": "my_func", "reason": "testing"}, nil)
@@ -198,7 +199,7 @@ func testGrepComplexPatterns(t *testing.T) {
 
 func testGrepErrorPaths(t *testing.T) {
 	fs, root := setupGrepTest(t, map[string]string{})
-	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs}
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: fs, policy: infra_persistence.NewWorkspacePolicy()}
 
 	t.Run("no results", func(t *testing.T) {
 		res, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": root, "query": "nonexistent", "reason": "testing"}, nil)
@@ -220,7 +221,7 @@ func TestSearchFiles_TooManyResults(t *testing.T) {
 	}
 
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem()}
+	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
 	ctx := context.Background()
 
 	args := map[string]interface{}{

--- a/internal/tools/workspace/utils.go
+++ b/internal/tools/workspace/utils.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
 )
 
 // fileProcessor is a callback function for processing a file during a walk.
@@ -47,7 +48,7 @@ func walkHeartbeat(ctx context.Context, count int, hb chan<- struct{}) error {
 }
 
 // shouldSkipEntry checks whether a walk entry should be skipped (inaccessible, cancelled, or directory).
-func shouldSkipEntry(ctx context.Context, info os.FileInfo, err error) (bool, error) {
+func shouldSkipEntry(ctx context.Context, info os.FileInfo, err error, policy services.WorkspacePolicy) (bool, error) {
 	if err != nil {
 		return true, nil
 	}
@@ -55,7 +56,7 @@ func shouldSkipEntry(ctx context.Context, info os.FileInfo, err error) (bool, er
 		return true, ctx.Err()
 	}
 	if info.IsDir() {
-		if isIgnoredDir(info.Name()) {
+		if policy.ShouldIgnoreDir(info.Name()) {
 			return true, filepath.SkipDir
 		}
 		return true, nil
@@ -64,7 +65,7 @@ func shouldSkipEntry(ctx context.Context, info os.FileInfo, err error) (bool, er
 }
 
 // walkAndProcess handles the generic filesystem traversal, safety checks, and directory filtering.
-func walkAndProcess(ctx context.Context, sm domain_security.PathValidator, fs persistence.FileSystem, path string, hb chan<- struct{}, fn fileProcessor) error {
+func walkAndProcess(ctx context.Context, sm domain_security.PathValidator, fs persistence.FileSystem, path string, hb chan<- struct{}, fn fileProcessor, policy services.WorkspacePolicy) error {
 	if path == "" {
 		path = "."
 	}
@@ -76,7 +77,7 @@ func walkAndProcess(ctx context.Context, sm domain_security.PathValidator, fs pe
 
 	count := 0
 	return fs.Walk(ctx, path, func(filePath string, info os.FileInfo, err error) error {
-		if skip, retErr := shouldSkipEntry(ctx, info, err); skip {
+		if skip, retErr := shouldSkipEntry(ctx, info, err, policy); skip {
 			return retErr
 		}
 
@@ -90,7 +91,7 @@ func walkAndProcess(ctx context.Context, sm domain_security.PathValidator, fs pe
 }
 
 // ConcurrentSearch walks the path and processes files in parallel using workers.
-func ConcurrentSearch(ctx context.Context, sp domain_security.PathValidator, fs persistence.FileSystem, root string, hb chan<- struct{}, matcher func(path, line string) (string, bool)) (<-chan string, <-chan error) {
+func ConcurrentSearch(ctx context.Context, sp domain_security.PathValidator, fs persistence.FileSystem, root string, hb chan<- struct{}, matcher func(path, line string) (string, bool), policy services.WorkspacePolicy) (<-chan string, <-chan error) {
 	errChan := make(chan error, 1)
 	if ctx.Err() != nil {
 		errChan <- ctx.Err()
@@ -119,6 +120,7 @@ func ConcurrentSearch(ctx context.Context, sp domain_security.PathValidator, fs 
 		hb:          hb,
 		root:        resolvedRoot,
 		ctx:         ctx,
+		policy:      policy,
 	}
 
 	return p.Execute()
@@ -133,6 +135,7 @@ type searchPipeline struct {
 	hb          chan<- struct{}
 	root        string
 	ctx         context.Context
+	policy      services.WorkspacePolicy
 }
 
 func (p *searchPipeline) Execute() (<-chan string, <-chan error) {
@@ -172,7 +175,7 @@ func (p *searchPipeline) walkFunc(path string, info os.FileInfo, err error) erro
 	}
 
 	if info.IsDir() {
-		if isIgnoredDir(info.Name()) {
+		if p.policy.ShouldIgnoreDir(info.Name()) {
 			return filepath.SkipDir
 		}
 		return nil
@@ -291,10 +294,6 @@ func checkBinary(file persistence.File) (bool, error) {
 		return false, err
 	}
 	return persistence.IsBinary(buf[:n]), nil
-}
-
-func isIgnoredDir(name string) bool {
-	return name == ".git" || name == "node_modules" || name == "vendor" || name == "output" || name == "dist"
 }
 
 func formatMatch(path string, lineNum int, text string) string {

--- a/internal/tools/workspace/utils_test.go
+++ b/internal/tools/workspace/utils_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 

--- a/internal/tools/workspace/utils_test.go
+++ b/internal/tools/workspace/utils_test.go
@@ -11,10 +11,13 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
-func TestIsIgnoredDir(t *testing.T) {
+func TestWorkspacePolicyShouldIgnoreDir(t *testing.T) {
+	policy := infra_persistence.NewWorkspacePolicy()
+
 	tests := []struct {
 		name     string
 		input    string
@@ -23,14 +26,22 @@ func TestIsIgnoredDir(t *testing.T) {
 		{"dot git", ".git", true},
 		{"node_modules", "node_modules", true},
 		{"vendor", "vendor", true},
+		{"bin", "bin", true},
+		{"obj", "obj", true},
+		{"output", "output", true},
+		{"dist", "dist", true},
+		{"testdata", "testdata", true},
+		{"configs", "configs", true},
+		{"hidden dir", ".hidden", true},
+		{"current dir dot", ".", false},
 		{"src", "src", false},
 		{"internal", "internal", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := isIgnoredDir(tt.input); got != tt.expected {
-				t.Errorf("isIgnoredDir(%q) = %v, want %v", tt.input, got, tt.expected)
+			if got := policy.ShouldIgnoreDir(tt.input); got != tt.expected {
+				t.Errorf("ShouldIgnoreDir(%q) = %v, want %v", tt.input, got, tt.expected)
 			}
 		})
 	}
@@ -84,7 +95,7 @@ func TestWalkAndProcess(t *testing.T) {
 	}
 
 	t.Run("safe path", func(t *testing.T) {
-		err := walkAndProcess(ctx, sm, persistencetest.NewPlainOSFileSystem(), tempDir, nil, processor)
+		err := walkAndProcess(ctx, sm, persistencetest.NewPlainOSFileSystem(), tempDir, nil, processor, infra_persistence.NewWorkspacePolicy())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -94,7 +105,7 @@ func TestWalkAndProcess(t *testing.T) {
 	})
 
 	t.Run("unsafe path", func(t *testing.T) {
-		err := walkAndProcess(ctx, sm, persistencetest.NewPlainOSFileSystem(), "/etc", nil, processor)
+		err := walkAndProcess(ctx, sm, persistencetest.NewPlainOSFileSystem(), "/etc", nil, processor, infra_persistence.NewWorkspacePolicy())
 		if err == nil {
 			t.Error("expected error for unsafe path")
 		}


### PR DESCRIPTION
## Summary

Closes #331.

Centralizes five inconsistent `isIgnoredDir`/`isSkippedDir` implementations into a single `WorkspacePolicy` domain service.

### Before
Five locations with mutually inconsistent ignore sets:
| Location | Ignored |
|---|---|
| `suggestions/service.go` | `.git`, `node_modules`, `vendor`, `bin`, `obj`, hidden dirs |
| `workspace/utils.go` | `.git`, `node_modules`, `vendor`, `output`, `dist` |
| `analysis/info.go` | hidden dirs, `testdata`, `vendor`, `node_modules` |
| `analysis/dependency.go` | `vendor`, hidden dirs |
| `developer/release.go` | `.git`, `vendor`, `node_modules`, `configs` + file exts |

### After
Single `WorkspacePolicy` interface with the union of all rules:
- `ShouldIgnoreDir(name)` — 9 canonical directories + hidden-directory heuristic
- `ShouldIgnorePath(path)` — directory policy + file extension exclusions

### Architecture
```
domain/services/workspace_policy.go      ← interface
infrastructure/persistence/workspace_policy.go ← concrete impl
infrastructure/di/container.go           ← DI wiring
tools/tools.go                           ← threaded through ToolRegistrationParams
→ analysis, workspace, developer, suggestions consumers
```

### Verification
- ✅ Full build passes (`go build ./...`)
- ✅ All 56 test packages pass (`go test ./...`)