### PR TITLE
test(integrations): Error Path Hardening — Coverage 89.1% → 94.3%

### DIFF
--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -5,6 +5,7 @@ package ado
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -346,6 +347,26 @@ func TestAdoManager_ListPipelineLogs_Errors(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "resource not found")
 	})
+
+	t.Run("Fetch Log Content - processLogContent error (scanner.Err)", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Return a single line larger than the scanner's max buffer (1MB)
+			// to trigger bufio.ErrTooLong wrapped as "log stream interrupted"
+			w.WriteHeader(http.StatusOK)
+			tooLong := make([]byte, 1*1024*1024+1)
+			for i := range tooLong {
+				tooLong[i] = 'A'
+			}
+			w.Write(tooLong)
+		}))
+		t.Cleanup(ts.Close)
+
+		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101, "log_id": 1}
+		_, err := m.getPipelineLogContent(context.Background(), args, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to process log content")
+	})
 }
 
 func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
@@ -625,4 +646,26 @@ func TestAdoManager_UpdateBuildDefinitionVariables_Errors(t *testing.T) {
 		assert.True(t, res.Cancelled)
 		assert.Equal(t, 1, res.DefinitionID)
 	})
+}
+
+func TestBuildVariablesUpdatePayload_NonMapVariables(t *testing.T) {
+	// When existingDef["variables"] exists but is not a map[string]interface{},
+	// the function should replace it with an empty map and proceed.
+	existingDef := map[string]interface{}{
+		"variables": "not-a-map", // wrong type
+	}
+	inputVars := map[string]adoVariable{
+		"MY_VAR": {Value: "x", IsSecret: false},
+	}
+
+	body, err := buildVariablesUpdatePayload(existingDef, inputVars)
+	assert.NoError(t, err)
+
+	var result map[string]interface{}
+	err = json.Unmarshal(body, &result)
+	assert.NoError(t, err)
+
+	vars, ok := result["variables"].(map[string]interface{})
+	assert.True(t, ok, "variables should be a map after buildVariablesUpdatePayload")
+	assert.Contains(t, vars, "MY_VAR")
 }

--- a/internal/tools/integrations/ado/pipeline_logs_test.go
+++ b/internal/tools/integrations/ado/pipeline_logs_test.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ado
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSendScannerHeartbeat(t *testing.T) {
+	t.Run("nil channel does nothing", func(t *testing.T) {
+		// Should not panic when hb is nil
+		sendScannerHeartbeat(nil, 1000)
+		sendScannerHeartbeat(nil, 2000)
+	})
+
+	t.Run("non-multiple-of-1000 does not send", func(t *testing.T) {
+		hb := make(chan struct{}, 1)
+		sendScannerHeartbeat(hb, 999)
+		select {
+		case <-hb:
+			t.Fatal("unexpected heartbeat for count 999")
+		default:
+			// expected — no heartbeat
+		}
+	})
+
+	t.Run("sends heartbeat at count 1000", func(t *testing.T) {
+		hb := make(chan struct{}, 1)
+		sendScannerHeartbeat(hb, 1000)
+		select {
+		case <-hb:
+			// expected
+		default:
+			t.Fatal("expected heartbeat for count 1000")
+		}
+	})
+
+	t.Run("full channel drops heartbeat gracefully", func(t *testing.T) {
+		hb := make(chan struct{}) // unbuffered, no receiver
+		// This should not block or panic — the default case handles it
+		done := make(chan struct{})
+		go func() {
+			sendScannerHeartbeat(hb, 1000)
+			close(done)
+		}()
+		select {
+		case <-done:
+			// expected — didn't block
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("sendScannerHeartbeat blocked on full channel")
+		}
+	})
+}

--- a/internal/tools/integrations/atlassian/provider_test.go
+++ b/internal/tools/integrations/atlassian/provider_test.go
@@ -245,3 +245,67 @@ func TestAtlassianProvider_Constructor_FailsWhenMissingURL(t *testing.T) {
 	require.Nil(t, p)
 	assert.Contains(t, err.Error(), "missing required environment variable: ATLASSIAN_BASE_URL")
 }
+
+func TestAtlassianProvider_GetWaitTime_EdgeCases(t *testing.T) {
+	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+	t.Setenv("ATLASSIAN_TOKEN", "token")
+
+	t.Run("BaseDelay zero defaults to 1 second", func(t *testing.T) {
+		p, err := NewAtlassianProvider()
+		require.NoError(t, err)
+		p.BaseDelay = 0 // trigger the BaseDelay == 0 branch
+
+		resp := &http.Response{Header: make(http.Header)}
+		wait := p.GetWaitTime(resp, 0)
+		assert.Equal(t, 1*time.Second, wait)
+	})
+
+	t.Run("invalid Retry-After falls back to exponential backoff", func(t *testing.T) {
+		p, err := NewAtlassianProvider()
+		require.NoError(t, err)
+		p.BaseDelay = 1 * time.Second
+
+		headers := make(http.Header)
+		headers.Set("Retry-After", "not-a-number")
+		resp := &http.Response{Header: headers}
+
+		wait := p.GetWaitTime(resp, 1)
+		// Falls back to BaseDelay * 2^1 = 2 seconds
+		assert.Equal(t, 2*time.Second, wait)
+	})
+}
+
+func TestAtlassianProvider_Do_ResetBodyError(t *testing.T) {
+	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+	t.Setenv("ATLASSIAN_TOKEN", "token")
+
+	t.Run("GetBody error on retry propagates", func(t *testing.T) {
+		p, err := NewAtlassianProvider()
+		require.NoError(t, err)
+		p.BaseDelay = 0
+
+		mockClient := new(mockRetryClient)
+		bodyText := "hello"
+		req, _ := http.NewRequest(http.MethodPut, "https://test.com", strings.NewReader(bodyText))
+		// Set GetBody to a function that returns an error
+		req.GetBody = func() (io.ReadCloser, error) {
+			return nil, assert.AnError
+		}
+
+		// First attempt: 429, body consumed
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("throttled")),
+		}, nil).Once()
+
+		// The retry should try to reset the body and fail
+		// No second Do call should happen
+		_, err = p.Do(context.Background(), mockClient, req)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to reset request body")
+		mockClient.AssertExpectations(t)
+	})
+}

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"go.uber.org/goleak"
 )
@@ -214,6 +215,11 @@ func TestMediaTools_ReadImage(t *testing.T) {
 	unreadableFile := filepath.Join(tmpDir, "unreadable.png")
 	_ = os.WriteFile(unreadableFile, []byte("secret"), 0200)
 
+	webpFile := filepath.Join(tmpDir, "test.webp")
+	_ = os.WriteFile(webpFile, []byte("webp-data"), 0644)
+	bmpFile := filepath.Join(tmpDir, "test.bmp")
+	_ = os.WriteFile(bmpFile, []byte("bmp-data"), 0644)
+
 	tests := []struct {
 		name         string
 		filepath     string
@@ -250,6 +256,18 @@ func TestMediaTools_ReadImage(t *testing.T) {
 			filepath:   subDir,
 			isPathSafe: true,
 			wantErr:    true,
+		},
+		{
+			name:         "read webp",
+			filepath:     webpFile,
+			isPathSafe:   true,
+			wantMimeType: "image/webp",
+		},
+		{
+			name:         "read unknown extension defaults to png",
+			filepath:     bmpFile,
+			isPathSafe:   true,
+			wantMimeType: "image/png",
 		},
 		{
 			name:       "permission denied failure",
@@ -322,4 +340,205 @@ func TestMediaManager_DefaultOptions(t *testing.T) {
 	if m.heartbeatInterval != 2*time.Second {
 		t.Errorf("default heartbeatInterval = %v, want 2s", m.heartbeatInterval)
 	}
+}
+
+// mkdirFailFS overrides MkdirAll to simulate a filesystem that cannot create directories.
+type mkdirFailFS struct{ *mockFileSystem }
+
+func (m *mkdirFailFS) MkdirAll(ctx context.Context, path string, perm os.FileMode) error {
+	return errors.New("mkdir failed")
+}
+
+// atomicWriteFailFS overrides AtomicWrite to simulate a write failure after directory creation succeeds.
+type atomicWriteFailFS struct{ *mockFileSystem }
+
+func (m *atomicWriteFailFS) MkdirAll(ctx context.Context, path string, perm os.FileMode) error {
+	return nil
+}
+
+func (m *atomicWriteFailFS) AtomicWrite(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+	return errors.New("write failed")
+}
+
+func TestMediaTools_ErrorPaths(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).readLoop"),
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name        string
+		setup       func() *mediaManager
+		action      func(m *mediaManager) error
+		errText     string
+		errSentinel error
+	}{
+		{
+			name: "nil LLM client returns ErrNotImplemented",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, newMediaMockSecurityManager(), nil, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.createImage(ctx, map[string]interface{}{"prompt": "test"}, nil)
+				return err
+			},
+			errSentinel: tools.ErrNotImplemented,
+		},
+		{
+			name: "parseImageArgs failure on invalid args",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, newMediaMockSecurityManager(), &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.createImage(ctx, map[string]interface{}{"prompt": 123}, nil)
+				return err
+			},
+			errText: "unmarshal args",
+		},
+		{
+			name: "MkdirAll failure in saveImagesToDisk",
+			setup: func() *mediaManager {
+				client := &mockLLMClient{
+					generateImagesFunc: func(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+						return [][]byte{[]byte("data")}, nil
+					},
+				}
+				return newMediaManager(
+					&mkdirFailFS{&mockFileSystem{}},
+					newMediaMockSecurityManager(),
+					client,
+					"/nonexistent/path",
+				)
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.createImage(ctx, map[string]interface{}{"prompt": "test"}, nil)
+				return err
+			},
+			errText: "create assets directory",
+		},
+		{
+			name: "AtomicWrite failure in saveImagesToDisk",
+			setup: func() *mediaManager {
+				client := &mockLLMClient{
+					generateImagesFunc: func(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+						return [][]byte{[]byte("data")}, nil
+					},
+				}
+				return newMediaManager(
+					&atomicWriteFailFS{&mockFileSystem{}},
+					newMediaMockSecurityManager(),
+					client,
+					tmpDir,
+				)
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.createImage(ctx, map[string]interface{}{"prompt": "test"}, nil)
+				return err
+			},
+			errText: "write image file",
+		},
+		{
+			name: "nil security manager in readImage",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, nil, &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readImage(ctx, map[string]interface{}{"filepath": "test.png"}, nil)
+				return err
+			},
+			errText: "path validator is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.setup()
+			err := tt.action(m)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if tt.errSentinel != nil && !errors.Is(err, tt.errSentinel) {
+				t.Errorf("expected error %v, got %v", tt.errSentinel, err)
+			}
+			if tt.errText != "" && !strings.Contains(err.Error(), tt.errText) {
+				t.Errorf("expected error to contain %q, got %q", tt.errText, err.Error())
+			}
+		})
+	}
+}
+
+// faultyRegistry wraps a real registry and forces a registration error after failOn
+// successful registrations. Used to test error propagation through register* functions.
+type faultyRegistry struct {
+	tools.Registry
+	failOn int
+	count  int
+}
+
+func newFaultyRegistry(real tools.Registry, failOn int) *faultyRegistry {
+	return &faultyRegistry{Registry: real, failOn: failOn}
+}
+
+func (r *faultyRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	r.count++
+	if r.count > r.failOn {
+		return errors.New("simulated registration failure")
+	}
+	return r.Registry.RegisterToToolkit(toolkit, def, handler)
+}
+
+func (r *faultyRegistry) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	r.count++
+	if r.count > r.failOn {
+		return errors.New("simulated registration failure")
+	}
+	return r.Registry.RegisterToToolkitWithOptions(toolkit, def, handler, opts)
+}
+
+func (r *faultyRegistry) Register(def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	r.count++
+	if r.count > r.failOn {
+		return errors.New("simulated registration failure")
+	}
+	return r.Registry.Register(def, handler)
+}
+
+func (r *faultyRegistry) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	r.count++
+	if r.count > r.failOn {
+		return errors.New("simulated registration failure")
+	}
+	return r.Registry.RegisterWithOptions(def, handler, opts)
+}
+
+func TestRegisterMedia_ErrorPaths(t *testing.T) {
+	sm := newMediaMockSecurityManager()
+	fs := &mockFileSystem{}
+	client := &mockLLMClient{}
+	tmpDir := t.TempDir()
+
+	t.Run("first RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 0)
+		err := registerMedia(r, fs, sm, client, tmpDir)
+		if err == nil {
+			t.Fatal("expected error on first registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
+
+	t.Run("second RegisterToToolkit fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 1)
+		err := registerMedia(r, fs, sm, client, tmpDir)
+		if err == nil {
+			t.Fatal("expected error on second registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
 }

--- a/internal/tools/integrations/network_test.go
+++ b/internal/tools/integrations/network_test.go
@@ -653,3 +653,31 @@ Loop:
 		// OK
 	}
 }
+
+func TestRegisterNetwork_ErrorPaths(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	t.Run("first RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 0)
+		tool := newnetworkTool(sm, nil)
+		err := registerNetwork(r, tool)
+		if err == nil {
+			t.Fatal("expected error on first registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
+
+	t.Run("second RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 1)
+		tool := newnetworkTool(sm, nil)
+		err := registerNetwork(r, tool)
+		if err == nil {
+			t.Fatal("expected error on second registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
+}

--- a/internal/tools/integrations/teams_test.go
+++ b/internal/tools/integrations/teams_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
@@ -179,4 +180,24 @@ func TestNewTeamsManager_DefaultClient(t *testing.T) {
 	if m.client == nil {
 		t.Error("Expected default client to be initialized")
 	}
+}
+
+func TestRegisterTeams_ErrorPaths(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	client := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader("OK"))}, nil
+		},
+	}
+
+	t.Run("RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 0)
+		err := registerTeams(r, sm, client)
+		if err == nil {
+			t.Fatal("expected error on registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

Closes #370

Hardens error-path test coverage across the integrations package and its ADO/Atlassian sub-packages.

## Coverage Improvements

| Package | Before | After |
|---|---|---|
| `integrations/` (media, network, teams) | 89.1% | **94.3%** |
| `integrations/ado/` | 92.8% | **93.2%** |
| `integrations/atlassian/` | 92.1% | **92.7%** |

## Changes

### `media_test.go` — Primary gap closure
- Nil LLM client → `ErrNotImplemented`
- `tools.UnmarshalArgs` failure on invalid args
- `MkdirAll` and `AtomicWrite` filesystem error paths
- Nil security manager guard in `readImage`
- `.webp` and unknown-extension (default to png) MIME type branches
- `registerMedia` failure propagation via `faultyRegistry`

### `network_test.go` / `teams_test.go` — Registration error paths
- `registerNetwork` and `registerTeams` failure via shared `faultyRegistry` mock

### `ado/pipeline_logs_test.go` (new) — Scanner heartbeat
- All 4 branches of `sendScannerHeartbeat`: nil chan, non-1000 counts, successful send, full channel graceful drop

### `ado/negative_test.go` — Log streaming + payload builder
- `getPipelineLogContent` `scanner.ErrTooLong` truncated-response path
- `buildVariablesUpdatePayload` non-map variables field branch

### `atlassian/provider_test.go` — Retry/boundary coverage
- `GetWaitTime` `BaseDelay=0` default and invalid `Retry-After` fallback
- `resetRequestBody` `GetBody` error propagation on retry
- `provider.go` now at **100%**