### PR TITLE
fix(workspace): close error handling gaps, achieve 91.1% coverage (#382)

### DIFF
--- a/internal/tools/workspace/backup.go
+++ b/internal/tools/workspace/backup.go
@@ -46,19 +46,23 @@ func newBackupManager(sm domain_security.PathValidator, fs domain_persistence.Fi
 }
 
 // snapshot records the current state of a file before it is modified.
-func (b *backupManager) snapshot(ctx context.Context, path string, action string) {
+func (b *backupManager) snapshot(ctx context.Context, path string, action string) error {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return
+		return fmt.Errorf("snapshot: resolve path %s: %w", path, err)
 	}
 
 	content, err := b.fs.ReadFile(ctx, absPath)
 	if err != nil {
-		// If file doesn't exist, we store nil content to represent "new file"
-		content = nil
+		if os.IsNotExist(err) {
+			// Genuinely new file — store nil content to represent "new file"
+			content = nil
+		} else {
+			return fmt.Errorf("snapshot: read %s: %w", absPath, err)
+		}
 	}
 
 	snap := fileSnapshot{
@@ -72,6 +76,7 @@ func (b *backupManager) snapshot(ctx context.Context, path string, action string
 	if len(b.backups) > b.maxStored {
 		b.backups = b.backups[1:]
 	}
+	return nil
 }
 
 // undo reverts the last N changes.

--- a/internal/tools/workspace/backup.go
+++ b/internal/tools/workspace/backup.go
@@ -47,9 +47,9 @@ func newBackupManager(sm domain_security.PathValidator, fs domain_persistence.Fi
 
 // snapshot records the current state of a file before it is modified.
 func (b *backupManager) snapshot(ctx context.Context, path string, action string) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
+	// Resolve path and read file content OUTSIDE the critical section.
+	// Holding the mutex across synchronous disk I/O would cause thread
+	// starvation for concurrent callers.
 	absPath, err := filepath.Abs(path)
 	if err != nil {
 		return fmt.Errorf("snapshot: resolve path %s: %w", path, err)
@@ -71,6 +71,10 @@ func (b *backupManager) snapshot(ctx context.Context, path string, action string
 		Content:   content,
 		Action:    action,
 	}
+
+	// Lock ONLY for the in-memory state mutation.
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
 	b.backups = append(b.backups, snap)
 	if len(b.backups) > b.maxStored {

--- a/internal/tools/workspace/backup_test.go
+++ b/internal/tools/workspace/backup_test.go
@@ -6,12 +6,14 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -26,13 +28,17 @@ func TestBackupManager_Undo(t *testing.T) {
 	path := filepath.Join(tempDir, "test.txt")
 
 	// 1. Snapshot new file creation
-	bm.snapshot(ctx, path, "WRITE")
+	if err := bm.snapshot(ctx, path, "WRITE"); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte("v1"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	// 2. Snapshot modification
-	bm.snapshot(ctx, path, "REPLACE")
+	if err := bm.snapshot(ctx, path, "REPLACE"); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(path, []byte("v2"), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -73,6 +79,7 @@ type undoErrorTestCase struct {
 	snapshotOp    string
 	wantErrSubstr string
 	wantResSubstr string
+	mockFS        persistence.FileSystem // optional: override FS for snapshot (e.g. to simulate ReadFile returning os.ErrNotExist)
 }
 
 func TestBackupManager_Undo_Errors(t *testing.T) {
@@ -118,6 +125,9 @@ func TestBackupManager_Undo_Errors(t *testing.T) {
 			snapshotPath:  "is_a_dir",
 			snapshotOp:    "WRITE",
 			wantErrSubstr: "failed to remove new file",
+			// Mock FS reports os.ErrNotExist for ReadFile so snapshot stores nil content,
+			// causing undoOne to call Remove on the non-empty directory which fails.
+			mockFS: &mockFS_NotExist{FileSystem: persistencetest.NewPlainOSFileSystem()},
 		},
 		{
 			name: "AtomicWriteFailed",
@@ -162,7 +172,11 @@ func TestBackupManager_Undo_Errors(t *testing.T) {
 func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
 	tempDir := t.TempDir()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	fs := tc.mockFS
+	if fs == nil {
+		fs = persistencetest.NewPlainOSFileSystem()
+	}
+	bm := newBackupManager(sm, fs, 10)
 	ctx := context.Background()
 
 	cleanup := tc.setup(t, tempDir, sm)
@@ -173,7 +187,9 @@ func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
 		if !filepath.IsAbs(fullPath) {
 			fullPath = filepath.Join(tempDir, fullPath)
 		}
-		bm.snapshot(ctx, fullPath, tc.snapshotOp)
+		if err := bm.snapshot(ctx, fullPath, tc.snapshotOp); err != nil {
+			t.Fatalf("unexpected snapshot error: %v", err)
+		}
 	}
 
 	res, err := bm.undo(ctx, 1)
@@ -221,4 +237,154 @@ func TestNewBackupManager_Normalization(t *testing.T) {
 			t.Errorf("expected maxStored=3 for input 3, got %d", bm.maxStored)
 		}
 	})
+}
+
+// mockFS_NotExist is a FileSystem decorator that returns os.ErrNotExist
+// from ReadFile. Used to test undo paths that need a nil-content snapshot
+// on a path that actually exists as a directory.
+type mockFS_NotExist struct {
+	persistence.FileSystem
+}
+
+func (m *mockFS_NotExist) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return nil, os.ErrNotExist
+}
+
+// ---------------------------------------------------------------------------
+// snapshot error path tests (Phase 3+4)
+// ---------------------------------------------------------------------------
+
+// mockFS_ReadError is a FileSystem decorator that returns a non-IsNotExist
+// error from ReadFile.
+type mockFS_ReadError struct {
+	persistence.FileSystem
+	err error
+}
+
+func (m *mockFS_ReadError) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return nil, m.err
+}
+
+func TestSnapshot_ReadFileIOError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	expectedErr := errors.New("disk failure")
+	fs := &mockFS_ReadError{FileSystem: persistencetest.NewPlainOSFileSystem(), err: expectedErr}
+	bm := newBackupManager(sm, fs, 10)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+
+	err := bm.snapshot(ctx, path, "WRITE")
+	if err == nil {
+		t.Fatal("expected error from ReadFile I/O failure")
+	}
+	if !strings.Contains(err.Error(), "snapshot: read") {
+		t.Errorf("expected 'snapshot: read' in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "disk failure") {
+		t.Errorf("expected 'disk failure' in error, got %q", err.Error())
+	}
+}
+
+func TestSnapshot_ReadFileNotExist(t *testing.T) {
+	// Verifies os.ErrNotExist is treated as new-file (nil content, no error)
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "nonexistent.txt")
+
+	err := bm.snapshot(ctx, path, "WRITE")
+	if err != nil {
+		t.Fatalf("expected no error for non-existent file, got: %v", err)
+	}
+
+	// Verify a snapshot was stored
+	res, undoErr := bm.undo(ctx, 1)
+	if undoErr != nil {
+		t.Fatalf("unexpected undo error: %v", undoErr)
+	}
+	if !strings.Contains(res, "Removed") {
+		t.Errorf("expected 'Removed' for new-file undo, got %q", res)
+	}
+}
+
+func TestSnapshot_RingBufferEviction(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	maxStored := 3
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), maxStored)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+
+	// Create 5 snapshots (exceeds maxStored=3)
+	for i := 0; i < 5; i++ {
+		path := filepath.Join(tempDir, fmt.Sprintf("file%d.txt", i))
+		if err := os.WriteFile(path, []byte(fmt.Sprintf("v%d", i)), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := bm.snapshot(ctx, path, "WRITE"); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// undo with n=3 should restore the 3 most recent files
+	res, err := bm.undo(ctx, 3)
+	if err != nil {
+		t.Fatalf("unexpected undo error: %v", err)
+	}
+	if !strings.Contains(res, "Undo successful") {
+		t.Errorf("expected successful undo, got %q", res)
+	}
+
+	// After undoing 3, there should be 0 left (since 5 snapshots - 3 undone = 2,
+	// but ring-buffer evicted the first 2, so only 3 were stored)
+	// Actually, we stored 5 but maxStored=3 so only last 3 kept. Undo 3 leaves 0.
+	_, err = bm.undo(ctx, 1)
+	if err != nil {
+		t.Fatalf("unexpected undo error: %v", err)
+	}
+	// Third undo should show "No snapshots available"
+	res, err = bm.undo(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected no error for empty undo, got: %v", err)
+	}
+	if !strings.Contains(res, "No snapshots available") {
+		t.Errorf("expected 'No snapshots available', got %q", res)
+	}
+}
+
+func TestUndo_NExceedingSnapshotCount(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "single.txt")
+	if err := os.WriteFile(path, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := bm.snapshot(ctx, path, "WRITE"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Request more undos than available snapshots
+	res, err := bm.undo(ctx, 5)
+	if err != nil {
+		t.Fatalf("unexpected undo error: %v", err)
+	}
+	if !strings.Contains(res, "Undo successful") {
+		t.Errorf("expected 'Undo successful', got %q", res)
+	}
+
+	// All snapshots should be consumed
+	res, err = bm.undo(ctx, 1)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if !strings.Contains(res, "No snapshots available") {
+		t.Errorf("expected 'No snapshots available', got %q", res)
+	}
 }

--- a/internal/tools/workspace/diagnostic_tools_test.go
+++ b/internal/tools/workspace/diagnostic_tools_test.go
@@ -88,3 +88,31 @@ func TestDiagnosticTool_CheckSystemHealth(t *testing.T) {
 		}
 	})
 }
+
+func TestDiagnosticTool_CheckSystemHealth_MarshalFailure(t *testing.T) {
+	ctx := context.Background()
+
+	// Put a non-serializable value (channel) in Details to trigger marshal error
+	report := &ports.HealthReport{
+		OverallStatus: ports.StatusHealthy,
+		Components: map[ports.Component]ports.ComponentReport{
+			ports.CompPersistence: {
+				Component: ports.CompPersistence,
+				Status:    ports.StatusHealthy,
+				Message:   "db ok",
+				Details:   make(chan struct{}), // channels are not JSON-serializable
+			},
+		},
+		Timestamp: time.Now(),
+	}
+	mock := &mockHealthCheckManager{report: report}
+	tool := newDiagnosticTool(mock)
+
+	_, err := tool.checkSystemHealth(ctx, nil, nil)
+	if err == nil {
+		t.Fatal("expected marshal error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to serialize health report") {
+		t.Errorf("expected 'failed to serialize health report' in error, got: %v", err)
+	}
+}

--- a/internal/tools/workspace/git.go
+++ b/internal/tools/workspace/git.go
@@ -66,6 +66,11 @@ func (m *gitManager) getGitCommit(ctx context.Context, args map[string]interface
 	}
 
 	hash := params.Hash
+	// Defense-in-depth presence guard. The central validateRequiredArgs in
+	// registry.Execute catches missing required params before this handler
+	// runs in production. We keep this guard for direct invocation paths
+	// (unit tests, embedding, in-process callers). See writeFile's comment
+	// for the full rationale.
 	if hash == "" {
 		return tools.ToolResult{}, fmt.Errorf("hash argument is required")
 	}
@@ -90,6 +95,7 @@ func (m *gitManager) getGitBlame(ctx context.Context, args map[string]interface{
 	}
 
 	path := params.FilePath
+	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
 	if path == "" {
 		return tools.ToolResult{}, fmt.Errorf("filepath argument is required")
 	}
@@ -113,6 +119,7 @@ func (m *gitManager) gitCommit(ctx context.Context, args map[string]interface{},
 	}
 
 	message := params.Message
+	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
 	if message == "" {
 		return tools.ToolResult{}, fmt.Errorf("message is required")
 	}
@@ -121,10 +128,10 @@ func (m *gitManager) gitCommit(ctx context.Context, args map[string]interface{},
 	if err != nil {
 		// If git failed and the output indicates no staged changes, return an actionable error
 		if strings.Contains(res, "nothing to commit") || strings.Contains(res, "no changes added to commit") {
-			return tools.ToolResult{Text: res}, fmt.Errorf("no staged changes. You must stage files first (e.g., using execute_command with 'git add .') before committing")
+			return tools.ToolResult{Text: "Error: no staged changes. You must stage files first (e.g., using execute_command with 'git add .') before committing"}, nil
 		}
-		// Otherwise, return the generic error with the raw output
-		return tools.ToolResult{Text: res}, err
+		// Otherwise, return the generic error as an infrastructure fault
+		return tools.ToolResult{}, fmt.Errorf("git commit failed: %w", err)
 	}
 	return tools.ToolResult{Text: res}, nil
 }
@@ -139,6 +146,7 @@ func (m *gitManager) gitCreateBranch(ctx context.Context, args map[string]interf
 	}
 
 	name := params.Name
+	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
 	if name == "" {
 		return tools.ToolResult{}, fmt.Errorf("branch name is required")
 	}

--- a/internal/tools/workspace/git.go
+++ b/internal/tools/workspace/git.go
@@ -66,11 +66,8 @@ func (m *gitManager) getGitCommit(ctx context.Context, args map[string]interface
 	}
 
 	hash := params.Hash
-	// Defense-in-depth presence guard. The central validateRequiredArgs in
-	// registry.Execute catches missing required params before this handler
-	// runs in production. We keep this guard for direct invocation paths
-	// (unit tests, embedding, in-process callers). See writeFile's comment
-	// for the full rationale.
+	// Per ADR-022: handler-level guard for direct invocation (tests,
+	// embedding) where registry validateRequiredArgs is bypassed.
 	if hash == "" {
 		return tools.ToolResult{}, fmt.Errorf("hash argument is required")
 	}
@@ -95,7 +92,8 @@ func (m *gitManager) getGitBlame(ctx context.Context, args map[string]interface{
 	}
 
 	path := params.FilePath
-	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
+	// Per ADR-022: handler-level guard for direct invocation (tests,
+	// embedding) where registry validateRequiredArgs is bypassed.
 	if path == "" {
 		return tools.ToolResult{}, fmt.Errorf("filepath argument is required")
 	}
@@ -119,7 +117,8 @@ func (m *gitManager) gitCommit(ctx context.Context, args map[string]interface{},
 	}
 
 	message := params.Message
-	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
+	// Per ADR-022: handler-level guard for direct invocation (tests,
+	// embedding) where registry validateRequiredArgs is bypassed.
 	if message == "" {
 		return tools.ToolResult{}, fmt.Errorf("message is required")
 	}
@@ -146,7 +145,8 @@ func (m *gitManager) gitCreateBranch(ctx context.Context, args map[string]interf
 	}
 
 	name := params.Name
-	// Defense-in-depth presence guard — see getGitCommit hash guard for rationale.
+	// Per ADR-022: handler-level guard for direct invocation (tests,
+	// embedding) where registry validateRequiredArgs is bypassed.
 	if name == "" {
 		return tools.ToolResult{}, fmt.Errorf("branch name is required")
 	}

--- a/internal/tools/workspace/git_test.go
+++ b/internal/tools/workspace/git_test.go
@@ -215,15 +215,13 @@ func TestGitDestructiveActions(t *testing.T) {
 			expected: "[main abc] feat: test",
 		},
 		{
-			name:        "git_commit nothing to commit",
-			toolName:    "git_commit",
-			args:        map[string]interface{}{"message": "feat: test", "reason": "ship it"},
-			approved:    true,
-			mockOut:     "On branch main\nnothing to commit, working tree clean",
-			mockErr:     fmt.Errorf("exit status 1"),
-			expected:    "On branch main\nnothing to commit, working tree clean",
-			expectedErr: "no staged changes. You must stage files first (e.g., using execute_command with 'git add .') before committing",
-			wantErr:     true,
+			name:     "git_commit nothing to commit",
+			toolName: "git_commit",
+			args:     map[string]interface{}{"message": "feat: test", "reason": "ship it"},
+			approved: true,
+			mockOut:  "On branch main\nnothing to commit, working tree clean",
+			mockErr:  fmt.Errorf("exit status 1"),
+			expected: "Error: no staged changes. You must stage files first (e.g., using execute_command with 'git add .') before committing",
 		},
 		{
 			name:     "git_create_branch approved",
@@ -381,5 +379,84 @@ func TestRunGitCommand_WithHeartbeat(t *testing.T) {
 		// heartbeat received — the hb != nil branch was exercised
 	default:
 		// May not have fired; this is non-fatal.
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Direct invocation tests (bypass registry, exercise defense-in-depth guards)
+// ---------------------------------------------------------------------------
+
+func TestGitManager_DirectInvocation_MissingArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	executor := &mockGitExecutor{
+		handler: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("ok"), nil
+		},
+	}
+
+	m := &gitManager{sm: sm, Exec: executor}
+	ctx := context.Background()
+
+	t.Run("getGitBlame empty filepath", func(t *testing.T) {
+		_, err := m.getGitBlame(ctx, map[string]interface{}{}, nil)
+		if err == nil {
+			t.Fatal("expected error for empty filepath")
+		}
+		if !strings.Contains(err.Error(), "filepath argument is required") {
+			t.Errorf("expected 'filepath argument is required', got: %v", err)
+		}
+	})
+
+	t.Run("getGitCommit empty hash", func(t *testing.T) {
+		_, err := m.getGitCommit(ctx, map[string]interface{}{}, nil)
+		if err == nil {
+			t.Fatal("expected error for empty hash")
+		}
+		if !strings.Contains(err.Error(), "hash argument is required") {
+			t.Errorf("expected 'hash argument is required', got: %v", err)
+		}
+	})
+
+	t.Run("gitCommit empty message", func(t *testing.T) {
+		_, err := m.gitCommit(ctx, map[string]interface{}{}, nil)
+		if err == nil {
+			t.Fatal("expected error for empty message")
+		}
+		if !strings.Contains(err.Error(), "message is required") {
+			t.Errorf("expected 'message is required', got: %v", err)
+		}
+	})
+
+	t.Run("gitCreateBranch empty name", func(t *testing.T) {
+		_, err := m.gitCreateBranch(ctx, map[string]interface{}{}, nil)
+		if err == nil {
+			t.Fatal("expected error for empty name")
+		}
+		if !strings.Contains(err.Error(), "branch name is required") {
+			t.Errorf("expected 'branch name is required', got: %v", err)
+		}
+	})
+}
+
+func TestGitCommit_GenericError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	// Simulate a generic git error (not "nothing to commit")
+	executor := &mockGitExecutor{
+		handler: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("fatal: not a git repository"), fmt.Errorf("exit status 128")
+		},
+	}
+
+	m := &gitManager{sm: sm, Exec: executor}
+	ctx := context.Background()
+
+	_, err := m.gitCommit(ctx, map[string]interface{}{"message": "test", "reason": "test"}, nil)
+	if err == nil {
+		t.Fatal("expected error for generic git failure")
+	}
+	if !strings.Contains(err.Error(), "git commit failed") {
+		t.Errorf("expected 'git commit failed' in error, got: %v", err)
 	}
 }

--- a/internal/tools/workspace/persistence_tools.go
+++ b/internal/tools/workspace/persistence_tools.go
@@ -124,7 +124,7 @@ func (t *persistenceTools) ManageTasks(ctx context.Context, args map[string]inte
 	case "clear":
 		return t.clearTasks(ctx)
 	default:
-		return tools.ToolResult{}, fmt.Errorf("unknown action: %s", params.Action)
+		return tools.ToolResult{Text: fmt.Sprintf("Error: unknown action: %s", params.Action)}, nil
 	}
 }
 

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -204,9 +204,9 @@ func TestPersistenceTools_ManageTasks(t *testing.T) {
 			expectedResult: "All tasks cleared",
 		},
 		{
-			name:        "Error on unknown action",
-			args:        map[string]interface{}{"action": "unknown"},
-			expectError: true,
+			name:           "Error on unknown action",
+			args:           map[string]interface{}{"action": "unknown"},
+			expectedResult: "Error: unknown action: unknown",
 		},
 	}
 
@@ -336,4 +336,102 @@ func TestPersistenceTools_Errors(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error for non-existent task in deleteTask")
 	}
+}
+
+func TestNewPersistenceTools_InterfaceNilPointer(t *testing.T) {
+	// Create a typed nil pointer stored in an interface variable:
+	// the interface itself is non-nil, but the underlying pointer is nil.
+	var nilProvider *mockSessionProvider = nil
+	var sp ports.SessionProvider = nilProvider // non-nil interface wrapping nil ptr
+
+	pt := newpersistenceTools(sp, nil)
+	if pt.state != nil {
+		t.Error("Expected nil state when interface wraps nil pointer")
+	}
+
+	// Verify no panic and no tools registered
+	reg := registry.New()
+	if err := pt.Register(reg); err != nil {
+		t.Errorf("Register should not fail for interface-nil-pointer: %v", err)
+	}
+	if len(reg.GetDeclarations()) != 0 {
+		t.Error("Expected no tools registered for interface-nil-pointer")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mockToolRegistrar — minimal ToolRegistrar for testing Register error paths
+// ---------------------------------------------------------------------------
+
+type mockToolRegistrar struct {
+	failOn  string
+	failErr error
+	called  []string
+}
+
+func (m *mockToolRegistrar) Register(def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	m.called = append(m.called, def.Name)
+	if def.Name == m.failOn {
+		if m.failErr != nil {
+			return m.failErr
+		}
+		return fmt.Errorf("injected failure for %s", def.Name)
+	}
+	return nil
+}
+
+func (m *mockToolRegistrar) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	m.called = append(m.called, def.Name)
+	if def.Name == m.failOn {
+		if m.failErr != nil {
+			return m.failErr
+		}
+		return fmt.Errorf("injected failure for %s", def.Name)
+	}
+	return nil
+}
+
+func (m *mockToolRegistrar) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return m.Register(def, handler)
+}
+
+func (m *mockToolRegistrar) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return m.RegisterWithOptions(def, handler, opts)
+}
+
+func TestPersistenceTools_Register_ErrorPaths(t *testing.T) {
+	pt, _ := setupPersistenceTools()
+
+	t.Run("get_session_info Register fails", func(t *testing.T) {
+		reg := &mockToolRegistrar{failOn: "get_session_info"}
+		err := pt.Register(reg)
+		if err == nil {
+			t.Fatal("expected error from Register")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
+
+	t.Run("load_toolkit RegisterWithOptions fails", func(t *testing.T) {
+		reg := &mockToolRegistrar{failOn: "load_toolkit"}
+		err := pt.Register(reg)
+		if err == nil {
+			t.Fatal("expected error from Register")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
+
+	t.Run("manage_tasks RegisterWithOptions fails", func(t *testing.T) {
+		reg := &mockToolRegistrar{failOn: "manage_tasks"}
+		err := pt.Register(reg)
+		if err == nil {
+			t.Fatal("expected error from Register")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
 }

--- a/internal/tools/workspace/reader.go
+++ b/internal/tools/workspace/reader.go
@@ -224,7 +224,7 @@ func (r *fileReader) readFiles(ctx context.Context, args map[string]interface{},
 
 	const maxFilesPerCall = 50
 	if len(params.FilePaths) > maxFilesPerCall {
-		return tools.ToolResult{}, fmt.Errorf("requested too many files (%d). Maximum allowed per call is %d", len(params.FilePaths), maxFilesPerCall)
+		return tools.ToolResult{Text: fmt.Sprintf("Error: requested too many files (%d). Maximum is %d files per call.", len(params.FilePaths), maxFilesPerCall)}, nil
 	}
 
 	var sb strings.Builder
@@ -339,7 +339,7 @@ func (r *fileReader) interpretDiffResult(res executionResult, runErr error) (too
 	}
 
 	if res.ExitCode != 0 && res.ExitCode != 1 { // 1 is normal for diff finding differences
-		return tools.ToolResult{Text: res.Output}, fmt.Errorf("diff process failed with exit code %d", res.ExitCode)
+		return tools.ToolResult{Text: fmt.Sprintf("Error: diff failed with exit code %d: %s", res.ExitCode, res.Output)}, nil
 	}
 
 	return tools.ToolResult{Text: res.Output}, nil

--- a/internal/tools/workspace/reader_test.go
+++ b/internal/tools/workspace/reader_test.go
@@ -484,12 +484,12 @@ func TestReadFiles_Limit(t *testing.T) {
 		paths[i] = "f" + string(rune(i)) + ".txt"
 	}
 
-	_, err := r.readFiles(ctx, map[string]interface{}{"filepaths": paths, "reason": "testing"}, nil)
-	if err == nil {
-		t.Fatal("expected error for exceeding file limit")
+	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": paths, "reason": "testing"}, nil)
+	if err != nil {
+		t.Fatalf("expected domain outcome (nil error), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "requested too many files") {
-		t.Errorf("expected limit error message, got %q", err.Error())
+	if !strings.Contains(res.Text, "Error: requested too many files") {
+		t.Errorf("expected limit error message in result text, got %q", res.Text)
 	}
 }
 
@@ -646,4 +646,327 @@ func TestBuildTree_ReadDirError(t *testing.T) {
 			t.Error("expected heartbeat to be sent on hb channel")
 		}
 	})
+}
+
+// ---------------------------------------------------------------------------
+// interpretDiffResult exit code tests
+// ---------------------------------------------------------------------------
+
+func TestInterpretDiffResult(t *testing.T) {
+	r := &fileReader{}
+
+	t.Run("exit code 2 returns domain outcome", func(t *testing.T) {
+		res := executionResult{ExitCode: 2, Output: "diff: fatal error"}
+		tr, err := r.interpretDiffResult(res, nil)
+		if err != nil {
+			t.Fatalf("expected nil error (domain outcome), got: %v", err)
+		}
+		if !strings.Contains(tr.Text, "Error: diff failed with exit code 2") {
+			t.Errorf("expected domain error message, got: %q", tr.Text)
+		}
+	})
+
+	t.Run("exit code 1 with output returns output", func(t *testing.T) {
+		res := executionResult{ExitCode: 1, Output: "1c1\n< a\n---\n> b"}
+		tr, err := r.interpretDiffResult(res, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tr.Text != "1c1\n< a\n---\n> b" {
+			t.Errorf("expected diff output, got: %q", tr.Text)
+		}
+	})
+
+	t.Run("runErr returns infrastructure fault", func(t *testing.T) {
+		res := executionResult{}
+		_, err := r.interpretDiffResult(res, fmt.Errorf("exec failed"))
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if !strings.Contains(err.Error(), "diff failed") {
+			t.Errorf("expected 'diff failed' in error, got: %v", err)
+		}
+	})
+
+	t.Run("empty output no error returns identical", func(t *testing.T) {
+		res := executionResult{}
+		tr, err := r.interpretDiffResult(res, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if tr.Text != "Files are identical." {
+			t.Errorf("expected 'Files are identical.', got %q", tr.Text)
+		}
+	})
+}
+
+func TestReadFiles_WithHeartbeat(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	hb := make(chan struct{}, 5)
+	// Create enough files to trigger at least one heartbeat (every 5 files)
+	paths := make([]interface{}, 6)
+	for i := 0; i < 6; i++ {
+		paths[i] = path // reuse the same valid file
+	}
+
+	res, err := r.readFiles(ctx, map[string]interface{}{"filepaths": paths, "reason": "testing"}, hb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "content") {
+		t.Errorf("expected content in output, got %q", res.Text)
+	}
+
+	// Expect at least one heartbeat
+	select {
+	case <-hb:
+		// heartbeat received
+	default:
+		// Acceptable if heartbeat was consumed by the sendHeartbeat function
+	}
+}
+
+// ---------------------------------------------------------------------------
+// readBoundedContent error tests
+// ---------------------------------------------------------------------------
+
+type mockFS_OpenError struct {
+	persistence.FileSystem
+	openErr error
+}
+
+func (m *mockFS_OpenError) Open(ctx context.Context, name string) (persistence.File, error) {
+	return nil, m.openErr
+}
+
+type mockFile_ReadError struct {
+	*os.File
+	readErr error
+}
+
+func (m *mockFile_ReadError) Read(p []byte) (n int, err error) {
+	return 0, m.readErr
+}
+
+type mockFS_ReadErrorFile struct {
+	persistence.FileSystem
+	readErr error
+}
+
+func (m *mockFS_ReadErrorFile) Open(ctx context.Context, name string) (persistence.File, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return nil, err
+	}
+	return &mockFile_ReadError{File: f, readErr: m.readErr}, nil
+}
+
+func TestReadBoundedContent_OpenError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs := &mockFS_OpenError{FileSystem: persistencetest.NewPlainOSFileSystem(), openErr: fmt.Errorf("open failure")}
+	r := &fileReader{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: mfs, policy: infra_persistence.NewWorkspacePolicy()}
+
+	_, _, err := r.readBoundedContent(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected open error")
+	}
+	if !strings.Contains(err.Error(), "open failure") {
+		t.Errorf("expected 'open failure', got: %v", err)
+	}
+}
+
+func TestReadBoundedContent_ReadError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs := &mockFS_ReadErrorFile{FileSystem: persistencetest.NewPlainOSFileSystem(), readErr: fmt.Errorf("read failure")}
+	r := &fileReader{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: mfs, policy: infra_persistence.NewWorkspacePolicy()}
+
+	_, _, err := r.readBoundedContent(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected read error")
+	}
+	if !strings.Contains(err.Error(), "read failure") {
+		t.Errorf("expected 'read failure', got: %v", err)
+	}
+}
+
+func TestProcessSingleFile_SecurityError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsSafeFunc = func(p string) (string, error) {
+		return "", fmt.Errorf("security: path not allowed")
+	}
+
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+
+	var sb strings.Builder
+	err := r.processSingleFile(context.Background(), path, &sb)
+	if err != nil {
+		t.Fatalf("processSingleFile should not return error for security rejection: %v", err)
+	}
+	if !strings.Contains(sb.String(), "ERROR: security") {
+		t.Errorf("expected security error in output, got: %q", sb.String())
+	}
+}
+
+func TestProcessSingleFile_StatError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "nonexistent.txt")
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+
+	var sb strings.Builder
+	err := r.processSingleFile(context.Background(), path, &sb)
+	if err != nil {
+		t.Fatalf("processSingleFile should not return error for stat failure: %v", err)
+	}
+	if !strings.Contains(sb.String(), "ERROR: failed to read file") {
+		t.Errorf("expected stat error in output, got: %q", sb.String())
+	}
+}
+
+func TestListFiles_DefaultPath(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	res, err := r.listFiles(ctx, map[string]interface{}{"reason": "testing"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Text == "" {
+		t.Error("expected non-empty output for default path")
+	}
+}
+
+func TestReadFiles_EmptyFilepaths(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	_, err := r.readFiles(ctx, map[string]interface{}{"filepaths": []interface{}{}, "reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected error for empty filepaths")
+	}
+	if !strings.Contains(err.Error(), "filepaths argument is required") {
+		t.Errorf("expected 'filepaths argument is required', got: %v", err)
+	}
+}
+
+func TestReadFiles_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	_, err := r.readFiles(ctx, map[string]interface{}{"filepaths": "not_an_array", "reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for invalid args")
+	}
+}
+
+func TestGetFileDiff_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	_, err := r.getFileDiff(ctx, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for missing args")
+	}
+}
+
+func TestSearchFiles_MissingQuery(t *testing.T) {
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	_, err := s.searchFiles(context.Background(), map[string]interface{}{"reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+	if !strings.Contains(err.Error(), "query argument is required") {
+		t.Errorf("expected 'query argument is required', got: %v", err)
+	}
+}
+
+func TestGrepDefinitions_InvalidArgs(t *testing.T) {
+	s := &fileSearcher{sm: &toolstest.MockSecurityManager{AllowAll: true}, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	_, err := s.grepDefinitions(context.Background(), map[string]interface{}{"path": 123, "reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for invalid args")
+	}
+}
+
+func TestFindFile_MissingPattern(t *testing.T) {
+	r := &fileReader{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	_, err := r.findFile(context.Background(), map[string]interface{}{"reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected error for missing pattern")
+	}
+}
+
+func TestGetFileDiff_SecurityErrorFile2(t *testing.T) {
+	tempDir := t.TempDir()
+	f1 := filepath.Join(tempDir, "f1.txt")
+	if err := os.WriteFile(f1, []byte("line1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	// Override IsPathSafe to allow file1 but reject file2
+	sm.IsSafeFunc = func(path string) (string, error) {
+		if strings.Contains(path, "f2") {
+			return "", fmt.Errorf("security: path not allowed")
+		}
+		return path, nil
+	}
+
+	r := &fileReader{
+		sm:       sm,
+		fs:       persistencetest.NewPlainOSFileSystem(),
+		policy:   infra_persistence.NewWorkspacePolicy(),
+		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
+	}
+	ctx := context.Background()
+
+	_, err := r.getFileDiff(ctx, map[string]interface{}{
+		"file1":  f1,
+		"file2":  filepath.Join(tempDir, "f2.txt"),
+		"reason": "testing",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected security error for file2")
+	}
+	if !strings.Contains(err.Error(), "security") {
+		t.Errorf("expected security error, got: %v", err)
+	}
 }

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -8,10 +8,14 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 )
@@ -175,25 +179,55 @@ func (f *failingRegistry) RegisterToToolkitWithOptions(toolkit string, def *tool
 // ---------------------------------------------------------------------------
 
 func TestRegisterFiles_PartialFailure(t *testing.T) {
-	registry := &failingRegistry{
-		mockToolRegistry: &mockToolRegistry{},
-		failOnTool:       "replace_text",
-	}
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	exec := &toolstest.MockExecutor{}
 	fs := persistencetest.NewPlainOSFileSystem()
 	wp := infra_persistence.NewWorkspacePolicy()
 
-	err := registerFiles(registry, sm, fs, exec, wp)
-	if err == nil {
-		t.Fatal("expected error from registerFiles partial failure")
-	}
-	if !strings.Contains(err.Error(), "injected failure") {
-		t.Errorf("expected 'injected failure' in error, got %q", err.Error())
-	}
-	if !strings.Contains(err.Error(), "replace_text") {
-		t.Errorf("expected 'replace_text' in error, got %q", err.Error())
-	}
+	t.Run("replace_text fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "replace_text",
+		}
+		err := registerFiles(registry, sm, fs, exec, wp)
+		if err == nil {
+			t.Fatal("expected error from registerFiles partial failure")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure' in error, got %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), "replace_text") {
+			t.Errorf("expected 'replace_text' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("write_file fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "write_file",
+		}
+		err := registerFiles(registry, sm, fs, exec, wp)
+		if err == nil {
+			t.Fatal("expected error from registerFiles partial failure")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure' in error, got %q", err.Error())
+		}
+	})
+
+	t.Run("list_files fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "list_files",
+		}
+		err := registerFiles(registry, sm, fs, exec, wp)
+		if err == nil {
+			t.Fatal("expected error from registerFiles partial failure")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure' in error, got %q", err.Error())
+		}
+	})
 }
 
 func TestRegisterSystem_PartialFailure(t *testing.T) {
@@ -234,6 +268,21 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			failOnTool:       "ask_user",
 		}
 		err := registerSystem(registry, sm, validator, nil)
+		if err == nil {
+			t.Fatal("expected error from registerSystem")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
+
+	t.Run("check_system_health fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "check_system_health",
+		}
+		mockHealth := &mockHealthCheckManager{}
+		err := registerSystem(registry, sm, validator, mockHealth)
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -288,6 +337,48 @@ func TestRegisterGit_PartialFailure(t *testing.T) {
 			t.Errorf("expected 'injected failure', got %q", err.Error())
 		}
 	})
+
+	t.Run("second RegisterToToolkit fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "get_git_diff",
+		}
+		err := registerGit(registry, sm, exec)
+		if err == nil {
+			t.Fatal("expected error from registerGit")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
+
+	t.Run("last RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "git_create_branch",
+		}
+		err := registerGit(registry, sm, exec)
+		if err == nil {
+			t.Fatal("expected error from registerGit")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
+
+	t.Run("third RegisterToToolkit fails", func(t *testing.T) {
+		registry := &failingRegistry{
+			mockToolRegistry: &mockToolRegistry{},
+			failOnTool:       "get_git_log",
+		}
+		err := registerGit(registry, sm, exec)
+		if err == nil {
+			t.Fatal("expected error from registerGit")
+		}
+		if !strings.Contains(err.Error(), "injected failure") {
+			t.Errorf("expected 'injected failure', got %q", err.Error())
+		}
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -328,4 +419,52 @@ func TestRegister_PartialFailure(t *testing.T) {
 			t.Errorf("expected 'injected failure', got %q", err.Error())
 		}
 	})
+}
+
+func TestRegister_SystemToolsOnly(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	reg := registry.New()
+	// Register only system tools (skip git/files)
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), nil)
+	if err != nil {
+		t.Fatalf("registerSystem failed: %v", err)
+	}
+	decls := reg.GetDeclarations()
+	// Should have execute_command, pipe_commands, ask_user (and check_system_health NOT, since health is nil)
+	found := make(map[string]bool)
+	for _, d := range decls {
+		found[d.Name] = true
+	}
+	if !found["execute_command"] {
+		t.Error("execute_command not registered")
+	}
+	if found["check_system_health"] {
+		t.Error("check_system_health should NOT be registered when health is nil")
+	}
+}
+
+func TestRegister_WithHealth(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	reg := registry.New()
+	// Use mock health check manager
+	mockHealth := &mockHealthCheckManager{report: &ports.HealthReport{
+		OverallStatus: ports.StatusHealthy,
+		Components:    map[ports.Component]ports.ComponentReport{},
+		Timestamp:     time.Now(),
+	}}
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), mockHealth)
+	if err != nil {
+		t.Fatalf("registerSystem failed: %v", err)
+	}
+	decls := reg.GetDeclarations()
+	found := false
+	for _, d := range decls {
+		if d.Name == "check_system_health" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("check_system_health should be registered when health is non-nil")
+	}
 }

--- a/internal/tools/workspace/search_test.go
+++ b/internal/tools/workspace/search_test.go
@@ -341,3 +341,254 @@ func TestCheckConcurrentSearchError(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// getPathOrDefault tests
+// ---------------------------------------------------------------------------
+
+func TestGetPathOrDefault(t *testing.T) {
+	s := &fileSearcher{}
+
+	t.Run("empty path returns dot", func(t *testing.T) {
+		got := s.getPathOrDefault("")
+		if got != "." {
+			t.Errorf("expected '.', got %q", got)
+		}
+	})
+
+	t.Run("non-empty path preserved", func(t *testing.T) {
+		got := s.getPathOrDefault("/some/path")
+		if got != "/some/path" {
+			t.Errorf("expected '/some/path', got %q", got)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// grepDefinitions with concurrent search error
+// ---------------------------------------------------------------------------
+
+// mockFS_WalkError overrides Walk to return an error, triggering errChan
+type mockFS_WalkError struct {
+	persistence.FileSystem
+	walkErr error
+}
+
+func (m *mockFS_WalkError) Walk(ctx context.Context, root string, fn persistence.WalkFunc) error {
+	return m.walkErr
+}
+
+func TestGrepDefinitions_ConcurrentSearchError(t *testing.T) {
+	expectedErr := fmt.Errorf("walk failure")
+	fs := &mockFS_WalkError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		walkErr:    expectedErr,
+	}
+
+	s := &fileSearcher{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     fs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	_, err := s.grepDefinitions(context.Background(), map[string]interface{}{"reason": "testing"}, nil)
+	if err == nil {
+		t.Fatal("expected error from concurrent search")
+	}
+	if !strings.Contains(err.Error(), "walk failure") {
+		t.Errorf("expected 'walk failure' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// searchFiles comprehensive tests
+// ---------------------------------------------------------------------------
+
+func TestSearchFiles_RegexMode(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("hello world"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	t.Run("regex match", func(t *testing.T) {
+		res, err := s.searchFiles(ctx, map[string]interface{}{
+			"path":     tempDir,
+			"query":    "^hello",
+			"is_regex": true,
+			"reason":   "testing",
+		}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(res.Text, "hello world") {
+			t.Errorf("expected match, got: %q", res.Text)
+		}
+	})
+
+	t.Run("regex no match", func(t *testing.T) {
+		res, err := s.searchFiles(ctx, map[string]interface{}{
+			"path":     tempDir,
+			"query":    "^goodbye",
+			"is_regex": true,
+			"reason":   "testing",
+		}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(res.Text, "0 matches found") {
+			t.Errorf("expected '0 matches found', got: %q", res.Text)
+		}
+	})
+
+	t.Run("invalid regex", func(t *testing.T) {
+		_, err := s.searchFiles(ctx, map[string]interface{}{
+			"path":     tempDir,
+			"query":    "[invalid",
+			"is_regex": true,
+			"reason":   "testing",
+		}, nil)
+		if err == nil {
+			t.Fatal("expected error for invalid regex")
+		}
+		if !strings.Contains(err.Error(), "invalid regex") {
+			t.Errorf("expected 'invalid regex', got: %v", err)
+		}
+	})
+}
+
+func TestSearchFiles_NoResults(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	s := &fileSearcher{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	res, err := s.searchFiles(ctx, map[string]interface{}{
+		"path":   tempDir,
+		"query":  "xyznonexistent",
+		"reason": "testing",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "0 matches found") {
+		t.Errorf("expected '0 matches found', got: %q", res.Text)
+	}
+}
+
+func TestSearchFiles_ConcurrentSearchError(t *testing.T) {
+	fs := &mockFS_WalkError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		walkErr:    fmt.Errorf("walk failure"),
+	}
+
+	s := &fileSearcher{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     fs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	_, err := s.searchFiles(ctx, map[string]interface{}{
+		"path":   ".",
+		"query":  "hello",
+		"reason": "testing",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from concurrent search walk failure")
+	}
+	if !strings.Contains(err.Error(), "walk failure") {
+		t.Errorf("expected 'walk failure', got: %v", err)
+	}
+}
+
+func TestGetTree_DeepRecursion(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "a/b/c"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "a/b/c/d.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{sm: sm, fs: persistencetest.NewPlainOSFileSystem(), policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	t.Run("depth 1 shows two levels", func(t *testing.T) {
+		res, err := r.getTree(ctx, map[string]interface{}{"path": tempDir, "max_depth": 1, "reason": "testing"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// At maxDepth=1 we see depth 0 entries and depth 1 children
+		if !strings.Contains(res.Text, "a") {
+			t.Errorf("expected 'a' directory in output, got: %s", res.Text)
+		}
+	})
+
+	t.Run("path default", func(t *testing.T) {
+		// When path is empty, it defaults to current dir
+		_, err := r.getTree(ctx, map[string]interface{}{"reason": "testing"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Should not error
+	})
+}
+
+func TestFindFile_WalkError(t *testing.T) {
+	fs := &mockFS_WalkError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		walkErr:    fmt.Errorf("walk failure"),
+	}
+
+	r := &fileReader{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     fs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	_, err := r.findFile(ctx, map[string]interface{}{
+		"path":    ".",
+		"pattern": "*.go",
+		"reason":  "testing",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected walk error")
+	}
+	if !strings.Contains(err.Error(), "walk failure") {
+		t.Errorf("expected 'walk failure', got: %v", err)
+	}
+}
+
+func TestReplaceText_ReadError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+
+	// Use mock FS that fails ReadFile
+	mfs := &mockFS_ReadError{FileSystem: persistencetest.NewPlainOSFileSystem(), err: fmt.Errorf("read failure")}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.replaceText(ctx, map[string]interface{}{
+		"filepath": path,
+		"old_text": "old",
+		"new_text": "new",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "failed to read file") {
+		t.Errorf("expected 'failed to read file' error, got: %v", err)
+	}
+}

--- a/internal/tools/workspace/writer.go
+++ b/internal/tools/workspace/writer.go
@@ -59,7 +59,9 @@ func (w *fileWriter) writeFile(ctx context.Context, args map[string]interface{},
 
 	// Confirmation Gate
 
-	w.bm.snapshot(ctx, resolvedPath, "WRITE")
+	if err := w.bm.snapshot(ctx, resolvedPath, "WRITE"); err != nil {
+		return tools.ToolResult{}, err
+	}
 
 	// Create parent directories if they don't exist
 	dir := filepath.Dir(resolvedPath)
@@ -97,7 +99,9 @@ func (w *fileWriter) replaceText(ctx context.Context, args map[string]interface{
 
 	// Confirmation Gate
 
-	w.bm.snapshot(ctx, resolvedPath, "REPLACE")
+	if err := w.bm.snapshot(ctx, resolvedPath, "REPLACE"); err != nil {
+		return tools.ToolResult{}, err
+	}
 
 	contentBytes, err := w.fs.ReadFile(ctx, resolvedPath)
 	if err != nil {
@@ -150,7 +154,9 @@ func (w *fileWriter) appendText(ctx context.Context, args map[string]interface{}
 
 	// Confirmation Gate
 
-	w.bm.snapshot(ctx, resolvedPath, "APPEND")
+	if err := w.bm.snapshot(ctx, resolvedPath, "APPEND"); err != nil {
+		return tools.ToolResult{}, err
+	}
 
 	// Use OpenFile with O_APPEND
 	f, oerr := w.fs.OpenFile(ctx, resolvedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -187,7 +193,7 @@ func (w *fileWriter) undoFileChange(ctx context.Context, args map[string]interfa
 
 	res, err := w.bm.undo(ctx, n)
 	if err == nil && strings.Contains(res, "No snapshots available") {
-		return tools.ToolResult{Text: res}, fmt.Errorf("no history found")
+		return tools.ToolResult{Text: "Error: no history found"}, nil
 	}
 
 	return tools.ToolResult{Text: res}, err
@@ -247,7 +253,9 @@ func (w *fileWriter) performSingleDelete(ctx context.Context, path string) (tool
 
 	// Only snapshot if it is a file and not a directory
 	if statErr == nil && !info.IsDir() {
-		w.bm.snapshot(ctx, path, "DELETE")
+		if err := w.bm.snapshot(ctx, path, "DELETE"); err != nil {
+			return tools.ToolResult{}, err
+		}
 	}
 
 	if err := w.fs.Remove(ctx, path); err != nil {

--- a/internal/tools/workspace/writer.go
+++ b/internal/tools/workspace/writer.go
@@ -34,8 +34,8 @@ func (w *fileWriter) writeFile(ctx context.Context, args map[string]interface{},
 	//   (b) Future callers (other registries, embedding scenarios,
 	//       in-process tool invocation by tests/scripts) get the same
 	//       safety without depending on the registry's behavior.
-	// The two layers cannot disagree because both check key-presence
-	// (not value-zero-ness) on the same args map.
+	// The registry checks key-presence (is the param in the map?); this
+	// handler additionally validates the value itself is non-empty.
 	if _, ok := args["content"]; !ok {
 		return tools.ToolResult{}, fmt.Errorf("required parameter 'content' is missing (to write an empty file, pass content=\"\" explicitly)")
 	}

--- a/internal/tools/workspace/writer_test.go
+++ b/internal/tools/workspace/writer_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -301,9 +302,12 @@ func TestUndoFileChange_Errors(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("no backups", func(t *testing.T) {
-		_, err := w.undoFileChange(ctx, map[string]interface{}{"n": 1}, nil)
-		if err == nil || !strings.Contains(err.Error(), "no history found") {
-			t.Errorf("expected 'no history found' error, got %v", err)
+		res, err := w.undoFileChange(ctx, map[string]interface{}{"n": 1}, nil)
+		if err != nil {
+			t.Fatalf("expected domain outcome (nil error), got: %v", err)
+		}
+		if !strings.Contains(res.Text, "Error: no history found") {
+			t.Errorf("expected 'Error: no history found' in result text, got %q", res.Text)
 		}
 	})
 
@@ -778,5 +782,425 @@ func TestAppendText_MissingContent(t *testing.T) {
 	got, _ = os.ReadFile(path)
 	if string(got) != "original" {
 		t.Errorf("explicit empty append must be a no-op; got %q, want %q", string(got), "original")
+	}
+}
+
+func TestCreateDirectory_MkdirAllFailure(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath("/mock")
+
+	mfs := &mockFS{mkdirErr: fmt.Errorf("disk full")}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.createDirectory(ctx, map[string]interface{}{
+		"path":   "/mock/new_dir",
+		"reason": "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "disk full") {
+		t.Errorf("expected 'disk full' error, got %v", err)
+	}
+}
+
+func TestDeletePath_StatErrorStillDeletes(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "stat_error_file.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Mock FS where Stat returns an error, but Remove succeeds
+	mfs := &mockFS_StatError{FileSystem: persistencetest.NewPlainOSFileSystem(), statErr: fmt.Errorf("stat error")}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.deletePath(ctx, map[string]interface{}{
+		"path":      path,
+		"recursive": false,
+		"reason":    "testing stat error",
+	}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("file should have been deleted despite stat error")
+	}
+}
+
+type mockFS_StatError struct {
+	persistence.FileSystem
+	statErr error
+}
+
+func (m *mockFS_StatError) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return nil, m.statErr
+}
+
+func TestAppendText_SyncCloseError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "append_sync.txt")
+	if err := os.WriteFile(path, []byte("init"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	// Mock FS that returns a file whose Close always errors
+	mfs := &mockFS_CloseError{FileSystem: persistencetest.NewPlainOSFileSystem(), closeErr: fmt.Errorf("close failed")}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+
+	_, err := w.appendText(context.Background(), map[string]interface{}{
+		"filepath": path,
+		"content":  "test",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "failed to close file") {
+		t.Errorf("expected 'failed to close file' error, got: %v", err)
+	}
+}
+
+type mockFS_CloseError struct {
+	persistence.FileSystem
+	closeErr error
+}
+
+func (m *mockFS_CloseError) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (persistence.File, error) {
+	f, err := os.OpenFile(name, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return &mockFileCloseErr{File: f, closeErr: m.closeErr}, nil
+}
+
+type mockFileCloseErr struct {
+	*os.File
+	closeErr error
+}
+
+func (m *mockFileCloseErr) Close() error {
+	_ = m.File.Close()
+	return m.closeErr
+}
+
+func (m *mockFileCloseErr) ReadDir(n int) ([]os.DirEntry, error) {
+	return nil, fmt.Errorf("not a directory")
+}
+
+func TestWriteFile_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security violation")
+	}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.writeFile(ctx, map[string]interface{}{
+		"filepath": "/etc/passwd",
+		"content":  "malicious",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "security violation") {
+		t.Errorf("expected 'security violation' error, got: %v", err)
+	}
+}
+
+func TestReplaceText_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security violation")
+	}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.replaceText(ctx, map[string]interface{}{
+		"filepath": "/etc/passwd",
+		"old_text": "old",
+		"new_text": "new",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "security violation") {
+		t.Errorf("expected 'security violation' error, got: %v", err)
+	}
+}
+
+func TestAppendText_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security violation")
+	}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.appendText(ctx, map[string]interface{}{
+		"filepath": "/etc/passwd",
+		"content":  "malicious",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "security violation") {
+		t.Errorf("expected 'security violation' error, got: %v", err)
+	}
+}
+
+func TestDeletePath_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security violation")
+	}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.deletePath(ctx, map[string]interface{}{
+		"path":   "/etc/passwd",
+		"reason": "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "security violation") {
+		t.Errorf("expected 'security violation' error, got: %v", err)
+	}
+}
+
+func TestCreateDirectory_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security violation")
+	}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.createDirectory(ctx, map[string]interface{}{
+		"path":   "/etc/new_dir",
+		"reason": "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "security violation") {
+		t.Errorf("expected 'security violation' error, got: %v", err)
+	}
+}
+
+func TestDeletePath_RecursiveAuthorizationError(t *testing.T) {
+	tempDir := t.TempDir()
+	dir := filepath.Join(tempDir, "auth_err")
+	_ = os.MkdirAll(dir, 0755)
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(false)
+	sm.RegisterSafePath(tempDir)
+	sm.AuthorizeFunc = func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+		return false, fmt.Errorf("authorization service down")
+	}
+
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.deletePath(ctx, map[string]interface{}{
+		"path":      dir,
+		"recursive": true,
+		"reason":    "testing auth error",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "authorization failed") {
+		t.Errorf("expected 'authorization failed' error, got: %v", err)
+	}
+}
+
+func TestDeletePath_RecursiveRemoveAllError(t *testing.T) {
+	tempDir := t.TempDir()
+	dir := filepath.Join(tempDir, "rm_error")
+	_ = os.MkdirAll(dir, 0755)
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	mfs := &mockFS_RemoveAllError{FileSystem: persistencetest.NewPlainOSFileSystem(), rmErr: fmt.Errorf("device busy")}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.deletePath(ctx, map[string]interface{}{
+		"path":      dir,
+		"recursive": true,
+		"reason":    "testing rm error",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "failed to delete path recursively") {
+		t.Errorf("expected 'failed to delete path recursively' error, got: %v", err)
+	}
+}
+
+type mockFS_RemoveAllError struct {
+	persistence.FileSystem
+	rmErr error
+}
+
+func (m *mockFS_RemoveAllError) RemoveAll(ctx context.Context, path string) error {
+	return m.rmErr
+}
+
+func TestReplaceText_WriteError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	mfs := &mockFS{FileSystem: persistencetest.NewPlainOSFileSystem(), writeErr: fmt.Errorf("write failure")}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.replaceText(ctx, map[string]interface{}{
+		"filepath": path,
+		"old_text": "old content",
+		"new_text": "new content",
+		"reason":   "testing",
+	}, nil)
+	if err == nil || !strings.Contains(err.Error(), "write failure") {
+		t.Errorf("expected 'write failure' error, got: %v", err)
+	}
+}
+
+func TestPerformSingleDelete_RemoveError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "remove_err.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	mfs := &mockFS_RemoveError{FileSystem: persistencetest.NewPlainOSFileSystem(), rmErr: fmt.Errorf("remove failure")}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: mfs}
+	ctx := context.Background()
+
+	_, err := w.performSingleDelete(ctx, path)
+	if err == nil || !strings.Contains(err.Error(), "failed to delete path") {
+		t.Errorf("expected 'failed to delete path' error, got: %v", err)
+	}
+}
+
+type mockFS_RemoveError struct {
+	persistence.FileSystem
+	rmErr error
+}
+
+func (m *mockFS_RemoveError) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return m.FileSystem.Stat(ctx, name)
+}
+
+func (m *mockFS_RemoveError) Remove(ctx context.Context, name string) error {
+	return m.rmErr
+}
+
+func TestUndoFileChange_UndoError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "undo_err.txt")
+	if err := os.WriteFile(path, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	// Add a snapshot with a path that will fail at security check
+	if err := bm.snapshot(context.Background(), path, "WRITE"); err != nil {
+		t.Fatal(err)
+	}
+	// Now block the path — must disable both AllowAll and BypassActive
+	sm.AllowAll = false
+	sm.SetBypassActive(false)
+	sm.IsWritableFunc = func(p string) (string, error) {
+		return "", fmt.Errorf("security block")
+	}
+
+	w := &fileWriter{sm: sm, bm: bm, fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.undoFileChange(ctx, map[string]interface{}{"n": 1}, nil)
+	if err == nil {
+		t.Fatal("expected undo error from security block")
+	}
+	if !strings.Contains(err.Error(), "security block") {
+		t.Errorf("expected 'security block' error, got: %v", err)
+	}
+}
+
+func TestUndo_NormalizeN(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	ctx := context.Background()
+
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "file.txt")
+	if err := os.WriteFile(path, []byte("v1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := bm.snapshot(ctx, path, "WRITE"); err != nil {
+		t.Fatal(err)
+	}
+
+	// n=0 should normalize to 1 and undo the single snapshot
+	res, err := bm.undo(ctx, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res, "Undo successful") {
+		t.Errorf("expected 'Undo successful', got %q", res)
+	}
+}
+
+func TestWriteFile_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.writeFile(ctx, map[string]interface{}{"content": "test"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for missing filepath")
+	}
+}
+
+func TestReplaceText_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.replaceText(ctx, map[string]interface{}{}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for missing args")
+	}
+}
+
+func TestFindFile_InvalidArgs(t *testing.T) {
+	r := &fileReader{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	_, err := r.findFile(context.Background(), map[string]interface{}{"path": 123, "pattern": "*.go", "reason": "test"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error")
+	}
+}
+
+func TestListFiles_InvalidArgs(t *testing.T) {
+	r := &fileReader{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	_, err := r.listFiles(context.Background(), map[string]interface{}{"path": 123, "reason": "test"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error")
 	}
 }


### PR DESCRIPTION
Closes #382.

## Summary
- **Architectural Blocker**: `backup.go` `snapshot()` now returns `error`; distinguishes `os.IsNotExist` from genuine I/O failures — fixes silent data loss when pre-modification snapshot fails.
- **ADR-022 Compliance**: `gitCommit` "nothing to commit", `undoFileChange` "no history", `interpretDiffResult` exit code ≠ 0,1, `readFiles` "too many files", `ManageTasks` unknown action — all converted to pure domain outcomes (`ToolResult{Text:"Error:..."}, nil`).
- **Defense-in-depth comments** on git.go missing-arg guards.
- **1580+ lines** of table-driven error-path tests across all key files.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (fmt/tidy/build/lint) | PASS |
| `go test -race ./internal/tools/workspace/...` | PASS |
| Coverage (target ≥91%) | **91.1%** |
| `go test -race ./...` (full suite) | PASS — no regressions |
| `golangci-lint run ./...` | 0 issues |
| Detailed coverage gaps (was 160) | **0 remaining** |
