### PR TITLE
refactor(workspace): inject pathResolver into backupManager for testable os.Getwd error path

### DIFF
--- a/internal/tools/workspace/backup.go
+++ b/internal/tools/workspace/backup.go
@@ -24,25 +24,45 @@ type fileSnapshot struct {
 	Action    string    `json:"action"` // "WRITE", "REPLACE", "APPEND", or "DELETE"
 }
 
+// pathResolver resolves a relative or absolute path to an absolute path.
+type pathResolver func(string) (string, error)
+
+// BackupManagerOption configures a backupManager.
+type BackupManagerOption func(*backupManager)
+
+// WithPathResolver sets a custom path resolution function.
+// The default is filepath.Abs.
+func WithPathResolver(r pathResolver) BackupManagerOption {
+	return func(bm *backupManager) {
+		bm.resolvePath = r
+	}
+}
+
 // backupManager handles the snapshotting and restoration of files.
 type backupManager struct {
-	mu        sync.Mutex
-	backups   []fileSnapshot
-	maxStored int
-	sm        domain_security.PathValidator
-	fs        domain_persistence.FileSystem
+	mu          sync.Mutex
+	backups     []fileSnapshot
+	maxStored   int
+	sm          domain_security.PathValidator
+	fs          domain_persistence.FileSystem
+	resolvePath pathResolver
 }
 
 // newBackupManager creates a new backupManager.
-func newBackupManager(sm domain_security.PathValidator, fs domain_persistence.FileSystem, maxStored int) *backupManager {
+func newBackupManager(sm domain_security.PathValidator, fs domain_persistence.FileSystem, maxStored int, opts ...BackupManagerOption) *backupManager {
 	if maxStored <= 0 {
 		maxStored = 10
 	}
-	return &backupManager{
-		maxStored: maxStored,
-		sm:        sm,
-		fs:        fs,
+	bm := &backupManager{
+		maxStored:   maxStored,
+		sm:          sm,
+		fs:          fs,
+		resolvePath: filepath.Abs,
 	}
+	for _, opt := range opts {
+		opt(bm)
+	}
+	return bm
 }
 
 // snapshot records the current state of a file before it is modified.
@@ -50,7 +70,7 @@ func (b *backupManager) snapshot(ctx context.Context, path string, action string
 	// Resolve path and read file content OUTSIDE the critical section.
 	// Holding the mutex across synchronous disk I/O would cause thread
 	// starvation for concurrent callers.
-	absPath, err := filepath.Abs(path)
+	absPath, err := b.resolvePath(path)
 	if err != nil {
 		return fmt.Errorf("snapshot: resolve path %s: %w", path, err)
 	}

--- a/internal/tools/workspace/backup_test.go
+++ b/internal/tools/workspace/backup_test.go
@@ -395,42 +395,16 @@ func TestUndo_NExceedingSnapshotCount(t *testing.T) {
 
 func TestSnapshot_WorkingDirectoryRemoved(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
+	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10,
+		WithPathResolver(func(path string) (string, error) {
+			return "", fmt.Errorf("getwd failed: no such file or directory")
+		}),
+	)
 	ctx := context.Background()
 
-	// Create a temp dir, chdir into it, then remove it
-	tmpDir := t.TempDir()
-	subDir := filepath.Join(tmpDir, "subdir")
-	if err := os.Mkdir(subDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	oldWd, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(subDir); err != nil {
-		t.Fatal(err)
-	}
-	// Remove the directory we're in — this causes os.Getwd() to fail on next call
-	t.Cleanup(func() {
-		_ = os.Chdir(oldWd)
-	})
-	if err := os.Remove(subDir); err != nil {
-		// On some OSes, you can't remove the current working directory
-		t.Skipf("cannot remove current working directory on this OS: %v", err)
-	}
-	// On some OSes (macOS), removing the CWD succeeds but os.Getwd still
-	// resolves because the kernel holds a VFS reference to the unlinked
-	// directory. Skip if Getwd still works — the error path is not testable.
-	if _, err := os.Getwd(); err == nil {
-		t.Skip("os.Getwd still succeeds after CWD removal on this OS; error path not reachable")
-	}
-
-	// Now filepath.Abs should fail because os.Getwd fails
-	err = bm.snapshot(ctx, "test.txt", "WRITE")
+	err := bm.snapshot(ctx, "test.txt", "WRITE")
 	if err == nil {
-		t.Fatal("expected error from filepath.Abs when working directory is removed")
+		t.Fatal("expected error from path resolver failure")
 	}
 	if !strings.Contains(err.Error(), "snapshot: resolve path") {
 		t.Errorf("expected 'snapshot: resolve path' in error, got: %v", err)


### PR DESCRIPTION
## Summary

Replaces the hardwired `filepath.Abs` call in `backupManager.snapshot()` with an injectable `pathResolver` function field, configured via the functional options pattern (`WithPathResolver`). Defaults to `filepath.Abs` — zero production impact.

Rewrites `TestSnapshot_WorkingDirectoryRemoved` to use mock injection instead of OS-dependent `os.Chdir` / `os.Remove` / `t.Skip` workarounds. The error path is now properly tested for the first time.

## Changes

| File | Change |
|------|--------|
| `backup.go` | Added `pathResolver` type, `BackupManagerOption` type, `WithPathResolver` constructor, `resolvePath` field, options loop in `newBackupManager` |
| `backup_test.go` | Replaced 27 lines of OS-specific hackery with 9 lines of mock injection via `WithPathResolver` |

## Verification

- `go build ./internal/tools/workspace/` ✅
- `go test -race ./internal/tools/workspace/` ✅ (all tests pass)
- Production call site `newBackupManager(sm, fs, 10)` in `registration.go` compiles unchanged

Closes #425