### PR TITLE
refactor(analysis): break circular back-reference and unexport analysisManager fields

### DIFF
--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -19,10 +19,11 @@ import (
 )
 
 type healthManager struct {
-	SP     security.PolicyEvaluator
-	Exec   tools.CommandExecutor
-	Runner AnalysisGoRunner
-	Ana    *analysisManager
+	SP         security.PolicyEvaluator
+	Exec       tools.CommandExecutor
+	Runner     AnalysisGoRunner
+	complexity complexityAnalyzer
+	deadCode   deadCodeAnalyzer
 }
 
 type healthResult struct {
@@ -225,7 +226,7 @@ func (m *healthManager) runLint(ctx context.Context) (string, string) {
 
 func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
 	// Complexity check is internal and doesn't need TerminalLock unless it uses a tool
-	complexities, err := m.Ana.Complexity.GatherComplexities(ctx, ".", hb)
+	complexities, err := m.complexity.GatherComplexities(ctx, ".", hb)
 	if err != nil {
 		return "ERROR", err.Error(), nil
 	}
@@ -250,7 +251,7 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 }
 
 func (m *healthManager) checkDeadCode(ctx context.Context, hb chan<- struct{}) (string, string) {
-	reports, err := m.Ana.deadCode.GatherOrphanReports(ctx, ".", hb)
+	reports, err := m.deadCode.GatherOrphanReports(ctx, ".", hb)
 	if err != nil {
 		return "ERROR", err.Error()
 	}

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -146,7 +146,7 @@ func TestHealthManager_GetCodeHealth(t *testing.T) {
 	mockRunner := &mockGoRunner{}
 	mockDead := &mockDeadCodeAnalyzer{}
 	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), mockDead)
-	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
+	hea := &healthManager{SP: sm, complexity: ana.complexity, deadCode: mockDead, Exec: mockExec, Runner: mockRunner}
 
 	ctx := context.Background()
 	res, err := hea.GetCodeHealth(ctx, nil, nil)
@@ -179,7 +179,7 @@ func TestHealthManager_GetCodeHealth_Cancelled(t *testing.T) {
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
 	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), &mockDeadCodeAnalyzer{})
-	hea := &healthManager{SP: sm, Ana: ana, Exec: mockExec, Runner: mockRunner}
+	hea := &healthManager{SP: sm, complexity: ana.complexity, deadCode: &mockDeadCodeAnalyzer{}, Exec: mockExec, Runner: mockRunner}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
@@ -311,7 +311,7 @@ func TestHealthManager_CheckDeadCode(t *testing.T) {
 
 			// Inject into a dummy healthManager
 			hea := &healthManager{
-				Ana: newAnalysisManager(nil, nil, nil, nil, nil, nil, nil, mockAna),
+				deadCode: mockAna,
 			}
 
 			status, details := hea.checkDeadCode(context.Background(), nil)

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -57,50 +57,51 @@ type AnalysisGoRunner interface {
 
 // analysisManager is the consolidated hub for all code analysis, refactoring, and development tools.
 type analysisManager struct {
-	Complexity complexityAnalyzer
-	Dependency dependencyAnalyzer
-	Sequence   sequenceAnalyzer
-	Change     changeAnalyzer
-	Types      typeManager
+	complexity complexityAnalyzer
+	dependency dependencyAnalyzer
+	sequence   sequenceAnalyzer
+	change     changeAnalyzer
+	types      typeManager
 	deadCode   deadCodeAnalyzer
 
 	// Refactoring
-	Refactor *refactorManager
+	refactor *refactorManager
 
 	// Information & Search
-	Info   *infoManager
-	Search *searchManager
+	info   *infoManager
+	search *searchManager
 
 	// Project Health & Architecture
-	Health *healthManager
-	Arch   *architectureManager
+	health *healthManager
+	arch   *architectureManager
 
 	// EventBus for progress reporting
-	Events events.EventBus
+	events events.EventBus
 }
 
 func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy, dc deadCodeAnalyzer) *analysisManager {
 	runner := toolchain.NewGoRunner(executor)
 	m := &analysisManager{
-		Complexity: newComplexityAnalyzer(cache, sp),
-		Dependency: newDependencyAnalyzer(runner, sp, bus, wp),
-		Sequence:   newSequenceAnalyzer(executor, sp, idx),
-		Change:     newChangeAnalyzer(cache, executor),
-		Types:      newTypeManager(idx, cache, sp),
+		complexity: newComplexityAnalyzer(cache, sp),
+		dependency: newDependencyAnalyzer(runner, sp, bus, wp),
+		sequence:   newSequenceAnalyzer(executor, sp, idx),
+		change:     newChangeAnalyzer(cache, executor),
+		types:      newTypeManager(idx, cache, sp),
 		deadCode:   dc,
 
-		Refactor: newRefactorManager(sp),
-		Info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp},
-		Search:   &searchManager{SP: sp, FS: fs, Policy: wp},
-		Arch:     &architectureManager{SP: sp, Runner: runner, idx: idx},
-		Events:   bus,
+		refactor: newRefactorManager(sp),
+		info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp},
+		search:   &searchManager{SP: sp, FS: fs, Policy: wp},
+		arch:     &architectureManager{SP: sp, Runner: runner, idx: idx},
+		events:   bus,
 	}
 
-	m.Health = &healthManager{
-		SP:     sp,
-		Ana:    m,
-		Exec:   executor,
-		Runner: runner,
+	m.health = &healthManager{
+		SP:         sp,
+		complexity: m.complexity,
+		deadCode:   m.deadCode,
+		Exec:       executor,
+		Runner:     runner,
 	}
 
 	return m
@@ -113,37 +114,37 @@ func (m *analysisManager) FindOrphanedSymbols(ctx context.Context, args map[stri
 }
 
 func (m *analysisManager) AnalyzeComplexity(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Complexity.Analyze(ctx, args, hb)
+	return m.complexity.Analyze(ctx, args, hb)
 }
 
 func (m *analysisManager) GetPackageGraph(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Dependency.GetPackageGraph(ctx, args, hb)
+	return m.dependency.GetPackageGraph(ctx, args, hb)
 }
 
 func (m *analysisManager) AnalyzeSequenceFlow(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Sequence.AnalyzeSequenceFlow(ctx, args, hb)
+	return m.sequence.AnalyzeSequenceFlow(ctx, args, hb)
 }
 
 func (m *analysisManager) SemanticDiff(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Change.SemanticDiff(ctx, args, hb)
+	return m.change.SemanticDiff(ctx, args, hb)
 }
 
 func (m *analysisManager) ListImplementations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Types.ListImplementations(ctx, args, hb)
+	return m.types.ListImplementations(ctx, args, hb)
 }
 
 func (m *analysisManager) FindUsages(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Types.FindUsages(ctx, args, hb)
+	return m.types.FindUsages(ctx, args, hb)
 }
 
 func (m *analysisManager) ListSymbols(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Types.ListSymbols(ctx, args, hb)
+	return m.types.ListSymbols(ctx, args, hb)
 }
 
 func (m *analysisManager) GetTypeInfo(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Types.GetTypeInfo(ctx, args, hb)
+	return m.types.GetTypeInfo(ctx, args, hb)
 }
 
 func (m *analysisManager) FindDefinitions(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	return m.Types.FindDefinitions(ctx, args, hb)
+	return m.types.FindDefinitions(ctx, args, hb)
 }

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -74,9 +74,6 @@ type analysisManager struct {
 	// Project Health & Architecture
 	health *healthManager
 	arch   *architectureManager
-
-	// EventBus for progress reporting
-	events events.EventBus
 }
 
 func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy, dc deadCodeAnalyzer) *analysisManager {
@@ -93,7 +90,6 @@ func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Man
 		info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp},
 		search:   &searchManager{SP: sp, FS: fs, Policy: wp},
 		arch:     &architectureManager{SP: sp, Runner: runner, idx: idx},
-		events:   bus,
 	}
 
 	m.health = &healthManager{

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -31,7 +31,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 				Name:        "verify_architecture",
 				Description: "Map component dependencies and identify 'God Objects' or circular references. Verifies adherence to Hexagonal/Clean Architecture layers.",
 			},
-			handler: m.Arch.VerifyArchitecture,
+			handler: m.arch.VerifyArchitecture,
 			opts:    &tools.ToolOptions{LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -39,7 +39,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 				Name:        "get_code_health",
 				Description: "Returns a high-level summary of project health, including test status, coverage, linting issues, and complexity alerts. Use this to verify system integrity after major refactors.",
 			},
-			handler: m.Health.GetCodeHealth,
+			handler: m.health.GetCodeHealth,
 			opts:    &tools.ToolOptions{LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -54,7 +54,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"path"},
 				},
 			},
-			handler: m.Health.GetDetailedCoverage,
+			handler: m.health.GetDetailedCoverage,
 			opts:    &tools.ToolOptions{LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -137,7 +137,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 				Name:        "get_project_summary",
 				Description: "Returns a high-level summary of the project architecture, including packages, file counts, and Go module info.",
 			},
-			handler: m.Info.GetProjectSummary,
+			handler: m.info.GetProjectSummary,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -151,7 +151,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"filepath"},
 				},
 			},
-			handler: m.Info.GetFileSkeleton,
+			handler: m.info.GetFileSkeleton,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -167,7 +167,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"query"},
 				},
 			},
-			handler: m.Search.SearchUsagesGlobally,
+			handler: m.search.SearchUsagesGlobally,
 			opts:    &tools.ToolOptions{LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -200,7 +200,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"old_name", "new_name", "reason"},
 				},
 			},
-			handler: m.Refactor.RenameSymbol,
+			handler: m.refactor.RenameSymbol,
 			opts:    &tools.ToolOptions{Serial: true, LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -214,7 +214,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					},
 				},
 			},
-			handler: m.Search.ListTodos,
+			handler: m.search.ListTodos,
 			opts:    &tools.ToolOptions{LongRunning: true, LivenessThreshold: 30 * time.Second},
 		},
 		{
@@ -229,7 +229,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"symbol"},
 				},
 			},
-			handler: m.Info.GoDoc,
+			handler: m.info.GoDoc,
 		},
 		{
 			decl: &tools.ToolDeclaration{
@@ -308,7 +308,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Required: []string{"symbol", "src_file", "dst_file", "reason"},
 				},
 			},
-			handler: m.Refactor.MoveDefinition,
+			handler: m.refactor.MoveDefinition,
 			opts:    &tools.ToolOptions{Serial: true},
 		},
 		{
@@ -339,5 +339,5 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 		}
 	}
 
-	return m.Arch.VerifyArchitecture, nil
+	return m.arch.VerifyArchitecture, nil
 }


### PR DESCRIPTION
## Summary

Closes #365

### Problem
`healthManager` held a circular back-reference `Ana *analysisManager` to its parent hub, reaching into it to call `Complexity.GatherComplexities()` and `deadCode.GatherOrphanReports()`. Additionally, `analysisManager` had 11 exported fields despite being an unexported struct — the casing was misleading since no external package could access them.

### Changes
1. **Broke the circular dependency**: `healthManager` now receives only the two specific interfaces it needs (`complexityAnalyzer`, `deadCodeAnalyzer`) via constructor injection instead of the full `*analysisManager` back-reference
2. **Unexported all fields on `analysisManager`**: `Complexity` → `complexity`, `Dependency` → `dependency`, etc. — all 11 fields
3. **Simplified test setup**: Tests now construct `healthManager` with only the dependencies they need, eliminating dummy `analysisManager` structs with nil fields

### Before / After

| Before | After |
|--------|-------|
| `healthManager.Ana *analysisManager` (circular) | `healthManager.complexity complexityAnalyzer` + `healthManager.deadCode deadCodeAnalyzer` |
| `analysisManager` — 11 exported fields | `analysisManager` — 0 exported fields |
| Tests construct dummy `analysisManager` with nil fields | Tests inject only needed interfaces |

### Verification
- ✅ `go build ./internal/tools/analysis/...`
- ✅ `go test ./internal/tools/analysis/...` — PASS
- ✅ Zero residual references to `.Ana` or uppercase field names on `analysisManager`