### PR TITLE
Refactor emitHeartbeats into InternalTools method with logger injection

### DIFF
--- a/docs/adr/2026-05-test-hook-policy.md
+++ b/docs/adr/2026-05-test-hook-policy.md
@@ -36,13 +36,14 @@ A nil-in-production `func()` test hook is **acceptable** when **all** of the fol
 | 4 | **Nil `func()` — zero overhead** | The hook field is a single function pointer. The production path executes one nil-check branch. Zero allocations. |
 | 5 | **Single synchronization point** | The hook observes one well-defined state transition, not broad behavioral verification. Broad verification belongs with interface mocks. |
 | 6 | **Documented** | The field carries a `// Test hook: nil in production` comment and a reference to this ADR. |
+| 7 | **Must not change production behavior** | The hook produces zero observable side effects in production when nil. The only permitted exception is fault-injection for exercising `recover()` blocks, where a `panic()` is the only viable mechanism to trigger the defer/recover path. Hooks that inject faults must be clearly suffixed `Panic` and reference this ADR. |
 
 A hook that violates any criterion **must** use an alternative mechanism:
 
 - **Exported type or interface exists** → Interface mock (ADR-011 Rule 2).
 - **Broad behavioral verification** → Interface mock.
 - **Multiple hooks accumulating on one struct** → Re-evaluate the struct's responsibilities; consider decomposition.
-- **Hook has side effects beyond observation** → Forbidden. Hooks are observation-only.
+- **Hook has side effects beyond observation** → Forbidden, with one exception: fault-injection hooks targeting `recover()` blocks are permitted when no other mechanism can trigger the recovery path. Such hooks must be suffixed `Panic` and documented in the registry.
 
 ### Rationale
 
@@ -60,6 +61,27 @@ Every authorized test hook **must** be registered in Appendix A of this ADR. Add
 requires amending this ADR — making proliferation visible and forcing a conscious architectural
 decision each time.
 
+### Fault-Injection Exception
+
+ADR-032 §Decision Criteria Rule 4 requires hooks to be "observation-only" — they must not alter
+program flow or inject side effects. However, Go's `recover()` mechanism can only be exercised by
+an actual `panic()`. There is no interface-based alternative: a mock that returns an error does
+not trigger `recover()`, and refactoring the `defer/recover` block into an interface defeats the
+purpose of testing the recovery logic itself.
+
+A narrow exception is therefore granted: **fault-injection hooks that call `panic()` are permitted
+when and only when:**
+
+1. The hook targets a specific `defer/recover()` block that cannot be tested by any other means.
+2. The hook field name is suffixed with `Panic` (e.g., `testEmitHeartbeatsPanic`).
+3. The hook is nil in production and set only in dedicated panic-recovery tests.
+4. The test validates both that the panic was caught (no goroutine leak) and that the recovery
+   logic executed (e.g., the error was logged).
+
+This exception does not extend to hooks that inject other side effects (e.g., mutating shared
+state, modifying function arguments, altering control flow beyond `panic()`). Fault-injection
+hooks remain subject to all other ADR-032 criteria, including the registry requirement.
+
 ## Consequences
 
 - **Positive**: Eliminates inconsistent review outcomes for test hooks.
@@ -74,7 +96,5 @@ decision each time.
 | # | Struct | Field | File | Purpose | Since |
 |---|--------|-------|------|---------|-------|
 | 1 | `eventQueue` | `beforeBlockingSendHook` | `internal/agent/session/ui/event_queue.go:31` | Observe goroutine entry into blocking `select` in `enqueueCritical` | 2026-05 |
-| 2 | N/A (package-level) | `testEmitHeartbeatsPanic` | `internal/agent/session/internal_tools.go:18` | Inject a panic on the next ticker firing to verify graceful recovery in `emitHeartbeats` | 2026-05 |
-| 3 | N/A (package-level) | `testEmitHeartbeatsTickHook` | `internal/agent/session/internal_tools.go:23` | Observe ticker firings for deterministic coordination in heartbeat channel-state tests | 2026-05 |
-
-> **Note**: Entries #2 and #3 are package-level variables rather than struct fields. They serve the free function `emitHeartbeats`, which has no receiver and therefore no struct to attach hooks to. The ADR-032 criteria are satisfied by analogy: unexported function, no interface boundary, `time.Sleep` is the only alternative, nil `func()` with zero overhead.
+| 2 | `InternalTools` | `testEmitHeartbeatsPanic` | `internal/agent/session/internal_tools.go:22` | Fault-injection: inject a panic on the next ticker firing to verify graceful recovery in `emitHeartbeats` | 2026-05 |
+| 3 | `InternalTools` | `testEmitHeartbeatsTickHook` | `internal/agent/session/internal_tools.go:23` | Observe ticker firings for deterministic coordination in heartbeat channel-state tests | 2026-05 |

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -88,7 +88,7 @@ func NewAgent(client domain_llm.LLMGateway, bus events.EventBus, registry tools.
 	}
 
 	if a.registerInternal {
-		if err := session.RegisterInternal(a.registry, a.ctxManager); err != nil {
+		if err := session.RegisterInternal(a.registry, a.ctxManager, a.getLogger()); err != nil {
 			return nil, fmt.Errorf("failed to register internal tools: %w", err)
 		}
 	}

--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -95,7 +95,7 @@ func TestInternalTools_Errors(t *testing.T) {
 	hm := &agenttest.MockHistoryManager{}
 	cm := sessctx.NewManager(cs, hm, nil, nil)
 
-	it := session.NewInternalTools(cm)
+	it := session.NewInternalTools(cm, &ports.NoOpLogger{})
 
 	_, err := it.SummarizeHistory(context.Background(), map[string]interface{}{"turns": "invalid"}, nil)
 	if err == nil {

--- a/internal/agent/session/internal_tools.go
+++ b/internal/agent/session/internal_tools.go
@@ -23,6 +23,9 @@ type InternalTools struct {
 
 // NewInternalTools creates a new InternalTools provider.
 func NewInternalTools(cm *sessctx.Manager, logger ports.Logger) *InternalTools {
+	if logger == nil {
+		logger = &ports.NoOpLogger{}
+	}
 	return &InternalTools{ctxManager: cm, logger: logger}
 }
 

--- a/internal/agent/session/internal_tools.go
+++ b/internal/agent/session/internal_tools.go
@@ -9,34 +9,28 @@ import (
 	"time"
 
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-// testEmitHeartbeatsPanic is nil in production. Tests set it to a function
-// that panics on the next tick, enabling deterministic panic-recovery testing.
-// See ADR-032 for the test-hook policy.
-var testEmitHeartbeatsPanic func()
-
-// testEmitHeartbeatsTickHook is nil in production. Tests set it to observe
-// tick firings and coordinate with the test goroutine.
-var testEmitHeartbeatsTickHook func()
-
 // InternalTools provides tool wrappers that interact with agent services.
 type InternalTools struct {
-	ctxManager *sessctx.Manager
+	ctxManager                *sessctx.Manager
+	logger                    ports.Logger
+	testEmitHeartbeatsPanic    func() // nil in production; see ADR-032 §Fault-Injection Exception
+	testEmitHeartbeatsTickHook func() // nil in production; see ADR-032
 }
 
 // NewInternalTools creates a new InternalTools provider.
-func NewInternalTools(cm *sessctx.Manager) *InternalTools {
-	return &InternalTools{ctxManager: cm}
+func NewInternalTools(cm *sessctx.Manager, logger ports.Logger) *InternalTools {
+	return &InternalTools{ctxManager: cm, logger: logger}
 }
 
 // emitHeartbeats sends periodic heartbeats until the done channel is closed.
-func emitHeartbeats(done <-chan struct{}, hb chan<- struct{}) {
+func (t *InternalTools) emitHeartbeats(done <-chan struct{}, hb chan<- struct{}) {
 	defer func() {
 		if r := recover(); r != nil {
-			// Prevent crashing the tool execution silently
-			fmt.Printf("panic in summarize history background drainer: %v\n", r)
+			t.logger.Error("panic in summarize history background drainer: %v", r)
 		}
 	}()
 	ticker := time.NewTicker(2 * time.Second)
@@ -46,11 +40,11 @@ func emitHeartbeats(done <-chan struct{}, hb chan<- struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			if testEmitHeartbeatsPanic != nil {
-				testEmitHeartbeatsPanic()
+			if t.testEmitHeartbeatsPanic != nil {
+				t.testEmitHeartbeatsPanic()
 			}
-			if testEmitHeartbeatsTickHook != nil {
-				testEmitHeartbeatsTickHook()
+			if t.testEmitHeartbeatsTickHook != nil {
+				t.testEmitHeartbeatsTickHook()
 			}
 			if hb != nil {
 				select {
@@ -80,7 +74,7 @@ func (t *InternalTools) SummarizeHistory(ctx context.Context, args map[string]in
 	// Emit heartbeat while waiting for the slow summarization process
 	done := make(chan struct{})
 	defer close(done)
-	go emitHeartbeats(done, hb)
+	go t.emitHeartbeats(done, hb)
 
 	res, metrics, err := t.ctxManager.SummarizeRange(ctx, targetTurns, params.Focus)
 	if err != nil {
@@ -130,8 +124,8 @@ func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]inter
 }
 
 // RegisterInternal registers the internal tools with the provided registrar.
-func RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager) error {
-	it := NewInternalTools(cm)
+func RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager, logger ports.Logger) error {
+	it := NewInternalTools(cm, logger)
 
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{
 		Name:        "summarize_history",

--- a/internal/agent/session/internal_tools_test.go
+++ b/internal/agent/session/internal_tools_test.go
@@ -6,8 +6,7 @@ package session
 import (
 	"context"
 	"errors"
-	"io"
-	"os"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,6 +17,16 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/require"
 )
+
+// mockLogger is a test spy that captures Error calls for assertion.
+type mockLogger struct {
+	ports.Logger
+	errors []string
+}
+
+func (m *mockLogger) Error(msg string, args ...any) {
+	m.errors = append(m.errors, fmt.Sprintf(msg, args...))
+}
 
 // setPinnedFailingHM wraps a MockHistoryManager and overrides SetPinned to return an error.
 type setPinnedFailingHM struct {
@@ -36,7 +45,7 @@ func TestManageHistory_SetPinnedError(t *testing.T) {
 	}
 
 	cm := &sessctx.Manager{History: failingHM}
-	tools := NewInternalTools(cm)
+	tools := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "pin",
@@ -56,7 +65,7 @@ func TestManageHistory_SetPinnedError_Unpin(t *testing.T) {
 	}
 
 	cm := &sessctx.Manager{History: failingHM}
-	tools := NewInternalTools(cm)
+	tools := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "unpin",
@@ -75,7 +84,7 @@ func TestSummarizeHistory_SummarizeRangeError(t *testing.T) {
 		History:  &failingHMBase{},
 		Strategy: sessctx.NewStrategy(&mockTokenCounter{}),
 	}
-	tools := NewInternalTools(cm)
+	tools := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"turns": float64(3),
@@ -144,7 +153,7 @@ func TestRegisterInternal_RegisterWithOptionsError(t *testing.T) {
 		registerWithOptionsErr: errors.New("register with options failed"),
 	}
 
-	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}})
+	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "register with options failed")
 }
@@ -154,20 +163,20 @@ func TestRegisterInternal_RegisterError(t *testing.T) {
 		registerErr: errors.New("register failed"),
 	}
 
-	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}})
+	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "register failed")
 }
 
 func TestRegisterInternal_Success(t *testing.T) {
 	reg := &mockToolRegistrar{} // zero value: both error fields nil → both registrations succeed
-	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}})
+	err := RegisterInternal(reg, &sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
 	require.NoError(t, err)
 }
 
 func TestManageHistory_NegativeIndex(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "pin",
@@ -186,9 +195,11 @@ func TestEmitHeartbeats(t *testing.T) {
 		close(done)
 		hb := make(chan struct{})
 
+		it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
+
 		returned := make(chan struct{})
 		go func() {
-			emitHeartbeats(done, hb)
+			it.emitHeartbeats(done, hb)
 			close(returned)
 		}()
 
@@ -203,8 +214,10 @@ func TestEmitHeartbeats(t *testing.T) {
 		done := make(chan struct{})
 		close(done)
 
+		it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
+
 		// Should return cleanly without panic
-		emitHeartbeats(done, nil)
+		it.emitHeartbeats(done, nil)
 	})
 
 	t.Run("does not block when heartbeat channel is full", func(t *testing.T) {
@@ -216,9 +229,11 @@ func TestEmitHeartbeats(t *testing.T) {
 			close(done)
 		}()
 
+		it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
+
 		returned := make(chan struct{})
 		go func() {
-			emitHeartbeats(done, hb)
+			it.emitHeartbeats(done, hb)
 			close(returned)
 		}()
 
@@ -232,7 +247,7 @@ func TestEmitHeartbeats(t *testing.T) {
 
 func TestSummarizeHistory_UnmarshalArgsError(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"turns": "not-a-number",
@@ -255,7 +270,7 @@ func TestSummarizeHistory_InvalidTurns(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cm := &sessctx.Manager{History: &failingHMBase{}}
-			it := NewInternalTools(cm)
+			it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 			args := map[string]interface{}{
 				"turns": tt.turns,
@@ -271,7 +286,7 @@ func TestSummarizeHistory_InvalidTurns(t *testing.T) {
 
 func TestSummarizeHistory_LargeTurns(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"turns": float64(1e20),
@@ -300,7 +315,7 @@ func TestSummarizeHistory_Success(t *testing.T) {
 	})
 	cm.Summarizer = mockSum
 
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"turns": float64(1),
@@ -316,7 +331,7 @@ func TestSummarizeHistory_Success(t *testing.T) {
 
 func TestManageHistory_UnsupportedAction(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "delete",
@@ -335,7 +350,7 @@ func TestManageHistory_OutOfBoundsIndex(t *testing.T) {
 		err:            errors.New("index out of range"),
 	}
 	cm := &sessctx.Manager{History: failingHM}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "pin",
@@ -350,7 +365,7 @@ func TestManageHistory_OutOfBoundsIndex(t *testing.T) {
 
 func TestManageHistory_UnmarshalArgsError(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	// Type mismatch: "action" is a number, but params.Action expects a string
 	args := map[string]interface{}{
@@ -365,7 +380,7 @@ func TestManageHistory_UnmarshalArgsError(t *testing.T) {
 
 func TestManageHistory_Success(t *testing.T) {
 	cm := &sessctx.Manager{History: &failingHMBase{}}
-	it := NewInternalTools(cm)
+	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	t.Run("pin", func(t *testing.T) {
 		args := map[string]interface{}{
@@ -389,18 +404,14 @@ func TestManageHistory_Success(t *testing.T) {
 }
 
 func TestEmitHeartbeats_PanicRecovery(t *testing.T) {
-	// 1. Capture os.Stdout via pipe to observe panic recovery output.
-	oldStdout := os.Stdout
-	r, w, err := os.Pipe()
-	require.NoError(t, err)
-	os.Stdout = w
-	defer func() { os.Stdout = oldStdout }()
+	// 1. Create InternalTools with a mockLogger to capture the Error call.
+	logger := &mockLogger{}
+	it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, logger)
 
-	// 2. Install the test-only panic hook, reset on cleanup.
-	testEmitHeartbeatsPanic = func() {
+	// 2. Install the test-only panic hook on the struct field.
+	it.testEmitHeartbeatsPanic = func() {
 		panic("injected test panic")
 	}
-	defer func() { testEmitHeartbeatsPanic = nil }()
 
 	// 3. Start emitHeartbeats in a background goroutine.
 	done := make(chan struct{})
@@ -408,12 +419,12 @@ func TestEmitHeartbeats_PanicRecovery(t *testing.T) {
 
 	returned := make(chan struct{})
 	go func() {
-		emitHeartbeats(done, hb)
+		it.emitHeartbeats(done, hb)
 		close(returned)
 	}()
 
 	// 4. Wait for the goroutine to exit. The panic fires on the first tick
-	//    (2s interval), recover catches it, and the function returns cleanly.
+	//    (2s interval), recover catches it, and the method returns cleanly.
 	select {
 	case <-returned:
 		// goroutine exited as expected
@@ -424,18 +435,14 @@ func TestEmitHeartbeats_PanicRecovery(t *testing.T) {
 	// Cleanup: close done channel (no-op since goroutine already exited).
 	close(done)
 
-	// 5. Close the write end so the read doesn't block.
-	_ = w.Close()
-
-	// 6. Read captured stdout and verify the panic message was printed.
-	output, err := io.ReadAll(r)
-	require.NoError(t, err)
-	require.Contains(t, string(output),
+	// 5. Verify the logger captured the panic message.
+	require.NotEmpty(t, logger.errors)
+	require.Contains(t, logger.errors[0],
 		"panic in summarize history background drainer: injected test panic")
 }
 
 func TestEmitHeartbeats_TickerPaths(t *testing.T) {
-	// These subtests share the global testEmitHeartbeatsTickHook and must
+	// These subtests set a tick hook on the InternalTools instance and must
 	// not run in parallel.
 
 	tests := []struct {
@@ -462,21 +469,22 @@ func TestEmitHeartbeats_TickerPaths(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, &ports.NoOpLogger{})
+
 			// Install an idempotent tick hook that signals once.
 			ticked := make(chan struct{}, 1)
-			testEmitHeartbeatsTickHook = func() {
+			it.testEmitHeartbeatsTickHook = func() {
 				select {
 				case ticked <- struct{}{}:
 				default:
 				}
 			}
-			defer func() { testEmitHeartbeatsTickHook = nil }()
 
 			done := make(chan struct{})
 
 			returned := make(chan struct{})
 			go func() {
-				emitHeartbeats(done, tt.hb)
+				it.emitHeartbeats(done, tt.hb)
 				close(returned)
 			}()
 

--- a/internal/agent/session/internal_tools_test.go
+++ b/internal/agent/session/internal_tools_test.go
@@ -20,7 +20,7 @@ import (
 
 // mockLogger is a test spy that captures Error calls for assertion.
 type mockLogger struct {
-	ports.Logger
+	ports.NoOpLogger    // safe default for unused log methods
 	errors []string
 }
 

--- a/tests/integration/agent/agent_integration_test.go
+++ b/tests/integration/agent/agent_integration_test.go
@@ -328,7 +328,7 @@ func TestAgent_ToolRegistry_PropagatedToPipeline(t *testing.T) {
 	agentinternal.AsAgentInternal(a).GetCtxManager().SetPipeline(agentinternal.AsAgentInternal(a).GetCtxManager().Factory.BuildStandardPipeline(events.Limits{MaxHistoryTokens: 1000}))
 
 	// Register should update pipeline via ContextManager
-	err = session.RegisterInternal(reg, agentinternal.AsAgentInternal(a).GetCtxManager())
+	err = session.RegisterInternal(reg, agentinternal.AsAgentInternal(a).GetCtxManager(), &ports.NoOpLogger{})
 	require.NoError(t, err)
 
 	// Verify that at least one transformer has the registry
@@ -342,7 +342,7 @@ func TestAgent_PinningFlow(t *testing.T) {
 		defer cancel()
 		_ = a.Shutdown(shutdownCtx)
 	})
-	it := session.NewInternalTools(agentinternal.AsAgentInternal(a).GetCtxManager())
+	it := session.NewInternalTools(agentinternal.AsAgentInternal(a).GetCtxManager(), &ports.NoOpLogger{})
 
 	t.Run("PinTurn", func(t *testing.T) {
 		verifyPinAction(t, it, h, ctx, "pin", 0)

--- a/tests/integration/agent/session/internal_tools_test.go
+++ b/tests/integration/agent/session/internal_tools_test.go
@@ -14,6 +14,7 @@ import (
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
@@ -32,7 +33,7 @@ func TestAgent_ManageHistory(t *testing.T) {
 	_ = hManager.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "M2"}}})
 
 	cm := sessctx.NewManager(nil, hManager, nil, nil)
-	it := session.NewInternalTools(cm)
+	it := session.NewInternalTools(cm, &ports.NoOpLogger{})
 
 	tests := []struct {
 		name        string
@@ -99,7 +100,7 @@ func TestAgent_ManageHistory(t *testing.T) {
 func TestRegisterInternal(t *testing.T) {
 	registry := &agenttest.MockToolRegistry{}
 	cm := sessctx.NewManager(nil, nil, nil, nil)
-	if err := session.RegisterInternal(registry, cm); err != nil {
+	if err := session.RegisterInternal(registry, cm, &ports.NoOpLogger{}); err != nil {
 		t.Fatalf("RegisterInternal failed: %v", err)
 	}
 
@@ -172,7 +173,7 @@ func TestInternalTools_SummarizeHistory(t *testing.T) {
 		{Role: "model", Parts: []*llm.Part{{Text: "M2"}}},
 	})
 	cm := sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hManager, &eventstest.MockEventBus{}, factory)
-	it := session.NewInternalTools(cm)
+	it := session.NewInternalTools(cm, &ports.NoOpLogger{})
 
 	ctx := context.Background()
 
@@ -234,7 +235,7 @@ func TestRegisterInternal_ErrorPath(t *testing.T) {
 			registry.SetRegisterErr(fmt.Errorf("registry error"))
 			registry.SetFailAfter(tt.failAfter)
 			cm := sessctx.NewManager(nil, nil, nil, nil)
-			err := session.RegisterInternal(registry, cm)
+			err := session.RegisterInternal(registry, cm, &ports.NoOpLogger{})
 			if err == nil {
 				t.Fatalf("expected initialization to fail when registry returns an error (failAfter=%d)", tt.failAfter)
 			}

--- a/tests/integration/agent/session/summarize_test.go
+++ b/tests/integration/agent/session/summarize_test.go
@@ -176,7 +176,7 @@ func setupInternalTools(t *testing.T, client *gemini.Client, h ports.HistoryMana
 		Events:     bus,
 	}
 	cm := sessctx.NewManager(strategy, h, bus, factory)
-	return session.NewInternalTools(cm)
+	return session.NewInternalTools(cm, &ports.NoOpLogger{})
 }
 
 func verifySummarizeResult(t *testing.T, tt summarizeTestCase, resp tools.ToolResult, err error, h ports.HistoryManager) {


### PR DESCRIPTION
Closes #355.

## Summary

Refactors four deferred technical debt items from PR #354:

### 1. Method Conversion
`emitHeartbeats` free function → `(*InternalTools).emitHeartbeats` method.

### 2. Encapsulate Test State
Package-level `testEmitHeartbeatsPanic` / `testEmitHeartbeatsTickHook` vars → `InternalTools` struct fields. Eliminates global mutable state and enables `t.Parallel()`.

### 3. Logger Injection
- `NewInternalTools` and `RegisterInternal` accept `ports.Logger`
- Panic recovery uses `t.logger.Error(...)` instead of `fmt.Printf`
- `os.Stdout` pipe tests replaced with `mockLogger` assertions

### 4. ADR-032 Amendment
Added Fault-Injection Exception clause for `panic()` hooks targeting `recover()` blocks. Updated Appendix A registry.

## Changes

| File | Change |
|------|--------|
| `internal/agent/session/internal_tools.go` | Struct fields, method conversion, logger injection |
| `internal/agent/agent.go` | Pass `a.getLogger()` to `RegisterInternal` |
| `internal/agent/session/internal_tools_test.go` | `mockLogger` spy, struct-field hooks, NoOpLogger |
| `internal/agent/session/context/gatekeeper_error_test.go` | Logger arg |
| `tests/integration/agent/session/internal_tools_test.go` | Logger arg |
| `tests/integration/agent/agent_integration_test.go` | Logger arg |
| `docs/adr/2026-05-test-hook-policy.md` | Fault-Injection Exception + registry update |

## Verification

- `go build ./...` ✅
- `go vet ./...` ✅
- `go test ./internal/agent/session/...` ✅
- `go test ./tests/integration/agent/...` ✅