### PR TITLE
test(developer): harden error paths across dev/release/registration tools (closes #371)

### DIFF
--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -130,6 +130,7 @@ func TestCheckVulnerabilities(t *testing.T) {
 		lookPathErr  error
 		executeOut   string
 		executeErr   error
+		decline      bool
 		wantSubstr   string
 		wantErr      bool
 		wantAuthFail bool
@@ -158,17 +159,36 @@ func TestCheckVulnerabilities(t *testing.T) {
 			wantSubstr: "Govulncheck execution failed",
 			wantErr:    true,
 		},
+		{
+			name:       "user declined",
+			decline:    true,
+			wantSubstr: "Action denied by user.",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, executor, _ := setupDevManager(t)
-			m.runner.(*mockGoRunner).checkGovulncheckFunc = func(ctx context.Context) error {
-				return tt.lookPathErr
-			}
-			executor.executeFunc = func(ctx context.Context, name string, args ...string) ([]byte, error) {
-				return []byte(tt.executeOut), tt.executeErr
+			m, executor, sm := setupDevManager(t)
+			if tt.decline {
+				sm.AllowAll = false
+				m.validator = &mockValidator{
+					CommandValidator: m.validator,
+					isSafeFunc: func(command string) (bool, string) {
+						if strings.Contains(command, "vulncheck") {
+							return false, "forced prompt for test"
+						}
+						return true, ""
+					},
+				}
+			} else {
+				m.runner.(*mockGoRunner).checkGovulncheckFunc = func(ctx context.Context) error {
+					return tt.lookPathErr
+				}
+				executor.executeFunc = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					return []byte(tt.executeOut), tt.executeErr
+				}
 			}
 
 			res, err := m.checkVulnerabilities(context.Background(), nil, nil)
@@ -215,6 +235,7 @@ func TestGetCoverage(t *testing.T) {
 		summaryOut string
 		tempErr    error
 		noGoFiles  bool
+		decline    bool
 		wantSubstr string
 		wantErr    bool
 	}{
@@ -240,13 +261,32 @@ func TestGetCoverage(t *testing.T) {
 			wantSubstr: "0.0% coverage (No Go files found in target path to test)",
 			wantErr:    false,
 		},
+		{
+			name:       "user declined",
+			decline:    true,
+			wantSubstr: "declined",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, _, _ := setupDevManager(t)
-			setupCoverageMock(t, m, tt.executeErr, tt.summaryOut, tt.tempErr, tt.noGoFiles)
+			m, _, sm := setupDevManager(t)
+			if tt.decline {
+				sm.AllowAll = false
+				m.validator = &mockValidator{
+					CommandValidator: m.validator,
+					isSafeFunc: func(command string) (bool, string) {
+						if strings.Contains(command, "coverage") {
+							return false, "forced prompt for test"
+						}
+						return true, ""
+					},
+				}
+			} else {
+				setupCoverageMock(t, m, tt.executeErr, tt.summaryOut, tt.tempErr, tt.noGoFiles)
+			}
 
 			res, err := m.getCoverage(context.Background(), nil, nil)
 			actualErr := err
@@ -384,6 +424,7 @@ func TestGoTidy_Errors(t *testing.T) {
 		name       string
 		executeErr error
 		cmdFail    string
+		decline    bool
 	}{
 		{
 			name:       "go mod tidy fails",
@@ -395,25 +436,65 @@ func TestGoTidy_Errors(t *testing.T) {
 			executeErr: errors.New("fmt error"),
 			cmdFail:    "fmt",
 		},
+		{
+			name:    "user declined",
+			decline: true,
+		},
+		{
+			name:       "error with empty output",
+			executeErr: errors.New("tidy error"),
+			cmdFail:    "tidy",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, _, _ := setupDevManager(t)
-			runner := m.runner.(*mockGoRunner)
-
-			if tt.cmdFail == "tidy" {
-				runner.runModTidyFunc = func(ctx context.Context) ([]byte, error) {
-					return []byte("failed"), tt.executeErr
+			m, _, sm := setupDevManager(t)
+			if tt.decline {
+				sm.AllowAll = false
+				m.validator = &mockValidator{
+					CommandValidator: m.validator,
+					isSafeFunc: func(command string) (bool, string) {
+						if strings.Contains(command, "tidy") {
+							return false, "forced prompt for test"
+						}
+						return true, ""
+					},
 				}
 			} else {
-				runner.formatCodeFunc = func(ctx context.Context, path string) ([]byte, error) {
-					return []byte("failed"), tt.executeErr
+				runner := m.runner.(*mockGoRunner)
+				if tt.cmdFail == "tidy" {
+					runner.runModTidyFunc = func(ctx context.Context) ([]byte, error) {
+						// Return empty output when testing the error+empty path
+						if tt.name == "error with empty output" {
+							return nil, tt.executeErr
+						}
+						return []byte("failed"), tt.executeErr
+					}
+				} else {
+					runner.formatCodeFunc = func(ctx context.Context, path string) ([]byte, error) {
+						return []byte("failed"), tt.executeErr
+					}
 				}
 			}
 
 			res, err := m.goTidy(context.Background(), nil, nil)
+			if tt.name == "error with empty output" {
+				if err == nil {
+					t.Error("expected error for empty output, got nil")
+				}
+				return
+			}
+			if tt.decline {
+				if err == nil {
+					t.Error("expected error for user declined, got nil")
+				}
+				if !strings.Contains(res.Text, "Action denied by user.") {
+					t.Errorf("expected 'Action denied by user.', got %q", res.Text)
+				}
+				return
+			}
 			if err != nil {
 				t.Errorf("expected nil error for %s, got %v", tt.name, err)
 			}
@@ -431,6 +512,7 @@ func TestRunBenchmark_Error(t *testing.T) {
 		name       string
 		executeOut string
 		executeErr error
+		decline    bool
 		wantSubstr string
 		wantErr    bool
 	}{
@@ -448,14 +530,33 @@ func TestRunBenchmark_Error(t *testing.T) {
 			wantSubstr: "No Go files found in target path to benchmark",
 			wantErr:    false,
 		},
+		{
+			name:       "user declined",
+			decline:    true,
+			wantSubstr: "declined",
+			wantErr:    true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, _, _ := setupDevManager(t)
-			m.runner.(*mockGoRunner).runBenchmarksFunc = func(ctx context.Context, path string, benchRegex string) (string, error) {
-				return tt.executeOut, tt.executeErr
+			m, _, sm := setupDevManager(t)
+			if tt.decline {
+				sm.AllowAll = false
+				m.validator = &mockValidator{
+					CommandValidator: m.validator,
+					isSafeFunc: func(command string) (bool, string) {
+						if strings.Contains(command, "benchmark") {
+							return false, "forced prompt for test"
+						}
+						return true, ""
+					},
+				}
+			} else {
+				m.runner.(*mockGoRunner).runBenchmarksFunc = func(ctx context.Context, path string, benchRegex string) (string, error) {
+					return tt.executeOut, tt.executeErr
+				}
 			}
 
 			res, err := m.runBenchmark(context.Background(), nil, nil)
@@ -510,12 +611,20 @@ func TestRunTests_Violations(t *testing.T) {
 			name:    "Invalid command structure",
 			command: "go test ; rm -rf /",
 		},
+		{
+			name:    "Allowed script run_tests.sh",
+			command: "./run_tests.sh",
+		},
+		{
+			name:    "Allowed tool make",
+			command: "make test",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m, _, _ := setupDevManager(t)
+			m, executor, _ := setupDevManager(t)
 			if tt.name == "Path safety violation" {
 				m.validator.(*toolstest.MockCommandValidator).CheckPathSafetyFunc = func(parts []string) (bool, string) {
 					return false, "forced violation"
@@ -525,6 +634,17 @@ func TestRunTests_Violations(t *testing.T) {
 				m.validator.(*toolstest.MockCommandValidator).ValidateStructureFunc = func(parts []string) error {
 					return errors.New("forced structure error")
 				}
+			}
+			// For allowed commands, set up a successful executor
+			if tt.name == "Allowed script run_tests.sh" || tt.name == "Allowed tool make" {
+				executor.executeFunc = func(ctx context.Context, name string, args ...string) ([]byte, error) {
+					return []byte("PASS"), nil
+				}
+				_, err := m.runTests(context.Background(), map[string]interface{}{"command": tt.command}, nil)
+				if err != nil {
+					t.Errorf("expected no error for %s, got %v", tt.name, err)
+				}
+				return
 			}
 			_, err := m.runTests(context.Background(), map[string]interface{}{"command": tt.command}, nil)
 			if err == nil {
@@ -550,6 +670,25 @@ func TestRunTests_Failure(t *testing.T) {
 	}
 }
 
+func TestRunTests_Decline(t *testing.T) {
+	t.Parallel()
+	m, _, sm := setupDevManager(t)
+	sm.AllowAll = false
+	m.validator = &mockValidator{
+		CommandValidator: m.validator,
+		isSafeFunc: func(command string) (bool, string) {
+			if strings.Contains(command, "test") {
+				return false, "forced prompt for test"
+			}
+			return true, ""
+		},
+	}
+
+	res, err := m.runTests(context.Background(), map[string]interface{}{"command": "go test ./..."}, nil)
+	require.Error(t, err)
+	assert.Contains(t, res.Text, "Action denied by user.")
+}
+
 func TestNewDevManager(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
@@ -562,11 +701,65 @@ func TestNewDevManager(t *testing.T) {
 
 func TestAuthorizeAction_Error(t *testing.T) {
 	t.Parallel()
-	_, _, sm := setupDevManager(t)
-	sm.AllowAll = false
-	// We need to make sm.Authorize return an error.
-	// But our mock always returns true, nil.
-	// Let's just skip this for now or improve MockSecurityManager.
+	tests := []struct {
+		name          string
+		authorizeFunc func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error)
+		wantApproved  bool
+		wantErr       bool
+		errContains   string
+	}{
+		{
+			name: "Auth backend error",
+			authorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+				return false, fmt.Errorf("timeout")
+			},
+			wantApproved: false,
+			wantErr:      true,
+			errContains:  "authorization error: timeout",
+		},
+		{
+			name: "User declines",
+			authorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+				return false, nil
+			},
+			wantApproved: false,
+			wantErr:      false,
+		},
+		{
+			name: "User approves",
+			authorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+				return true, nil
+			},
+			wantApproved: true,
+			wantErr:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m, _, sm := setupDevManager(t)
+			sm.AllowAll = false
+			sm.AuthorizeFunc = tt.authorizeFunc
+
+			approved, err := m.authorizeAction(context.Background(), "test_action", "echo hello", "Run a test command")
+
+			if approved != tt.wantApproved {
+				t.Errorf("approved = %v, want %v", approved, tt.wantApproved)
+			}
+			if tt.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				} else if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("error = %v, want contains %q", err, tt.errContains)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			}
+		})
+	}
 }
 
 func TestFormatExecutionResult(t *testing.T) {
@@ -682,6 +875,59 @@ func TestExecuteWithHeartbeat_Telemetry(t *testing.T) {
 
 	close(wait) // Let the executor finish
 	<-done
+}
+
+func TestRunWithHeartbeat_Resilience(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Channel full does not block fn", func(t *testing.T) {
+		t.Parallel()
+		m, _, _ := setupDevManager(t)
+		m.heartbeatInterval = 1 * time.Millisecond
+
+		// Buffer of 1, pre-fill it so subsequent heartbeats hit default:
+		hb := make(chan struct{}, 1)
+		hb <- struct{}{}
+
+		var fnCalled bool
+		err := m.runWithHeartbeat(context.Background(), hb, "test", "cmd", "reason", func() error {
+			time.Sleep(50 * time.Millisecond) // Let several ticks fire into full channel
+			fnCalled = true
+			return nil
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, fnCalled, "fn should have been called despite full heartbeat channel")
+	})
+
+	t.Run("Fn error propagated through heartbeat", func(t *testing.T) {
+		t.Parallel()
+		m, _, _ := setupDevManager(t)
+		m.heartbeatInterval = 1 * time.Millisecond
+		hb := make(chan struct{}, 10)
+
+		expectedErr := errors.New("fn failed")
+		err := m.runWithHeartbeat(context.Background(), hb, "test", "cmd", "reason", func() error {
+			return expectedErr
+		})
+
+		assert.ErrorIs(t, err, expectedErr)
+	})
+
+	t.Run("Nil hb runs fn successfully", func(t *testing.T) {
+		t.Parallel()
+		m, _, _ := setupDevManager(t)
+		m.heartbeatInterval = 1 * time.Millisecond
+
+		var fnCalled bool
+		err := m.runWithHeartbeat(context.Background(), nil, "test", "cmd", "reason", func() error {
+			fnCalled = true
+			return nil
+		})
+
+		assert.NoError(t, err)
+		assert.True(t, fnCalled, "fn should have been called with nil hb")
+	})
 }
 
 func TestSecurityRemediation(t *testing.T) {

--- a/internal/tools/developer/registration_test.go
+++ b/internal/tools/developer/registration_test.go
@@ -5,6 +5,8 @@ package developer
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -15,7 +17,8 @@ import (
 )
 
 type mockToolRegistry struct {
-	tools map[string]bool
+	tools  map[string]bool
+	failOn string // tool name that should trigger Register error
 }
 
 func (m *mockToolRegistry) Register(def *tools.ToolDeclaration, handler tools.ToolFunc) error {
@@ -27,6 +30,9 @@ func (m *mockToolRegistry) Register(def *tools.ToolDeclaration, handler tools.To
 }
 
 func (m *mockToolRegistry) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	if m.failOn != "" && def.Name == m.failOn {
+		return fmt.Errorf("simulated registration failure for %s", def.Name)
+	}
 	return m.Register(def, handler)
 }
 
@@ -93,6 +99,101 @@ func TestRegister(t *testing.T) {
 			t.Parallel()
 			assert.True(t, registry.tools[name], "tool %s should be registered", name)
 		})
+	}
+}
+
+func TestRegister_PartialFailure(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name              string
+		failOn            string
+		wantRegistered    []string
+		wantNotRegistered string
+	}{
+		{
+			name:              "First tool fails",
+			failOn:            "run_tests",
+			wantRegistered:    nil,
+			wantNotRegistered: "run_tests",
+		},
+		{
+			name:              "Middle tool fails",
+			failOn:            "run_linter",
+			wantRegistered:    []string{"run_tests", "go_tidy", "get_coverage"},
+			wantNotRegistered: "run_linter",
+		},
+		{
+			name:              "Last tool fails",
+			failOn:            "verify_release_readiness",
+			wantRegistered:    []string{"run_tests", "go_tidy", "get_coverage", "run_linter", "run_benchmark", "check_vulnerabilities"},
+			wantNotRegistered: "verify_release_readiness",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			registry := &mockToolRegistry{failOn: tt.failOn}
+			sm := &toolstest.MockSecurityManager{AllowAll: true}
+			validator := &toolstest.MockCommandValidator{}
+			fs := persistence.NewMockFileSystem()
+			exec := &mockToolchainExecutor{}
+
+			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil)
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.failOn) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.failOn)
+			}
+
+			for _, name := range tt.wantRegistered {
+				if !registry.tools[name] {
+					t.Errorf("tool %q should be registered before failure", name)
+				}
+			}
+			if registry.tools[tt.wantNotRegistered] {
+				t.Errorf("tool %q should NOT be registered (was the failing one)", tt.wantNotRegistered)
+			}
+		})
+	}
+}
+
+func TestRegister_DuplicateRegistration(t *testing.T) {
+	t.Parallel()
+	registry := &mockToolRegistry{}
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	validator := &toolstest.MockCommandValidator{}
+	fs := persistence.NewMockFileSystem()
+	exec := &mockToolchainExecutor{}
+
+	// First registration
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+		t.Fatalf("first Register failed: %v", err)
+	}
+
+	allTools := []string{
+		"run_tests",
+		"go_tidy",
+		"get_coverage",
+		"run_linter",
+		"run_benchmark",
+		"check_vulnerabilities",
+		"verify_release_readiness",
+	}
+
+	for _, name := range allTools {
+		assert.True(t, registry.tools[name], "tool %s should be registered after first call", name)
+	}
+
+	// Second registration
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+		t.Fatalf("second Register failed: %v", err)
+	}
+
+	for _, name := range allTools {
+		assert.True(t, registry.tools[name], "tool %s should still be registered after second call", name)
 	}
 }
 

--- a/internal/tools/developer/release_test.go
+++ b/internal/tools/developer/release_test.go
@@ -7,8 +7,10 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
@@ -306,6 +308,70 @@ func TestVerifyReleaseReadiness_Parallelism(t *testing.T) {
 	})
 }
 
+func TestSecretScanner_ScanFile_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	// Create a real temp file to get a non-directory os.FileInfo.
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*.go")
+	require.NoError(t, err)
+	fileInfo, err := os.Stat(tmpFile.Name())
+	require.NoError(t, err)
+
+	// Create a real temp dir to get a directory os.FileInfo.
+	tmpDir := t.TempDir()
+	dirInfo, err := os.Stat(tmpDir)
+	require.NoError(t, err)
+
+	acc := &scanAccumulator{}
+	patterns := []*regexp.Regexp{regexp.MustCompile(`sk-[a-zA-Z0-9]{32,}`)}
+
+	tests := []struct {
+		name    string
+		path    string
+		info    os.FileInfo
+		walkErr error
+	}{
+		{
+			name:    "Walk passes an error",
+			path:    "secret.go",
+			info:    fileInfo,
+			walkErr: os.ErrPermission,
+		},
+		{
+			name: "Path is a directory",
+			path: tmpDir,
+			info: dirInfo,
+		},
+		{
+			name: "Path is ignored",
+			path: ".git/config",
+			info: fileInfo,
+		},
+		{
+			name: "ReadFile fails",
+			path: "/test/nonexistent.go",
+			info: fileInfo,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := &secretScanner{
+				root:   "/test",
+				fs:     persistence.NewMockFileSystem(),
+				policy: infra_persistence.NewWorkspacePolicy(),
+			}
+
+			err := s.scanFile(context.Background(), tt.path, tt.info, tt.walkErr, patterns, acc)
+			assert.NoError(t, err, "scanFile should not propagate errors")
+			assert.False(t, acc.secretsFound, "should not have found secrets")
+			assert.Empty(t, acc.findings, "should have no findings")
+		})
+	}
+}
 func TestSecretScanner_IsIgnored(t *testing.T) {
 	s := &secretScanner{policy: infra_persistence.NewWorkspacePolicy()}
 	tests := []struct {
@@ -324,4 +390,133 @@ func TestSecretScanner_IsIgnored(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStartHeartbeat_Release(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		hb   chan<- struct{}
+	}{
+		{name: "Done channel close exits goroutine", hb: make(chan struct{}, 1)},
+		{name: "Nil hb channel does not panic", hb: nil},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &releaseManager{}
+			done := make(chan struct{})
+
+			go m.startHeartbeat(tt.hb, done)
+
+			close(done)
+			time.Sleep(50 * time.Millisecond)
+			// Test passes if no panic and no deadlock
+		})
+	}
+}
+func TestHandleLinterResult(t *testing.T) {
+	t.Parallel()
+	c := &linterChecker{}
+
+	tests := []struct {
+		name     string
+		out      []byte
+		err      error
+		wantOK   bool
+		contains string
+	}{
+		{
+			name:     `Success with "0 issues." string`,
+			out:      []byte("0 issues."),
+			err:      nil,
+			wantOK:   true,
+			contains: "passed",
+		},
+		{
+			name:     "Success with empty output",
+			out:      []byte(""),
+			err:      nil,
+			wantOK:   true,
+			contains: "passed",
+		},
+		{
+			name:     `err == "exit status 1" but output says "0 issues."`,
+			out:      []byte("0 issues."),
+			err:      fmt.Errorf("exit status 1"),
+			wantOK:   true,
+			contains: "passed",
+		},
+		{
+			name:     "Generic linter crash (non-exit-status-1)",
+			out:      []byte("panic: runtime error"),
+			err:      fmt.Errorf("exec failed"),
+			wantOK:   false,
+			contains: "failed:",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := c.handleLinterResult(tt.out, tt.err, "golangci-lint")
+			if result.OK != tt.wantOK {
+				t.Errorf("OK = %v, want %v", result.OK, tt.wantOK)
+			}
+			if !strings.Contains(result.Message, tt.contains) {
+				t.Errorf("Message = %q, want contains %q", result.Message, tt.contains)
+			}
+		})
+	}
+}
+func TestSecretScanner_ScanFile_BinaryContent(t *testing.T) {
+	t.Parallel()
+	fs := persistence.NewMockFileSystem()
+	ctx := context.Background()
+	require.NoError(t, fs.WriteFile(ctx, "/test/binary.bin", []byte{0x00, 0x01, 0x02}, 0644))
+
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-*")
+	require.NoError(t, err)
+	fileInfo, err := os.Stat(tmpFile.Name())
+	require.NoError(t, err)
+
+	s := &secretScanner{
+		root:   "/test",
+		fs:     fs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	acc := &scanAccumulator{}
+	patterns := []*regexp.Regexp{regexp.MustCompile(`sk-[a-zA-Z0-9]{32,}`)}
+
+	err = s.scanFile(ctx, "/test/binary.bin", fileInfo, nil, patterns, acc)
+	assert.NoError(t, err)
+	assert.False(t, acc.secretsFound, "binary files should not trigger secret detection")
+	assert.Empty(t, acc.findings)
+}
+
+func TestScanContent_ShortSecret(t *testing.T) {
+	t.Parallel()
+	s := &secretScanner{}
+	patterns := []*regexp.Regexp{regexp.MustCompile(`sk-.{3,}`)}
+	matches := s.scanContent([]byte("sk-abc"), "/test/file.go", patterns)
+
+	require.Len(t, matches, 1)
+	assert.Contains(t, matches[0], "****", "short secrets (<=8 chars) should be masked as ****")
+}
+func TestVerifyReleaseReadiness_PathError(t *testing.T) {
+	t.Parallel()
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsSafeFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("sandbox error")
+	}
+	m := &releaseManager{
+		policy: infra_persistence.NewWorkspacePolicy(),
+		sm:     sm,
+	}
+	_, err := m.verifyReleaseReadiness(context.Background(), nil, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "security error")
 }


### PR DESCRIPTION
## Summary

Error path hardening for `internal/tools/developer/` as specified in #371.

**Coverage: 88.4% → 93.0%** (+4.6%)

## Changes

### `dev_test.go` (~280 lines added)
- **`TestAuthorizeAction_Error`** — replaced placeholder with table-driven test (auth backend error, user decline, user approve)
- **`ErrUserDeclined`** scenarios added to 4 existing tests: `TestCheckVulnerabilities`, `TestGetCoverage`, `TestGoTidy_Errors`, `TestRunBenchmark_Error`
- **`TestRunTests_Decline`** — standalone test for `runTests` decline path
- **`TestRunWithHeartbeat_Resilience`** — 3 sub-tests: channel-full, fn error propagation, nil hb
- **`TestRunTests_Violations`** — added `./run_tests.sh` and `make test` as allowed commands

### `registration_test.go` (~100 lines added)
- **`mockToolRegistry.failOn`** — new field for controlled registration failures
- **`TestRegister_PartialFailure`** — first/middle/last tool registration failure
- **`TestRegister_DuplicateRegistration`** — idempotent double-register

### `release_test.go` (~190 lines added)
- **`TestSecretScanner_ScanFile_ErrorPaths`** — 4 scenarios: Walk error, IsDir, isIgnored, ReadFile fail
- **`TestSecretScanner_ScanFile_BinaryContent`** — binary file skip via `IsBinary`
- **`TestStartHeartbeat_Release`** — done close exit + nil hb no-panic
- **`TestHandleLinterResult`** — 4 edge cases (80% → **100%**)
- **`TestScanContent_ShortSecret`** — ≤8 char masking as `****`
- **`TestVerifyReleaseReadiness_PathError`** — `IsPathSafe` error path

## Verification

```
go test ./internal/tools/developer/ -race -count=1 -cover
# ok  github.com/gosharplite/tell-me-go/internal/tools/developer  2.130s  coverage: 93.0% of statements
```

All 20 tests (55+ sub-test scenarios) pass with race detector. No non-test files modified.