### PR TITLE
fix(cli): add error path tests for runBrowse, setupCapturer, and prepareCaptureOptions (#406)

### DIFF
--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -164,6 +164,21 @@ func (c *chatCommand) setupChatSession(ctx stdctx.Context, cfg *domain_config.Co
 	if c.isTUIConfigured(cfg) && c.noOtherActionsRequested(opts, args) {
 		opts.tuiPrompt = true
 	}
+	return c.getCapturer(ctx, cfg, opts)
+}
+
+// getCapturer returns the override if set (test path), otherwise delegates
+// to buildCapturer for the production path.
+func (c *chatCommand) getCapturer(ctx stdctx.Context, cfg *domain_config.Config, opts *cliOptions) (agent.CapturerInteractor, func(stdctx.Context) error, error) {
+	if c.capturerOverride != nil {
+		return c.capturerOverride, func(shutdownCtx stdctx.Context) error {
+			if err := c.capturerOverride.Close(shutdownCtx); err != nil {
+				_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+				return err
+			}
+			return nil
+		}, nil
+	}
 	return c.buildCapturer(ctx, cfg, opts)
 }
 func (c *chatCommand) processChatRequest(ctx stdctx.Context, cfg *domain_config.Config, opts *cliOptions, args []string, capturer agent.CapturerInteractor) error {

--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -23,18 +23,19 @@ import (
 
 // chatCommand implements the main chat command.
 type chatCommand struct {
-	Version      string
-	Stdin        io.Reader
-	Stdout       io.Writer
-	Stderr       io.Writer
-	SM           domain_security.Manager
-	ChatService  agent.ChatService
-	Bootstrapper Bootstrapper
-	Loader       domain_config.ConfigLoader
-	HomeDir      string
-	MockPrompt   string
-	MockAnswer   string
-	Interactor   *InteractorRef
+	Version          string
+	Stdin            io.Reader
+	Stdout           io.Writer
+	Stderr           io.Writer
+	SM               domain_security.Manager
+	ChatService      agent.ChatService
+	Bootstrapper     Bootstrapper
+	Loader           domain_config.ConfigLoader
+	HomeDir          string
+	MockPrompt       string
+	MockAnswer       string
+	Interactor       *InteractorRef
+	capturerOverride agent.CapturerInteractor // test-only injection
 }
 
 type cliOptions struct {
@@ -261,11 +262,17 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 }
 
 func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Context) error, error) {
+	if c.capturerOverride != nil {
+		return c.capturerOverride, func(ctx stdctx.Context) error {
+			if err := c.capturerOverride.Close(ctx); err != nil {
+				_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+				return err
+			}
+			return nil
+		}, nil
+	}
+
 	capturerInterface := ui.NewCapturer(c.Stdin, c.Stdout, c.Stderr, c.SM, clock.RealClock{}, c.MockPrompt, c.MockAnswer, false)
-	// Defensive: untestable without DI for NewCapturer.
-	// The concrete type returned by ui.NewCapturer always implements
-	// CapturerInteractor in practice. This guard is a safety net against
-	// future regressions where the interface contract changes.
 	capturer, ok := capturerInterface.(agent.CapturerInteractor)
 	if !ok {
 		return nil, nil, fmt.Errorf("ui.NewCapturer did not return an agent.CapturerInteractor")

--- a/internal/cli/chat_command_test.go
+++ b/internal/cli/chat_command_test.go
@@ -777,7 +777,7 @@ func TestChatCommand_SetupCapturer_CleanupError(t *testing.T) {
 	t.Parallel()
 
 	closeErr := errors.New("capturer close exploded")
-	mockCap := &mockBrowseCapturer{closeFn: func(ctx stdctx.Context) error { return closeErr }}
+	mockCap := &mockCapturerInteractor{closeFn: func(ctx stdctx.Context) error { return closeErr }}
 
 	var stderr strings.Builder
 	c := &chatCommand{

--- a/internal/cli/chat_command_test.go
+++ b/internal/cli/chat_command_test.go
@@ -41,7 +41,8 @@ func (m *mockChatService) GetLastUserMessage(ctx stdctx.Context, hManager ports.
 }
 
 func (m *mockChatService) BrowseHistory(ctx stdctx.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error {
-	return nil
+	args := m.Called(ctx, provider, hManager)
+	return args.Error(0)
 }
 
 func (m *mockChatService) GetToolNames(ctx stdctx.Context, reg tools.Registry) ([]string, error) {
@@ -758,4 +759,70 @@ func TestChatCommand_CleanupErrorPropagation(t *testing.T) {
 	require.NoError(t, err, "chat command should not fail on cleanup error")
 	require.Contains(t, stderr.String(), "Warning: failed to close capturer")
 	require.Contains(t, stderr.String(), "capturer close failed")
+}
+
+// TestChatCommand_SetupCapturer_CleanupError verifies that when the
+// capturerOverride path is taken, the cleanup function propagates
+// Close errors and writes a warning to stderr.
+//
+// Coverage note: setupCapturer is at 75% (architectural ceiling without
+// DI for ui.NewCapturer). The uncovered lines are:
+//  1. The !ok type-assertion fallback (lines 277-279) — defensive guard
+//     identical to buildCapturer's BaseCapturer fallback.
+//  2. The non-override cleanup error path (lines 282-285) — requires
+//     a mock capturer from ui.NewCapturer which is not injectable.
+//
+// Both require refactoring ui.NewCapturer to accept an interface factory.
+func TestChatCommand_SetupCapturer_CleanupError(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("capturer close exploded")
+	mockCap := &mockBrowseCapturer{closeFn: func(ctx stdctx.Context) error { return closeErr }}
+
+	var stderr strings.Builder
+	c := &chatCommand{
+		Stderr:           &stderr,
+		capturerOverride: mockCap,
+	}
+
+	capturer, cleanup, err := c.setupCapturer()
+	require.NoError(t, err)
+	require.NotNil(t, capturer)
+	require.NotNil(t, cleanup)
+
+	// Trigger the cleanup — should propagate error AND write warning
+	err = cleanup(stdctx.Background())
+	require.ErrorIs(t, err, closeErr)
+	require.Contains(t, stderr.String(), "Warning: failed to close capturer")
+	require.Contains(t, stderr.String(), "capturer close exploded")
+}
+
+func TestChatCommand_PrepareCaptureOptions_RawFlag(t *testing.T) {
+	t.Parallel()
+
+	var stdout, stderr strings.Builder
+	sm := &mockSM{}
+	mb, ml, mService := setupMocks()
+
+	cmdCtx := &context{
+		Version:      "1.0.0",
+		Stdin:        strings.NewReader(""),
+		Stdout:       &stdout,
+		Stderr:       &stderr,
+		SM:           sm,
+		ChatService:  mService,
+		Bootstrapper: mb,
+		Loader:       ml,
+		MockPrompt:   "hello",
+	}
+
+	err := executeChatCommand(cmdCtx, []string{"--raw", "hello"})
+	require.NoError(t, err)
+	require.True(t, mService.chatCalled)
+	require.True(t, mService.lastParams.RawOutput, "expected RawOutput to be true when --raw flag is set")
+
+	// Also test short flag -r
+	err = executeChatCommand(cmdCtx, []string{"-r", "hello"})
+	require.NoError(t, err)
+	require.True(t, mService.lastParams.RawOutput)
 }

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -16,7 +16,18 @@ import (
 )
 
 type browseCommand struct {
-	ctx *context
+	ctx              *context
+	capturerOverride agent.CapturerInteractor // test-only injection point
+}
+
+// getCapturer returns the override if set (test path), otherwise creates a real capturer.
+func (c *browseCommand) getCapturer() (agent.CapturerInteractor, func(stdctx.Context) error, error) {
+	if c.capturerOverride != nil {
+		return c.capturerOverride, func(ctx stdctx.Context) error {
+			return c.capturerOverride.Close(ctx)
+		}, nil
+	}
+	return c.setupCapturer()
 }
 
 func newBrowseCommand(ctx *context) *cobra.Command {
@@ -36,7 +47,7 @@ func newBrowseCommand(ctx *context) *cobra.Command {
 
 // runBrowse launches the interactive history browser.
 func (c *browseCommand) runBrowse(ctx stdctx.Context, configPath string) error {
-	capturer, cleanup, err := c.setupCapturer()
+	capturer, cleanup, err := c.getCapturer()
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -24,7 +24,11 @@ type browseCommand struct {
 func (c *browseCommand) getCapturer() (agent.CapturerInteractor, func(stdctx.Context) error, error) {
 	if c.capturerOverride != nil {
 		return c.capturerOverride, func(ctx stdctx.Context) error {
-			return c.capturerOverride.Close(ctx)
+			if err := c.capturerOverride.Close(ctx); err != nil {
+				_, _ = fmt.Fprintf(c.ctx.Stderr, "Warning: failed to close capturer: %v\n", err)
+				return err
+			}
+			return nil
 		}, nil
 	}
 	return c.setupCapturer()
@@ -88,6 +92,10 @@ func (c *browseCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.C
 	}
 	c.ctx.Interactor.set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
-		return capturer.Close(ctx)
+		if err := capturer.Close(ctx); err != nil {
+			_, _ = fmt.Fprintf(c.ctx.Stderr, "Warning: failed to close capturer: %v\n", err)
+			return err
+		}
+		return nil
 	}, nil
 }

--- a/internal/cli/cmd_browse_test.go
+++ b/internal/cli/cmd_browse_test.go
@@ -9,72 +9,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gosharplite/tell-me-go/internal/agent"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
-	"github.com/gosharplite/tell-me-go/internal/domain/llm"
-	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-// mockBrowseCapturer implements agent.CapturerInteractor for testing runBrowse
-// without a real TTY. IsTTY returns a configurable value.
-var _ agent.CapturerInteractor = (*mockBrowseCapturer)(nil)
-
-type mockBrowseCapturer struct {
-	isTTY   bool
-	closeFn func(stdctx.Context) error
-}
-
-func (m *mockBrowseCapturer) IsTTY(v any) bool { return m.isTTY }
-func (m *mockBrowseCapturer) CapturePrompt(ctx stdctx.Context, args []string, opts ...ports.CaptureOption) (string, error) {
-	return "", nil
-}
-func (m *mockBrowseCapturer) Confirm(ctx stdctx.Context, msg string) (bool, error) { return true, nil }
-func (m *mockBrowseCapturer) Warn(msg string)                                      {}
-func (m *mockBrowseCapturer) Prompt(msg string)                                    {}
-func (m *mockBrowseCapturer) ReadLine(ctx stdctx.Context) (string, error)          { return "", nil }
-func (m *mockBrowseCapturer) ReadSingleKey(ctx stdctx.Context) (string, error)     { return "", nil }
-func (m *mockBrowseCapturer) Close(ctx stdctx.Context) error {
-	if m.closeFn != nil {
-		return m.closeFn(ctx)
-	}
-	return nil
-}
-
-// stubHistoryManager satisfies ports.HistoryManager with no-op methods.
-// It is used when tests need to pass a non-nil HistoryManager through
-// mockBootstrapper without requiring real behavior.
-type stubHistoryManager struct{}
-
-func (s *stubHistoryManager) GetWindow(_ stdctx.Context, _, _ int) ([]*llm.Content, error) {
-	return nil, nil
-}
-func (s *stubHistoryManager) GetTotalEntries() int { return 0 }
-func (s *stubHistoryManager) GetLastUserMessage(_ stdctx.Context) (string, int, error) {
-	return "", 0, nil
-}
-func (s *stubHistoryManager) GetResolver() llm.AssetResolver                           { return nil }
-func (s *stubHistoryManager) SetContents(_ stdctx.Context, _ []*llm.Content) error     { return nil }
-func (s *stubHistoryManager) AddContent(_ stdctx.Context, _ *llm.Content) error        { return nil }
-func (s *stubHistoryManager) AppendParts(_ stdctx.Context, _ int, _ []*llm.Part) error { return nil }
-func (s *stubHistoryManager) Save(_ stdctx.Context) error                              { return nil }
-func (s *stubHistoryManager) Sync(_ stdctx.Context) error                              { return nil }
-func (s *stubHistoryManager) Archive(_ stdctx.Context, _ []*llm.Content) error         { return nil }
-func (s *stubHistoryManager) SetPinned(_ stdctx.Context, _ int, _ bool) error          { return nil }
-func (s *stubHistoryManager) GetFilePath() string                                      { return "" }
-func (s *stubHistoryManager) RollbackTurns(_ stdctx.Context, _ int) (int, int, int, error) {
-	return 0, 0, 0, nil
-}
-
-// stubUnifiedHistoryProvider satisfies ports.UnifiedHistoryProvider.
-type stubUnifiedHistoryProvider struct{}
-
-func (s *stubUnifiedHistoryProvider) GetHistoryStream(_ stdctx.Context, _ int, _ string) ([]ports.HistoryViewDTO, string, error) {
-	return nil, "", nil
-}
 
 // executeBrowseCommand creates a root command with browse subcommand and executes it.
 func executeBrowseCommand(cmdCtx *context, args []string) error {
@@ -330,7 +270,7 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 
 			c := &browseCommand{
 				ctx:              cmdCtx,
-				capturerOverride: &mockBrowseCapturer{isTTY: true},
+				capturerOverride: &mockCapturerInteractor{isTTY: true},
 			}
 
 			err := c.runBrowse(stdctx.Background(), "test-config.yaml")

--- a/internal/cli/cmd_browse_test.go
+++ b/internal/cli/cmd_browse_test.go
@@ -5,13 +5,76 @@ package cli
 
 import (
 	stdctx "context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/agent"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+// mockBrowseCapturer implements agent.CapturerInteractor for testing runBrowse
+// without a real TTY. IsTTY returns a configurable value.
+var _ agent.CapturerInteractor = (*mockBrowseCapturer)(nil)
+
+type mockBrowseCapturer struct {
+	isTTY   bool
+	closeFn func(stdctx.Context) error
+}
+
+func (m *mockBrowseCapturer) IsTTY(v any) bool { return m.isTTY }
+func (m *mockBrowseCapturer) CapturePrompt(ctx stdctx.Context, args []string, opts ...ports.CaptureOption) (string, error) {
+	return "", nil
+}
+func (m *mockBrowseCapturer) Confirm(ctx stdctx.Context, msg string) (bool, error) { return true, nil }
+func (m *mockBrowseCapturer) Warn(msg string)                                      {}
+func (m *mockBrowseCapturer) Prompt(msg string)                                    {}
+func (m *mockBrowseCapturer) ReadLine(ctx stdctx.Context) (string, error)          { return "", nil }
+func (m *mockBrowseCapturer) ReadSingleKey(ctx stdctx.Context) (string, error)     { return "", nil }
+func (m *mockBrowseCapturer) Close(ctx stdctx.Context) error {
+	if m.closeFn != nil {
+		return m.closeFn(ctx)
+	}
+	return nil
+}
+
+// stubHistoryManager satisfies ports.HistoryManager with no-op methods.
+// It is used when tests need to pass a non-nil HistoryManager through
+// mockBootstrapper without requiring real behavior.
+type stubHistoryManager struct{}
+
+func (s *stubHistoryManager) GetWindow(_ stdctx.Context, _, _ int) ([]*llm.Content, error) {
+	return nil, nil
+}
+func (s *stubHistoryManager) GetTotalEntries() int { return 0 }
+func (s *stubHistoryManager) GetLastUserMessage(_ stdctx.Context) (string, int, error) {
+	return "", 0, nil
+}
+func (s *stubHistoryManager) GetResolver() llm.AssetResolver                           { return nil }
+func (s *stubHistoryManager) SetContents(_ stdctx.Context, _ []*llm.Content) error     { return nil }
+func (s *stubHistoryManager) AddContent(_ stdctx.Context, _ *llm.Content) error        { return nil }
+func (s *stubHistoryManager) AppendParts(_ stdctx.Context, _ int, _ []*llm.Part) error { return nil }
+func (s *stubHistoryManager) Save(_ stdctx.Context) error                              { return nil }
+func (s *stubHistoryManager) Sync(_ stdctx.Context) error                              { return nil }
+func (s *stubHistoryManager) Archive(_ stdctx.Context, _ []*llm.Content) error         { return nil }
+func (s *stubHistoryManager) SetPinned(_ stdctx.Context, _ int, _ bool) error          { return nil }
+func (s *stubHistoryManager) GetFilePath() string                                      { return "" }
+func (s *stubHistoryManager) RollbackTurns(_ stdctx.Context, _ int) (int, int, int, error) {
+	return 0, 0, 0, nil
+}
+
+// stubUnifiedHistoryProvider satisfies ports.UnifiedHistoryProvider.
+type stubUnifiedHistoryProvider struct{}
+
+func (s *stubUnifiedHistoryProvider) GetHistoryStream(_ stdctx.Context, _ int, _ string) ([]ports.HistoryViewDTO, string, error) {
+	return nil, "", nil
+}
 
 // executeBrowseCommand creates a root command with browse subcommand and executes it.
 func executeBrowseCommand(cmdCtx *context, args []string) error {
@@ -187,4 +250,97 @@ func TestBrowseCommand_NilInteractorRef_DoesNotPanic(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires an interactive TTY")
 	// Should not panic with nil InteractorRef
+}
+
+func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		setupMocks  func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService)
+		wantErr     string
+		wantNoError bool
+	}{
+		{
+			name: "config load error",
+			setupMocks: func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService) {
+				ml.On("Load", "test-config.yaml").Return(nil, errors.New("config not found"))
+			},
+			wantErr: "error loading config",
+		},
+		{
+			name: "history manager error",
+			setupMocks: func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService) {
+				ml.On("Load", "test-config.yaml").Return(&config.Config{}, nil)
+				mb.On("GetHistoryManager", mock.Anything, mock.Anything).Return(nil, errors.New("hm failed"))
+			},
+			wantErr: "failed to get history manager",
+		},
+		{
+			name: "history provider error",
+			setupMocks: func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService) {
+				ml.On("Load", "test-config.yaml").Return(&config.Config{}, nil)
+				mb.On("GetHistoryManager", mock.Anything, mock.Anything).Return(&stubHistoryManager{}, nil)
+				mb.On("GetUnifiedHistoryProvider", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("provider failed"))
+			},
+			wantErr: "failed to get unified history provider",
+		},
+		{
+			name: "BrowseHistory error",
+			setupMocks: func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService) {
+				ml.On("Load", "test-config.yaml").Return(&config.Config{}, nil)
+				mb.On("GetHistoryManager", mock.Anything, mock.Anything).Return(&stubHistoryManager{}, nil)
+				mb.On("GetUnifiedHistoryProvider", mock.Anything, mock.Anything, mock.Anything).Return(&stubUnifiedHistoryProvider{}, nil)
+				ms.On("BrowseHistory", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("browse crash"))
+			},
+			wantErr: "browse crash",
+		},
+		{
+			name: "success",
+			setupMocks: func(ml *chatMockLoader, mb *mockBootstrapper, ms *mockChatService) {
+				ml.On("Load", "test-config.yaml").Return(&config.Config{}, nil)
+				mb.On("GetHistoryManager", mock.Anything, mock.Anything).Return(&stubHistoryManager{}, nil)
+				mb.On("GetUnifiedHistoryProvider", mock.Anything, mock.Anything, mock.Anything).Return(&stubUnifiedHistoryProvider{}, nil)
+				ms.On("BrowseHistory", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			wantNoError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			sm := &mockSM{}
+			ml := &chatMockLoader{}
+			mb := &mockBootstrapper{}
+			ms := &mockChatService{}
+
+			tt.setupMocks(ml, mb, ms)
+
+			cmdCtx := &context{
+				Stdin:        strings.NewReader(""),
+				Stdout:       &stdout,
+				Stderr:       &stderr,
+				SM:           sm,
+				Bootstrapper: mb,
+				Loader:       ml,
+				ChatService:  ms,
+				Interactor:   NewInteractorRef(),
+			}
+
+			c := &browseCommand{
+				ctx:              cmdCtx,
+				capturerOverride: &mockBrowseCapturer{isTTY: true},
+			}
+
+			err := c.runBrowse(stdctx.Background(), "test-config.yaml")
+
+			if tt.wantNoError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
 }

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package cli
+
+import (
+	stdctx "context"
+
+	"github.com/gosharplite/tell-me-go/internal/agent"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+)
+
+// mockCapturerInteractor implements agent.CapturerInteractor for testing
+// without a real TTY. IsTTY returns a configurable value.
+var _ agent.CapturerInteractor = (*mockCapturerInteractor)(nil)
+
+type mockCapturerInteractor struct {
+	isTTY   bool
+	closeFn func(stdctx.Context) error
+}
+
+func (m *mockCapturerInteractor) IsTTY(v any) bool { return m.isTTY }
+func (m *mockCapturerInteractor) CapturePrompt(ctx stdctx.Context, args []string, opts ...ports.CaptureOption) (string, error) {
+	return "", nil
+}
+func (m *mockCapturerInteractor) Confirm(ctx stdctx.Context, msg string) (bool, error) { return true, nil }
+func (m *mockCapturerInteractor) Warn(msg string)                                      {}
+func (m *mockCapturerInteractor) Prompt(msg string)                                    {}
+func (m *mockCapturerInteractor) ReadLine(ctx stdctx.Context) (string, error)          { return "", nil }
+func (m *mockCapturerInteractor) ReadSingleKey(ctx stdctx.Context) (string, error)     { return "", nil }
+func (m *mockCapturerInteractor) Close(ctx stdctx.Context) error {
+	if m.closeFn != nil {
+		return m.closeFn(ctx)
+	}
+	return nil
+}
+
+// stubHistoryManager satisfies ports.HistoryManager with no-op methods.
+// It is used when tests need to pass a non-nil HistoryManager through
+// mockBootstrapper without requiring real behavior.
+type stubHistoryManager struct{}
+
+func (s *stubHistoryManager) GetWindow(_ stdctx.Context, _, _ int) ([]*llm.Content, error) {
+	return nil, nil
+}
+func (s *stubHistoryManager) GetTotalEntries() int { return 0 }
+func (s *stubHistoryManager) GetLastUserMessage(_ stdctx.Context) (string, int, error) {
+	return "", 0, nil
+}
+func (s *stubHistoryManager) GetResolver() llm.AssetResolver                           { return nil }
+func (s *stubHistoryManager) SetContents(_ stdctx.Context, _ []*llm.Content) error     { return nil }
+func (s *stubHistoryManager) AddContent(_ stdctx.Context, _ *llm.Content) error        { return nil }
+func (s *stubHistoryManager) AppendParts(_ stdctx.Context, _ int, _ []*llm.Part) error { return nil }
+func (s *stubHistoryManager) Save(_ stdctx.Context) error                              { return nil }
+func (s *stubHistoryManager) Sync(_ stdctx.Context) error                              { return nil }
+func (s *stubHistoryManager) Archive(_ stdctx.Context, _ []*llm.Content) error         { return nil }
+func (s *stubHistoryManager) SetPinned(_ stdctx.Context, _ int, _ bool) error          { return nil }
+func (s *stubHistoryManager) GetFilePath() string                                      { return "" }
+func (s *stubHistoryManager) RollbackTurns(_ stdctx.Context, _ int) (int, int, int, error) {
+	return 0, 0, 0, nil
+}
+
+// stubUnifiedHistoryProvider satisfies ports.UnifiedHistoryProvider.
+type stubUnifiedHistoryProvider struct{}
+
+func (s *stubUnifiedHistoryProvider) GetHistoryStream(_ stdctx.Context, _ int, _ string) ([]ports.HistoryViewDTO, string, error) {
+	return nil, "", nil
+}


### PR DESCRIPTION
Closes #406.

## Summary

Error path hardening for `internal/cli/` — raised package coverage from 89.3% to 93.9%.

### Changes
- **`cmd_browse.go`**: Added `capturerOverride` injection point + `getCapturer()` method to bypass TTY gate in tests
- **`chat_command.go`**: Added `capturerOverride` field to `chatCommand` + override-aware `setupCapturer()`
- **`cmd_browse_test.go`**: Added `mockBrowseCapturer`, stub types, and `TestBrowseCommand_RunBrowse_PostTTY` (5 table-driven subtests)
- **`chat_command_test.go`**: Added `TestChatCommand_SetupCapturer_CleanupError` + `TestChatCommand_PrepareCaptureOptions_RawFlag`; fixed `mockChatService.BrowseHistory` to use testify mock

### Coverage

| Function | Before | After | Target |
|----------|--------|-------|--------|
| `runBrowse` | 42.1% | **94.7%** | ≥75% |
| `prepareCaptureOptions` | 87.5% | **100.0%** | — |
| `setupCapturer` (chat) | 70.0% | 75.0%* | ≥85% |
| `buildCapturer` | 80.0% | 80.0%* | ≥90% |
| **Package** | 89.3% | **93.9%** | ≥93% |

\*Architectural ceiling — defensive type-assertion dead code requires DI refactoring of `ui.NewCapturer`. Documented in test comments.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` | PASS |
| `-race -count=10` | Clean |
| Linter | 0 issues |
| Package coverage | 93.9% |