### PR TITLE
refactor: migrate analysisManager.DeadCode to unexported + constructor injection

### DIFF
--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -250,7 +250,7 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 }
 
 func (m *healthManager) checkDeadCode(ctx context.Context, hb chan<- struct{}) (string, string) {
-	reports, err := m.Ana.DeadCode.GatherOrphanReports(ctx, ".", hb)
+	reports, err := m.Ana.deadCode.GatherOrphanReports(ctx, ".", hb)
 	if err != nil {
 		return "ERROR", err.Error()
 	}

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -144,8 +144,8 @@ func TestHealthManager_GetCodeHealth(t *testing.T) {
 	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
-	ana.DeadCode = &mockDeadCodeAnalyzer{}
+	mockDead := &mockDeadCodeAnalyzer{}
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), mockDead)
 	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
 
 	ctx := context.Background()
@@ -178,7 +178,7 @@ func TestHealthManager_GetCodeHealth_Cancelled(t *testing.T) {
 	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), &mockDeadCodeAnalyzer{})
 	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -311,7 +311,7 @@ func TestHealthManager_CheckDeadCode(t *testing.T) {
 
 			// Inject into a dummy healthManager
 			hea := &healthManager{
-				Ana: &analysisManager{DeadCode: mockAna},
+				Ana: newAnalysisManager(nil, nil, nil, nil, nil, nil, nil, mockAna),
 			}
 
 			status, details := hea.checkDeadCode(context.Background(), nil)

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -62,7 +62,7 @@ type analysisManager struct {
 	Sequence   sequenceAnalyzer
 	Change     changeAnalyzer
 	Types      typeManager
-	DeadCode   deadCodeAnalyzer
+	deadCode   deadCodeAnalyzer
 
 	// Refactoring
 	Refactor *refactorManager
@@ -79,7 +79,7 @@ type analysisManager struct {
 	Events events.EventBus
 }
 
-func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy) *analysisManager {
+func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy, dc deadCodeAnalyzer) *analysisManager {
 	runner := toolchain.NewGoRunner(executor)
 	m := &analysisManager{
 		Complexity: newComplexityAnalyzer(cache, sp),
@@ -87,7 +87,7 @@ func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Man
 		Sequence:   newSequenceAnalyzer(executor, sp, idx),
 		Change:     newChangeAnalyzer(cache, executor),
 		Types:      newTypeManager(idx, cache, sp),
-		DeadCode:   newDeadCodeAnalyzer(sp, idx),
+		deadCode:   dc,
 
 		Refactor: newRefactorManager(sp),
 		Info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp},
@@ -109,7 +109,7 @@ func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Man
 // Delegated methods for registration
 
 func (m *analysisManager) FindOrphanedSymbols(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.DeadCode.FindOrphanedSymbols(ctx, args, hb)
+	return m.deadCode.FindOrphanedSymbols(ctx, args, hb)
 }
 
 func (m *analysisManager) AnalyzeComplexity(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {

--- a/internal/tools/analysis/manager_test.go
+++ b/internal/tools/analysis/manager_test.go
@@ -25,7 +25,7 @@ func setupAnalysisManager(t *testing.T) (*analysisManager, string) {
 	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 
-	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy())
+	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), newDeadCodeAnalyzer(sp, idx))
 	return m, tmpDir
 }
 

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -17,7 +17,7 @@ import (
 func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy) (tools.ToolFunc, error) {
 	idx, _ := newIndexer(".")
 	cache := newASTCache(".")
-	m := newAnalysisManager(idx, cache, sm, bus, executor, fs, wp)
+	m := newAnalysisManager(idx, cache, sm, bus, executor, fs, wp, newDeadCodeAnalyzer(sm, idx))
 
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration


### PR DESCRIPTION
## Summary

Unexports `analysisManager.DeadCode` and injects `deadCodeAnalyzer` via the constructor. The field was exported solely to enable test mocking — zero production consumers outside the `analysis` package.

## Changes

| File | Change |
|---|---|
| `manager.go` | Unexport `DeadCode` → `deadCode`, add `dc deadCodeAnalyzer` parameter to `newAnalysisManager` |
| `health.go` | Update `checkDeadCode` consumer from `m.Ana.DeadCode` → `m.Ana.deadCode` |
| `registration.go` | Pass `newDeadCodeAnalyzer(sm, idx)` in constructor call |
| `health_test.go` | Inject mock via constructor instead of direct field assignment |
| `manager_test.go` | Pass real analyzer in constructor call |

## Verification

- `go build ./...` — clean
- `go test ./internal/tools/analysis/... -race -count=1` — pass (13.5s)
- `golangci-lint run ./internal/tools/analysis/...` — zero issues
- Zero `.DeadCode` references remain in the codebase

Closes #360