### PR TITLE
fix(llm): add error path test coverage for LLM and encoding (#396)

### DIFF
--- a/internal/infrastructure/encoding/encoding.go
+++ b/internal/infrastructure/encoding/encoding.go
@@ -22,10 +22,14 @@ func DecodeBytes(b []byte) []byte {
 	if len(b) == 0 || utf8.Valid(b) {
 		return b
 	}
-	r := WrapReader(bytes.NewReader(b))
+	return decodeFromReader(WrapReader(bytes.NewReader(b)), b)
+}
+
+// decodeFromReader reads all bytes from r, falling back to fallback on error.
+func decodeFromReader(r io.Reader, fallback []byte) []byte {
 	decoded, err := io.ReadAll(r)
 	if err != nil {
-		return b
+		return fallback
 	}
 	return decoded
 }

--- a/internal/infrastructure/encoding/encoding_test.go
+++ b/internal/infrastructure/encoding/encoding_test.go
@@ -4,6 +4,8 @@
 package encoding
 
 import (
+	"bytes"
+	"errors"
 	"io"
 	"runtime"
 	"strings"
@@ -164,4 +166,32 @@ func TestDecodeBytes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeBytes_ReadAllError(t *testing.T) {
+	t.Run("io.ReadAll error returns fallback", func(t *testing.T) {
+		fr := &faultyReader{}
+		fallback := []byte("fallback")
+		got := decodeFromReader(fr, fallback)
+		if string(got) != string(fallback) {
+			t.Errorf("got %q; want %q", got, fallback)
+		}
+	})
+
+	t.Run("successful read returns decoded bytes", func(t *testing.T) {
+		input := []byte("success")
+		fallback := []byte("fallback")
+		got := decodeFromReader(bytes.NewReader(input), fallback)
+		if string(got) != string(input) {
+			t.Errorf("got %q; want %q", got, input)
+		}
+	})
+}
+
+// faultyReader is an io.Reader that always returns an error, used for testing.
+type faultyReader struct{}
+
+// Read implements io.Reader for fault injection in tests.
+func (f *faultyReader) Read(p []byte) (int, error) {
+	return 0, errors.New("simulated read failure")
 }

--- a/internal/infrastructure/llm/factory_test.go
+++ b/internal/infrastructure/llm/factory_test.go
@@ -147,6 +147,65 @@ func TestCreateAuthenticator_MissingKeysAndFallbacks(t *testing.T) {
 	}
 }
 
+func TestCreateAuthenticator_Public(t *testing.T) {
+	tests := []struct {
+		name        string
+		provider    config.LLMProvider
+		wantErr     bool
+		wantAuthNil bool
+		wantType    string // "bearer", "vertex", or "" for nil
+	}{
+		{
+			name:        "Valid key returns BearerAuth",
+			provider:    config.LLMProvider{Type: "openai", APIKey: "secret"},
+			wantErr:     false,
+			wantAuthNil: false,
+			wantType:    "bearer",
+		},
+		{
+			name:        "Missing key returns error",
+			provider:    config.LLMProvider{Type: "anthropic", APIKey: ""},
+			wantErr:     true,
+			wantAuthNil: true,
+			wantType:    "",
+		},
+		{
+			name:        "Vertex fallback when no key",
+			provider:    config.LLMProvider{Type: "google", APIKey: ""},
+			wantErr:     false,
+			wantAuthNil: false,
+			wantType:    "vertex",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a, err := CreateAuthenticator(&tt.provider)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CreateAuthenticator() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if (a == nil) != tt.wantAuthNil {
+				t.Errorf("CreateAuthenticator() auth = %v, wantAuthNil %v", a, tt.wantAuthNil)
+			}
+
+			if !tt.wantErr && a != nil {
+				switch tt.wantType {
+				case "bearer":
+					if _, ok := a.(*auth.BearerAuth); !ok {
+						t.Errorf("expected *auth.BearerAuth, got %T", a)
+					}
+				case "vertex":
+					if _, ok := a.(*auth.VertexAuth); !ok {
+						t.Errorf("expected *auth.VertexAuth, got %T", a)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestNewClient_FallbackToGemini(t *testing.T) {
 	t.Setenv("GOOGLE_API_KEY", "dummy")
 	cfg := &config.Config{

--- a/internal/infrastructure/llm/provider_health_test.go
+++ b/internal/infrastructure/llm/provider_health_test.go
@@ -148,3 +148,170 @@ func TestLLMProviderHealthChecker_AnthropicHealthyFallback(t *testing.T) {
 		t.Errorf("expected StatusHealthy for Anthropic 404, got %s", report.Status)
 	}
 }
+
+func TestNewLLMProviderHealthChecker_BaseURLFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		providerName    string
+		expectedBaseURL string
+	}{
+		{
+			name:            "openai fallback",
+			providerName:    "openai",
+			expectedBaseURL: "https://api.openai.com/v1",
+		},
+		{
+			name:            "deepseek fallback",
+			providerName:    "deepseek",
+			expectedBaseURL: "https://api.openai.com/v1",
+		},
+		{
+			name:            "anthropic fallback",
+			providerName:    "anthropic",
+			expectedBaseURL: "https://api.anthropic.com/v1",
+		},
+		{
+			name:            "google fallback",
+			providerName:    "google",
+			expectedBaseURL: "https://generativelanguage.googleapis.com/v1beta",
+		},
+		{
+			name:            "gemini fallback",
+			providerName:    "gemini",
+			expectedBaseURL: "https://generativelanguage.googleapis.com/v1beta",
+		},
+		{
+			name:            "unknown provider no fallback",
+			providerName:    "unknown-provider",
+			expectedBaseURL: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := NewLLMProviderHealthChecker(tt.providerName, nil, "", nil)
+			report, err := checker.Check(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if report.Status != ports.StatusUnhealthy {
+				t.Errorf("expected StatusUnhealthy, got %s", report.Status)
+			}
+
+			if report.Message != "LLM API key is missing (no authenticator)" {
+				t.Errorf("unexpected message: %s", report.Message)
+			}
+
+			details, ok := report.Details.(map[string]any)
+			if !ok {
+				t.Fatalf("expected Details to be map[string]any, got %T", report.Details)
+			}
+
+			if details["endpoint_url"] != tt.expectedBaseURL {
+				t.Errorf("expected endpoint_url %q, got %q", tt.expectedBaseURL, details["endpoint_url"])
+			}
+		})
+	}
+}
+
+func TestLLMProviderHealthChecker_BuildRequestError(t *testing.T) {
+	t.Parallel()
+
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("openai", authMock, "://invalid", nil)
+
+	report, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.Status != ports.StatusUnhealthy {
+		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
+	}
+	if !strings.Contains(report.Message, "failed to create health check request") {
+		t.Errorf("expected message to contain 'failed to create health check request', got: %s", report.Message)
+	}
+	if report.Error == nil {
+		t.Error("expected report.Error to be non-nil")
+	}
+}
+
+func TestLLMProviderHealthChecker_NonTransientNonAuthError(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer server.Close()
+
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("openai", authMock, server.URL, nil)
+
+	report, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if report.Status != ports.StatusUnhealthy {
+		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
+	}
+	if report.Message != "LLM provider returned error status: 400" {
+		t.Errorf("expected message 'LLM provider returned error status: 400', got: %s", report.Message)
+	}
+	if report.Error == nil {
+		t.Error("expected report.Error to be non-nil")
+	}
+}
+
+func TestLLMProviderHealthChecker_GeminiEndpointSelection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		providerName string
+		baseURL      string
+	}{
+		{
+			name:         "vertex aiplatform url",
+			providerName: "gemini",
+			baseURL:      "https://us-central1-aiplatform.googleapis.com/v1",
+		},
+		{
+			name:         "custom proxy url",
+			providerName: "gemini",
+			baseURL:      "https://my-proxy.example.com/v1",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := NewLLMProviderHealthChecker(tt.providerName, nil, tt.baseURL, nil)
+			report, err := checker.Check(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if report.Status != ports.StatusUnhealthy {
+				t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
+			}
+
+			details, ok := report.Details.(map[string]any)
+			if !ok {
+				t.Fatalf("expected Details to be map[string]any, got %T", report.Details)
+			}
+
+			if details["endpoint_url"] != tt.baseURL {
+				t.Errorf("expected endpoint_url %q, got %q", tt.baseURL, details["endpoint_url"])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #396.

## Summary
Added comprehensive test coverage for 14 error handling and adapter gaps across `internal/infrastructure/llm/` and `internal/infrastructure/encoding/`, raising coverage from 90.9%/92.9% to 98.1%/100.0%.

### Changes
- **factory_test.go**: Test for `CreateAuthenticator` public wrapper
- **provider_health_test.go**: Tests for baseURL fallback chain, `buildRequest` error path, nil authenticator guard, HTTP 400 classification, and Gemini endpoint selection
- **encoding.go**: Extracted `decodeFromReader` helper for testable `io.ReadAll` error path
- **encoding_test.go**: Fault-injecting reader test for `decodeFromReader`

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| llm coverage | 98.1% (target ≥95%) |
| encoding coverage | 100.0% (target ≥95%) |
| go test -race | PASS (all packages) |
| Dependent packages (di, exec, workspace) | PASS |