### PR TITLE
test(openai): replace brittle 127.0.0.1:1 mocking with httptest guard pattern

### DIFF
--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -509,9 +509,11 @@ func TestSendChat_EmptyToolResponseID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Use an unreachable server — the error occurs during
-			// request construction, before the HTTP call is made.
-			c := NewClient("http://127.0.0.1:1", tt.model,
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("HTTP server should not have been reached; validation must fail first")
+			}))
+			defer server.Close()
+			c := NewClient(server.URL, tt.model,
 				&auth.BearerAuth{Token: "test-key"},
 				WithHeaders(tt.headers),
 			)
@@ -577,9 +579,11 @@ func TestSendChat_EmptyToolCallID(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// Use an unreachable server — the error occurs during
-			// request construction, before the HTTP call is made.
-			c := NewClient("http://127.0.0.1:1", tt.model,
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				t.Fatal("HTTP server should not have been reached; validation must fail first")
+			}))
+			defer server.Close()
+			c := NewClient(server.URL, tt.model,
 				&auth.BearerAuth{Token: "test-key"},
 				WithHeaders(tt.headers),
 			)
@@ -707,7 +711,11 @@ func TestSendChat_MarshallingError(t *testing.T) {
 func TestSendChat_MarshalToolResponseError(t *testing.T) {
 	t.Parallel()
 
-	c := NewClient("http://127.0.0.1:1", "gpt-4", &auth.BearerAuth{Token: "test-key"})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("HTTP server should not have been reached; validation must fail first")
+	}))
+	defer server.Close()
+	c := NewClient(server.URL, "gpt-4", &auth.BearerAuth{Token: "test-key"})
 
 	history := []*llm.Content{
 		{


### PR DESCRIPTION
## Summary

Replace `http://127.0.0.1:1` unreachable-endpoint mocking with `httptest.NewServer` + `t.Fatal` guard pattern in the OpenAI LLM provider test suite.

Closes #343

## Problem

Tests that verify validation errors occur **before** any HTTP request used an unreachable address (`http://127.0.0.1:1`) to ensure the HTTP layer is never hit. If validation logic is accidentally reordered to occur **after** the request, the test would produce a confusing `connection refused` error instead of a clear validation failure message.

## Changes

| Test | Before | After |
|------|--------|-------|
| `TestSendChat_EmptyToolResponseID` | `NewClient("http://127.0.0.1:1", ...)` | `httptest.NewServer` + `t.Fatal` guard |
| `TestSendChat_EmptyToolCallID` | `NewClient("http://127.0.0.1:1", ...)` | `httptest.NewServer` + `t.Fatal` guard |
| `TestSendChat_MarshalToolResponseError` | `NewClient("http://127.0.0.1:1", ...)` | `httptest.NewServer` + `t.Fatal` guard |

### Anthropic — no changes needed

`TestPrepareRequest_ToAnthropicMessagesError` already calls `prepareAnthropicRequest` directly at the unit level and never touches the network.

## Verification

- `go test ./internal/infrastructure/llm/openai/...` — **PASS**
- `go test ./internal/infrastructure/llm/anthropic/...` — **PASS**
- `grep -r "127.0.0.1:1" internal/infrastructure/llm/` — **zero matches**
- Zero production code changes