### PR TITLE
fix(atlassian): harden error path coverage to 99.2% (#430)

### DIFF
--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -1273,3 +1273,328 @@ func TestConfluenceManager_SecureURLConstruction(t *testing.T) {
 		assert.Contains(t, u.String(), "space-id=123%3F456%26789")
 	})
 }
+
+func TestConfluenceManager_HTTPStatusErrors(t *testing.T) {
+	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+	t.Setenv("ATLASSIAN_TOKEN", "api-token")
+	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+	// ──────────────────────────────────────────────────────────
+	// Gap A: FetchSearchPage status codes (88.9% → 100%)
+	// ──────────────────────────────────────────────────────────
+
+	t.Run("FetchSearchPage_HTTP401", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.FetchSearchPage(context.Background(), "https://test.atlassian.net/wiki/api/v2/pages")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confluence API returned status: 401 Unauthorized")
+	})
+
+	t.Run("FetchSearchPage_HTTP429", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusTooManyRequests,
+			Status:     "429 Too Many Requests",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.FetchSearchPage(context.Background(), "https://test.atlassian.net/wiki/api/v2/pages")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confluence API returned status: 429 Too Many Requests")
+	})
+
+	t.Run("FetchSearchPage_HTTP503", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.FetchSearchPage(context.Background(), "https://test.atlassian.net/wiki/api/v2/pages")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confluence API returned status: 503 Service Unavailable")
+	})
+
+	t.Run("FetchSearchPage_BodyReadError", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(&errorReader{err: fmt.Errorf("read error")}),
+		}, nil)
+
+		_, err = m.FetchSearchPage(context.Background(), "https://test.atlassian.net/wiki/api/v2/pages")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confluence API returned status")
+		assert.Contains(t, err.Error(), "failed to read response body")
+	})
+
+	// ──────────────────────────────────────────────────────────
+	// Gap B: getCurrentPageVersion status codes (89.5% → 100%)
+	// ──────────────────────────────────────────────────────────
+
+	t.Run("getCurrentPageVersion_HTTP401", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.getCurrentPageVersion(context.Background(), "123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch current version, status: 401 Unauthorized")
+	})
+
+	t.Run("getCurrentPageVersion_HTTP404", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusNotFound,
+			Status:     "404 Not Found",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.getCurrentPageVersion(context.Background(), "123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch current version, status: 404 Not Found")
+	})
+
+	t.Run("getCurrentPageVersion_HTTP500", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		_, err = m.getCurrentPageVersion(context.Background(), "123")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch current version, status: 500 Internal Server Error")
+	})
+
+	// ──────────────────────────────────────────────────────────
+	// Gap C: executeUpdate status codes (90.9% → 100%)
+	// ──────────────────────────────────────────────────────────
+
+	t.Run("executeUpdate_HTTP401", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		err = m.executeUpdate(context.Background(), "123", map[string]interface{}{"title": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed with status: 401 Unauthorized")
+	})
+
+	t.Run("executeUpdate_HTTP403", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		err = m.executeUpdate(context.Background(), "123", map[string]interface{}{"title": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed with status: 403 Forbidden")
+	})
+
+	t.Run("executeUpdate_HTTP500", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		err = m.executeUpdate(context.Background(), "123", map[string]interface{}{"title": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed with status: 500 Internal Server Error")
+	})
+
+	t.Run("executeUpdate_HTTP503", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusServiceUnavailable,
+			Status:     "503 Service Unavailable",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		err = m.executeUpdate(context.Background(), "123", map[string]interface{}{"title": "test"})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed with status: 503 Service Unavailable")
+	})
+
+	// ──────────────────────────────────────────────────────────
+	// Gap D: confluenceWrite error propagation (89.5% → 100%)
+	// ──────────────────────────────────────────────────────────
+
+	t.Run("confluenceWrite_VersionFetchError", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		// GET returns 500 → getCurrentPageVersion fails
+		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodGet
+		})).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		args := map[string]interface{}{
+			"page_id":          "123",
+			"markdown_content": "# Test",
+		}
+
+		_, err = m.confluenceWrite(context.Background(), args, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to fetch current version, status: 500 Internal Server Error")
+	})
+
+	t.Run("confluenceWrite_UpdateNonConflictError", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		// GET returns 200 with version info
+		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodGet
+		})).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"id": "123", "title": "Old Title", "version": {"number": 5}}`)),
+		}, nil)
+
+		// PUT returns 500 (not 409, so error propagates)
+		mockClient.On("Do", mock.MatchedBy(func(req *http.Request) bool {
+			return req.Method == http.MethodPut
+		})).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil)
+
+		args := map[string]interface{}{
+			"page_id":          "123",
+			"markdown_content": "# Test",
+		}
+
+		_, err = m.confluenceWrite(context.Background(), args, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "update failed with status: 500 Internal Server Error")
+	})
+
+	// ──────────────────────────────────────────────────────────
+	// Additional gaps: decode error & validation
+	// ──────────────────────────────────────────────────────────
+
+	t.Run("FetchSearchPage_DecodeError", func(t *testing.T) {
+		mockClient := new(mockConfluenceClient)
+		m, err := NewConfluenceManager(nil, mockClient)
+		assert.NoError(t, err)
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("{ invalid json")),
+		}, nil)
+
+		_, err = m.FetchSearchPage(context.Background(), "https://test.atlassian.net/wiki/api/v2/pages")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode response")
+	})
+
+	t.Run("confluenceWrite_MissingPageID", func(t *testing.T) {
+		m, err := NewConfluenceManager(nil, nil)
+		assert.NoError(t, err)
+
+		args := map[string]interface{}{
+			"page_id":          "",
+			"markdown_content": "# Test",
+		}
+
+		_, err = m.confluenceWrite(context.Background(), args, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page_id and markdown_content are required")
+	})
+
+	t.Run("confluenceWrite_MissingContent", func(t *testing.T) {
+		m, err := NewConfluenceManager(nil, nil)
+		assert.NoError(t, err)
+
+		args := map[string]interface{}{
+			"page_id":          "123",
+			"markdown_content": "",
+		}
+
+		_, err = m.confluenceWrite(context.Background(), args, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "page_id and markdown_content are required")
+	})
+}
+
+func TestConfluenceManager_RemainingErrorPaths(t *testing.T) {
+	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+	t.Setenv("ATLASSIAN_TOKEN", "api-token")
+	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+	t.Run("fetchPageContent_InvalidBaseURL", func(t *testing.T) {
+		m, err := NewConfluenceManager(nil, nil)
+		require.NoError(t, err)
+		m.provider.baseURL = " ://broken"
+		_, err = m.fetchPageContent(context.Background(), "123")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid base url")
+	})
+
+	t.Run("ConfluenceRead_MissingPageID", func(t *testing.T) {
+		m, err := NewConfluenceManager(nil, nil)
+		require.NoError(t, err)
+		_, err = m.ConfluenceRead(context.Background(), map[string]interface{}{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "page_id argument is required")
+	})
+}

--- a/internal/tools/integrations/atlassian/jira_test.go
+++ b/internal/tools/integrations/atlassian/jira_test.go
@@ -143,6 +143,27 @@ func TestJiraManager_JiraSearchIssues(t *testing.T) {
 			expectedText: "Found 1 issues (showing 1):",
 		},
 		{
+			name: "Success Unassigned Issue",
+			args: map[string]interface{}{"jql": "project = PROJ"},
+			mockResp: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(strings.NewReader(`{
+					"total": 1,
+					"issues": [
+						{
+							"key": "PROJ-2",
+							"fields": {
+								"summary": "Unassigned Issue",
+								"status": { "name": "Backlog" },
+								"assignee": { "displayName": "" }
+							}
+						}
+					]
+				}`)),
+			},
+			expectedText: "[PROJ-2] Unassigned Issue (Status: Backlog, Assignee: Unassigned)",
+		},
+		{
 			name: "Context Timeout",
 			args: map[string]interface{}{"jql": "project = PROJ"},
 			mockErr: func() error {
@@ -470,5 +491,175 @@ func TestJiraManager_EdgeCases(t *testing.T) {
 
 		require.Error(t, err)
 		assert.True(t, strings.Contains(err.Error(), "invalid base url") || strings.Contains(err.Error(), "failed to initialize Atlassian provider"))
+	})
+}
+
+func TestJiraManager_ErrorPaths(t *testing.T) {
+	// ── Gap A ─────────────────────────────────────────────────────
+	t.Run("NewJiraManager_ProviderInitFailure", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_BASE_URL", "")
+		m, err := NewJiraManager(nil, nil)
+		assert.Nil(t, m)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to initialize Atlassian provider")
+	})
+
+	// ── Gap B ─────────────────────────────────────────────────────
+	t.Run("checkIssueResponse_BodyReadError", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+
+		resp := &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(&errorReader{err: errors.New("read failure")}),
+		}
+
+		err = m.checkIssueResponse(resp, "PROJ-1")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "additionally, failed to read response body")
+	})
+
+	// ── Gap C ─────────────────────────────────────────────────────
+	t.Run("JiraSearchIssues_HTTP401", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+		m.provider.BaseDelay = 1 * time.Microsecond
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader("Unauthorized")),
+		}, nil)
+
+		_, err = m.JiraSearchIssues(context.Background(), map[string]interface{}{"jql": "project = PROJ"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jira API returned status: 401 Unauthorized")
+	})
+
+	t.Run("JiraSearchIssues_HTTP403", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+		m.provider.BaseDelay = 1 * time.Microsecond
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader("Forbidden")),
+		}, nil)
+
+		_, err = m.JiraSearchIssues(context.Background(), map[string]interface{}{"jql": "project = PROJ"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jira API returned status: 403 Forbidden")
+	})
+
+	t.Run("JiraSearchIssues_BodyReadError", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+		m.provider.BaseDelay = 1 * time.Microsecond
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Status:     "500 Internal Server Error",
+			Body:       io.NopCloser(&errorReader{err: errors.New("read failure")}),
+		}, nil)
+
+		_, err = m.JiraSearchIssues(context.Background(), map[string]interface{}{"jql": "project = PROJ"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "additionally, failed to read response body")
+	})
+
+	// ── Gap D ─────────────────────────────────────────────────────
+	t.Run("JiraGetIssue_HTTP401", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+		m.provider.BaseDelay = 1 * time.Microsecond
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusUnauthorized,
+			Status:     "401 Unauthorized",
+			Body:       io.NopCloser(strings.NewReader("Unauthorized")),
+		}, nil)
+
+		_, err = m.JiraGetIssue(context.Background(), map[string]interface{}{"issue_key": "PROJ-1"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jira API returned status: 401 Unauthorized")
+	})
+
+	t.Run("JiraGetIssue_HTTP403", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+		m.provider.BaseDelay = 1 * time.Microsecond
+
+		mockClient.On("Do", mock.Anything).Return(&http.Response{
+			StatusCode: http.StatusForbidden,
+			Status:     "403 Forbidden",
+			Body:       io.NopCloser(strings.NewReader("Forbidden")),
+		}, nil)
+
+		_, err = m.JiraGetIssue(context.Background(), map[string]interface{}{"issue_key": "PROJ-1"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jira API returned status: 403 Forbidden")
+	})
+
+	// ── Nil context tests: trigger http.NewRequestWithContext failure ──
+	t.Run("JiraSearchIssues_NilContext", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+
+		var nilCtx context.Context
+		_, err = m.JiraSearchIssues(nilCtx, map[string]interface{}{"jql": "project = PROJ"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil Context")
+	})
+
+	t.Run("JiraGetIssue_NilContext", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+		t.Setenv("ATLASSIAN_TOKEN", "api-token")
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+
+		mockClient := new(mockJiraClient)
+		m, err := NewJiraManager(nil, mockClient)
+		require.NoError(t, err)
+
+		var nilCtx context.Context
+		_, err = m.JiraGetIssue(nilCtx, map[string]interface{}{"issue_key": "PROJ-1"}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "nil Context")
 	})
 }

--- a/internal/tools/integrations/atlassian/register_test.go
+++ b/internal/tools/integrations/atlassian/register_test.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package atlassian
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// mockRegistry — test double for tools.Registry
+// ---------------------------------------------------------------------------
+
+type mockRegistry struct {
+	toolkitRegs []toolkitRegistration
+
+	// Error providers: called with the 1-based call number; return nil to succeed.
+	registerToToolkitErrProvider            func(callNum int) error
+	registerToToolkitWithOptionsErrProvider func(callNum int) error
+
+	registerToToolkitCallCount            int
+	registerToToolkitWithOptionsCallCount int
+}
+
+type toolkitRegistration struct {
+	toolkit string
+	def     *tools.ToolDeclaration
+	handler tools.ToolFunc
+	opts    tools.ToolOptions
+	hasOpts bool // true if registered via RegisterToToolkitWithOptions
+}
+
+// --- ToolRegistrar ---
+
+func (m *mockRegistry) Register(def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return errors.New("Register: not expected in atlassian registration tests")
+}
+
+func (m *mockRegistry) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return errors.New("RegisterWithOptions: not expected in atlassian registration tests")
+}
+
+func (m *mockRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	m.registerToToolkitCallCount++
+	if m.registerToToolkitErrProvider != nil {
+		if err := m.registerToToolkitErrProvider(m.registerToToolkitCallCount); err != nil {
+			return err
+		}
+	}
+	m.toolkitRegs = append(m.toolkitRegs, toolkitRegistration{
+		toolkit: toolkit, def: def, handler: handler,
+	})
+	return nil
+}
+
+func (m *mockRegistry) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	m.registerToToolkitWithOptionsCallCount++
+	if m.registerToToolkitWithOptionsErrProvider != nil {
+		if err := m.registerToToolkitWithOptionsErrProvider(m.registerToToolkitWithOptionsCallCount); err != nil {
+			return err
+		}
+	}
+	m.toolkitRegs = append(m.toolkitRegs, toolkitRegistration{
+		toolkit: toolkit, def: def, handler: handler,
+		opts: opts, hasOpts: true,
+	})
+	return nil
+}
+
+// --- ToolExecutor (stubs) ---
+
+func (m *mockRegistry) Execute(ctx context.Context, name string, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	return tools.ToolResult{}, nil
+}
+
+func (m *mockRegistry) IsSerial(name string) bool                { return false }
+func (m *mockRegistry) IsLongRunning(name string) bool           { return false }
+func (m *mockRegistry) GetOptions(name string) tools.ToolOptions { return tools.ToolOptions{} }
+
+// --- ToolMetadataProvider (stubs) ---
+
+func (m *mockRegistry) GetDeclarations() []*tools.ToolDeclaration     { return nil }
+func (m *mockRegistry) GetCoreDeclarations() []*tools.ToolDeclaration { return nil }
+func (m *mockRegistry) GetDeclarationsByToolkits(toolkits []string) []*tools.ToolDeclaration {
+	return nil
+}
+func (m *mockRegistry) ListAvailableToolkits() []string { return nil }
+
+// Compile-time check
+var _ tools.Registry = (*mockRegistry)(nil)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func setAtlassianEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+	t.Setenv("ATLASSIAN_EMAIL", "test@example.com")
+	t.Setenv("ATLASSIAN_TOKEN", "api-token")
+}
+
+func findReg(regs []toolkitRegistration, name string) (toolkitRegistration, bool) {
+	for _, r := range regs {
+		if r.def.Name == name {
+			return r, true
+		}
+	}
+	return toolkitRegistration{}, false
+}
+
+// sm is the security manager used by RegisterConfluence/RegisterJira.
+var sm security.Manager = &toolstest.MockSecurityManager{AllowAll: true}
+
+// ---------------------------------------------------------------------------
+// RegisterConfluence
+// ---------------------------------------------------------------------------
+
+func TestRegisterConfluence(t *testing.T) {
+	t.Run("Success_AllThreeTools", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+
+		err := RegisterConfluence(reg, sm, nil)
+		require.NoError(t, err)
+		require.Len(t, reg.toolkitRegs, 3)
+
+		// --- confluence_search ---
+		search, ok := findReg(reg.toolkitRegs, "confluence_search")
+		require.True(t, ok, "confluence_search should be registered")
+		assert.Equal(t, "confluence", search.toolkit)
+		assert.NotNil(t, search.handler)
+		assert.False(t, search.hasOpts)
+
+		// --- confluence_read ---
+		read, ok := findReg(reg.toolkitRegs, "confluence_read")
+		require.True(t, ok, "confluence_read should be registered")
+		assert.Equal(t, "confluence", read.toolkit)
+		assert.NotNil(t, read.handler)
+		assert.False(t, read.hasOpts)
+		require.NotNil(t, read.def.Parameters)
+		assert.Contains(t, read.def.Parameters.Required, "page_id")
+
+		// --- confluence_write ---
+		write, ok := findReg(reg.toolkitRegs, "confluence_write")
+		require.True(t, ok, "confluence_write should be registered")
+		assert.Equal(t, "confluence", write.toolkit)
+		assert.NotNil(t, write.handler)
+		assert.True(t, write.hasOpts, "confluence_write should use RegisterToToolkitWithOptions")
+		assert.True(t, write.def.RequiresConsent, "confluence_write should require consent")
+		assert.True(t, write.opts.Serial, "confluence_write should have Serial: true")
+		require.NotNil(t, write.def.Parameters)
+		assert.Contains(t, write.def.Parameters.Required, "page_id")
+		assert.Contains(t, write.def.Parameters.Required, "markdown_content")
+	})
+
+	t.Run("ProviderInitFailure_Skips", func(t *testing.T) {
+		// Explicitly clear ATLASSIAN_BASE_URL so NewAtlassianProvider fails.
+		t.Setenv("ATLASSIAN_BASE_URL", "")
+		reg := &mockRegistry{}
+
+		err := RegisterConfluence(reg, sm, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, reg.toolkitRegs)
+	})
+
+	t.Run("RegisterToToolkit_Error_Propagates_FirstCall", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		testErr := errors.New("register toolkit boom")
+
+		// Fail on the 1st RegisterToToolkit call (confluence_search).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 1 {
+				return testErr
+			}
+			return nil
+		}
+
+		err := RegisterConfluence(reg, sm, nil)
+		assert.ErrorIs(t, err, testErr)
+		assert.Empty(t, reg.toolkitRegs)
+	})
+
+	t.Run("RegisterToToolkit_Error_Propagates_SecondCall", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		testErr := errors.New("register toolkit boom")
+
+		// Fail on the 2nd RegisterToToolkit call (confluence_read).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 2 {
+				return testErr
+			}
+			return nil
+		}
+
+		err := RegisterConfluence(reg, sm, nil)
+		assert.ErrorIs(t, err, testErr)
+		// Only the first tool (search) should have been recorded before the error.
+		assert.Len(t, reg.toolkitRegs, 1)
+	})
+
+	t.Run("RegisterToToolkitWithOptions_Error_Propagates", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		testErr := errors.New("register with options boom")
+
+		reg.registerToToolkitWithOptionsErrProvider = func(_ int) error {
+			return testErr
+		}
+
+		err := RegisterConfluence(reg, sm, nil)
+		assert.ErrorIs(t, err, testErr)
+		// The first two calls (RegisterToToolkit) should have succeeded.
+		assert.Len(t, reg.toolkitRegs, 2)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RegisterJira
+// ---------------------------------------------------------------------------
+
+func TestRegisterJira(t *testing.T) {
+	t.Run("Success_BothTools", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+
+		err := RegisterJira(reg, sm, nil)
+		require.NoError(t, err)
+		require.Len(t, reg.toolkitRegs, 2)
+
+		// --- jira_search_issues ---
+		search, ok := findReg(reg.toolkitRegs, "jira_search_issues")
+		require.True(t, ok, "jira_search_issues should be registered")
+		assert.Equal(t, "jira", search.toolkit)
+		assert.NotNil(t, search.handler)
+		assert.False(t, search.hasOpts)
+		require.NotNil(t, search.def.Parameters)
+		assert.Contains(t, search.def.Parameters.Required, "jql")
+
+		// --- jira_get_issue ---
+		get, ok := findReg(reg.toolkitRegs, "jira_get_issue")
+		require.True(t, ok, "jira_get_issue should be registered")
+		assert.Equal(t, "jira", get.toolkit)
+		assert.NotNil(t, get.handler)
+		assert.False(t, get.hasOpts)
+		require.NotNil(t, get.def.Parameters)
+		assert.Contains(t, get.def.Parameters.Required, "issue_key")
+	})
+
+	t.Run("ProviderInitFailure_Skips", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_BASE_URL", "")
+		reg := &mockRegistry{}
+
+		err := RegisterJira(reg, sm, nil)
+		assert.NoError(t, err)
+		assert.Empty(t, reg.toolkitRegs)
+	})
+
+	t.Run("RegisterToToolkit_Error_Propagates_FirstCall", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		testErr := errors.New("register toolkit boom")
+
+		// Fail on the 1st RegisterToToolkit call (jira_search_issues).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 1 {
+				return testErr
+			}
+			return nil
+		}
+
+		err := RegisterJira(reg, sm, nil)
+		assert.ErrorIs(t, err, testErr)
+		assert.Empty(t, reg.toolkitRegs)
+	})
+
+	t.Run("RegisterToToolkit_Error_Propagates_SecondCall", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		testErr := errors.New("register toolkit boom")
+
+		// Fail on the 2nd RegisterToToolkit call (jira_get_issue).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 2 {
+				return testErr
+			}
+			return nil
+		}
+
+		err := RegisterJira(reg, sm, nil)
+		assert.ErrorIs(t, err, testErr)
+		// Only the first tool (search) should have been recorded before the error.
+		assert.Len(t, reg.toolkitRegs, 1)
+	})
+}


### PR DESCRIPTION
Closes #430.

## Summary
Hardened error path test coverage for the `internal/tools/integrations/atlassian/` package from 92.7% to 99.2%. All 28 ERROR_HANDLING gaps addressed — 24 tested, 4 proven unreachable (`http.NewRequestWithContext` boilerplate after `url.Parse` validation).

### Changes
| File | Action | Details |
|------|--------|---------|
| `register_test.go` | **New** | `RegisterConfluence` 0→100%, `RegisterJira` 0→100% (9 subtests) |
| `jira_test.go` | Modified | HTTP 401/403/5xx, body-read errors, nil-context tests (+9 subtests) |
| `confluence_test.go` | Modified | HTTP 401/403/429/500/503, write/version/update errors (+18 subtests) |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage | 99.2% (≥95% ✓) |
| Race detector | Clean |
| Linter | 0 issues |
| Vulncheck | 0 vulnerabilities |