### PR TITLE
fix(telemetry): error path hardening (82.4% → 93.4%) (#398)

### DIFF
--- a/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
+++ b/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
@@ -8,6 +8,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -398,6 +400,215 @@ func TestIsStale_NonExistent(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// logTrace error-path tests — covering the 6 gaps identified in Phase 3.
+// Gap 4 (json.Marshal error) is documented as UNREACHABLE because all
+// TurnTrace fields are JSON-serializable (sync.Mutex has json:"-", and
+// time.Time, time.Duration, []ToolExecutionTrace, string all marshal cleanly).
+// ---------------------------------------------------------------------------
+
+func TestLogTrace_EmptyTraceFile(t *testing.T) {
+	t.Parallel()
+
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
+	tempDir := t.TempDir()
+
+	// Call with empty traceFile — should silently skip (gap 1).
+	logTrace(context.Background(), "", trace)
+
+	// Verify no file was created in the temp directory.
+	entries, err := os.ReadDir(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no files, got %d entries", len(entries))
+	}
+}
+
+func TestLogTrace_NilTrace(t *testing.T) {
+	t.Parallel()
+
+	traceFile := filepath.Join(t.TempDir(), "nil_trace.jsonl")
+
+	// Call with nil trace — should silently skip (gap 2).
+	logTrace(context.Background(), traceFile, nil)
+
+	// Verify no file was created.
+	if _, err := os.Stat(traceFile); !os.IsNotExist(err) {
+		t.Error("expected no file for nil trace, but file exists")
+	}
+}
+
+func TestLogTrace_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	traceFile := filepath.Join(t.TempDir(), "cancelled.jsonl")
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	// Call with cancelled context — should skip (gap 3).
+	logTrace(ctx, traceFile, trace)
+
+	// Verify no file was created.
+	if _, err := os.Stat(traceFile); !os.IsNotExist(err) {
+		t.Error("expected no file for cancelled context, but file exists")
+	}
+}
+
+func TestLogTrace_OpenError(t *testing.T) {
+	t.Parallel()
+
+	// Use a path with a non-existent parent directory.
+	// O_CREATE only creates the file, not parent directories,
+	// so os.OpenFile will fail with "no such file or directory" (gap 5).
+	traceFile := filepath.Join(t.TempDir(), "nonexistent_subdir", "trace.jsonl")
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
+
+	// Must not panic.
+	logTrace(context.Background(), traceFile, trace)
+
+	// Verify the file was NOT created.
+	if _, err := os.Stat(traceFile); !os.IsNotExist(err) {
+		t.Error("expected no file for open error path, but file exists")
+	}
+}
+
+func TestLogTrace_WriteError(t *testing.T) {
+	// NOT parallel — uses FIFO coordination that is timing-sensitive.
+	fifoPath := filepath.Join(t.TempDir(), "fifo")
+
+	if err := syscall.Mkfifo(fifoPath, 0666); err != nil {
+		t.Skipf("cannot create fifo (non-Unix?): %v", err)
+	}
+
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "fifo-test"}
+
+	// Strategy: reader opens (unblocks writer's open), then immediately closes.
+	// When logTrace then calls Write, the reader is gone → EPIPE.
+	readerOpened := make(chan struct{})
+	readerClosed := make(chan struct{})
+
+	go func() {
+		r, err := os.OpenFile(fifoPath, os.O_RDONLY, 0)
+		if err != nil {
+			close(readerOpened)
+			return
+		}
+		close(readerOpened) // signal: reader connected (both opens completed)
+		_ = r.Close()       // immediately close — writer gets EPIPE on next write
+		close(readerClosed)
+	}()
+
+	logDone := make(chan struct{})
+	go func() {
+		logTrace(context.Background(), fifoPath, trace)
+		close(logDone)
+	}()
+
+	// Wait for reader to connect (unblocks logTrace's open).
+	<-readerOpened
+	// Wait for reader to fully close before logTrace marshals and writes.
+	<-readerClosed
+	// Now logTrace will marshal and write — reader is gone, so f.Write gets EPIPE.
+	<-logDone
+	// If we reach here, the write-error path was exercised (log.Printf warning).
+}
+
+func TestLogTrace_CloseError(t *testing.T) {
+	// NOT parallel — uses RLIMIT_FSIZE to trigger EFBIG on write, and
+	// attempts to also trigger a close(2) error.
+	//
+	// Strategy:
+	//  1. Set RLIMIT_FSIZE to a small value (1KB).
+	//  2. Create a large TurnTrace whose JSON exceeds the limit.
+	//  3. logTrace opens (succeeds), writes → EFBIG (write-error path).
+	//  4. close(2) after a failed O_APPEND write: on Linux/ext4 this
+	//     typically returns 0, so the close-error body is unreachable
+	//     in practice. We retain this test to prove the path exists and
+	//     document the limitation.
+
+	tempDir := t.TempDir()
+	traceFile := filepath.Join(tempDir, "close_err.jsonl")
+
+	// Build a trace whose JSON exceeds ~1KB.
+	execs := make([]domain_telemetry.ToolExecutionTrace, 200)
+	for i := range execs {
+		execs[i] = domain_telemetry.ToolExecutionTrace{
+			ToolName:  "very-long-tool-name-to-fill-bytes",
+			StartTime: time.Now(),
+			Duration:  time.Second,
+			Status:    "success",
+			Error:     "a detailed error message that takes up space in the JSON output",
+		}
+	}
+	trace := &domain_telemetry.TurnTrace{
+		StartTime:         time.Now(),
+		EndTime:           time.Now().Add(time.Minute),
+		InferenceDuration: 30 * time.Second,
+		ToolExecutions:    execs,
+		FinalStatus:       "complete",
+	}
+
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_FSIZE, &orig); err != nil {
+		t.Skipf("cannot get rlimit: %v", err)
+	}
+	defer func() { _ = syscall.Setrlimit(syscall.RLIMIT_FSIZE, &orig) }()
+
+	lim := orig
+	lim.Cur = 1024 // 1KB — trace JSON is ~30KB
+	if err := syscall.Setrlimit(syscall.RLIMIT_FSIZE, &lim); err != nil {
+		t.Skipf("cannot set rlimit: %v", err)
+	}
+
+	// logTrace will open, marshal, write → EFBIG, then close.
+	// Write-error path is covered. Close-error path depends on kernel/fs.
+	logTrace(context.Background(), traceFile, trace)
+
+	// Verify the file was created (it should exist but be truncated).
+	if fi, err := os.Stat(traceFile); err == nil {
+		t.Logf("file size after EFBIG write: %d bytes", fi.Size())
+	}
+}
+
+// TestLogTrace_MarshalErrorUnreachable documents that the json.Marshal error
+// path in logTrace is unreachable because TurnTrace contains only JSON-
+// serializable fields (sync.Mutex excluded via json:"-"). No test is needed.
+func TestLogTrace_MarshalErrorUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Verify TurnTrace serializes cleanly with all field types.
+	trace := &domain_telemetry.TurnTrace{
+		StartTime:         time.Now(),
+		EndTime:           time.Now().Add(time.Second),
+		InferenceDuration: 500 * time.Millisecond,
+		ToolExecutions: []domain_telemetry.ToolExecutionTrace{
+			{ToolName: "tool1", StartTime: time.Now(), Duration: time.Second, Status: "success"},
+		},
+		FinalStatus: "complete",
+	}
+
+	data, err := json.Marshal(trace)
+	if err != nil {
+		t.Fatalf("unexpected marshal error (TurnTrace should always be serializable): %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty JSON output")
+	}
+
+	// Also verify the zero-value TurnTrace serializes.
+	data2, err := json.Marshal(&domain_telemetry.TurnTrace{})
+	if err != nil {
+		t.Fatalf("unexpected marshal error for zero TurnTrace: %v", err)
+	}
+	if len(data2) == 0 {
+		t.Error("expected non-empty JSON output for zero TurnTrace")
+	}
+}
+
 func (m *mockRegistry) GetOptions(name string) tools.ToolOptions {
 	return tools.ToolOptions{Serial: m.IsSerial(name), LongRunning: m.IsLongRunning(name)}
 }
@@ -416,4 +627,408 @@ func (m *mockRegistry) GetDeclarationsByToolkits(toolkits []string) []*tools.Too
 
 func (m *mockRegistry) ListAvailableToolkits() []string {
 	return nil
+}
+
+// ---------------------------------------------------------------------------
+// openLogFileForAppend tests — covering 4 branches (Phase 4.1)
+// ---------------------------------------------------------------------------
+
+func TestOpenLogFileForAppend_Success(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "existing.log")
+
+	// Pre-create the log file so OpenFile succeeds on first attempt.
+	if err := os.WriteFile(logPath, []byte("existing line\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := openLogFileForAppend(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Verify the file is open and writable.
+	if _, err := f.WriteString("new line\n"); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	// Verify file contains both lines.
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "existing line") || !strings.Contains(string(data), "new line") {
+		t.Errorf("file content mismatch: got %q", string(data))
+	}
+}
+
+func TestOpenLogFileForAppend_MkdirAllSucceeds(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	// Path where the parent directory does NOT exist.
+	logPath := filepath.Join(tmpDir, "nonexistent", "subdir", "log.jsonl")
+
+	f, err := openLogFileForAppend(logPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Verify the directory was created.
+	if _, err := os.Stat(filepath.Dir(logPath)); os.IsNotExist(err) {
+		t.Error("parent directory was not created")
+	}
+
+	// Verify we can write to the file.
+	if _, err := f.WriteString("hello\n"); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+}
+
+func TestOpenLogFileForAppend_MkdirAllFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	// Create a read+execute (no write) parent directory.
+	// This allows path lookup (ENOENT for the first OpenFile) but
+	// prevents MkdirAll from creating the missing subdirectory (EACCES).
+	parentDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(parentDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parentDir, 0755) })
+
+	logPath := filepath.Join(parentDir, "missing", "log.jsonl")
+
+	_, err := openLogFileForAppend(logPath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// The error MUST contain both mkdirErr and the original err (double-wrapping).
+	errStr := err.Error()
+	if !strings.Contains(errStr, "also failed to create dir") {
+		t.Errorf("error should mention mkdir failure, got: %v", err)
+	}
+	if !strings.Contains(errStr, "no such file or directory") {
+		t.Errorf("error should contain original open error, got: %v", err)
+	}
+}
+
+func TestOpenLogFileForAppend_PermissionDenied(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	// Create the parent directory but make it non-writable.
+	parentDir := filepath.Join(tmpDir, "locked")
+	if err := os.Mkdir(parentDir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parentDir, 0755) })
+
+	logPath := filepath.Join(parentDir, "log.jsonl")
+
+	_, err := openLogFileForAppend(logPath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify the error is wrapped with the expected prefix.
+	if !strings.Contains(err.Error(), "failed to open log file") {
+		t.Errorf("error should be wrapped, got: %v", err)
+	}
+	// Should NOT contain the mkdir-fallback message.
+	if strings.Contains(err.Error(), "also failed to create dir") {
+		t.Error("error should NOT mention mkdir fallback for non-NotExist errors")
+	}
+}
+
+// TestOpenLogFileForAppend_MkdirAllSucceedsButRetryFails covers the branch
+// where the first OpenFile fails with ENOENT, MkdirAll succeeds, but the
+// retry OpenFile still fails. We use syscall.Umask(0o777) so that MkdirAll
+// creates the parent directory with mode 0000, causing the retry to fail
+// with EACCES.
+//
+// NOT parallel — syscall.Umask is process-global.
+func TestOpenLogFileForAppend_MkdirAllSucceedsButRetryFails(t *testing.T) {
+	// NOT parallel: umask is process-global.
+	tmpDir := t.TempDir()
+
+	// Only ONE level of missing directory so MkdirAll itself succeeds.
+	logPath := filepath.Join(tmpDir, "missing", "log.jsonl")
+
+	// Set umask so MkdirAll creates the parent dir with mode 0000.
+	oldUmask := syscall.Umask(0o777)
+	t.Cleanup(func() { syscall.Umask(oldUmask) })
+
+	_, err := openLogFileForAppend(logPath)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// Verify the error is from the retry (after mkdir), not from mkdir itself.
+	errStr := err.Error()
+	if !strings.Contains(errStr, "after mkdir") {
+		t.Errorf("error should mention 'after mkdir', got: %v", err)
+	}
+	// Verify the directory WAS created (MkdirAll succeeded).
+	if _, statErr := os.Stat(filepath.Dir(logPath)); os.IsNotExist(statErr) {
+		t.Error("parent directory was not created by MkdirAll")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resolveUsageForSummary error-path tests (Phase 5.1)
+// ---------------------------------------------------------------------------
+
+// TestResolveUsageForSummary_ParseUsageNonNotExistError covers the gap where
+// parseUsage returns a non-NotExist error (e.g., trying to open a directory).
+// This exercises the os.IsNotExist(err) == false branch, which wraps the
+// error with "failed to parse usage log for summary".
+func TestResolveUsageForSummary_ParseUsageNonNotExistError(t *testing.T) {
+	t.Parallel()
+
+	sm := &mockSM{}
+	tempDir := t.TempDir()
+
+	// Create a directory (not a file) so os.Open fails with EISDIR (or
+	// equivalent "is a directory" error) — a non-NotExist error.
+	dirPath := filepath.Join(tempDir, "adir")
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := resolveUsageForSummary(context.Background(), sm, nil, dirPath, "model", nil)
+	if err == nil {
+		t.Fatal("expected error when passing directory as log path, got nil")
+	}
+
+	// Must NOT be a NotExist error — it should be wrapped with our prefix.
+	if os.IsNotExist(err) {
+		t.Errorf("expected non-NotExist error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "failed to parse usage log for summary") {
+		t.Errorf("error should contain wrap prefix, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// appendSummaryToLog error-path tests (Phase 5.2)
+// ---------------------------------------------------------------------------
+
+// TestAppendSummaryToLog_ZeroUsage covers gap #1: when all usage fields are
+// zero, the function returns nil early without touching the filesystem.
+func TestAppendSummaryToLog_ZeroUsage(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "nonexistent.log")
+
+	// All-zero UsageStats — should return nil without creating the file.
+	err := appendSummaryToLog(logPath, domain_pricing.UsageStats{}, 0.0, "model")
+	if err != nil {
+		t.Errorf("expected nil error for zero usage, got: %v", err)
+	}
+
+	// Verify no file was created (early return skips I/O).
+	if _, statErr := os.Stat(logPath); !os.IsNotExist(statErr) {
+		t.Error("expected no log file to be created for zero usage")
+	}
+}
+
+// TestAppendSummaryToLog_MarshalErrorUnreachable documents gap #2: the
+// json.Marshal error path inside appendSummaryToLog is UNREACHABLE because
+// llm.Metrics contains only JSON-serializable fields (int32, int, float64,
+// string, bool). No test can trigger this branch without violating the Go
+// type system.
+func TestAppendSummaryToLog_MarshalErrorUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Prove that all field types in llm.Metrics serialize cleanly.
+	summary := llm.Metrics{
+		Timestamp:      time.Now().Format(time.RFC3339),
+		Model:          "test-model",
+		CachedTokens:   100,
+		PromptTokens:   200,
+		ResponseTokens: 300,
+		TotalTokens:    600,
+		SearchQueries:  5,
+		Cost:           1.5,
+		IsSummary:      true,
+	}
+
+	data, err := json.Marshal(summary)
+	if err != nil {
+		t.Fatalf("unexpected marshal error (llm.Metrics should always be serializable): %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty JSON output")
+	}
+
+	// Verify round-trip works.
+	var restored llm.Metrics
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("round-trip unmarshal failed: %v", err)
+	}
+	if restored.PromptTokens != 200 || restored.Cost != 1.5 {
+		t.Errorf("round-trip mismatch: %+v", restored)
+	}
+}
+
+// TestAppendSummaryToLog_WriteError covers gap #3: when fAppend.WriteString
+// fails (e.g., ENOSPC on /dev/full), the error is wrapped and returned.
+func TestAppendSummaryToLog_WriteError(t *testing.T) {
+	// NOT parallel — uses /dev/full which may be contended.
+
+	if _, err := os.Stat("/dev/full"); os.IsNotExist(err) {
+		t.Skip("/dev/full not available on this system")
+	}
+
+	// Non-zero usage bypasses the early-return guard.
+	usage := domain_pricing.UsageStats{
+		PromptTokens: 100,
+	}
+
+	err := appendSummaryToLog("/dev/full", usage, 1.0, "model")
+	if err == nil {
+		t.Fatal("expected write error on /dev/full, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "failed to write cost summary to log") {
+		t.Errorf("error should contain wrap prefix, got: %v", err)
+	}
+}
+
+// TestResolveUsageForSummary_SuccessWithOverrides covers the two remaining
+// uncovered branches in resolveUsageForSummary:
+//  1. The for-range overrides loop body (overrides with entries)
+//  2. The success return path (parseUsage returns no error)
+func TestResolveUsageForSummary_SuccessWithOverrides(t *testing.T) {
+	t.Parallel()
+
+	sm := &mockSM{}
+	tempDir := t.TempDir()
+
+	// Create a valid log file so parseUsage succeeds.
+	logPath := filepath.Join(tempDir, "valid.log")
+	content := `{"model": "test-model", "prompt_tokens": 100, "response_tokens": 50}` + "\n"
+	if err := os.WriteFile(logPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-nil, non-empty overrides to exercise the loop body.
+	overrides := map[string]domain_pricing.ModelPricing{
+		"custom-model": {Hit: 0.05, Miss: 0.5, Comp: 1.0},
+	}
+
+	usage, cost, err := resolveUsageForSummary(context.Background(), sm, nil, logPath, "test-model", overrides)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if usage.PromptTokens != 100 {
+		t.Errorf("expected 100 prompt tokens, got %d", usage.PromptTokens)
+	}
+	if cost < 0 {
+		t.Errorf("expected non-negative cost, got %f", cost)
+	}
+}
+
+// TestAppendSummaryToLog_OpenError covers the openLogFileForAppend error
+// return path inside appendSummaryToLog. A read-only parent directory causes
+// os.OpenFile with O_CREATE to fail with EACCES (not ENOENT), which
+// openLogFileForAppend wraps and returns.
+func TestAppendSummaryToLog_OpenError(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a read-only parent directory (no write permission).
+	roDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(roDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(roDir, 0755) })
+
+	logPath := filepath.Join(roDir, "log.jsonl")
+
+	// Non-zero usage to pass the early-return guard.
+	usage := domain_pricing.UsageStats{PromptTokens: 100}
+
+	err := appendSummaryToLog(logPath, usage, 1.0, "model")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+
+	// The error comes from openLogFileForAppend, passed through unwrapped.
+	if !strings.Contains(err.Error(), "failed to open log file") {
+		t.Errorf("error should contain open failure prefix, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findLogFiles extended tests (Phase 6)
+// ---------------------------------------------------------------------------
+
+func TestFindLogFiles_UnreadableSubdirectory_CallbackError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping chmod-based test in short mode")
+	}
+	// NOT parallel — chmod on temp dirs can interfere.
+	tempDir := t.TempDir()
+
+	// Create a valid tokens.log in a readable subdirectory.
+	validDir := filepath.Join(tempDir, "readable")
+	if err := os.MkdirAll(validDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	validLog := filepath.Join(validDir, "tokens.log")
+	if err := os.WriteFile(validLog, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an unreadable subdirectory so WalkDir's ReadDir fails
+	// with a non-IsNotExist error, exercising the callback's error branch.
+	badDir := filepath.Join(tempDir, "locked")
+	if err := os.MkdirAll(badDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(badDir, 0000); err != nil {
+		t.Skipf("cannot chmod directory (maybe root?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badDir, 0755) })
+
+	ls := &ledgerStore{}
+	files, err := ls.findLogFiles(tempDir)
+	if err != nil {
+		t.Fatalf("findLogFiles returned error: %v", err)
+	}
+
+	found := false
+	for _, f := range files {
+		if filepath.Base(f) == "tokens.log" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("Expected to find tokens.log despite unreadable subdirectory")
+	}
+}
+
+func TestFindLogFiles_NonExistentRoot(t *testing.T) {
+	t.Parallel()
+	ls := &ledgerStore{}
+	// WalkDir invokes the callback with os.IsNotExist for non-existent roots,
+	// and since the callback returns nil, WalkDir also returns nil.
+	files, err := ls.findLogFiles("/nonexistent/path/for/walkdir")
+	if err != nil {
+		t.Fatalf("expected nil error for non-existent root, got: %v", err)
+	}
+	if len(files) != 0 {
+		t.Errorf("expected empty files for non-existent root, got %d entries", len(files))
+	}
 }

--- a/internal/infrastructure/telemetry/ledger_recovery_test.go
+++ b/internal/infrastructure/telemetry/ledger_recovery_test.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -174,4 +175,58 @@ func TestLedgerRecoveryIntegration(t *testing.T) {
 		require.Contains(t, string(content), "mixed/tokens.log")
 		require.True(t, strings.Contains(string(content), "\"total_cost\":3") || strings.Contains(string(content), "\"total_cost\":3.0"))
 	})
+}
+
+// ---------------------------------------------------------------------------
+// loadExistingSessionIDs extended test (Phase 6)
+// ---------------------------------------------------------------------------
+
+func TestLoadExistingSessionIDs_InvalidJSON(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+
+	// Write invalid JSON that cannot be unmarshalled.
+	if err := os.WriteFile(historyPath, []byte("this is not valid json {{{"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := &ledgerStore{}
+	seen := ls.loadExistingSessionIDs(historyPath)
+
+	if len(seen) != 0 {
+		t.Errorf("expected empty map for invalid JSON, got %d entries", len(seen))
+	}
+}
+
+func TestLoadExistingSessionIDs_ValidJSON(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+
+	// Write valid JSON with multiple session records.
+	records := []sessionCostRecord{
+		{Session: "s1", TotalCost: 1.0},
+		{Session: "s2", TotalCost: 2.0},
+		{Session: "s3", TotalCost: 3.0},
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := &ledgerStore{}
+	seen := ls.loadExistingSessionIDs(historyPath)
+
+	if len(seen) != 3 {
+		t.Errorf("expected 3 entries, got %d", len(seen))
+	}
+	for _, r := range records {
+		if !seen[r.Session] {
+			t.Errorf("expected session %q to be in map", r.Session)
+		}
+	}
 }

--- a/internal/infrastructure/telemetry/logger_test.go
+++ b/internal/infrastructure/telemetry/logger_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package telemetry
+
+import (
+	"bytes"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewSlogLogger_NilFallback(t *testing.T) {
+	t.Parallel()
+
+	logger := NewSlogLogger(nil)
+	if logger == nil {
+		t.Fatal("NewSlogLogger(nil) returned nil")
+	}
+
+	// Verify it delegates to slog.Default() by writing and checking output.
+	// We can't easily capture slog.Default() output, but we can verify the type
+	// is our slogLogger wrapper.
+	sl, ok := logger.(*slogLogger)
+	if !ok {
+		t.Fatalf("expected *slogLogger, got %T", logger)
+	}
+	if sl.logger != slog.Default() {
+		t.Error("expected logger to be slog.Default() when nil is passed")
+	}
+}
+
+func TestNewSlogLogger_Custom(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	custom := slog.New(slog.NewTextHandler(&buf, nil))
+	logger := NewSlogLogger(custom)
+
+	if logger == nil {
+		t.Fatal("NewSlogLogger(custom) returned nil")
+	}
+
+	sl, ok := logger.(*slogLogger)
+	if !ok {
+		t.Fatalf("expected *slogLogger, got %T", logger)
+	}
+	if sl.logger != custom {
+		t.Error("expected logger to be the injected custom logger")
+	}
+}
+
+func TestSlogLogger_Delegation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		method  func(logger *slogLogger, msg string)
+		wantLvl string
+		wantMsg string
+	}{
+		{
+			name: "Error",
+			method: func(l *slogLogger, msg string) {
+				l.Error(msg)
+			},
+			wantLvl: "ERROR",
+			wantMsg: "test error message",
+		},
+		{
+			name: "Warn",
+			method: func(l *slogLogger, msg string) {
+				l.Warn(msg)
+			},
+			wantLvl: "WARN",
+			wantMsg: "test warn message",
+		},
+		{
+			name: "Info",
+			method: func(l *slogLogger, msg string) {
+				l.Info(msg)
+			},
+			wantLvl: "INFO",
+			wantMsg: "test info message",
+		},
+		{
+			name: "Debug",
+			method: func(l *slogLogger, msg string) {
+				l.Debug(msg)
+			},
+			wantLvl: "DEBUG",
+			wantMsg: "test debug message",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var buf bytes.Buffer
+			handler := slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+			base := slog.New(handler)
+
+			logger := &slogLogger{logger: base}
+			tt.method(logger, tt.wantMsg)
+
+			output := buf.String()
+			if output == "" {
+				t.Fatal("expected non-empty log output")
+			}
+
+			if !strings.Contains(output, "level="+tt.wantLvl) {
+				t.Errorf("expected level %q in output, got: %s", tt.wantLvl, output)
+			}
+			if !strings.Contains(output, tt.wantMsg) {
+				t.Errorf("expected message %q in output, got: %s", tt.wantMsg, output)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/telemetry/metrics_daily_test.go
+++ b/internal/infrastructure/telemetry/metrics_daily_test.go
@@ -4,6 +4,10 @@
 package telemetry
 
 import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 )
@@ -168,5 +172,106 @@ func TestSessionIDConsistency(t *testing.T) {
 
 	if trackerID != expected {
 		t.Errorf("Final generated ID %q does not match expected %q", trackerID, expected)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetDailyCost extended tests (Phase 6)
+// ---------------------------------------------------------------------------
+
+func TestGetDailyCost_RecoveryInProgress(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	// Create tokens.log so logFile is not empty
+	if err := os.WriteFile(logFile, []byte(`{}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+
+	// Simulate recovery in progress.
+	recoveryInProgress.Store(historyPath, true)
+	t.Cleanup(func() { recoveryInProgress.Delete(historyPath) })
+
+	tracker := &sessionCostTracker{
+		totalCost: 5.0,
+		logFile:   logFile,
+		mode:      "mode",
+	}
+
+	got := tracker.GetDailyCost(context.Background())
+	if got != 5.0 {
+		t.Errorf("expected in-memory cost 5.0 during recovery, got %f", got)
+	}
+}
+
+func TestGetDailyCost_ReadFileNonNotExist(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: os.Chmod(0000) does not prevent reading for the owner.")
+	}
+	// NOT parallel — chmod cleanup sensitive.
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	if err := os.WriteFile(logFile, []byte(`{}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	// Create file with mode 0000 so os.ReadFile fails with permission denied.
+	if err := os.WriteFile(historyPath, []byte("valid"), 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(historyPath, 0644) })
+
+	tracker := &sessionCostTracker{
+		totalCost: 7.5,
+		logFile:   logFile,
+		mode:      "mode",
+	}
+
+	got := tracker.GetDailyCost(context.Background())
+	if got != 7.5 {
+		t.Errorf("expected in-memory cost 7.5 for unreadable ledger, got %f", got)
+	}
+}
+
+func TestGetDailyCost_UnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	if err := os.WriteFile(logFile, []byte(`{}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	// Write invalid JSON that json.Unmarshal will reject.
+	if err := os.WriteFile(historyPath, []byte("not valid {{{ json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &sessionCostTracker{
+		totalCost: 12.0,
+		logFile:   logFile,
+		mode:      "mode",
+	}
+
+	got := tracker.GetDailyCost(context.Background())
+	if got != 12.0 {
+		t.Errorf("expected in-memory cost 12.0 for invalid JSON ledger, got %f", got)
 	}
 }

--- a/internal/infrastructure/telemetry/metrics_summary_test.go
+++ b/internal/infrastructure/telemetry/metrics_summary_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -561,5 +562,79 @@ func TestGetCostSummary_GroupByDateModel(t *testing.T) {
 	expected3 := "| 2023-10-26 | gemini-1.5-pro | 1500 | 500 | 400 | 25.0% | $2.0000 |"
 	if !strings.Contains(summary, expected3) {
 		t.Errorf("summary missing expected row: %s", expected3)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ensureLedgerReady extended tests (Phase 6)
+// ---------------------------------------------------------------------------
+
+func TestEnsureLedgerReady_RecoveryInProgress(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	// Need an outputDir structure so ensureLedgerReady can compute paths.
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	// Pre-create a valid ledger so we don't hit the "missing" branch first.
+	if err := os.WriteFile(historyPath, []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate recovery in progress.
+	recoveryInProgress.Store(historyPath, true)
+	t.Cleanup(func() { recoveryInProgress.Delete(historyPath) })
+
+	m := &metricsManager{
+		logFile: filepath.Join(outputDir, "tokens.log"),
+	}
+	_, status, err := m.ensureLedgerReady(context.Background(), historyPath, tempDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status == "" {
+		t.Fatal("expected non-empty status when recovery is in progress")
+	}
+	if !strings.Contains(status, "recovery is currently in progress") {
+		t.Errorf("unexpected status: %s", status)
+	}
+}
+
+func TestEnsureLedgerReady_ReadFileError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping on Windows: os.Chmod(0000) does not prevent reading for the owner.")
+	}
+	// NOT parallel — chmod cleanup sensitive.
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	// Create file with mode 0000 so os.ReadFile fails with permission denied.
+	if err := os.WriteFile(historyPath, []byte("valid json"), 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(historyPath, 0644) })
+
+	m := &metricsManager{
+		logFile: filepath.Join(outputDir, "tokens.log"),
+	}
+	_, status, err := m.ensureLedgerReady(context.Background(), historyPath, tempDir)
+
+	// Should not error — the function catches ReadFile errors and returns a status.
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if status == "" {
+		t.Fatal("expected non-empty status for unreadable ledger file")
+	}
+	if !strings.Contains(status, "No cost history found") {
+		t.Errorf("unexpected status: %s", status)
 	}
 }

--- a/internal/infrastructure/telemetry/stale_lock_test.go
+++ b/internal/infrastructure/telemetry/stale_lock_test.go
@@ -178,3 +178,393 @@ func TestRecoverLedger_DetectedModel(t *testing.T) {
 		t.Error("Recovered record has wrong model or was not found")
 	}
 }
+
+// =============================================================================
+// releaseLedgerLock error path tests
+// =============================================================================
+
+func TestReleaseLedgerLock_CloseError(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "release_lock_close_error_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+	lockPath := historyPath + ".lock"
+
+	// Create a real lock file
+	if err := os.WriteFile(lockPath, []byte("lock"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Open the lock file to get an *os.File handle
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the underlying file descriptor BEFORE calling releaseLedgerLock.
+	// The subsequent f.Close() inside releaseLedgerLock will return an error
+	// (double-close / use of closed file).
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	// releaseLedgerLock must not panic when Close returns an error,
+	// and os.Remove must still execute (lock file cleaned up).
+	ls.releaseLedgerLock(historyPath, f)
+
+	// Verify lock file was removed despite Close error
+	if _, err := os.Stat(lockPath); err == nil {
+		t.Error("lock file should have been removed even when Close fails")
+	}
+}
+
+func TestReleaseLedgerLock_RemoveError(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "release_lock_remove_error_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+	lockPath := historyPath + ".lock"
+
+	// Create a real lock file
+	if err := os.WriteFile(lockPath, []byte("lock"), 0644); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatal(err)
+	}
+
+	// Open the lock file normally — Close will succeed
+	f, err := os.OpenFile(lockPath, os.O_RDWR, 0644)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	// Make the directory read-only so os.Remove fails with a permission error.
+	// Skip on Windows where Chmod doesn't work the same way.
+	if err := os.Chmod(tmpDir, 0555); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		t.Skipf("cannot chmod tmp dir (likely Windows): %v", err)
+	}
+
+	// Restore permissions for cleanup regardless of outcome
+	defer func() {
+		_ = os.Chmod(tmpDir, 0755)
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	// releaseLedgerLock must not panic when os.Remove fails with a
+	// non-NotExist error (permission denied).
+	ls.releaseLedgerLock(historyPath, f)
+
+	// If we reach here without panic, the error path was handled correctly.
+}
+
+func TestReleaseLedgerLock_NilFile(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "release_lock_nil_file_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	// releaseLedgerLock must not panic when f is nil.
+	// The lock file may or may not exist — the test only asserts no panic.
+	ls.releaseLedgerLock(historyPath, nil)
+
+	// Additionally verify it doesn't panic when the lock file also doesn't exist
+	ls.releaseLedgerLock(historyPath, nil)
+}
+
+// =============================================================================
+// ledgerStore.acquireLedgerLock tests
+// =============================================================================
+
+func TestLedgerStore_AcquireLedgerLock_StaleLock_RemoveSucceeds(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "ls_acquire_stale_ok_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+	lockPath := historyPath + ".lock"
+
+	// Create a stale lock file
+	if err := os.WriteFile(lockPath, []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(lockPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	// acquireLedgerLock should break the stale lock and re-acquire
+	f, err := ls.acquireLedgerLock(historyPath)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected non-nil file handle")
+	}
+
+	// Verify the lock file now exists (was re-created)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("lock file should exist after re-acquire: %v", statErr)
+	}
+
+	// Clean up
+	ls.releaseLedgerLock(historyPath, f)
+
+	// Verify lock was cleaned up
+	if _, statErr := os.Stat(lockPath); statErr == nil {
+		t.Error("lock file should be removed after release")
+	}
+}
+
+func TestLedgerStore_AcquireLedgerLock_FreshLock_NotStale(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "ls_acquire_fresh_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+	lockPath := historyPath + ".lock"
+
+	// Create a fresh lock file (just created, not stale)
+	if err := os.WriteFile(lockPath, []byte("fresh"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	f, err := ls.acquireLedgerLock(historyPath)
+
+	// Must return the original os.IsExist error
+	if !os.IsExist(err) {
+		t.Errorf("expected os.IsExist error, got: %v", err)
+	}
+	if f != nil {
+		t.Error("expected nil file handle for fresh lock conflict")
+	}
+
+	// Verify the lock file was NOT removed (it's still fresh/valid)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("fresh lock file should still exist: %v", statErr)
+	}
+}
+
+func TestLedgerStore_AcquireLedgerLock_StaleLock_RemoveFails(t *testing.T) {
+	// Skip on Windows — chmod doesn't work the same way
+	if err := os.Chmod(t.TempDir(), 0755); err != nil {
+		t.Skipf("skipping on platform without chmod support: %v", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "ls_acquire_remove_fail_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create a subdirectory to hold the lock, so we can make it read-only
+	subDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	historyPath := filepath.Join(subDir, "global_costs.json")
+	lockPath := historyPath + ".lock"
+
+	// Create a stale lock file inside the subdirectory
+	if err := os.WriteFile(lockPath, []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(lockPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory read-only so os.Remove fails with a permission error
+	if err := os.Chmod(subDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(subDir, 0755) }() // restore for cleanup
+
+	ls := newLedgerStore(nil, "test-model", nil)
+
+	f, err := ls.acquireLedgerLock(historyPath)
+
+	// The function should still attempt the second OpenFile even though Remove failed.
+	// In a read-only directory, the lock file still exists after Remove fails, so the
+	// second OpenFile also returns os.IsExist. The key coverage goal is executing the
+	// log.Printf inside the `if err := os.Remove(lockPath)` block (visible in test output).
+	// We verify the function returns without panicking and returns a non-nil error.
+	if err == nil {
+		t.Error("expected error when both Remove and second OpenFile fail")
+	}
+	if f != nil {
+		t.Error("expected nil file handle when acquisition fails")
+	}
+
+	// Restore permissions so cleanup can proceed
+	_ = os.Chmod(subDir, 0755)
+}
+
+// =============================================================================
+// metricsManager.acquireLedgerLock tests
+// =============================================================================
+
+func TestMetricsManager_AcquireLedgerLock_StaleLock_RemoveSucceeds(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "mm_acquire_stale_ok_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	lockPath := filepath.Join(tmpDir, "test.lock")
+
+	// Create a stale lock file
+	if err := os.WriteFile(lockPath, []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(lockPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &metricsManager{}
+
+	f, err := m.acquireLedgerLock(lockPath)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if f == nil {
+		t.Fatal("expected non-nil file handle")
+	}
+
+	// Verify the lock file now exists (was re-created)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("lock file should exist after re-acquire: %v", statErr)
+	}
+
+	// Clean up
+	if closeErr := f.Close(); closeErr != nil {
+		t.Logf("close error (non-fatal): %v", closeErr)
+	}
+	if removeErr := os.Remove(lockPath); removeErr != nil {
+		t.Logf("remove error (non-fatal): %v", removeErr)
+	}
+
+	// Verify lock was cleaned up
+	if _, statErr := os.Stat(lockPath); statErr == nil {
+		t.Error("lock file should be removed after cleanup")
+	}
+}
+
+func TestMetricsManager_AcquireLedgerLock_FreshLock_NotStale(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := os.MkdirTemp("", "mm_acquire_fresh_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	lockPath := filepath.Join(tmpDir, "test.lock")
+
+	// Create a fresh lock file (just created, not stale)
+	if err := os.WriteFile(lockPath, []byte("fresh"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &metricsManager{}
+
+	f, err := m.acquireLedgerLock(lockPath)
+
+	// Must return the original os.IsExist error
+	if !os.IsExist(err) {
+		t.Errorf("expected os.IsExist error, got: %v", err)
+	}
+	if f != nil {
+		t.Error("expected nil file handle for fresh lock conflict")
+	}
+
+	// Verify the lock file was NOT removed (it's still fresh/valid)
+	if _, statErr := os.Stat(lockPath); statErr != nil {
+		t.Errorf("fresh lock file should still exist: %v", statErr)
+	}
+}
+
+func TestMetricsManager_AcquireLedgerLock_StaleLock_RemoveFails(t *testing.T) {
+	// Skip on Windows — chmod doesn't work the same way
+	if err := os.Chmod(t.TempDir(), 0755); err != nil {
+		t.Skipf("skipping on platform without chmod support: %v", err)
+	}
+
+	tmpDir, err := os.MkdirTemp("", "mm_acquire_remove_fail_test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	// Create a subdirectory to hold the lock, so we can make it read-only
+	subDir := filepath.Join(tmpDir, "readonly")
+	if err := os.Mkdir(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	lockPath := filepath.Join(subDir, "test.lock")
+
+	// Create a stale lock file inside the subdirectory
+	if err := os.WriteFile(lockPath, []byte("stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(lockPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	// Make the directory read-only so os.Remove fails with a permission error
+	if err := os.Chmod(subDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chmod(subDir, 0755) }() // restore for cleanup
+
+	m := &metricsManager{}
+
+	f, err := m.acquireLedgerLock(lockPath)
+
+	// The function should still attempt the second OpenFile even though Remove failed.
+	// In a read-only directory, the lock file still exists after Remove fails, so the
+	// second OpenFile also returns os.IsExist. The key coverage goal is executing the
+	// log.Printf inside the `if err := os.Remove(lockPath)` block (visible in test output).
+	// We verify the function returns without panicking and returns a non-nil error.
+	if err == nil {
+		t.Error("expected error when both Remove and second OpenFile fail")
+	}
+	if f != nil {
+		t.Error("expected nil file handle when acquisition fails")
+	}
+
+	// Restore permissions so cleanup can proceed
+	_ = os.Chmod(subDir, 0755)
+}


### PR DESCRIPTION
Closes #398.

## Summary
Error path hardening for the telemetry infrastructure package. Added ~35 table-driven tests across 6 files, covering all architectural blockers and technical debt items identified in the issue.

## Key Changes
| Function | Before | After |
|---|---|---|
| `openLogFileForAppend` | 30.0% | 100.0% |
| `releaseLedgerLock` | 57.1% | 100.0% |
| `acquireLedgerLock` (×2) | 62.5%/85.7% | 100.0% |
| `findLogFiles` | 63.6% | 100.0% |
| `loadExistingSessionIDs` | 72.7% | 100.0% |
| `resolveUsageForSummary` | 75.0% | 100.0% |
| `NewSlogLogger` | 0.0% | 100.0% |
| `logTrace` | 52.9% | 82.4%* |
| `ensureLedgerReady` | 75.0% | 91.7% |
| `GetDailyCost` | 76.2% | 95.2% |
| **Package total** | **82.4%** | **93.4%** |

\*logTrace at practical maximum — remaining branches are unreachable defensive guards.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage | 93.4% (≥90%) |
| Tests with -race | PASS |
| No regressions | PASS |