### PR TITLE
fix(registry,security): close error handling gaps, achieve 100% coverage (#419)

### DIFF
--- a/internal/domain/security/service_test.go
+++ b/internal/domain/security/service_test.go
@@ -172,3 +172,71 @@ func TestSafetyService_IsSafeGoSubcommand(t *testing.T) {
 		})
 	}
 }
+
+func TestSafetyService_IsSafeGhSubcommand(t *testing.T) {
+	t.Parallel()
+	s := NewSafetyService(DefaultPolicy())
+	tests := []struct {
+		name string
+		sub  string
+		want bool
+	}{
+		{"auth", "auth", true},
+		{"pr", "pr", true},
+		{"push", "push", false},
+		{"unknown-subcommand", "unknown-subcommand", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := s.IsSafeGhSubcommand(tt.sub); got != tt.want {
+				t.Errorf("IsSafeGhSubcommand(%q) = %v, want %v", tt.sub, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("all_default_safe_subcommands", func(t *testing.T) {
+		t.Parallel()
+		for k := range DefaultPolicy().SafeGhSubcommands {
+			if !s.IsSafeGhSubcommand(k) {
+				t.Errorf("IsSafeGhSubcommand(%q) = false, want true", k)
+			}
+		}
+	})
+}
+
+func TestSafetyService_IsSafeAzSubcommand(t *testing.T) {
+	t.Parallel()
+	s := NewSafetyService(DefaultPolicy())
+	tests := []struct {
+		name string
+		sub  string
+		want bool
+	}{
+		{"devops", "devops", true},
+		{"account", "account", true},
+		{"vm", "vm", false},
+		{"unknown-subcommand", "unknown-subcommand", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := s.IsSafeAzSubcommand(tt.sub); got != tt.want {
+				t.Errorf("IsSafeAzSubcommand(%q) = %v, want %v", tt.sub, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("all_default_safe_subcommands", func(t *testing.T) {
+		t.Parallel()
+		for k := range DefaultPolicy().SafeAzSubcommands {
+			if !s.IsSafeAzSubcommand(k) {
+				t.Errorf("IsSafeAzSubcommand(%q) = false, want true", k)
+			}
+		}
+	})
+}

--- a/internal/infrastructure/registry/coverage_test.go
+++ b/internal/infrastructure/registry/coverage_test.go
@@ -56,6 +56,75 @@ func TestRegistry_DuplicateRegistration(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "re-register to different toolkit",
+			actions: func(t *testing.T, r tools.Registry) {
+				def1 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v1"}
+				h1 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+					return tools.ToolResult{Text: "v1"}, nil
+				}
+				if err := r.RegisterToToolkit("core", def1, h1); err != nil {
+					t.Fatalf("failed to register tool to core: %v", err)
+				}
+
+				def2 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v2"}
+				h2 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+					return tools.ToolResult{Text: "v2"}, nil
+				}
+				if err := r.RegisterToToolkitWithOptions("git", def2, h2, registry.ToolOptions{LongRunning: true}); err != nil {
+					t.Fatalf("failed to re-register tool to git: %v", err)
+				}
+			},
+			validate: func(t *testing.T, r tools.Registry) {
+				// 1. cross_tool remains in core declarations
+				coreDecls := r.GetCoreDeclarations()
+				foundInCore := false
+				for _, d := range coreDecls {
+					if d.Name == "cross_tool" {
+						foundInCore = true
+						break
+					}
+				}
+				if !foundInCore {
+					t.Errorf("expected cross_tool to remain in core declarations")
+				}
+
+				// 2. cross_tool also appears in git toolkit declarations
+				gitDecls := r.GetDeclarationsByToolkits([]string{"git"})
+				foundInGit := false
+				for _, d := range gitDecls {
+					if d.Name == "cross_tool" {
+						foundInGit = true
+						break
+					}
+				}
+				if !foundInGit {
+					t.Errorf("expected cross_tool to appear in git toolkit declarations")
+				}
+
+				// 3. Only one entry (no duplication)
+				decls := r.GetDeclarations()
+				if len(decls) != 1 {
+					t.Errorf("expected 1 declaration, got %d", len(decls))
+				}
+
+				// 4. Declaration was updated
+				if len(decls) > 0 && decls[0].Description != "desc_v2" {
+					t.Errorf("expected updated description 'desc_v2', got '%s'", decls[0].Description)
+				}
+
+				// 5. Options were updated (LongRunning enabled)
+				if !r.IsLongRunning("cross_tool") {
+					t.Errorf("expected cross_tool to be long-running after update")
+				}
+
+				// 6. Handler was updated
+				res, _ := r.Execute(context.Background(), "cross_tool", nil, nil)
+				if res.Text != "v2" {
+					t.Errorf("expected updated handler to return 'v2', got '%s'", res.Text)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/infrastructure/registry/registry_test.go
+++ b/internal/infrastructure/registry/registry_test.go
@@ -158,6 +158,25 @@ func TestRegistry_Toolkits(t *testing.T) {
 		assert.True(t, tks["git"])
 		assert.True(t, tks["k8s"])
 	})
+
+	t.Run("GetDeclarationsByToolkits - core explicitly requested", func(t *testing.T) {
+		// Explicitly requesting "core" should not double-add core tools.
+		decls := r.GetDeclarationsByToolkits([]string{"core"})
+		assert.Len(t, decls, 1)
+		assert.Equal(t, "core1", decls[0].Name)
+
+		// Requesting "core" alongside "git" should still dedupe correctly.
+		decls = r.GetDeclarationsByToolkits([]string{"core", "git"})
+		assert.Len(t, decls, 3)
+
+		freq := make(map[string]int)
+		for _, d := range decls {
+			freq[d.Name]++
+		}
+		for name, count := range freq {
+			assert.Equal(t, 1, count, "tool %q appeared %d times; expected exactly once", name, count)
+		}
+	})
 }
 
 func TestRegistry_RegisterToToolkitWithOptions(t *testing.T) {
@@ -178,4 +197,147 @@ func TestRegistry_RegisterToToolkitWithOptions(t *testing.T) {
 		}
 	}
 	assert.True(t, found, "git_serial should be in git toolkit")
+}
+
+func TestRegistry_GetOptions(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+
+	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "serial_tool"}, nil, registry.ToolOptions{Serial: true}); err != nil {
+		t.Fatalf("failed to register serial_tool: %v", err)
+	}
+	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "long_tool"}, nil, registry.ToolOptions{LongRunning: true}); err != nil {
+		t.Fatalf("failed to register long_tool: %v", err)
+	}
+	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "both_tool"}, nil, registry.ToolOptions{Serial: true, LongRunning: true}); err != nil {
+		t.Fatalf("failed to register both_tool: %v", err)
+	}
+
+	t.Run("serial tool", func(t *testing.T) {
+		t.Parallel()
+		got := r.GetOptions("serial_tool")
+		if !got.Serial {
+			t.Errorf("expected serial_tool to have Serial=true, got %+v", got)
+		}
+	})
+
+	t.Run("long-running tool", func(t *testing.T) {
+		t.Parallel()
+		got := r.GetOptions("long_tool")
+		if !got.LongRunning {
+			t.Errorf("expected long_tool to have LongRunning=true, got %+v", got)
+		}
+	})
+
+	t.Run("tool with both options", func(t *testing.T) {
+		t.Parallel()
+		got := r.GetOptions("both_tool")
+		if !got.Serial {
+			t.Errorf("expected both_tool to have Serial=true, got %+v", got)
+		}
+		if !got.LongRunning {
+			t.Errorf("expected both_tool to have LongRunning=true, got %+v", got)
+		}
+	})
+
+	t.Run("nonexistent tool", func(t *testing.T) {
+		t.Parallel()
+		got := r.GetOptions("no_such_tool")
+		if got != (registry.ToolOptions{}) {
+			t.Errorf("expected zero-value ToolOptions for nonexistent tool, got %+v", got)
+		}
+	})
+
+	t.Run("empty name", func(t *testing.T) {
+		t.Parallel()
+		got := r.GetOptions("")
+		if got != (registry.ToolOptions{}) {
+			t.Errorf("expected zero-value ToolOptions for empty name, got %+v", got)
+		}
+	})
+}
+
+func TestRegistry_RegisterToToolkit_EmptyDefaultsToCore(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+
+	t.Run("RegisterToToolkit(\"\", def, handler) succeeds", func(t *testing.T) {
+		err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: "empty_tk_tool"}, nil)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		decls := r.GetCoreDeclarations()
+		found := false
+		for _, d := range decls {
+			if d.Name == "empty_tk_tool" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected 'empty_tk_tool' in core declarations")
+		}
+	})
+
+	t.Run("RegisterToToolkitWithOptions(\"\", def, handler, opts) also defaults to core", func(t *testing.T) {
+		err := r.RegisterToToolkitWithOptions("", &tools.ToolDeclaration{Name: "empty_tk_serial"}, nil, registry.ToolOptions{Serial: true})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+
+		if !r.IsSerial("empty_tk_serial") {
+			t.Error("expected empty_tk_serial to be serial")
+		}
+
+		decls := r.GetCoreDeclarations()
+		found := false
+		for _, d := range decls {
+			if d.Name == "empty_tk_serial" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected 'empty_tk_serial' in core declarations")
+		}
+
+		toolkits := r.ListAvailableToolkits()
+		for _, tk := range toolkits {
+			if tk == "" {
+				t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
+			}
+		}
+	})
+
+	t.Run("multiple empty-toolkit registrations all go to core", func(t *testing.T) {
+		for _, name := range []string{"multi1", "multi2", "multi3"} {
+			if err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: name}, nil); err != nil {
+				t.Fatalf("failed to register %s: %v", name, err)
+			}
+		}
+
+		decls := r.GetCoreDeclarations()
+		// Expect 5 total: empty_tk_tool + empty_tk_serial + multi1 + multi2 + multi3
+		if len(decls) != 5 {
+			t.Errorf("expected 5 declarations, got %d", len(decls))
+		}
+
+		names := make(map[string]bool)
+		for _, d := range decls {
+			names[d.Name] = true
+		}
+		for _, name := range []string{"multi1", "multi2", "multi3"} {
+			if !names[name] {
+				t.Errorf("expected %q in core declarations", name)
+			}
+		}
+
+		toolkits := r.ListAvailableToolkits()
+		for _, tk := range toolkits {
+			if tk == "" {
+				t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
+			}
+		}
+	})
 }


### PR DESCRIPTION
Closes #419.

## Summary
Closed all 8 coverage gaps across two leaf packages:
- **domain/security/**: Added `IsSafeGhSubcommand` and `IsSafeAzSubcommand` tests with policy-iterate guards (93.8% → 100.0%)
- **infrastructure/registry/**: Added `GetOptions`, empty-toolkit defaults, dedup, and cross-toolkit re-registration tests (93.0% → 100.0%)

## Changes
| File | What |
|------|------|
| `internal/domain/security/service_test.go` | +2 test functions (12 subtests) |
| `internal/infrastructure/registry/registry_test.go` | +3 test functions / subtests |
| `internal/infrastructure/registry/coverage_test.go` | +1 table-driven test case |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| domain/security coverage | 100.0% |
| infrastructure/registry coverage | 100.0% |
| Race detector | Clean |
| Lint | 0 issues |