### PR TITLE
fix(workspace): add error path hardening tests (#431)

### DIFF
--- a/cmd/tell-me-go/main.go
+++ b/cmd/tell-me-go/main.go
@@ -45,6 +45,12 @@ var (
 
 	// newResourceFn is the resource constructor, overridable in tests for error injection.
 	newResourceFn = resource.New
+
+	// cliNewFn is the CLI application constructor, overridable in tests for error injection.
+	cliNewFn = cli.New
+
+	// newSecurityManagerFn is the security manager constructor, overridable in tests.
+	newSecurityManagerFn = security.NewSecurityManager
 )
 
 func getVersion() string {
@@ -149,7 +155,7 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 		}
 		return security.NoOpInteractor()
 	}
-	sm := security.NewSecurityManager(interactorProvider)
+	sm := newSecurityManagerFn(interactorProvider)
 
 	// 3. Setup Logger
 	isDebug := os.Getenv("TELL_ME_DEBUG") == "1"
@@ -170,7 +176,7 @@ func buildApp(appVersion string, stdin io.Reader, stdout, stderr io.Writer) (*cl
 	configLoader := &config.YAMLConfigLoader{
 		Finder: config.NewDefaultConfigFinder(config.WithBaseDir(wd)),
 	}
-	app, err := cli.New(cli.AppDependencies{
+	app, err := cliNewFn(cli.AppDependencies{
 		Version:      appVersion,
 		Stdin:        stdin,
 		Stdout:       stdout,

--- a/cmd/tell-me-go/main_test.go
+++ b/cmd/tell-me-go/main_test.go
@@ -15,6 +15,8 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/cli"
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 
 	"go.opentelemetry.io/otel/sdk/resource"
 )
@@ -322,6 +324,65 @@ func TestBuildApp_GetwdError(t *testing.T) {
 	if cleanup == nil {
 		t.Fatal("buildApp returned nil cleanup function")
 	}
+	cleanup()
+}
+
+func TestBuildApp_CLINewError(t *testing.T) {
+	// 1. Save and defer restoration of overrides
+	origCLINew := cliNewFn
+	origNewSM := newSecurityManagerFn
+	t.Cleanup(func() {
+		cliNewFn = origCLINew
+		newSecurityManagerFn = origNewSM
+	})
+
+	// 2. Capture the interactorProvider closure when newSecurityManagerFn is called
+	var capturedProvider func() domain_security.UserInteractor
+	newSecurityManagerFn = func(ip func() domain_security.UserInteractor) *security.SecurityManager {
+		capturedProvider = ip
+		return security.NewSecurityManager(ip)
+	}
+
+	// 3. Inject a cliNewFn that returns an error
+	cliNewErr := errors.New("injected cli.New failure")
+	cliNewFn = func(deps cli.AppDependencies, getenv func(string) string) (*cli.App, error) {
+		return nil, cliNewErr
+	}
+
+	// 4. Isolate environment
+	t.Setenv("TELL_ME_HOME", t.TempDir())
+
+	// 5. Call buildApp directly — cliNewFn should fail
+	app, cleanup, err := buildApp("test-version", strings.NewReader(""), io.Discard, io.Discard)
+
+	// 6. Assert: error must be non-nil (cli.New failure)
+	if err == nil {
+		t.Fatal("expected error from buildApp due to cli.New failure, got nil")
+	}
+	if !errors.Is(err, cliNewErr) {
+		t.Errorf("expected error %v, got %v", cliNewErr, err)
+	}
+
+	// 7. Assert: cleanup must be non-nil even on error (contract)
+	if cleanup == nil {
+		t.Fatal("expected non-nil cleanup function even on error")
+	}
+
+	// 8. Assert: app must be nil on error
+	if app != nil {
+		t.Error("expected nil app on error")
+	}
+
+	// 9. Exercise the interactorProvider closure to cover its body
+	if capturedProvider == nil {
+		t.Fatal("expected captured interactorProvider, got nil")
+	}
+	interactor := capturedProvider()
+	if interactor == nil {
+		t.Fatal("expected non-nil interactor from provider")
+	}
+
+	// 10. Run cleanup (must not panic)
 	cleanup()
 }
 

--- a/internal/tools/workspace/backup_test.go
+++ b/internal/tools/workspace/backup_test.go
@@ -311,6 +311,31 @@ func TestSnapshot_ReadFileNotExist(t *testing.T) {
 	}
 }
 
+func TestSnapshot_ResolvePathError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	fs := persistencetest.NewPlainOSFileSystem()
+	bm := newBackupManager(sm, fs, 10)
+
+	// Inject a failing resolvePath
+	resolveErr := errors.New("path resolution failed")
+	bm.resolvePath = func(path string) (string, error) {
+		return "", resolveErr
+	}
+
+	ctx := context.Background()
+	err := bm.snapshot(ctx, "/any/path", "WRITE")
+
+	if err == nil {
+		t.Fatal("expected error from resolvePath failure")
+	}
+	if !strings.Contains(err.Error(), "snapshot: resolve path") {
+		t.Errorf("expected 'snapshot: resolve path' in error, got: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), resolveErr.Error()) {
+		t.Errorf("expected %q in error, got: %q", resolveErr.Error(), err.Error())
+	}
+}
+
 func TestSnapshot_RingBufferEviction(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	maxStored := 3

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -793,6 +793,69 @@ func validateOpenResult(t *testing.T, f *os.File, err error, wantErr bool, errCo
 	}
 }
 
+func TestResolveAndValidateOutputPath_Escape(t *testing.T) {
+	tests := []struct {
+		name       string
+		path       string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name:       "bare dot-dot",
+			path:       "..",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
+		},
+		{
+			name:       "dot-dot prefix",
+			path:       "../etc/passwd",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
+		},
+		{
+			name:       "deep escape",
+			path:       "a/b/../../../etc/passwd",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
+		},
+		{
+			name:    "normal subdirectory",
+			path:    "a/b/c",
+			wantErr: false,
+		},
+		{
+			name:    "dot prefixed",
+			path:    "./foo/bar",
+			wantErr: false,
+		},
+		{
+			name:    "absolute path",
+			path:    "/tmp/foo",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			absPath, err := resolveAndValidateOutputPath(filepath.Clean(tt.path), tt.path)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.errContain)
+				} else if !strings.Contains(err.Error(), tt.errContain) {
+					t.Errorf("expected error containing %q, got: %v", tt.errContain, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !filepath.IsAbs(absPath) {
+				t.Errorf("expected absolute path, got %q", absPath)
+			}
+		})
+	}
+}
+
 func TestOpenOutputFile_Sanitization(t *testing.T) {
 	executor := newprocessExecutor()
 
@@ -804,6 +867,7 @@ func TestOpenOutputFile_Sanitization(t *testing.T) {
 		{"trim whitespace", "  out.txt  ", "out.txt"},
 		{"null bytes", "out" + string([]byte{0}) + ".txt", "out.txt"},
 		{"mixed", "  logs/test" + string([]byte{0}) + ".log  ", "logs/test.log"},
+		{"only nulls and spaces", "  \x00\x00  ", ""},
 	}
 
 	for _, tt := range tests {
@@ -814,6 +878,13 @@ func TestOpenOutputFile_Sanitization(t *testing.T) {
 			f, err := executor.openOutputFile(config)
 			if err != nil {
 				t.Fatalf("openOutputFile(%q) error = %v", tt.path, err)
+			}
+			if tt.expected == "" {
+				if f != nil {
+					_ = f.Close()
+					t.Errorf("expected nil file for empty path after sanitization, got %q", f.Name())
+				}
+				return
 			}
 			if f != nil {
 				name := f.Name()
@@ -837,33 +908,106 @@ func TestOpenOutputFile_Sanitization(t *testing.T) {
 	}
 }
 
+func TestOpenOutputFile_MkdirAllError(t *testing.T) {
+	executor := newprocessExecutor()
+	tmpDir := t.TempDir()
+
+	// Create a read-only parent directory so MkdirAll fails
+	parentDir := filepath.Join(tmpDir, "readonly_parent")
+	if err := os.MkdirAll(parentDir, 0555); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parentDir, 0755) })
+
+	config := executionConfig{
+		OutputFile: filepath.Join(parentDir, "child", "out.txt"),
+	}
+	f, err := executor.openOutputFile(config)
+	if f != nil {
+		_ = f.Close()
+	}
+	if err == nil {
+		t.Fatal("expected error from MkdirAll under read-only parent")
+	}
+	if !strings.Contains(err.Error(), "failed to create output directory") {
+		t.Errorf("expected 'failed to create output directory' in error, got: %v", err)
+	}
+}
+
 func TestProcessExecutor_Output(t *testing.T) {
 	executor := newprocessExecutor()
 	ctx := context.Background()
 
-	// Success
-	out, err := executor.Output(ctx, helperPath, "echo", "hello")
-	if err != nil {
-		t.Fatalf("Output failed: %v", err)
-	}
-	if string(out) != "hello\n" {
-		t.Errorf("expected 'hello\\n', got %q", string(out))
-	}
+	t.Run("success", func(t *testing.T) {
+		out, err := executor.Output(ctx, helperPath, "echo", "hello")
+		if err != nil {
+			t.Fatalf("Output failed: %v", err)
+		}
+		if string(out) != "hello\n" {
+			t.Errorf("expected 'hello\\n', got %q", string(out))
+		}
+	})
 
-	// Exit error
-	_, err = executor.Output(ctx, helperPath, "exit", "1")
-	if err == nil {
-		t.Error("expected error for non-zero exit")
-	}
+	t.Run("exit error", func(t *testing.T) {
+		out, err := executor.Output(ctx, helperPath, "exit", "1")
+		if err == nil {
+			t.Fatal("expected error for non-zero exit")
+		}
+		if !strings.Contains(err.Error(), "exit status 1") {
+			t.Errorf("expected 'exit status 1' in error, got: %v", err)
+		}
+		if out != nil {
+			t.Logf("partial output on exit error: %q", string(out))
+		}
+	})
 
-	// CombinedOutput success
-	out, err = executor.CombinedOutput(ctx, helperPath, "echo", "hello")
-	if err != nil {
-		t.Fatalf("CombinedOutput failed: %v", err)
-	}
-	if string(out) != "hello\n" {
-		t.Errorf("expected 'hello\\n', got %q", string(out))
-	}
+	t.Run("CombinedOutput success", func(t *testing.T) {
+		out, err := executor.CombinedOutput(ctx, helperPath, "echo", "hello")
+		if err != nil {
+			t.Fatalf("CombinedOutput failed: %v", err)
+		}
+		if string(out) != "hello\n" {
+			t.Errorf("expected 'hello\\n', got %q", string(out))
+		}
+	})
+
+	t.Run("CombinedOutput exit error", func(t *testing.T) {
+		out, err := executor.CombinedOutput(ctx, helperPath, "exit", "2")
+		if err == nil {
+			t.Fatal("expected error for non-zero exit")
+		}
+		if !strings.Contains(err.Error(), "exit status 2") {
+			t.Errorf("expected 'exit status 2' in error, got: %v", err)
+		}
+		if out != nil {
+			t.Logf("partial output on exit error: %q", string(out))
+		}
+	})
+}
+
+func TestProcessExecutor_Output_RunError(t *testing.T) {
+	executor := newprocessExecutor()
+	ctx := context.Background()
+
+	t.Run("Output with start failure", func(t *testing.T) {
+		out, err := executor.Output(ctx, "/nonexistent/binary_xyz_12345")
+		if err == nil {
+			t.Fatal("expected error for nonexistent binary")
+		}
+		if out == nil {
+			t.Error("expected partial output (empty), got nil")
+		}
+	})
+
+	t.Run("CombinedOutput with start failure", func(t *testing.T) {
+		out, err := executor.CombinedOutput(ctx, "/nonexistent/binary_xyz_12345")
+		if err == nil {
+			t.Fatal("expected error for nonexistent binary")
+		}
+		if out == nil {
+			t.Error("expected partial output (empty), got nil")
+		}
+	})
 }
 
 type errorReader struct{}
@@ -936,6 +1080,7 @@ func TestStreamProcessor_appendErr(t *testing.T) {
 		wantContains  string
 		wantTruncated bool
 		wantEmptySB   bool
+		useFeedback   bool
 	}{
 		{
 			name:          "nil error — no-op",
@@ -982,17 +1127,30 @@ func TestStreamProcessor_appendErr(t *testing.T) {
 			wantTruncated: true,
 			wantEmptySB:   true,
 		},
+		{
+			name:          "error with feedback writer",
+			totalCaptured: 0,
+			maxCapture:    500,
+			err:           fmt.Errorf("feedback test error"),
+			wantContains:  "[Warning] Output read error: feedback test error",
+			wantTruncated: false,
+			useFeedback:   true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			totalCaptured := tt.totalCaptured
+			var fb io.Writer
+			if tt.useFeedback {
+				fb = &bytes.Buffer{}
+			}
 			sp := &streamProcessor{
 				mu:            &sync.Mutex{},
 				truncated:     &atomic.Bool{},
 				totalCaptured: &totalCaptured,
 				maxCapture:    tt.maxCapture,
-				feedback:      nil, // no feedback writer for these cases
+				feedback:      fb,
 			}
 
 			var sb strings.Builder
@@ -1007,6 +1165,12 @@ func TestStreamProcessor_appendErr(t *testing.T) {
 			}
 			if sp.truncated.Load() != tt.wantTruncated {
 				t.Errorf("truncated = %v, want %v", sp.truncated.Load(), tt.wantTruncated)
+			}
+			if tt.useFeedback && fb != nil {
+				fbStr := fb.(*bytes.Buffer).String()
+				if !strings.Contains(fbStr, tt.wantContains) {
+					t.Errorf("expected feedback to contain %q, got %q", tt.wantContains, fbStr)
+				}
 			}
 		})
 	}
@@ -1249,6 +1413,27 @@ func TestProcessExecutor_handleCaptureError(t *testing.T) {
 		fb := feedback.String()
 		if !strings.Contains(fb, "[Warning] Output read error: test error") {
 			t.Errorf("expected warning in feedback, got %q", fb)
+		}
+	})
+
+	t.Run("truncation when message exceeds remaining capacity", func(t *testing.T) {
+		var sb strings.Builder
+		sb.WriteString("abcde") // 5 bytes prefilled
+		var mu sync.Mutex
+		truncated := &atomic.Bool{}
+
+		// maxCapture=10, sb has 5 bytes, remaining=5
+		// The fullMsg "\n[Warning] Output read error: ...\n" is > 5 bytes
+		e.handleCaptureError(fmt.Errorf("truncation test error"), &sb, &mu, executionConfig{}, truncated, 10)
+
+		if !truncated.Load() {
+			t.Error("expected truncated=true when message exceeds remaining capacity")
+		}
+		if sb.Len() > 10 {
+			t.Errorf("expected sb length <= 10, got %d", sb.Len())
+		}
+		if !strings.Contains(sb.String(), "[War") {
+			t.Errorf("expected warning prefix in sb, got %q", sb.String())
 		}
 	})
 }
@@ -1540,5 +1725,13 @@ func TestNewPipelineCmd_CancelGuard(t *testing.T) {
 	}
 	if runtime.GOOS == "windows" && cmd.Cancel == nil {
 		t.Error("expected cmd.Cancel to be set on Windows")
+	}
+
+	// Verify Cancel returns nil when Process is nil (before Start)
+	if runtime.GOOS == "windows" {
+		cancelErr := cmd.Cancel()
+		if cancelErr != nil {
+			t.Errorf("cmd.Cancel() with nil Process should return nil, got: %v", cancelErr)
+		}
 	}
 }

--- a/internal/tools/workspace/reader_test.go
+++ b/internal/tools/workspace/reader_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 	"unicode/utf8"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -968,5 +969,522 @@ func TestGetFileDiff_SecurityErrorFile2(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "security") {
 		t.Errorf("expected security error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Local mockFileInfo for reader tests
+// ---------------------------------------------------------------------------
+
+type mockFileInfo struct {
+	name  string
+	size  int64
+	isDir bool
+}
+
+func (m *mockFileInfo) Name() string       { return m.name }
+func (m *mockFileInfo) Size() int64        { return m.size }
+func (m *mockFileInfo) Mode() os.FileMode  { return 0 }
+func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m *mockFileInfo) IsDir() bool        { return m.isDir }
+func (m *mockFileInfo) Sys() interface{}   { return nil }
+
+// ---------------------------------------------------------------------------
+// mockFS_ReadDirError — fails ReadDir for getTree error-path coverage
+// ---------------------------------------------------------------------------
+
+type mockFS_ReadDirError struct {
+	persistence.FileSystem
+	readDirErr error
+}
+
+func (m *mockFS_ReadDirError) ReadDir(ctx context.Context, name string) ([]os.DirEntry, error) {
+	return nil, m.readDirErr
+}
+
+func (m *mockFS_ReadDirError) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return &mockFileInfo{name: filepath.Base(name), isDir: true}, nil
+}
+
+func TestGetTree_ReadDirError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.RegisterSafePath(t.TempDir())
+
+	mfs := &mockFS_ReadDirError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		readDirErr: fmt.Errorf("I/O error"),
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     mfs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	ctx := context.Background()
+	_, err := r.getTree(ctx, map[string]interface{}{
+		"path":   "/tmp",
+		"reason": "test",
+	}, nil)
+
+	if err == nil {
+		t.Fatal("expected error from ReadDir failure")
+	}
+	if !strings.Contains(err.Error(), "I/O error") {
+		t.Errorf("expected 'I/O error', got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestReadFiles_TooManyFiles — exercises the > maxFilesPerCall path
+// ---------------------------------------------------------------------------
+
+func TestReadFiles_TooManyFiles(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	paths := make([]string, 51)
+	for i := range paths {
+		paths[i] = fmt.Sprintf("/tmp/file%d.txt", i)
+	}
+
+	ctx := context.Background()
+	res, err := r.readFiles(ctx, map[string]interface{}{
+		"filepaths": paths,
+		"reason":    "test",
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "requested too many files") {
+		t.Errorf("expected 'requested too many files', got: %q", res.Text)
+	}
+	if !strings.Contains(res.Text, "Maximum is 50") {
+		t.Errorf("expected 'Maximum is 50', got: %q", res.Text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mockFS_StatError_Reader — fails Stat for processSingleFile error-path coverage
+// ---------------------------------------------------------------------------
+
+type mockFS_StatError_Reader struct {
+	persistence.FileSystem
+	statErr error
+}
+
+func (m *mockFS_StatError_Reader) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return nil, m.statErr
+}
+
+func TestProcessSingleFile_StatError_MockFS(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.RegisterSafePath(t.TempDir())
+
+	statErr := fmt.Errorf("stat failure")
+	mfs := &mockFS_StatError_Reader{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		statErr:    statErr,
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     mfs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	var sb strings.Builder
+	err := r.processSingleFile(context.Background(), "/tmp/nonexistent.txt", &sb)
+	if err != nil {
+		t.Fatalf("unexpected error from processSingleFile: %v", err)
+	}
+
+	output := sb.String()
+	if !strings.Contains(output, "ERROR: failed to read file") {
+		t.Errorf("expected 'ERROR: failed to read file' in output, got: %q", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getTree default path and maxDepth edge cases
+// ---------------------------------------------------------------------------
+
+func TestGetTree_DefaultPath(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	// No path provided — should default to "."
+	res, err := r.getTree(ctx, map[string]interface{}{
+		"reason": "test",
+	}, nil)
+	if err != nil {
+		t.Fatalf("getTree with default path failed: %v", err)
+	}
+	if res.Text == "" {
+		t.Error("expected non-empty output for default path")
+	}
+}
+
+func TestGetTree_DefaultMaxDepth(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "a/b/c"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "a/b/c/d.txt"), []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	// max_depth=0 should default to 2
+	res, err := r.getTree(ctx, map[string]interface{}{
+		"path":      tempDir,
+		"max_depth": 0,
+		"reason":    "test",
+	}, nil)
+	if err != nil {
+		t.Fatalf("getTree with max_depth=0 failed: %v", err)
+	}
+	// With default maxDepth=2, we should see dirs a, b, c but NOT file d (depth 3)
+	if !strings.Contains(res.Text, "a") {
+		t.Error("expected 'a' in output")
+	}
+	if !strings.Contains(res.Text, "b") {
+		t.Error("expected 'b' in output")
+	}
+	if strings.Contains(res.Text, "d.txt") {
+		t.Error("expected 'd.txt' NOT in output with maxDepth=2 (it is at depth 4)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildTree depth > maxDepth early return
+// ---------------------------------------------------------------------------
+
+func TestBuildTree_DepthExceedsMaxDepth(t *testing.T) {
+	fs := persistence.NewMockFileSystem()
+	if err := fs.WriteFile(context.Background(), "deep/file.txt", []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var sb strings.Builder
+	ctx := context.Background()
+
+	// depth (3) > maxDepth (2), should return immediately without error
+	err := buildTree(ctx, fs, ".", "", 3, 2, &sb, nil)
+	if err != nil {
+		t.Fatalf("expected nil when depth exceeds maxDepth, got: %v", err)
+	}
+	if sb.Len() != 0 {
+		t.Errorf("expected empty output when depth exceeds maxDepth, got: %q", sb.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getFileDiff file1 security rejection
+// ---------------------------------------------------------------------------
+
+func TestGetFileDiff_SecurityErrorFile1(t *testing.T) {
+	tempDir := t.TempDir()
+	f2 := filepath.Join(tempDir, "f2.txt")
+	if err := os.WriteFile(f2, []byte("line1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsSafeFunc = func(path string) (string, error) {
+		if strings.Contains(path, "f1") {
+			return "", fmt.Errorf("security: path not allowed")
+		}
+		return path, nil
+	}
+
+	r := &fileReader{
+		sm:       sm,
+		fs:       persistencetest.NewPlainOSFileSystem(),
+		policy:   infra_persistence.NewWorkspacePolicy(),
+		executor: &mockDiffExecutor{processExecutor: newprocessExecutor()},
+	}
+	ctx := context.Background()
+
+	_, err := r.getFileDiff(ctx, map[string]interface{}{
+		"file1":  filepath.Join(tempDir, "f1.txt"),
+		"file2":  f2,
+		"reason": "testing",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected security error for file1")
+	}
+	if !strings.Contains(err.Error(), "security") {
+		t.Errorf("expected security error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getTree invalid args and security error
+// ---------------------------------------------------------------------------
+
+func TestGetTree_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	_, err := r.getTree(context.Background(), map[string]interface{}{
+		"path": 123, // wrong type
+	}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for invalid args")
+	}
+}
+
+func TestGetTree_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsSafeFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security: path not allowed")
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	_, err := r.getTree(context.Background(), map[string]interface{}{
+		"path":   "/tmp",
+		"reason": "test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected security error")
+	}
+	if !strings.Contains(err.Error(), "security") {
+		t.Errorf("expected 'security' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildTree: writeTreeEntry error propagation (indirect via nested ReadDir failure)
+// ---------------------------------------------------------------------------
+
+type mockFS_NestedReadDirError struct {
+	persistence.FileSystem
+	failAfter int
+	callCount int
+}
+
+func (m *mockFS_NestedReadDirError) ReadDir(ctx context.Context, name string) ([]os.DirEntry, error) {
+	m.callCount++
+	if m.callCount > m.failAfter {
+		return nil, fmt.Errorf("nested I/O error")
+	}
+	// Delegate to the real FS
+	return m.FileSystem.ReadDir(ctx, name)
+}
+
+func TestBuildTree_WriteTreeEntryError(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tempDir, "sub/nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tempDir, "sub/nested/f.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail ReadDir after the first successful call (root read succeeds, sub read fails)
+	mfs := &mockFS_NestedReadDirError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		failAfter:  1,
+	}
+
+	var sb strings.Builder
+	ctx := context.Background()
+	err := buildTree(ctx, mfs, tempDir, "", 0, 2, &sb, nil)
+	if err == nil {
+		t.Fatal("expected error from nested ReadDir failure")
+	}
+	if !strings.Contains(err.Error(), "nested I/O error") {
+		t.Errorf("expected 'nested I/O error', got: %v", err)
+	}
+	// The root entry should have been written before the error
+	if !strings.Contains(sb.String(), "sub") {
+		t.Errorf("expected 'sub' in output before error, got: %q", sb.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processSingleFile: readBoundedContent error path (Open failure after Stat success)
+// ---------------------------------------------------------------------------
+
+type mockFS_OpenErrorAfterStat struct {
+	persistence.FileSystem
+	openErr error
+}
+
+func (m *mockFS_OpenErrorAfterStat) Open(ctx context.Context, name string) (persistence.File, error) {
+	return nil, m.openErr
+}
+
+func TestProcessSingleFile_ReadError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.RegisterSafePath(tempDir)
+
+	mfs := &mockFS_OpenErrorAfterStat{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		openErr:    fmt.Errorf("open failure"),
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     mfs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	var sb strings.Builder
+	err := r.processSingleFile(context.Background(), path, &sb)
+	if err != nil {
+		t.Fatalf("processSingleFile should not return error: %v", err)
+	}
+
+	output := sb.String()
+	if !strings.Contains(output, "ERROR: failed to read file") {
+		t.Errorf("expected 'ERROR: failed to read file' in output, got: %q", output)
+	}
+	if !strings.Contains(output, "open failure") {
+		t.Errorf("expected 'open failure' in output, got: %q", output)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// listFiles: ReadDir error path
+// ---------------------------------------------------------------------------
+
+func TestListFiles_ReadDirError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	mfs := &mockFS_ReadDirError{
+		FileSystem: persistencetest.NewPlainOSFileSystem(),
+		readDirErr: fmt.Errorf("I/O error"),
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     mfs,
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	ctx := context.Background()
+	_, err := r.listFiles(ctx, map[string]interface{}{
+		"path":   "/tmp",
+		"reason": "test",
+	}, nil)
+
+	if err == nil {
+		t.Fatal("expected error from ReadDir failure")
+	}
+	if !strings.Contains(err.Error(), "failed to list directory") {
+		t.Errorf("expected 'failed to list directory', got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findFile: filepath.Match error with malformed pattern
+// ---------------------------------------------------------------------------
+
+func TestFindFile_MalformedPattern(t *testing.T) {
+	tempDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tempDir, "test.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	// [unclosed is a malformed pattern that causes filepath.Match to return an error
+	_, err := r.findFile(context.Background(), map[string]interface{}{
+		"path":    tempDir,
+		"pattern": "[unclosed",
+		"reason":  "test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected error from malformed pattern")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getFileDiff: unmarshal error with type-mismatched args
+// ---------------------------------------------------------------------------
+
+func TestGetFileDiff_UnmarshalError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	// file1 must be a string; passing an int triggers unmarshal error
+	_, err := r.getFileDiff(context.Background(), map[string]interface{}{
+		"file1":  123,
+		"file2":  "/tmp/f2.txt",
+		"reason": "test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for type mismatch")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// listFiles: IsPathSafe error path
+// ---------------------------------------------------------------------------
+
+func TestListFiles_SecurityError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: false}
+	sm.IsSafeFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("security: path not allowed")
+	}
+
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+
+	_, err := r.listFiles(context.Background(), map[string]interface{}{
+		"path":   "/tmp",
+		"reason": "test",
+	}, nil)
+	if err == nil {
+		t.Fatal("expected security error")
+	}
+	if !strings.Contains(err.Error(), "security") {
+		t.Errorf("expected 'security' in error, got: %v", err)
 	}
 }

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -468,3 +468,110 @@ func TestRegister_WithHealth(t *testing.T) {
 		t.Error("check_system_health should be registered when health is non-nil")
 	}
 }
+
+func TestRegisterSystem_HealthNil(t *testing.T) {
+	reg := registry.New()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	validator := &toolstest.MockCommandValidator{}
+
+	err := registerSystem(reg, sm, validator, nil)
+	if err != nil {
+		t.Fatalf("registerSystem with nil health failed: %v", err)
+	}
+
+	decls := reg.GetDeclarations()
+	names := make(map[string]bool)
+	for _, d := range decls {
+		names[d.Name] = true
+	}
+
+	required := []string{"execute_command", "pipe_commands", "ask_user"}
+	for _, name := range required {
+		if !names[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+	if names["check_system_health"] {
+		t.Error("check_system_health should NOT be registered when health is nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Register — registerFiles partial failure
+// ---------------------------------------------------------------------------
+
+func TestRegister_RegisterFilesFails(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	validator := &toolstest.MockCommandValidator{}
+	fs := persistencetest.NewPlainOSFileSystem()
+	wp := infra_persistence.NewWorkspacePolicy()
+
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "list_files",
+	}
+	err := Register(registry, sm, exec, validator, fs, wp, nil)
+	if err == nil {
+		t.Fatal("expected error from Register when registerFiles fails")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure' in error, got %q", err.Error())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// registerFiles — non-processExecutor path
+// ---------------------------------------------------------------------------
+
+func TestRegisterFiles_NonProcessExecutor(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	fs := persistencetest.NewPlainOSFileSystem()
+	wp := infra_persistence.NewWorkspacePolicy()
+
+	// Use MockExecutor which does NOT implement *processExecutor
+	exec := &toolstest.MockExecutor{}
+
+	reg := &mockToolRegistry{}
+	err := registerFiles(reg, sm, fs, exec, wp)
+	if err != nil {
+		t.Fatalf("registerFiles with non-processExecutor failed: %v", err)
+	}
+
+	// Verify all expected file tools were registered
+	decls := reg.GetDeclarations()
+	names := make(map[string]bool)
+	for _, d := range decls {
+		names[d.Name] = true
+	}
+
+	expected := []string{"list_files", "get_tree", "read_files", "write_file", "replace_text",
+		"append_text", "get_file_diff", "undo_file_change", "delete_path", "create_directory",
+		"find_file", "search_files", "get_definitions"}
+	for _, name := range expected {
+		if !names[name] {
+			t.Errorf("expected tool %q to be registered", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// registerGit: get_git_show failure path
+// ---------------------------------------------------------------------------
+
+func TestRegisterGit_GetGitShowFails(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "get_git_show",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit when get_git_show fails")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure' in error, got %q", err.Error())
+	}
+}

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -438,6 +438,40 @@ func (m *mockShellSecurity) LogAudit(action string, args ...any) {
 	m.MockSecurityManager.LogAudit(action, args...)
 }
 
+func TestShellTool_AuthorizeAndAuditPipeline_OutputFileError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	validator := &toolstest.MockCommandValidator{}
+
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	// Block the output file path to force resolveOutputFile to fail
+	sm.AllowAll = false
+	sm.SetBypassActive(false)
+	sm.IsWritableFunc = func(path string) (string, error) {
+		return "", fmt.Errorf("permission denied on output path")
+	}
+
+	helperSlash := filepath.ToSlash(helperPath)
+	res, err := tool.PipeCommands(ctx, map[string]interface{}{
+		"commands":    []interface{}{fmt.Sprintf("%s echo hello", helperSlash), fmt.Sprintf("%s grep hello", helperSlash)},
+		"reason":      "test output file error",
+		"output_file": "/root/forbidden.txt",
+	}, nil)
+
+	// The error should be in res.Error
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected res.Error to be non-nil")
+	}
+	if !strings.Contains(res.Error.Error(), "permission denied") {
+		t.Errorf("expected 'permission denied' in res.Error, got: %v", res.Error)
+	}
+}
+
 func TestShellTool_Authorization_Denials(t *testing.T) {
 	t.Run("Authorization Denials", func(t *testing.T) {
 		tests := []struct {
@@ -502,6 +536,156 @@ func TestShellTool_Authorization_Denials(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestShellTool_ExecuteCommand_AuthorizeError(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	validator := &toolstest.MockCommandValidator{}
+
+	mockSec := &mockShellSecurity{
+		MockSecurityManager: sm,
+		AuthorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+			return false, fmt.Errorf("authorization service down")
+		},
+	}
+	tool := newTestShellTool(mockSec, validator)
+	ctx := context.Background()
+
+	helperSlash := filepath.ToSlash(helperPath)
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"command": fmt.Sprintf("%s echo hello", helperSlash),
+		"reason":  "test auth error",
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected res.Error from authorization failure")
+	}
+	if !strings.Contains(res.Error.Error(), "authorization service down") {
+		t.Errorf("expected 'authorization service down' in res.Error, got: %v", res.Error)
+	}
+}
+
+func TestShellTool_PrepareCommand_WrapShell(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+
+	// Force HasShellFeatures to return true so prepareCommand calls wrapper.Wrap
+	validator := &toolstest.MockCommandValidator{
+		HasShellFeaturesFunc: func(parts []string) bool {
+			return true
+		},
+	}
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	helperSlash := filepath.ToSlash(helperPath)
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"command": fmt.Sprintf("%s echo hello", helperSlash),
+		"reason":  "test shell wrap",
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("unexpected res.Error: %v", res.Error)
+	}
+	if !strings.Contains(res.Text, "hello") {
+		t.Errorf("expected output to contain 'hello', got: %s", res.Text)
+	}
+}
+
+func TestShellTool_StartHeartbeat_WithChannel(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	validator := &toolstest.MockCommandValidator{}
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	hb := make(chan struct{}, 1)
+	helperSlash := filepath.ToSlash(helperPath)
+
+	// Pass a non-nil heartbeat channel to exercise the hb != nil path
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"command": fmt.Sprintf("%s echo quick", helperSlash),
+		"reason":  "test heartbeat channel",
+	}, hb)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("unexpected res.Error: %v", res.Error)
+	}
+	if !strings.Contains(res.Text, "quick") {
+		t.Errorf("expected output to contain 'quick', got: %s", res.Text)
+	}
+}
+
+func TestShellTool_StartHeartbeat_TickFires(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	validator := &toolstest.MockCommandValidator{}
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	hb := make(chan struct{}, 1)
+	helperSlash := filepath.ToSlash(helperPath)
+
+	// Sleep long enough for the 2-second heartbeat ticker to fire at least once
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"command": fmt.Sprintf("%s sleep 3", helperSlash),
+		"reason":  "test heartbeat tick fires",
+		"timeout": 10,
+	}, hb)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != nil {
+		t.Fatalf("unexpected res.Error: %v", res.Error)
+	}
+}
+
+func TestShellTool_PrepareCommand_ValidateStructureAfterWrap(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+
+	// HasShellFeatures returns true so Wrap is called, then ValidateStructure fails on wrapped parts
+	validator := &toolstest.MockCommandValidator{
+		HasShellFeaturesFunc: func(parts []string) bool {
+			return true
+		},
+		ValidateStructureFunc: func(parts []string) error {
+			// Fail specifically for shell-wrapped parts ("sh", "-c", ...)
+			if len(parts) > 0 && parts[0] == "sh" {
+				return fmt.Errorf("shell wrapping validation failed")
+			}
+			return nil
+		},
+	}
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	helperSlash := filepath.ToSlash(helperPath)
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"command": fmt.Sprintf("%s echo hello", helperSlash),
+		"reason":  "test validate after wrap",
+	}, nil)
+
+	if err != nil {
+		t.Fatalf("unexpected Go error: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected res.Error from ValidateStructure after wrapping")
+	}
+	if !strings.Contains(res.Error.Error(), "shell wrapping validation failed") {
+		t.Errorf("expected 'shell wrapping validation failed' in res.Error, got: %v", res.Error)
+	}
 }
 
 func TestShellTool_TimeoutParameter(t *testing.T) {
@@ -638,6 +822,36 @@ func TestWindowsTranslator_Translate_LS(t *testing.T) {
 	}
 }
 
+func TestWindowsTranslator_Translate_CP_MV(t *testing.T) {
+	w := &windowsTranslator{}
+
+	tests := []struct {
+		name     string
+		input    []string
+		expected []string
+	}{
+		{
+			name:     "cp simple",
+			input:    []string{"cp", "src.txt", "dst.txt"},
+			expected: []string{"cmd", "/c", "copy", "src.txt", "dst.txt"},
+		},
+		{
+			name:     "mv simple",
+			input:    []string{"mv", "old.txt", "new.txt"},
+			expected: []string{"cmd", "/c", "move", "old.txt", "new.txt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := w.Translate(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("Translate() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestShellTool_TimeoutEnforcement(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
@@ -720,4 +934,45 @@ func TestShellTool_PipeCommands_TooFewCommands(t *testing.T) {
 	if !strings.Contains(res.Text, "at least two commands") {
 		t.Errorf("expected 'at least two commands' in Text, got: %q", res.Text)
 	}
+}
+
+func TestShellTool_SplitPipelineErrors(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+
+	t.Run("Split error", func(t *testing.T) {
+		validator := &toolstest.MockCommandValidator{
+			SplitFunc: func(cmd string) ([]string, error) {
+				return nil, fmt.Errorf("split failure")
+			},
+		}
+		tool := newTestShellTool(sm, validator)
+
+		res, err := tool.splitPipeline([]string{"valid-cmd", "also-valid"})
+		if err == nil {
+			t.Fatal("expected split error")
+		}
+		if !strings.Contains(err.Error(), "error parsing command at index 0") {
+			t.Errorf("expected 'error parsing command at index 0', got: %v", err)
+		}
+		_ = res
+	})
+
+	t.Run("ValidateStructure error", func(t *testing.T) {
+		validator := &toolstest.MockCommandValidator{
+			ValidateStructureFunc: func(parts []string) error {
+				return fmt.Errorf("invalid structure")
+			},
+		}
+		tool := newTestShellTool(sm, validator)
+
+		res, err := tool.splitPipeline([]string{"valid-cmd", "also-valid"})
+		if err == nil {
+			t.Fatal("expected validate structure error")
+		}
+		if !strings.Contains(err.Error(), "invalid command at index 0") {
+			t.Errorf("expected 'invalid command at index 0', got: %v", err)
+		}
+		_ = res
+	})
 }

--- a/internal/tools/workspace/utils_test.go
+++ b/internal/tools/workspace/utils_test.go
@@ -79,3 +79,21 @@ func TestWalkAndProcess(t *testing.T) {
 		}
 	})
 }
+
+func TestSendHeartbeat_DefaultCase(t *testing.T) {
+	// Create an unbuffered channel with no reader — the send will block and fall to default
+	hb := make(chan struct{})
+	ctx := context.Background()
+
+	// This should not panic; the default case prevents blocking
+	sendHeartbeat(ctx, hb)
+
+	// Verify no panic occurred (implicit — reaching here is success)
+}
+
+func TestSendHeartbeat_NilChannel(t *testing.T) {
+	ctx := context.Background()
+	// Nil channel — should return immediately
+	sendHeartbeat(ctx, nil)
+	// No panic == success
+}

--- a/internal/tools/workspace/writer_test.go
+++ b/internal/tools/workspace/writer_test.go
@@ -1246,3 +1246,66 @@ func TestReplaceText_ReadFileError(t *testing.T) {
 		t.Fatal("expected error from replaceText on nonexistent path")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// createDirectory: unmarshal error and mkdir failure with security bypass
+// ---------------------------------------------------------------------------
+
+func TestCreateDirectory_InvalidArgs(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	w := &fileWriter{sm: sm, bm: newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10), fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.createDirectory(ctx, map[string]interface{}{"path": 123, "reason": "test"}, nil)
+	if err == nil {
+		t.Fatal("expected unmarshal error for invalid path type")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// performSingleDelete: snapshot error path (ReadFile fails for existing file)
+// ---------------------------------------------------------------------------
+
+type mockFS_ReadFileError struct {
+	persistence.FileSystem
+	readFileErr error
+}
+
+func (m *mockFS_ReadFileError) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return nil, m.readFileErr
+}
+
+func (m *mockFS_ReadFileError) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return m.FileSystem.Stat(ctx, name)
+}
+
+func TestPerformSingleDelete_SnapshotError(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "snapshot_err.txt")
+	if err := os.WriteFile(path, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	sm.RegisterSafePath(tempDir)
+
+	// Backup manager uses a mock FS that fails ReadFile
+	bm := newBackupManager(sm, &mockFS_ReadFileError{
+		FileSystem:  persistencetest.NewPlainOSFileSystem(),
+		readFileErr: fmt.Errorf("read failure"),
+	}, 10)
+
+	// fileWriter uses a real FS for Stat and Remove
+	w := &fileWriter{sm: sm, bm: bm, fs: persistencetest.NewPlainOSFileSystem()}
+	ctx := context.Background()
+
+	_, err := w.performSingleDelete(ctx, path)
+	if err == nil {
+		t.Fatal("expected snapshot error from ReadFile failure")
+	}
+	if !strings.Contains(err.Error(), "read failure") {
+		t.Errorf("expected 'read failure' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #431.

## Summary
Added error-path hardening tests across **cmd/tell-me-go/** and **internal/tools/workspace/** to meet ≥94% coverage targets.

### Changes
- **cmd/tell-me-go/main.go**: Added `cliNewFn` and `newSecurityManagerFn` function-override injection points (matching existing `initTracerFn`/`buildAppFn` pattern)
- **cmd/tell-me-go/main_test.go**: `TestBuildApp_CLINewError` — exercises `cli.New()` error path
- **tools/workspace/**: 30+ new table-driven error-path tests across backup, process_executor, reader, registration, shell, utils, and writer

### Coverage
| Package | Before | After |
|---------|--------|-------|
| `cmd/tell-me-go/` | 92.3% | **96.9%** |
| `tools/workspace/` | 91.6% | **94.2%** |

EH gaps reduced: 63 → 39 (24 paths covered; remaining 39 are OS-specific, dead-code, or require complex injection)

## Verification
| Check | Status |
|-------|--------|
| make check-full | ✅ PASS (all 10 steps) |
| `go test -count=3 -race` | ✅ No flaky tests |
| Lint | ✅ 0 issues |
| Dead code | ✅ None found |
| Vulncheck | ✅ 0 vulnerabilities |