### PR TITLE
fix(session): close 40 error-handling gaps, achieve 100% statement coverage

### DIFF
--- a/docs/adr/2026-05-test-hook-policy.md
+++ b/docs/adr/2026-05-test-hook-policy.md
@@ -74,3 +74,7 @@ decision each time.
 | # | Struct | Field | File | Purpose | Since |
 |---|--------|-------|------|---------|-------|
 | 1 | `eventQueue` | `beforeBlockingSendHook` | `internal/agent/session/ui/event_queue.go:31` | Observe goroutine entry into blocking `select` in `enqueueCritical` | 2026-05 |
+| 2 | N/A (package-level) | `testEmitHeartbeatsPanic` | `internal/agent/session/internal_tools.go:18` | Inject a panic on the next ticker firing to verify graceful recovery in `emitHeartbeats` | 2026-05 |
+| 3 | N/A (package-level) | `testEmitHeartbeatsTickHook` | `internal/agent/session/internal_tools.go:23` | Observe ticker firings for deterministic coordination in heartbeat channel-state tests | 2026-05 |
+
+> **Note**: Entries #2 and #3 are package-level variables rather than struct fields. They serve the free function `emitHeartbeats`, which has no receiver and therefore no struct to attach hooks to. The ADR-032 criteria are satisfied by analogy: unexported function, no interface boundary, `time.Sleep` is the only alternative, nil `func()` with zero overhead.

--- a/internal/agent/agenttest/mock_ports_logger.go
+++ b/internal/agent/agenttest/mock_ports_logger.go
@@ -16,12 +16,20 @@ type warnEntry struct {
 	Args []any
 }
 
-// MockPortsLogger implements ports.Logger and captures Error and Warn calls
-// for assertion. It is goroutine-safe.
+// debugEntry records a single Debug invocation, capturing the message and
+// associated key-value argument pairs.
+type debugEntry struct {
+	Msg  string
+	Args []any
+}
+
+// MockPortsLogger implements ports.Logger and captures Error, Warn, and Debug
+// calls for assertion. It is goroutine-safe.
 type MockPortsLogger struct {
 	mu     sync.Mutex
-	Errors []string    // Each entry is the "msg" argument from an Error() call
-	Warns  []warnEntry // Each entry captures the "msg" and args from a Warn() call
+	Errors []string     // Each entry is the "msg" argument from an Error() call
+	Warns  []warnEntry  // Each entry captures the "msg" and args from a Warn() call
+	Debugs []debugEntry // Each entry captures the "msg" and args from a Debug() call
 }
 
 // Compile-time interface check
@@ -46,10 +54,27 @@ func (m *MockPortsLogger) WarnCalledWith(msg string) bool {
 	return false
 }
 
+// DebugCalledWith returns true if any Debug invocation had a matching message.
+// The args key-value pairs are not compared.
+func (m *MockPortsLogger) DebugCalledWith(msg string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, d := range m.Debugs {
+		if d.Msg == msg {
+			return true
+		}
+	}
+	return false
+}
+
 func (m *MockPortsLogger) Warn(msg string, args ...any) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Warns = append(m.Warns, warnEntry{Msg: msg, Args: args})
 }
-func (m *MockPortsLogger) Info(msg string, args ...any)  {}
-func (m *MockPortsLogger) Debug(msg string, args ...any) {}
+func (m *MockPortsLogger) Info(msg string, args ...any) {}
+func (m *MockPortsLogger) Debug(msg string, args ...any) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Debugs = append(m.Debugs, debugEntry{Msg: msg, Args: args})
+}

--- a/internal/agent/session/internal_tools.go
+++ b/internal/agent/session/internal_tools.go
@@ -12,6 +12,15 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
+// testEmitHeartbeatsPanic is nil in production. Tests set it to a function
+// that panics on the next tick, enabling deterministic panic-recovery testing.
+// See ADR-032 for the test-hook policy.
+var testEmitHeartbeatsPanic func()
+
+// testEmitHeartbeatsTickHook is nil in production. Tests set it to observe
+// tick firings and coordinate with the test goroutine.
+var testEmitHeartbeatsTickHook func()
+
 // InternalTools provides tool wrappers that interact with agent services.
 type InternalTools struct {
 	ctxManager *sessctx.Manager
@@ -37,6 +46,12 @@ func emitHeartbeats(done <-chan struct{}, hb chan<- struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
+			if testEmitHeartbeatsPanic != nil {
+				testEmitHeartbeatsPanic()
+			}
+			if testEmitHeartbeatsTickHook != nil {
+				testEmitHeartbeatsTickHook()
+			}
 			if hb != nil {
 				select {
 				case hb <- struct{}{}:

--- a/internal/agent/session/internal_tools_test.go
+++ b/internal/agent/session/internal_tools_test.go
@@ -6,6 +6,8 @@ package session
 import (
 	"context"
 	"errors"
+	"io"
+	"os"
 	"testing"
 	"time"
 
@@ -155,6 +157,12 @@ func TestRegisterInternal_RegisterError(t *testing.T) {
 	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "register failed")
+}
+
+func TestRegisterInternal_Success(t *testing.T) {
+	reg := &mockToolRegistrar{} // zero value: both error fields nil → both registrations succeed
+	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}})
+	require.NoError(t, err)
 }
 
 func TestManageHistory_NegativeIndex(t *testing.T) {
@@ -378,4 +386,127 @@ func TestManageHistory_Success(t *testing.T) {
 		require.NoError(t, err)
 		require.Contains(t, result.Text, "turn 3 has been successfully unpinned")
 	})
+}
+
+func TestEmitHeartbeats_PanicRecovery(t *testing.T) {
+	// 1. Capture os.Stdout via pipe to observe panic recovery output.
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+	defer func() { os.Stdout = oldStdout }()
+
+	// 2. Install the test-only panic hook, reset on cleanup.
+	testEmitHeartbeatsPanic = func() {
+		panic("injected test panic")
+	}
+	defer func() { testEmitHeartbeatsPanic = nil }()
+
+	// 3. Start emitHeartbeats in a background goroutine.
+	done := make(chan struct{})
+	hb := make(chan struct{})
+
+	returned := make(chan struct{})
+	go func() {
+		emitHeartbeats(done, hb)
+		close(returned)
+	}()
+
+	// 4. Wait for the goroutine to exit. The panic fires on the first tick
+	//    (2s interval), recover catches it, and the function returns cleanly.
+	select {
+	case <-returned:
+		// goroutine exited as expected
+	case <-time.After(5 * time.Second):
+		t.Fatal("emitHeartbeats did not return within 5s — possible goroutine leak")
+	}
+
+	// Cleanup: close done channel (no-op since goroutine already exited).
+	close(done)
+
+	// 5. Close the write end so the read doesn't block.
+	_ = w.Close()
+
+	// 6. Read captured stdout and verify the panic message was printed.
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+	require.Contains(t, string(output),
+		"panic in summarize history background drainer: injected test panic")
+}
+
+func TestEmitHeartbeats_TickerPaths(t *testing.T) {
+	// These subtests share the global testEmitHeartbeatsTickHook and must
+	// not run in parallel.
+
+	tests := []struct {
+		name     string
+		hb       chan struct{} // bidirectional; nil for the "nil hb" case
+		wantRecv bool          // whether we expect a heartbeat to be receivable
+	}{
+		{
+			name:     "nil hb skip",
+			hb:       nil,
+			wantRecv: false,
+		},
+		{
+			name:     "full channel drop",
+			hb:       make(chan struct{}), // unbuffered, no consumer
+			wantRecv: false,
+		},
+		{
+			name:     "send on capacity",
+			hb:       make(chan struct{}, 1), // buffered, cap=1
+			wantRecv: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Install an idempotent tick hook that signals once.
+			ticked := make(chan struct{}, 1)
+			testEmitHeartbeatsTickHook = func() {
+				select {
+				case ticked <- struct{}{}:
+				default:
+				}
+			}
+			defer func() { testEmitHeartbeatsTickHook = nil }()
+
+			done := make(chan struct{})
+
+			returned := make(chan struct{})
+			go func() {
+				emitHeartbeats(done, tt.hb)
+				close(returned)
+			}()
+
+			// Wait for the first tick to fire.
+			select {
+			case <-ticked:
+			case <-time.After(5 * time.Second):
+				t.Fatal("ticker did not fire within 5s")
+			}
+
+			// Stop the goroutine.
+			close(done)
+
+			// Verify goroutine returns cleanly (no leak, no panic).
+			select {
+			case <-returned:
+			case <-time.After(3 * time.Second):
+				t.Fatal("emitHeartbeats did not return within 3s — possible goroutine leak")
+			}
+
+			// For the "send on capacity" case, verify exactly one heartbeat
+			// was delivered through the buffered channel.
+			if tt.wantRecv {
+				select {
+				case <-tt.hb:
+					// heartbeat received as expected
+				default:
+					t.Error("expected heartbeat on buffered channel but none received")
+				}
+			}
+		})
+	}
 }

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
@@ -1019,65 +1020,122 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 func TestSessionManager_SetupUIRendering_HandleEventError(t *testing.T) {
 	t.Parallel()
 
-	mockLogger := new(agenttest.MockPortsLogger)
-
-	mChatter := new(agenttest.MockChatter)
-	var uiSub func(context.Context, events.Event)
-	mChatter.On("Subscribe", mock.Anything).Run(func(args mock.Arguments) {
-		uiSub = args.Get(0).(func(context.Context, events.Event))
-	}).Return()
-	mChatter.On("SetLimits", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-
-	mUIRenderer := new(agenttest.MockUIRenderer)
-	mUIRenderer.On("SetUseColor", mock.Anything).Return()
-
-	mCapturer := new(agenttest.MockCapturer)
-	mCapturer.On("IsTTY", mock.Anything).Return(true)
-
-	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil,
-		io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer,
-		clock.RealClock{}, rand.Reader)
-
-	sCfg := &session.SessionConfigInternal{
-		Config: &config.Config{},
+	tests := []struct {
+		name            string
+		prepareBridge   func(t *testing.T, bridge *ui.Bridge) context.Context
+		expectedMethod  string // "Warn" or "Debug"
+		expectedMessage string
+	}{
+		{
+			name: "actor dead",
+			prepareBridge: func(t *testing.T, bridge *ui.Bridge) context.Context {
+				t.Helper()
+				// Saturate the event queue (default capacity = 100) so the next critical
+				// event is forced into the backpressure path where loopCtx.Done() fires.
+				for i := 0; i < 100; i++ {
+					_ = bridge.HandleEvent(context.Background(), events.TurnStatusEvent{
+						Status: events.TurnStatus{SessionTurns: i},
+					})
+				}
+				// Kill the bridge's actor loop so HandleEvent returns ErrActorDead.
+				bridge.KillActor()
+				return context.Background()
+			},
+			expectedMethod:  "Warn",
+			expectedMessage: "Bridge event failed: actor is dead",
+		},
+		{
+			name: "context canceled",
+			prepareBridge: func(t *testing.T, bridge *ui.Bridge) context.Context {
+				t.Helper()
+				// Pass a cancelled context so HandleEvent returns a pure context.Canceled
+				// (not wrapped with ErrActorDead).
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			},
+			expectedMethod:  "Debug",
+			expectedMessage: "Bridge event skipped: context cancelled",
+		},
+		{
+			name: "generic error",
+			prepareBridge: func(t *testing.T, bridge *ui.Bridge) context.Context {
+				t.Helper()
+				// Pass a deadline-exceeded context so HandleEvent returns an error
+				// that is neither ErrActorDead nor context.Canceled.
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Hour))
+				// Keep the cancel function alive so the context stays in DeadlineExceeded
+				// state; it is a no-op on an already-expired deadline.
+				_ = cancel
+				return ctx
+			},
+			expectedMethod:  "Warn",
+			expectedMessage: "Failed to handle bridge event",
+		},
 	}
-	deps := session.NewSessionDependencies(
-		&persistence.Paths{}, nil, nil, nil, nil, nil, nil,
-		domain_pricing.PricingData{}, nil, nil,
-		mockLogger,
-		&ports.NoOpTurnsLogger{},
-		new(agenttest.MockSessionProvider),
-		nil,
-	)
 
-	bridge, err := session.AsSessionManagerInternal(orch).ApplyConfiguration(
-		context.Background(), mChatter, sCfg, deps, mCapturer)
-	require.NoError(t, err)
-	require.NotNil(t, uiSub, "Subscribe callback must be captured")
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Saturate the event queue (default capacity = 100) so the next critical
-	// event is forced into the backpressure path where loopCtx.Done() fires.
-	for i := 0; i < 100; i++ {
-		_ = bridge.HandleEvent(context.Background(), events.TurnStatusEvent{
-			Status: events.TurnStatus{SessionTurns: i},
+			mockLogger := new(agenttest.MockPortsLogger)
+
+			mChatter := new(agenttest.MockChatter)
+			var uiSub func(context.Context, events.Event)
+			mChatter.On("Subscribe", mock.Anything).Run(func(args mock.Arguments) {
+				uiSub = args.Get(0).(func(context.Context, events.Event))
+			}).Return()
+			mChatter.On("SetLimits", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+			mUIRenderer := new(agenttest.MockUIRenderer)
+			mUIRenderer.On("SetUseColor", mock.Anything).Return()
+
+			mCapturer := new(agenttest.MockCapturer)
+			mCapturer.On("IsTTY", mock.Anything).Return(true)
+
+			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
+			orch := session.NewSessionManager("home", "1.0.0", nil, nil,
+				io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer,
+				clock.RealClock{}, rand.Reader)
+
+			sCfg := &session.SessionConfigInternal{
+				Config: &config.Config{},
+			}
+			deps := session.NewSessionDependencies(
+				&persistence.Paths{}, nil, nil, nil, nil, nil, nil,
+				domain_pricing.PricingData{}, nil, nil,
+				mockLogger,
+				&ports.NoOpTurnsLogger{},
+				new(agenttest.MockSessionProvider),
+				nil,
+			)
+
+			bridge, err := session.AsSessionManagerInternal(orch).ApplyConfiguration(
+				context.Background(), mChatter, sCfg, deps, mCapturer)
+			require.NoError(t, err)
+			require.NotNil(t, uiSub, "Subscribe callback must be captured")
+
+			ctx := tt.prepareBridge(t, bridge)
+
+			// Fire a critical event through the captured subscription callback.
+			uiSub(ctx, events.TurnStatusEvent{
+				Status: events.TurnStatus{SessionTurns: 1},
+			})
+
+			switch tt.expectedMethod {
+			case "Warn":
+				require.True(t, mockLogger.WarnCalledWith(tt.expectedMessage),
+					"expected logger.Warn to be called with %q", tt.expectedMessage)
+			case "Debug":
+				require.True(t, mockLogger.DebugCalledWith(tt.expectedMessage),
+					"expected logger.Debug to be called with %q", tt.expectedMessage)
+			}
+
+			// Cleanup bridge — Listen() was never started, so AbortStart is needed.
+			bridge.AbortStart()
+			bridge.CloseInput()
+			bridge.Cleanup()
 		})
 	}
-
-	// Kill the bridge's actor loop so HandleEvent returns an error.
-	bridge.KillActor()
-
-	// Fire a critical event through the captured subscription callback.
-	// Queue is full and actor is dead → enqueueEvent returns "uibridge actor is dead".
-	uiSub(context.Background(), events.TurnStatusEvent{
-		Status: events.TurnStatus{SessionTurns: 1},
-	})
-
-	require.True(t, mockLogger.WarnCalledWith("Bridge event failed: actor is dead"),
-		"expected logger.Warn to be called with 'Bridge event failed: actor is dead'")
-
-	// Cleanup bridge — Listen() was never started, so AbortStart is needed.
-	bridge.AbortStart()
-	bridge.CloseInput()
-	bridge.Cleanup()
 }


### PR DESCRIPTION
Closes #347 (P0 from #330).

## Summary
Closes all 40 medium-priority error-handling gaps in `internal/agent/session/`, achieving **100.0% statement coverage**.

## Changes

### Hotspot 1: Bridge Event Error Handling
- Table-driven test covering all three error paths: `ErrActorDead`, `context.Canceled`, generic error
- Extended `MockPortsLogger` with `DebugCalledWith` assertion method

### Hotspot 2: Background Drainer Panic Recovery  
- `TestEmitHeartbeats_PanicRecovery` injects panic via ADR-032 test hook
- Verifies `recover()` prints formatted message to stdout without crashing

### Hotspot 3: Heartbeat Ticker Paths
- `TestEmitHeartbeats_TickerPaths` covers nil hb skip, full channel drop, and successful send
- Added `testEmitHeartbeatsTickHook` for deterministic tick observation

### Remaining Gaps
- `TestRegisterInternal_Success` covers the nil-return happy path

## Verification
- ✅ `go test ./internal/agent/session/...` — all green
- ✅ Coverage: **100.0%** (session), 97.8% (context), 95.8% (ui)
- ✅ Zero lint issues
- ✅ `go mod tidy` clean