### PR TITLE
refactor(di): eliminate toolchain abstraction leak from HealthFactory

### DIFF
--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -154,7 +154,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		lazyClient:       lazyClient,
 	}
 
-	deps.health = b.healthFactory.BuildHealthManager(cfg, sessionProvider, lazyClient)
+	deps.health = b.healthFactory.BuildHealthManager(cfg, sessionProvider, lazyClient, b.toolchainFactory)
 
 	lazyRegistry := newLazyRegistry(func() (tools.Registry, error) {
 		return b.toolchainFactory.BuildRegistry(toolchainParams{

--- a/internal/infrastructure/di/health_factory.go
+++ b/internal/infrastructure/di/health_factory.go
@@ -4,15 +4,13 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/exec"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/factory"
 	infra_llm "github.com/gosharplite/tell-me-go/internal/infrastructure/llm"
-	infra_toolchain "github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
 
 // healthFactory defines the interface for building health check components.
 type healthFactory interface {
-	BuildHealthManager(cfg *config.Config, sessionProvider ports.SessionProvider, lazyClient llm.ExtendedClient) ports.HealthCheckManager
+	BuildHealthManager(cfg *config.Config, sessionProvider ports.SessionProvider, lazyClient llm.ExtendedClient, tf toolchainFactory) ports.HealthCheckManager
 }
 
 // defaultHealthFactory implements healthFactory.
@@ -25,14 +23,14 @@ func newHealthFactory() healthFactory {
 
 // BuildHealthManager creates a HealthCheckManager wired with the three standard
 // health checkers: persistence, LLM provider, and toolchain.
-func (f *defaultHealthFactory) BuildHealthManager(cfg *config.Config, sessionProvider ports.SessionProvider, lazyClient llm.ExtendedClient) ports.HealthCheckManager {
+func (f *defaultHealthFactory) BuildHealthManager(cfg *config.Config, sessionProvider ports.SessionProvider, lazyClient llm.ExtendedClient, tf toolchainFactory) ports.HealthCheckManager {
 	p := cfg.GetActiveProvider()
 	authenticator, _ := infra_llm.CreateAuthenticator(&p) // Error is handled in health check itself
 
 	healthCheckers := map[ports.Component]ports.HealthChecker{
 		ports.CompPersistence: sessionProvider.GetHealthChecker(),
 		ports.CompLLMProvider: infra_llm.NewLLMProviderHealthChecker(p.Type, authenticator, p.URL, lazyClient),
-		ports.CompToolchain:   infra_toolchain.NewToolchainHealthChecker(&exec.RealExecutor{}, []string{"git", "go"}, []string{"make"}),
+		ports.CompToolchain:   tf.BuildHealthChecker(),
 	}
 
 	return factory.NewHealthCheckManager(healthCheckers)

--- a/internal/infrastructure/di/lazy_test.go
+++ b/internal/infrastructure/di/lazy_test.go
@@ -101,6 +101,7 @@ func TestBuildSessionDependencies_LazyRegistry(t *testing.T) {
 	mockToolchain.On("BuildRegistry", mock.Anything).Run(func(args mock.Arguments) {
 		callCount++
 	}).Return(nil, nil)
+	mockToolchain.On("BuildHealthChecker").Return(&stubHealthChecker{})
 	b.toolchainFactory = mockToolchain
 
 	// 1. BuildSessionDependencies should NOT trigger registry construction
@@ -132,6 +133,21 @@ func (m *mockToolchainFactory) BuildRegistry(params toolchainParams) (tools.Regi
 		return nil, args.Error(1)
 	}
 	return args.Get(0).(tools.Registry), args.Error(1)
+}
+
+func (m *mockToolchainFactory) BuildHealthChecker() ports.HealthChecker {
+	args := m.Called()
+	if args.Get(0) == nil {
+		return nil
+	}
+	return args.Get(0).(ports.HealthChecker)
+}
+
+// stubHealthChecker is a minimal ports.HealthChecker for tests.
+type stubHealthChecker struct{}
+
+func (s *stubHealthChecker) Check(ctx context.Context) (*ports.ComponentReport, error) {
+	return &ports.ComponentReport{Status: ports.StatusHealthy}, nil
 }
 
 type mockExtendedClient struct {

--- a/internal/infrastructure/di/toolchain_factory.go
+++ b/internal/infrastructure/di/toolchain_factory.go
@@ -17,11 +17,13 @@ import (
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	internal_security "github.com/gosharplite/tell-me-go/internal/infrastructure/security"
+	infra_toolchain "github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	infra_tools "github.com/gosharplite/tell-me-go/internal/tools"
 )
 
 type toolchainFactory interface {
 	BuildRegistry(params toolchainParams) (tools.Registry, error)
+	BuildHealthChecker() ports.HealthChecker
 }
 
 type toolchainParams struct {
@@ -91,4 +93,15 @@ func (f *defaultToolchainFactory) BuildRegistry(params toolchainParams) (tools.R
 	}
 
 	return reg, nil
+}
+
+// BuildHealthChecker creates a HealthChecker for the system toolchain binaries.
+// The required and optional binary lists are owned here — they are toolchain
+// implementation details, not DI orchestration concerns.
+func (f *defaultToolchainFactory) BuildHealthChecker() ports.HealthChecker {
+	return infra_toolchain.NewToolchainHealthChecker(
+		&exec.RealExecutor{},
+		[]string{"git", "go"}, // required binaries
+		[]string{"make"},      // optional binaries
+	)
 }


### PR DESCRIPTION
## What

Moves toolchain health checker construction from `healthFactory` into `toolchainFactory`, which already owns all other toolchain wiring including `exec.RealExecutor` instantiation.

## Why

`health_factory.go` had an abstraction leak — the DI orchestration layer knew about concrete toolchain implementation details:
- `exec.RealExecutor` (a concrete infrastructure type)
- The binary list `["git", "go"]` and `["make"]`

This violated Separation of Concerns: any change to the toolchain's health check (new binaries, different executor) required modifying the DI layer.

## Changes

| File | Change |
|------|--------|
| `toolchain_factory.go` | + `BuildHealthChecker() ports.HealthChecker` to interface & impl |
| `health_factory.go` | Accepts `toolchainFactory`, delegates; removes `exec` + `infra_toolchain` imports |
| `container.go` | Passes `b.toolchainFactory` through to `BuildHealthManager` |
| `lazy_test.go` | Mock + stub for new interface method |

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./... -count=1` ✅ (62/62 packages)
- Linter ✅

Closes #344