### PR TITLE
fix(sop): add self-referencing SOP path to example prompt

### DIFF
--- a/docs/sop/lifecycle/issue_to_pr_orchestration.md
+++ b/docs/sop/lifecycle/issue_to_pr_orchestration.md
@@ -56,7 +56,7 @@ Communication is **asynchronous and turn-based**. The Orchestrator is the hub â€
 
 **Example prompt to the AI orchestrator:**
 ```
-Execute the Issue-to-PR SOP.
+Execute the Issue-to-PR SOP as defined in docs/sop/lifecycle/issue_to_pr_orchestration.md.
 Ask me for the GitHub issue number if I haven't provided one.
 
 Find the Architect and Coder config files. Try these paths, in order:


### PR DESCRIPTION
## Summary
Add the SOP file path (`docs/sop/lifecycle/issue_to_pr_orchestration.md`) as the first line of the example orchestrator prompt so the AI knows exactly which SOP to execute.

## Verification
- [x] Only expected file changed