### PR TITLE
fix(analysis): add error path tests for health, deadcode, dependency, and methodset analyzers (#429)

### DIFF
--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -81,6 +81,10 @@ var rules = []classificationRule{
 // to allow test injection of marshal failures for error-path coverage.
 var jsonMarshalIndent = json.MarshalIndent
 
+// osOpenFile is the function used to open coverage profile files. Exposed as a
+// variable to allow test injection of file-open failures for error-path coverage.
+var osOpenFile = os.Open
+
 // Classify categorizes the block and assigns a priority based on heuristics.
 func (b *uncoveredBlock) Classify() {
 	b.Category = "OTHER"
@@ -391,7 +395,7 @@ func (m *healthManager) getDetailedCoverage(ctx context.Context, packagePath str
 		return nil, err
 	}
 
-	cf, err := os.Open(tempPath)
+	cf, err := osOpenFile(tempPath)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -955,6 +955,45 @@ func TestGetDetailedCoverage_CreateTempError(t *testing.T) {
 	}
 }
 
+func TestGetDetailedCoverage_OpenError(t *testing.T) {
+	// NOT parallel — modifies package-level osOpenFile variable
+	ctx := context.Background()
+
+	// Create a mock that returns a valid coverage profile
+	mock := &mockExecutor{
+		OutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("github.com/user/repo"), nil
+		},
+		CombinedOutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-coverprofile=") {
+					path := strings.TrimPrefix(arg, "-coverprofile=")
+					if err := os.WriteFile(path, []byte("mode: set\n"), 0644); err != nil {
+						t.Errorf("failed to write mock coverage file: %v", err)
+					}
+				}
+			}
+			return []byte("ok"), nil
+		},
+	}
+	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
+
+	// Inject osOpenFile to return an error
+	origOpen := osOpenFile
+	osOpenFile = func(name string) (*os.File, error) {
+		return nil, fmt.Errorf("injected open error")
+	}
+	defer func() { osOpenFile = origOpen }()
+
+	_, err := hea.getDetailedCoverage(ctx, ".", nil)
+	if err == nil {
+		t.Error("expected error from injected osOpenFile failure")
+	}
+	if !strings.Contains(err.Error(), "injected open error") {
+		t.Errorf("expected 'injected open error' in error, got: %v", err)
+	}
+}
+
 func TestGetDetailedCoverageJSON_ErrorWithData(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/tools/analysis/dead_code_constructor_propagation_test.go
+++ b/internal/tools/analysis/dead_code_constructor_propagation_test.go
@@ -23,6 +23,8 @@ package analysis
 
 import (
 	"context"
+	"go/token"
+	"go/types"
 	"os"
 	"path/filepath"
 	"testing"
@@ -407,4 +409,187 @@ func TestConstructorPropagation_TypeAliasNotPropagated(t *testing.T) {
 			"alias resolution has been added — update the doc-comment "+
 			"and either remove this test or invert its expectation.\n"+
 			"Report was:\n%s", report)
+}
+
+// TestPropagateConstructorUsages_WithHeartbeat verifies the heartbeat path
+// in propagateConstructorUsagesToReturnTypes. When totalUses is empty there
+// are zero ids to iterate, so the loop body (including the i%20==0 heartbeat
+// send) never executes. The function must not panic and must not send a
+// spurious heartbeat on an empty dataset.
+func TestPropagateConstructorUsages_WithHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	state := &scanState{
+		declarations: map[string]*symMeta{},
+		totalUses:    make(map[string]int),
+		externalUses: make(map[string]int),
+	}
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+	hb := make(chan struct{}, 1)
+
+	// The function iterates over ids and sends heartbeat when i%20==0.
+	// With 0 ids, it should not panic and not send heartbeat.
+	analyzer.propagateConstructorUsagesToReturnTypes(state, hb)
+
+	// Verify no heartbeat was sent (no ids to process).
+	select {
+	case <-hb:
+		t.Error("unexpected heartbeat with 0 ids")
+	default:
+		// expected: no heartbeat
+	}
+}
+
+// TestProcessConstructorUsage_GuardClauses verifies the early-return guards
+// in processConstructorUsage: nil obj (L140) and non-func obj (L143).
+// Neither path should panic.
+func TestProcessConstructorUsage_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil obj returns early", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			declarations: map[string]*symMeta{
+				"example.com/pkg.Func": {
+					id:      "example.com/pkg.Func",
+					pkgPath: "example.com/pkg",
+					name:    "Func",
+					symType: "Function",
+					obj:     nil, // nil obj — guard at L140
+				},
+			},
+			totalUses:    map[string]int{"example.com/pkg.Func": 1},
+			externalUses: map[string]int{"example.com/pkg.Func": 1},
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+		// Should not panic
+		analyzer.processConstructorUsage("example.com/pkg.Func", 1, state)
+		// No assertion needed — the test passes if no panic
+	})
+
+	t.Run("non-func obj returns early", func(t *testing.T) {
+		t.Parallel()
+		pkg := types.NewPackage("example.com/pkg", "pkg")
+		varObj := types.NewVar(token.NoPos, pkg, "Var", types.Typ[types.Int])
+		state := &scanState{
+			declarations: map[string]*symMeta{
+				"example.com/pkg.Var": {
+					id:      "example.com/pkg.Var",
+					pkgPath: "example.com/pkg",
+					name:    "Var",
+					symType: "Variable",
+					obj:     varObj,
+				},
+			},
+			totalUses:    map[string]int{"example.com/pkg.Var": 1},
+			externalUses: map[string]int{"example.com/pkg.Var": 1},
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+		analyzer.processConstructorUsage("example.com/pkg.Var", 1, state)
+		// No panic — guard at fn, ok := meta.obj.(*types.Func)
+	})
+}
+
+// TestMarkPropagated_GuardClauses verifies the four guard clauses in
+// markPropagated: zero return types, interface return types,
+// self-referential return types, and stdlib/basic return types not in
+// the declarations map.
+func TestMarkPropagated_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("zero return types skipped", func(t *testing.T) {
+		t.Parallel()
+		// Signature with no return values
+		sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+		state := &scanState{
+			declarations: make(map[string]*symMeta),
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+		analyzer.markPropagated("source.id", sig, 1, state)
+		// No panic — extractNamedReturnTypes returns nil, loop body never executes
+	})
+
+	t.Run("interface return type skipped", func(t *testing.T) {
+		t.Parallel()
+		iface := types.NewInterfaceType(nil, nil)
+		named := types.NewNamed(
+			types.NewTypeName(token.NoPos, types.NewPackage("example.com/pkg", "pkg"), "MyInterface", iface),
+			iface,
+			nil,
+		)
+		// Create signature returning the interface-named type
+		results := types.NewTuple(types.NewVar(token.NoPos, nil, "", named))
+		sig := types.NewSignatureType(nil, nil, nil, results, nil, false)
+
+		state := &scanState{
+			declarations: make(map[string]*symMeta),
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+		analyzer.markPropagated("source.id", sig, 1, state)
+		// No panic, no declarations added — interface types are skipped
+		if len(state.totalUses) != 0 {
+			t.Errorf("expected no totalUses entries for interface return type, got %d", len(state.totalUses))
+		}
+	})
+
+	t.Run("self-referential return type skipped", func(t *testing.T) {
+		t.Parallel()
+		pkg := types.NewPackage("example.com/pkg", "pkg")
+		structType := types.NewStruct(nil, nil)
+		named := types.NewNamed(
+			types.NewTypeName(token.NoPos, pkg, "SelfRef", structType),
+			structType,
+			nil,
+		)
+		results := types.NewTuple(types.NewVar(token.NoPos, nil, "", named))
+		sig := types.NewSignatureType(nil, nil, nil, results, nil, false)
+
+		state := &scanState{
+			declarations: map[string]*symMeta{
+				"example.com/pkg.SelfRef": {
+					id:      "example.com/pkg.SelfRef",
+					pkgPath: "example.com/pkg",
+					name:    "SelfRef",
+					symType: "Type",
+					obj:     named.Obj(),
+				},
+			},
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+
+		// Self-ref: sourceId is "example.com/pkg.SelfRef" and typeId is also
+		// "example.com/pkg.SelfRef" — the guard should skip it
+		analyzer.markPropagated("example.com/pkg.SelfRef", sig, 1, state)
+		// totalUses should NOT be bumped for self-ref
+		if state.totalUses["example.com/pkg.SelfRef"] != 0 {
+			t.Errorf("self-referential type should not bump totalUses, got %d",
+				state.totalUses["example.com/pkg.SelfRef"])
+		}
+	})
+
+	t.Run("stdlib return type skipped (not in declarations)", func(t *testing.T) {
+		t.Parallel()
+		// int is a basic type, not *types.Named → extractNamedReturnTypes skips it
+		results := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+		sig := types.NewSignatureType(nil, nil, nil, results, nil, false)
+
+		state := &scanState{
+			declarations: make(map[string]*symMeta),
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		analyzer := &defaultDeadCodeAnalyzer{}
+		analyzer.markPropagated("source.id", sig, 1, state)
+		if len(state.totalUses) != 0 {
+			t.Errorf("basic type should not add to totalUses, got %d", len(state.totalUses))
+		}
+	})
 }

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -4,10 +4,12 @@
 package analysis
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"go/token"
 	"go/types"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -734,6 +736,26 @@ func TestInternal_NilReceiverCoverage(t *testing.T) {
 		assert.False(t, analyzer.isInterfaceMethod(fnStructOther), "Struct method is not an interface method")
 	})
 
+	t.Run("Non-Nil Receiver with Interface Underlying Type", func(t *testing.T) {
+		// Create an interface type
+		iface := types.NewInterfaceType(nil, nil)
+		// Create a named type whose underlying is the interface
+		named := types.NewNamed(
+			types.NewTypeName(token.NoPos, nil, "MyInterface", iface),
+			iface,
+			nil,
+		)
+		// Create a receiver variable of that named type
+		recv := types.NewVar(token.NoPos, nil, "m", named)
+		// Create a method signature with that receiver
+		sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+		fn := types.NewFunc(token.NoPos, nil, "Helper", sig)
+
+		// The underlying type of the receiver's type is *types.Interface
+		assert.True(t, analyzer.isInterfaceMethod(fn),
+			"method on interface-named type should be treated as interface method")
+	})
+
 	t.Run("Non-Function Object Guard", func(t *testing.T) {
 		// Create a mock variable instead of a function/type
 		mockVar := types.NewVar(token.NoPos, nil, "MockVar", types.Typ[types.Int])
@@ -747,6 +769,67 @@ func TestInternal_NilReceiverCoverage(t *testing.T) {
 		}
 		if analyzer.isInterfaceType(mockVar) {
 			t.Errorf("Expected isInterfaceType to return false for a *types.Var")
+		}
+	})
+}
+
+func TestSignatureMatches_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	t.Run("param count mismatch", func(t *testing.T) {
+		t.Parallel()
+		// Signature with 1 param
+		paramType := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String]))
+		sig := types.NewSignatureType(nil, nil, nil, paramType, nil, false)
+
+		want := wellKnownContractSignature{
+			params:  []string{"[]byte"}, // different count
+			results: nil,
+		}
+		if signatureMatches(sig, want) {
+			t.Error("should not match when param count differs")
+		}
+	})
+
+	t.Run("result count mismatch", func(t *testing.T) {
+		t.Parallel()
+		resultType := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.String]))
+		sig := types.NewSignatureType(nil, nil, nil, nil, resultType, false)
+
+		want := wellKnownContractSignature{
+			params:  nil,
+			results: []string{"int", "error"}, // different count
+		}
+		if signatureMatches(sig, want) {
+			t.Error("should not match when result count differs")
+		}
+	})
+
+	t.Run("param type mismatch", func(t *testing.T) {
+		t.Parallel()
+		paramType := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+		sig := types.NewSignatureType(nil, nil, nil, paramType, nil, false)
+
+		want := wellKnownContractSignature{
+			params:  []string{"string"},
+			results: nil,
+		}
+		if signatureMatches(sig, want) {
+			t.Error("should not match when param type differs")
+		}
+	})
+
+	t.Run("result type mismatch", func(t *testing.T) {
+		t.Parallel()
+		resultType := types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int]))
+		sig := types.NewSignatureType(nil, nil, nil, nil, resultType, false)
+
+		want := wellKnownContractSignature{
+			params:  nil,
+			results: []string{"string"},
+		}
+		if signatureMatches(sig, want) {
+			t.Error("should not match when result type differs")
 		}
 	})
 }
@@ -1023,6 +1106,152 @@ func TestTrackExternalUsages_GetUsagesError(t *testing.T) {
 	}
 }
 
+func TestAnalyzeUsages_ErrorAccumulation(t *testing.T) {
+	t.Parallel()
+
+	// Capture slog output
+	var logBuf bytes.Buffer
+	oldLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	defer slog.SetDefault(oldLogger)
+
+	ctx := context.Background()
+	state := &scanState{
+		targetModule: "example.com/test",
+		pkgs:         []*packages.Package{},
+		declarations: map[string]*symMeta{
+			"example.com/test/foo.SymbolA": {
+				id:      "example.com/test/foo.SymbolA",
+				pkgPath: "example.com/test/foo",
+				name:    "SymbolA",
+				symType: "Function",
+			},
+			"example.com/test/bar.SymbolB": {
+				id:      "example.com/test/bar.SymbolB",
+				pkgPath: "example.com/test/bar",
+				name:    "SymbolB",
+				symType: "Function",
+			},
+		},
+		totalUses:    make(map[string]int),
+		externalUses: make(map[string]int),
+	}
+
+	sentinelErr := fmt.Errorf("index corruption")
+	callOrder := make([]string, 0)
+
+	mockIdx := &mockSymbolIndex{
+		IsSymbolUsedFunc: func(ctx context.Context, name string, hb chan<- struct{}) bool {
+			// Both symbols enter the GetUsages path so we can verify
+			// that SymbolB is processed despite SymbolA's error.
+			return true
+		},
+		GetUsagesFunc: func(ctx context.Context, symbol string, path string, hb chan<- struct{}) ([]location, error) {
+			callOrder = append(callOrder, symbol)
+			if symbol == "example.com/test/foo.SymbolA" {
+				return nil, sentinelErr
+			}
+			return nil, nil
+		},
+		GetImplementationsFunc: func(ctx context.Context, id string) []string {
+			return []string{}
+		},
+	}
+
+	analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+	analyzer.analyzeUsages(ctx, state, "/tmp/proj", nil)
+
+	// Both symbols must be processed despite the error on SymbolA
+	if len(callOrder) < 2 {
+		t.Errorf("expected at least 2 symbols processed, got %d: %v", len(callOrder), callOrder)
+	}
+
+	// slog.Warn must contain the sentinel error
+	if !strings.Contains(logBuf.String(), sentinelErr.Error()) {
+		t.Errorf("expected slog.Warn to contain %q, got: %s", sentinelErr.Error(), logBuf.String())
+	}
+}
+
+func TestProcessImplementations_ZeroTotalUses(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := &scanState{
+		declarations: map[string]*symMeta{
+			"example.com/foo.Symbol": {
+				id:      "example.com/foo.Symbol",
+				pkgPath: "example.com/foo",
+				name:    "Symbol",
+				symType: "Function",
+			},
+			"example.com/bar.Impl": {
+				id:      "example.com/bar.Impl",
+				pkgPath: "example.com/bar",
+				name:    "Impl",
+				symType: "Function",
+			},
+		},
+		totalUses:    map[string]int{"example.com/foo.Symbol": 0},
+		externalUses: make(map[string]int),
+	}
+
+	mockIdx := &mockSymbolIndex{
+		GetImplementationsFunc: func(ctx context.Context, id string) []string {
+			return []string{"example.com/bar.Impl"} // from a different package
+		},
+	}
+	analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+	analyzer.processImplementations(ctx, state, "example.com/foo.Symbol", nil)
+
+	if state.totalUses["example.com/foo.Symbol"] != 1 {
+		t.Errorf("expected totalUses to be bumped to 1, got %d", state.totalUses["example.com/foo.Symbol"])
+	}
+	if state.externalUses["example.com/foo.Symbol"] != 1 {
+		t.Errorf("expected externalUses to be incremented, got %d", state.externalUses["example.com/foo.Symbol"])
+	}
+}
+
+func TestProcessImplementations_SamePackageNoIncrement(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	state := &scanState{
+		declarations: map[string]*symMeta{
+			"example.com/foo.Symbol": {
+				id:      "example.com/foo.Symbol",
+				pkgPath: "example.com/foo",
+				name:    "Symbol",
+				symType: "Function",
+			},
+			"example.com/foo.Impl": {
+				id:      "example.com/foo.Impl",
+				pkgPath: "example.com/foo",
+				name:    "Impl",
+				symType: "Function",
+			},
+		},
+		totalUses:    map[string]int{"example.com/foo.Symbol": 0},
+		externalUses: make(map[string]int),
+	}
+
+	mockIdx := &mockSymbolIndex{
+		GetImplementationsFunc: func(ctx context.Context, id string) []string {
+			return []string{"example.com/foo.Impl"} // same package
+		},
+	}
+	analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+	analyzer.processImplementations(ctx, state, "example.com/foo.Symbol", nil)
+
+	// totalUses bumped to 1
+	if state.totalUses["example.com/foo.Symbol"] != 1 {
+		t.Errorf("expected totalUses bumped to 1, got %d", state.totalUses["example.com/foo.Symbol"])
+	}
+	// externalUses NOT incremented (same package)
+	if state.externalUses["example.com/foo.Symbol"] != 0 {
+		t.Errorf("expected externalUses to stay 0 for same-package impl, got %d", state.externalUses["example.com/foo.Symbol"])
+	}
+}
+
 func TestIdentifyModule_NoGoFilesError(t *testing.T) {
 	t.Parallel()
 
@@ -1030,29 +1259,64 @@ func TestIdentifyModule_NoGoFilesError(t *testing.T) {
 
 	// Package with "no Go files" error but NOT "does not contain main module".
 	// This exercises the skip-continue path in identifyModule.
+	t.Run("skip no-Go-files package, find module on second", func(t *testing.T) {
+		pkgs := []*packages.Package{
+			{
+				PkgPath: "example.com/empty",
+				Errors: []packages.Error{
+					{Msg: "no Go files in /some/dir"},
+				},
+				Module: nil, // no module from the empty package
+			},
+			{
+				PkgPath: "example.com/valid",
+				Errors:  nil,
+				Module: &packages.Module{
+					Path: "example.com/testmodule",
+				},
+			},
+		}
+
+		modulePath, err := analyzer.identifyModule(pkgs)
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if modulePath != "example.com/testmodule" {
+			t.Errorf("expected module path 'example.com/testmodule', got: %q", modulePath)
+		}
+	})
+}
+
+func TestIdentifyModule_AllPackagesNoModule(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+
+	// Simulates running outside a Go module directory (e.g., GO111MODULE=off).
+	// No package has a "does not contain main module" error, no non-"no Go files"
+	// error, and every package has Module == nil. This exercises the second
+	// "no go.mod found" fallback return in identifyModule.
 	pkgs := []*packages.Package{
 		{
-			PkgPath: "example.com/empty",
-			Errors: []packages.Error{
-				{Msg: "no Go files in /some/dir"},
-			},
-			Module: nil, // no module from the empty package
+			PkgPath: "example.com/pkg1",
+			Errors:  nil,
+			Module:  nil,
 		},
 		{
-			PkgPath: "example.com/valid",
-			Errors:  nil,
-			Module: &packages.Module{
-				Path: "example.com/testmodule",
-			},
+			PkgPath: "example.com/pkg2",
+			Module:  nil,
 		},
 	}
 
 	modulePath, err := analyzer.identifyModule(pkgs)
-	if err != nil {
-		t.Fatalf("expected no error, got: %v", err)
+	if err == nil {
+		t.Fatal("expected error, got nil")
 	}
-	if modulePath != "example.com/testmodule" {
-		t.Errorf("expected module path 'example.com/testmodule', got: %q", modulePath)
+	if !strings.Contains(err.Error(), "no go.mod found") {
+		t.Errorf("expected 'no go.mod found', got: %v", err)
+	}
+	if modulePath != "" {
+		t.Errorf("expected empty module path, got: %q", modulePath)
 	}
 }
 
@@ -1083,4 +1347,93 @@ func TestHasTextMatchOutsidePackage_ReadFileError(t *testing.T) {
 	if got {
 		t.Error("expected false when ReadFile fails on all files in other packages")
 	}
+}
+
+func TestHarvestInterfaceMethods_DefensiveGuards(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+	fset := token.NewFileSet()
+
+	t.Run("unexported method skipped", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			declarations: make(map[string]*symMeta),
+		}
+		// Interface with one unexported method
+		unexportedMethod := types.NewFunc(token.NoPos, nil, "unexported",
+			types.NewSignatureType(nil, nil, nil, nil, nil, false))
+		itf := types.NewInterfaceType([]*types.Func{unexportedMethod}, nil)
+
+		analyzer.harvestInterfaceMethods(itf, fset, state)
+		// unexported method must NOT appear in declarations
+		if len(state.declarations) != 0 {
+			t.Errorf("expected 0 declarations, got %d", len(state.declarations))
+		}
+	})
+
+	t.Run("exported method harvested", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			declarations: make(map[string]*symMeta),
+		}
+		// Interface with one exported method — exercises the non-nil, exported path
+		realMethod := types.NewFunc(token.NoPos,
+			types.NewPackage("example.com/pkg", "pkg"), "Exported",
+			types.NewSignatureType(nil, nil, nil, nil, nil, false))
+		itf := types.NewInterfaceType([]*types.Func{realMethod}, nil)
+
+		analyzer.harvestInterfaceMethods(itf, fset, state)
+		if len(state.declarations) != 1 {
+			t.Errorf("expected 1 declaration for exported method, got %d", len(state.declarations))
+		}
+	})
+
+	t.Run("nil fset treated as not export_test.go", func(t *testing.T) {
+		t.Parallel()
+		// isExportTestFile with nil fset returns false
+		if isExportTestFile(nil, token.NoPos) {
+			t.Error("isExportTestFile(nil, ...) should return false")
+		}
+	})
+
+	t.Run("invalid pos treated as not export_test.go", func(t *testing.T) {
+		t.Parallel()
+		fset := token.NewFileSet()
+		if isExportTestFile(fset, token.NoPos) {
+			t.Error("isExportTestFile with invalid pos should return false")
+		}
+	})
+}
+
+func TestIsEligibleForHarvest_EdgeCases(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+	fset := token.NewFileSet()
+
+	t.Run("nil object returns false", func(t *testing.T) {
+		t.Parallel()
+		if analyzer.isEligibleForHarvest(nil, fset) {
+			t.Error("nil object should not be eligible")
+		}
+	})
+
+	t.Run("nil package returns false", func(t *testing.T) {
+		t.Parallel()
+		obj := types.NewVar(token.NoPos, nil, "X", types.Typ[types.Int]) // Pkg() is nil
+		if analyzer.isEligibleForHarvest(obj, fset) {
+			t.Error("object with nil package should not be eligible")
+		}
+	})
+
+	t.Run("init function skipped", func(t *testing.T) {
+		t.Parallel()
+		pkg := types.NewPackage("example.com/pkg", "pkg")
+		obj := types.NewFunc(token.NoPos, pkg, "init",
+			types.NewSignatureType(nil, nil, nil, nil, nil, false))
+		if analyzer.isEligibleForHarvest(obj, fset) {
+			t.Error("init function should not be eligible")
+		}
+	})
 }

--- a/internal/tools/analysis/dependency_test.go
+++ b/internal/tools/analysis/dependency_test.go
@@ -326,6 +326,45 @@ func TestBuildGraph_ErrorPaths(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────
+// buildGraph: getImports error propagation through errgroup
+// ─────────────────────────────────────────────────────────
+
+func TestBuildGraph_GetImportsError(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Create a valid workspace with one package
+	pkgDir := filepath.Join(tmpDir, "pkg")
+	require.NoError(t, os.MkdirAll(pkgDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkgDir, "f.go"), []byte("package pkg"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/mod"), 0644))
+
+	// Also create a second package so the errgroup has work to do
+	pkg2Dir := filepath.Join(tmpDir, "pkg2")
+	require.NoError(t, os.MkdirAll(pkg2Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(pkg2Dir, "f.go"), []byte("package pkg2"), 0644))
+
+	runner := &mockAnalysisGoRunner{
+		getModulePathFunc: func(ctx context.Context) (string, error) {
+			return "example.com/mod", nil
+		},
+		getModuleDirFunc: func(ctx context.Context) (string, error) {
+			return tmpDir, nil
+		},
+	}
+
+	a := newDependencyAnalyzer(runner, &mockSecurityProvider{}, nil,
+		infra_persistence.NewWorkspacePolicy())
+
+	// Use a cancelled context so packages.Load inside getImports fails
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := a.buildGraph(ctx)
+	require.Error(t, err, "expected error from cancelled context in getImports")
+}
+
+// ─────────────────────────────────────────────────────────
 // getImports error path test
 // ─────────────────────────────────────────────────────────
 

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -5,10 +5,13 @@ package analysis
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
@@ -461,4 +464,269 @@ func TestGetDetailedCoverage_DefaultPath(t *testing.T) {
 	if !strings.Contains(result.Text, "Error:") {
 		t.Errorf("expected error text in result, got: %s", result.Text)
 	}
+}
+
+func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name             string
+		ctxFunc          func() (context.Context, func())
+		runnerFunc       func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+		wantTestStatus   string
+		wantTestContains string
+		wantCovStatus    string
+		wantCovContains  string
+	}{
+		{
+			name: "deadline exceeded",
+			ctxFunc: func() (context.Context, func()) {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Hour))
+				return ctx, cancel
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{}, context.DeadlineExceeded
+			},
+			wantTestStatus:   "TIMEOUT",
+			wantTestContains: "timed out",
+			wantCovStatus:    "ERROR",
+			wantCovContains:  "Failed to generate coverage summary",
+		},
+		{
+			name: "context canceled",
+			ctxFunc: func() (context.Context, func()) {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel() // ctx.Err() returns context.Canceled
+				return ctx, cancel
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{}, context.Canceled
+			},
+			wantTestStatus:   "CANCELLED",
+			wantTestContains: "cancelled",
+			wantCovStatus:    "ERROR",
+			wantCovContains:  "Failed to generate coverage summary",
+		},
+		{
+			name: "generic test failure",
+			ctxFunc: func() (context.Context, func()) {
+				return context.Background(), func() {}
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{}, errors.New("exit status 1")
+			},
+			wantTestStatus:   "FAIL",
+			wantTestContains: "failed",
+			wantCovStatus:    "ERROR",
+			wantCovContains:  "Failed to generate coverage summary",
+		},
+		{
+			name: "coverage N/A",
+			ctxFunc: func() (context.Context, func()) {
+				return context.Background(), func() {}
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{CoveragePct: "N/A", PassedCount: 3}, nil
+			},
+			wantTestStatus:   "PASS",
+			wantTestContains: "3 packages passed",
+			wantCovStatus:    "N/A",
+			wantCovContains:  "Could not parse coverage",
+		},
+		{
+			name: "no Go files",
+			ctxFunc: func() (context.Context, func()) {
+				return context.Background(), func() {}
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{NoGoFiles: true, PassedCount: 0}, nil
+			},
+			wantTestStatus:   "PASS",
+			wantTestContains: "0 packages passed",
+			wantCovStatus:    "ERROR",
+			wantCovContains:  "Failed to generate coverage summary",
+		},
+		{
+			name: "empty coverage",
+			ctxFunc: func() (context.Context, func()) {
+				return context.Background(), func() {}
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{CoveragePct: "", PassedCount: 1}, nil
+			},
+			wantTestStatus:   "PASS",
+			wantTestContains: "1 packages passed",
+			wantCovStatus:    "ERROR",
+			wantCovContains:  "Failed to generate coverage summary",
+		},
+		{
+			name: "coverage success",
+			ctxFunc: func() (context.Context, func()) {
+				return context.Background(), func() {}
+			},
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+				return toolchain.CoverageReport{CoveragePct: "85.0%", PassedCount: 5}, nil
+			},
+			wantTestStatus:   "PASS",
+			wantTestContains: "5 packages passed",
+			wantCovStatus:    "85.0%",
+			wantCovContains:  "Target: > 80%",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &healthManager{
+				Runner: &mockGoRunner{
+					runTestsWithCoverageFunc: tt.runnerFunc,
+				},
+			}
+			ctx, cleanup := tt.ctxFunc()
+			defer cleanup()
+			tStatus, tDetails, cStatus, cDetails := m.runTestsAndCoverage(ctx)
+			if tt.wantTestStatus != "" && tStatus != tt.wantTestStatus {
+				t.Errorf("test status: got %q, want %q", tStatus, tt.wantTestStatus)
+			}
+			if tt.wantTestContains != "" && !strings.Contains(strings.ToLower(tDetails), strings.ToLower(tt.wantTestContains)) {
+				t.Errorf("test details: got %q, want containing %q", tDetails, tt.wantTestContains)
+			}
+			if tt.wantCovStatus != "" && cStatus != tt.wantCovStatus {
+				t.Errorf("coverage status: got %q, want %q", cStatus, tt.wantCovStatus)
+			}
+			if tt.wantCovContains != "" && !strings.Contains(strings.ToLower(cDetails), strings.ToLower(tt.wantCovContains)) {
+				t.Errorf("coverage details: got %q, want containing %q", cDetails, tt.wantCovContains)
+			}
+		})
+	}
+}
+
+func TestRunLint_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		runLinterFn  func(ctx context.Context) (string, string, error)
+		wantStatus   string
+		wantContains string
+	}{
+		{
+			name: "no linter found",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "", "", toolchain.ErrNoSupportedLinter
+			},
+			wantStatus:   "SKIP",
+			wantContains: "No linter found",
+		},
+		{
+			name: "generic error",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "", "", errors.New("binary not found")
+			},
+			wantStatus:   "ERROR",
+			wantContains: "binary not found",
+		},
+		{
+			name: "exit error with issues",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "file.go:10:5: warning", "staticcheck", &exec.ExitError{}
+			},
+			wantStatus:   "1 Issues",
+			wantContains: "Using staticcheck",
+		},
+		{
+			name: "exit error but no output",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "", "golangci-lint", &exec.ExitError{}
+			},
+			wantStatus:   "CLEAN",
+			wantContains: "All checks passed",
+		},
+		{
+			name: "no issues no error",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "", "golangci-lint", nil
+			},
+			wantStatus:   "CLEAN",
+			wantContains: "All checks passed",
+		},
+		{
+			name: "output but not issue lines",
+			runLinterFn: func(ctx context.Context) (string, string, error) {
+				return "just a warning message\nno colon numbers", "staticcheck", &exec.ExitError{}
+			},
+			wantStatus:   "CLEAN",
+			wantContains: "All checks passed",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &healthManager{
+				Runner: &mockGoRunner{
+					runLinterFunc: tt.runLinterFn,
+				},
+			}
+			status, details := m.runLint(context.Background())
+			if status != tt.wantStatus {
+				t.Errorf("status: got %q, want %q", status, tt.wantStatus)
+			}
+			if !strings.Contains(details, tt.wantContains) {
+				t.Errorf("details: got %q, want containing %q", details, tt.wantContains)
+			}
+		})
+	}
+}
+
+func TestHealthStartHeartbeat(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil hb, already-done channel", func(t *testing.T) {
+		t.Parallel()
+		m := &healthManager{}
+		done := make(chan struct{})
+		close(done)
+		m.startHeartbeat(done, nil) // must return immediately, no panic
+	})
+
+	t.Run("nil hb, open done channel then close", func(t *testing.T) {
+		t.Parallel()
+		m := &healthManager{}
+		done := make(chan struct{})
+		go func() {
+			m.startHeartbeat(done, nil)
+		}()
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+	})
+
+	t.Run("buffered hb, receives heartbeat", func(t *testing.T) {
+		t.Parallel()
+		m := &healthManager{}
+		done := make(chan struct{})
+		hb := make(chan struct{}, 2)
+		go func() {
+			m.startHeartbeat(done, hb)
+		}()
+		select {
+		case <-hb:
+			// received
+		case <-time.After(3 * time.Second):
+			t.Error("timed out waiting for heartbeat")
+		}
+		close(done)
+	})
+
+	t.Run("hb full, does not block", func(t *testing.T) {
+		t.Parallel()
+		m := &healthManager{}
+		done := make(chan struct{})
+		hb := make(chan struct{}, 1)
+		hb <- struct{}{} // pre-fill buffer
+		go func() {
+			m.startHeartbeat(done, hb)
+		}()
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+		// test passes if we reach here without deadlock/panic
+	})
 }

--- a/internal/tools/analysis/index_impl_test.go
+++ b/internal/tools/analysis/index_impl_test.go
@@ -4,6 +4,9 @@
 package analysis
 
 import (
+	"context"
+	"go/token"
+	"go/types"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -115,5 +118,45 @@ func (e EnglishGreeter) Greet() string { return "hello" }
 	}
 	for i := 1; i < N; i++ {
 		assert.ElementsMatch(t, results[0], results[i])
+	}
+}
+
+// TestSatisfiesGenericInterface_EmptyInterface verifies the defensive guard
+// that prevents a panic when an empty interface (NumMethods()==0) is passed
+// to satisfiesGenericInterface. This is defense-in-depth because
+// mapTypeToInterfaces pre-filters interfaces with ptrMethodSetLen < itf.NumMethods(),
+// which would reject empty interfaces (0 < 0 is false, but the loop body
+// would never execute for empty interfaces anyway). The guard at L74
+// ensures the function returns false immediately for empty interfaces.
+func TestSatisfiesGenericInterface_EmptyInterface(t *testing.T) {
+	t.Parallel()
+
+	idx := &indexer{}
+	emptyIface := types.NewInterfaceType(nil, nil) // NumMethods() == 0
+	named := types.NewNamed(
+		types.NewTypeName(token.NoPos, nil, "MyType", types.NewStruct(nil, nil)),
+		types.NewStruct(nil, nil),
+		nil,
+	)
+	pkgTypes := types.NewPackage("example.com/pkg", "pkg")
+
+	got := idx.satisfiesGenericInterface(named, emptyIface, pkgTypes)
+	if got {
+		t.Error("satisfiesGenericInterface should return false for empty interface")
+	}
+}
+
+func TestGetImplementations_RefreshError(t *testing.T) {
+	t.Parallel()
+
+	// Create indexer pointing to a non-existent directory
+	idx, err := newIndexer("/nonexistent/directory/for/testing")
+	require.NoError(t, err)
+
+	// GetImplementations calls Refresh, which calls loadPackages,
+	// which fails because the directory doesn't exist
+	result := idx.GetImplementations(context.Background(), "some.Interface.Method", nil)
+	if result != nil {
+		t.Errorf("expected nil result on Refresh error, got %v", result)
 	}
 }

--- a/internal/tools/analysis/info_test.go
+++ b/internal/tools/analysis/info_test.go
@@ -377,3 +377,104 @@ func TestInfoManager_GetFileSkeleton(t *testing.T) {
 		}
 	})
 }
+
+// errorFileSystem implements persistence.FileSystem and always returns error from Walk and ReadFile.
+// Used to test error paths in GetProjectSummary and collectFileStats.
+type errorFileSystem struct {
+	persistence.FileSystem
+}
+
+func (e *errorFileSystem) Walk(ctx context.Context, root string, fn persistence.WalkFunc) error {
+	return fmt.Errorf("walk error")
+}
+
+func (e *errorFileSystem) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return nil, fmt.Errorf("read error")
+}
+
+func TestGetFileSkeleton_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		m := &infoManager{SP: &mockSecurityProvider{}, Policy: infra_persistence.NewWorkspacePolicy()}
+		_, err := m.GetFileSkeleton(context.Background(), map[string]interface{}{"filepath": make(chan int)}, nil)
+		if err == nil {
+			t.Error("expected error for unserializable args")
+		}
+	})
+
+	t.Run("IsPathSafe error", func(t *testing.T) {
+		t.Parallel()
+		m := &infoManager{SP: &denyingSecurityProvider{}, Policy: infra_persistence.NewWorkspacePolicy()}
+		_, err := m.GetFileSkeleton(context.Background(), map[string]interface{}{"filepath": "/some/path"}, nil)
+		if err == nil {
+			t.Error("expected error from IsPathSafe rejection")
+		}
+	})
+
+	t.Run("non-go file with FS read error", func(t *testing.T) {
+		t.Parallel()
+		fs := persistence.NewMockFileSystem()
+		m := &infoManager{
+			SP:     &mockSecurityProvider{},
+			FS:     fs,
+			Policy: infra_persistence.NewWorkspacePolicy(),
+		}
+		// Don't write the file — FS.ReadFile will fail
+		_, err := m.GetFileSkeleton(context.Background(), map[string]interface{}{"filepath": "/nonexistent.py"}, nil)
+		if err == nil {
+			t.Error("expected error from FS.ReadFile failure for non-go file")
+		}
+	})
+
+	t.Run("go file fallback with FS read error", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		fs := persistence.NewMockFileSystem()
+		m := &infoManager{
+			SP:     &mockSecurityProvider{},
+			FS:     fs,
+			Cache:  newASTCache(tmpDir),
+			Policy: infra_persistence.NewWorkspacePolicy(),
+		}
+		// Path is .go; AST cache fails (file not on real disk), fallback to extractGenericSkeleton
+		// which also fails because the mock FS has no such file
+		_, err := m.GetFileSkeleton(context.Background(), map[string]interface{}{"filepath": tmpDir + "/nonexistent.go"}, nil)
+		if err == nil {
+			t.Error("expected error from FS.ReadFile failure in go fallback path")
+		}
+	})
+}
+
+func TestGetProjectSummary_ErrorPath(t *testing.T) {
+	t.Parallel()
+	// Use a mock FS that always returns an error from Walk
+	fs := &errorFileSystem{}
+	m := &infoManager{FS: fs, Policy: infra_persistence.NewWorkspacePolicy()}
+	ctx := context.Background()
+
+	_, err := m.GetProjectSummary(ctx, nil, nil)
+	if err == nil {
+		t.Error("expected error from FS.Walk failure")
+	}
+}
+
+func TestPublishGoDocEvent_NilEvents(t *testing.T) {
+	t.Parallel()
+	m := &infoManager{Events: nil, Policy: infra_persistence.NewWorkspacePolicy()}
+	// Must not panic
+	m.publishGoDocEvent(context.Background(), "fmt.Println")
+}
+
+func TestFormatDocOutput_Error(t *testing.T) {
+	t.Parallel()
+	m := &infoManager{Policy: infra_persistence.NewWorkspacePolicy()}
+	result := m.formatDocOutput([]byte("partial output"), fmt.Errorf("go doc failed"))
+	if !strings.Contains(result.Text, "Error running go doc") {
+		t.Errorf("expected error message in output, got: %s", result.Text)
+	}
+	if !strings.Contains(result.Text, "partial output") {
+		t.Errorf("expected partial output in result, got: %s", result.Text)
+	}
+}

--- a/internal/tools/analysis/mermaid_tool_test.go
+++ b/internal/tools/analysis/mermaid_tool_test.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestCoerceGraphMap(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input map[string]interface{}
+		want  map[string][]string
+	}{
+		{
+			name:  "empty map",
+			input: map[string]interface{}{},
+			want:  map[string][]string{},
+		},
+		{
+			name: "[]string values",
+			input: map[string]interface{}{
+				"pkg1": []string{"pkg2", "pkg3"},
+			},
+			want: map[string][]string{
+				"pkg1": {"pkg2", "pkg3"},
+			},
+		},
+		{
+			name: "[]interface{} values",
+			input: map[string]interface{}{
+				"pkg1": []interface{}{"pkg2", "pkg3"},
+			},
+			want: map[string][]string{
+				"pkg1": {"pkg2", "pkg3"},
+			},
+		},
+		{
+			name: "mixed with non-string in []interface{}",
+			input: map[string]interface{}{
+				"pkg1": []interface{}{"pkg2", 42},
+			},
+			want: map[string][]string{
+				"pkg1": {"pkg2"}, // 42 is skipped
+			},
+		},
+		{
+			name: "unknown value type skipped",
+			input: map[string]interface{}{
+				"pkg1": 42,
+			},
+			want: map[string][]string{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := coerceGraphMap(tt.input)
+			if len(got) != len(tt.want) {
+				t.Errorf("len = %d, want %d", len(got), len(tt.want))
+			}
+			for k, wantV := range tt.want {
+				gotV, ok := got[k]
+				if !ok {
+					t.Errorf("missing key %q", k)
+					continue
+				}
+				if len(gotV) != len(wantV) {
+					t.Errorf("key %q: len = %d, want %d", k, len(gotV), len(wantV))
+				}
+			}
+		})
+	}
+}
+
+func TestNormalizeGraphArg(t *testing.T) {
+	t.Parallel()
+	t.Run("nil returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := normalizeGraphArg(nil)
+		if err == nil || err.Error() != "missing 'graph' argument" {
+			t.Errorf("expected 'missing graph' error, got: %v", err)
+		}
+	})
+	t.Run("map[string][]string passed through", func(t *testing.T) {
+		t.Parallel()
+		input := map[string][]string{"a": {"b"}}
+		got, err := normalizeGraphArg(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got["a"][0] != "b" {
+			t.Errorf("unexpected result: %v", got)
+		}
+	})
+	t.Run("map[string]interface{} coerced", func(t *testing.T) {
+		t.Parallel()
+		input := map[string]interface{}{"a": []string{"b"}}
+		got, err := normalizeGraphArg(input)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(got) != 1 || got["a"][0] != "b" {
+			t.Errorf("unexpected result: %v", got)
+		}
+	})
+	t.Run("wrong type returns error", func(t *testing.T) {
+		t.Parallel()
+		_, err := normalizeGraphArg("not a map")
+		if err == nil {
+			t.Error("expected error for wrong type")
+		}
+	})
+}
+
+func TestGenerateMermaidDiagram(t *testing.T) {
+	t.Parallel()
+	t.Run("missing graph key", func(t *testing.T) {
+		t.Parallel()
+		result, err := generateMermaidDiagram(context.Background(), map[string]interface{}{}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Text != "Error: missing 'graph' argument" {
+			t.Errorf("expected error text, got: %s", result.Text)
+		}
+	})
+	t.Run("valid graph", func(t *testing.T) {
+		t.Parallel()
+		graph := map[string][]string{"pkg1": {"pkg2"}}
+		result, err := generateMermaidDiagram(context.Background(), map[string]interface{}{"graph": graph}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if result.Text == "" {
+			t.Error("expected non-empty result")
+		}
+	})
+	t.Run("wrong graph type", func(t *testing.T) {
+		t.Parallel()
+		result, err := generateMermaidDiagram(context.Background(), map[string]interface{}{"graph": "invalid"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(result.Text, "Error:") {
+			t.Errorf("expected error text, got: %s", result.Text)
+		}
+	})
+}

--- a/internal/tools/analysis/move_test.go
+++ b/internal/tools/analysis/move_test.go
@@ -114,3 +114,50 @@ func verifyMove(t *testing.T, symbol string, files map[string]*ast.File, tr *mov
 		t.Errorf("symbol %s not in destination", symbol)
 	}
 }
+
+func parseTestMoveFile(code string) (*token.FileSet, *ast.File, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", code, parser.ParseComments)
+	return fset, f, err
+}
+
+func TestMatchSymbol_ValueSpec(t *testing.T) {
+	t.Parallel()
+	t.Run("matches const", func(t *testing.T) {
+		t.Parallel()
+		tr := newMoveTransform(&movePlan{Symbol: "MyConst"})
+		code := `package a
+const MyConst = 42`
+		fset, f, err := parseTestMoveFile(code)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = fset
+		if !tr.matchSymbol(f.Decls[0]) {
+			t.Error("matchSymbol should match const declaration")
+		}
+	})
+	t.Run("matches var", func(t *testing.T) {
+		t.Parallel()
+		tr := newMoveTransform(&movePlan{Symbol: "MyVar"})
+		code := `package a
+var MyVar = "hello"`
+		fset, f, err := parseTestMoveFile(code)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = fset
+		if !tr.matchSymbol(f.Decls[0]) {
+			t.Error("matchSymbol should match var declaration")
+		}
+	})
+}
+
+func TestMovePlanDescription(t *testing.T) {
+	t.Parallel()
+	plan := &movePlan{Symbol: "Foo", SrcFile: "a.go", DstFile: "b.go"}
+	desc := plan.Description()
+	if desc != "Move Foo from a.go to b.go" {
+		t.Errorf("unexpected description: %q", desc)
+	}
+}

--- a/internal/tools/analysis/refactor_manager_test.go
+++ b/internal/tools/analysis/refactor_manager_test.go
@@ -302,3 +302,139 @@ func TestRenameSymbol(t *testing.T) {
 		assert.Contains(t, err.Error(), "identical")
 	})
 }
+
+func TestMoveDefinition_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		sp := &refactorMockSecurityProvider{}
+		mgr := newRefactorManager(sp)
+		_, err := mgr.MoveDefinition(ctx, map[string]interface{}{"symbol": make(chan int)}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("dst IsPathWritable error", func(t *testing.T) {
+		t.Parallel()
+		callCount := 0
+		sp := &refactorMockSecurityProvider{
+			IsPathWritableFunc: func(path string) (string, error) {
+				callCount++
+				if callCount == 2 { // second call is for dst
+					return "", fmt.Errorf("dst not writable")
+				}
+				return path, nil
+			},
+		}
+		mgr := newRefactorManager(sp)
+		args := map[string]interface{}{
+			"symbol":   "MyFunc",
+			"src_file": "src.go",
+			"dst_file": "dst.go",
+			"reason":   "testing",
+		}
+		_, err := mgr.MoveDefinition(ctx, args, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "dst not writable")
+	})
+
+	t.Run("src file load error", func(t *testing.T) {
+		t.Parallel()
+		sp := &refactorMockSecurityProvider{}
+		mgr := newRefactorManager(sp)
+		args := map[string]interface{}{
+			"symbol":   "MyFunc",
+			"src_file": "/nonexistent/src.go",
+			"dst_file": "/tmp/dst.go",
+			"reason":   "testing",
+		}
+		_, err := mgr.MoveDefinition(ctx, args, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Commit error (symbol not found)", func(t *testing.T) {
+		t.Parallel()
+		mgr, tmpDir := setupMoveWorkspace(t, map[string]string{
+			"src.go": "package test\n\nfunc Foo() {}\n",
+			"dst.go": "package test\n",
+		})
+		args := map[string]interface{}{
+			"symbol":   "NonExistent",
+			"src_file": filepath.Join(tmpDir, "src.go"),
+			"dst_file": filepath.Join(tmpDir, "dst.go"),
+			"reason":   "testing",
+		}
+		_, err := mgr.MoveDefinition(ctx, args, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+}
+
+func TestRenameSymbol_ErrorPaths(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	t.Run("UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		sp := &refactorMockSecurityProvider{}
+		mgr := newRefactorManager(sp)
+		_, err := mgr.RenameSymbol(ctx, map[string]interface{}{"old_name": make(chan int)}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("IsPathWritable error", func(t *testing.T) {
+		t.Parallel()
+		sp := &refactorMockSecurityProvider{
+			IsPathWritableFunc: func(path string) (string, error) {
+				return "", fmt.Errorf("path not writable")
+			},
+		}
+		mgr := newRefactorManager(sp)
+		args := map[string]interface{}{
+			"old_name": "Foo",
+			"new_name": "Bar",
+			"path":     "/some/path",
+			"reason":   "testing",
+		}
+		_, err := mgr.RenameSymbol(ctx, args, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "path not writable")
+	})
+
+	t.Run("empty directory no go files", func(t *testing.T) {
+		t.Parallel()
+		emptyDir := t.TempDir()
+		sp := &refactorMockSecurityProvider{}
+		mgr := newRefactorManager(sp)
+		args := map[string]interface{}{
+			"old_name": "Foo",
+			"new_name": "Bar",
+			"path":     emptyDir,
+			"reason":   "testing",
+		}
+		_, err := mgr.RenameSymbol(ctx, args, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no .go files found")
+	})
+
+	t.Run("LoadFile error via invalid Go syntax", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		// Create a .go file with invalid syntax so parser.ParseFile fails.
+		brokenPath := filepath.Join(dir, "broken.go")
+		require.NoError(t, os.WriteFile(brokenPath, []byte("package test\nfunc broken() {"), 0644))
+
+		sp := &refactorMockSecurityProvider{}
+		mgr := newRefactorManager(sp)
+		args := map[string]interface{}{
+			"old_name": "Foo",
+			"new_name": "Bar",
+			"path":     dir,
+			"reason":   "testing",
+		}
+		_, err := mgr.RenameSymbol(ctx, args, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "load broken.go:")
+	})
+}

--- a/internal/tools/analysis/rename_test.go
+++ b/internal/tools/analysis/rename_test.go
@@ -1,0 +1,13 @@
+package analysis
+
+import "testing"
+
+func TestRenamePlanDescription(t *testing.T) {
+	t.Parallel()
+	plan := &renamePlan{OldName: "OldFunc", NewName: "NewFunc"}
+	desc := plan.Description()
+	expected := "Rename OldFunc → NewFunc"
+	if desc != expected {
+		t.Errorf("Description() = %q, want %q", desc, expected)
+	}
+}

--- a/internal/tools/analysis/sequence_test.go
+++ b/internal/tools/analysis/sequence_test.go
@@ -314,3 +314,199 @@ func TestSequenceAnalyzer_InterfaceTracing(t *testing.T) {
 		t.Errorf("failed to trace into interface implementation: %s", res.Text)
 	}
 }
+
+func TestNormalizeSymbolName(t *testing.T) {
+	t.Parallel()
+	a := newSequenceAnalyzer(nil, nil, nil)
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"Foo", "Foo"},
+		{"pkg.Foo", "Foo"},
+		{"pkg.sub.Foo", "Foo"},
+		{"(*Type).Method", "Method"},
+		{"(Type).Method", "Method"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			got := a.normalizeSymbolName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeSymbolName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsMethodMatch(t *testing.T) {
+	t.Parallel()
+	a := newSequenceAnalyzer(nil, nil, nil)
+
+	t.Run("function match without receiver", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+func MyFunc() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		fd := f.Decls[0].(*ast.FuncDecl)
+		if !a.isMethodMatch(fd, "MyFunc") {
+			t.Error("isMethodMatch should match plain function")
+		}
+	})
+
+	t.Run("method match with pointer receiver", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+type T struct{}
+func (t *T) Method() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		fd := f.Decls[1].(*ast.FuncDecl)
+		if !a.isMethodMatch(fd, "(*T).Method") {
+			t.Error("isMethodMatch should match pointer receiver method")
+		}
+	})
+
+	t.Run("method match with value receiver", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+type T struct{}
+func (t T) Method() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		fd := f.Decls[1].(*ast.FuncDecl)
+		if !a.isMethodMatch(fd, "(T).Method") {
+			t.Error("isMethodMatch should match value receiver method")
+		}
+	})
+
+	t.Run("receiver type mismatch", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+type T struct{}
+func (t *T) Foo() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		fd := f.Decls[1].(*ast.FuncDecl)
+		if a.isMethodMatch(fd, "(*U).Foo") {
+			t.Error("isMethodMatch should not match different receiver type")
+		}
+	})
+
+	t.Run("plain function vs method symbol", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+func Foo() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		fd := f.Decls[0].(*ast.FuncDecl)
+		if a.isMethodMatch(fd, "(*T).Foo") {
+			t.Error("isMethodMatch should not match method symbol on plain function")
+		}
+	})
+}
+
+func TestResolveStartFunc(t *testing.T) {
+	t.Parallel()
+	a := newSequenceAnalyzer(nil, nil, nil)
+
+	t.Run("finds function in package", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+func TargetFunc() {}
+func OtherFunc() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		pkg := &packages.Package{
+			Syntax: []*ast.File{f},
+		}
+		fd, err := a.resolveStartFunc(pkg, "TargetFunc")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd.Name.Name != "TargetFunc" {
+			t.Errorf("expected TargetFunc, got %s", fd.Name.Name)
+		}
+	})
+
+	t.Run("returns error when not found", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+func OtherFunc() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		pkg := &packages.Package{
+			Syntax: []*ast.File{f},
+		}
+		_, err := a.resolveStartFunc(pkg, "MissingFunc")
+		if err == nil {
+			t.Error("expected error for missing function")
+		}
+	})
+
+	t.Run("resolves method with receiver", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+type T struct{}
+func (t *T) Method() {}
+func StandaloneFunc() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		pkg := &packages.Package{
+			Syntax: []*ast.File{f},
+		}
+		fd, err := a.resolveStartFunc(pkg, "(*T).Method")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if fd.Name.Name != "Method" {
+			t.Errorf("expected Method, got %s", fd.Name.Name)
+		}
+	})
+
+	t.Run("falls back to bestMatch when no isMethodMatch succeeds", func(t *testing.T) {
+		t.Parallel()
+		code := `package test
+type T struct{}
+func (t *T) Method() {}
+`
+		fset, f := parseTestFile(t, code)
+		_ = fset
+		pkg := &packages.Package{
+			Syntax: []*ast.File{f},
+		}
+		fd, err := a.resolveStartFunc(pkg, "Method")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// isMethodMatch fails for a method when remaining has no dot,
+		// but bestMatch captures it as fallback
+		if fd.Name.Name != "Method" {
+			t.Errorf("expected Method, got %s", fd.Name.Name)
+		}
+		if fd.Recv == nil {
+			t.Error("expected method with receiver (bestMatch fallback), got plain function")
+		}
+	})
+}
+
+// parseTestFile is a helper that parses Go source into an AST.
+func parseTestFile(t *testing.T, code string) (*token.FileSet, *ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "test.go", code, parser.ParseComments)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	return fset, f
+}

--- a/internal/tools/analysis/types_test.go
+++ b/internal/tools/analysis/types_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -268,4 +269,96 @@ func unexported() {}
 	if strings.Contains(res.Text, "unexported") {
 		t.Errorf("Did not expect unexported in output")
 	}
+}
+
+func TestTypeManager_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	// denyingSP rejects all paths
+	denyingSP := &denyingSecurityProvider{}
+
+	t.Run("FindUsages UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: &mockSecurityProvider{}}
+		_, err := m.FindUsages(context.Background(), map[string]interface{}{"query": make(chan int)}, nil)
+		if err == nil {
+			t.Error("expected error for unserializable args")
+		}
+	})
+
+	t.Run("FindUsages IsPathSafe error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: denyingSP}
+		_, err := m.FindUsages(context.Background(), map[string]interface{}{"query": "Foo"}, nil)
+		if err == nil {
+			t.Error("expected error from IsPathSafe rejection")
+		}
+	})
+
+	t.Run("FindUsages GetUsages error", func(t *testing.T) {
+		t.Parallel()
+		mockIdx := &mockSymbolIndex{
+			GetUsagesFunc: func(ctx context.Context, symbol string, path string, hb chan<- struct{}) ([]location, error) {
+				return nil, fmt.Errorf("index lookup failed")
+			},
+		}
+		m := &defaultTypeManager{SP: &mockSecurityProvider{}, Indexer: mockIdx}
+		_, err := m.FindUsages(context.Background(), map[string]interface{}{"query": "Foo", "path": "."}, nil)
+		if err == nil {
+			t.Error("expected error from GetUsages")
+		}
+	})
+
+	t.Run("FindUsages no results", func(t *testing.T) {
+		t.Parallel()
+		mockIdx := &mockSymbolIndex{
+			GetUsagesFunc: func(ctx context.Context, symbol string, path string, hb chan<- struct{}) ([]location, error) {
+				return nil, nil
+			},
+		}
+		m := &defaultTypeManager{SP: &mockSecurityProvider{}, Indexer: mockIdx}
+		result, err := m.FindUsages(context.Background(), map[string]interface{}{"query": "Foo", "path": "."}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(result.Text, "No usages found") {
+			t.Errorf("expected 'No usages found', got %q", result.Text)
+		}
+	})
+
+	t.Run("FindDefinitions UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: &mockSecurityProvider{}}
+		_, err := m.FindDefinitions(context.Background(), map[string]interface{}{"query": make(chan int)}, nil)
+		if err == nil {
+			t.Error("expected error for unserializable args")
+		}
+	})
+
+	t.Run("FindDefinitions resolvePath error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: denyingSP}
+		_, err := m.FindDefinitions(context.Background(), map[string]interface{}{"query": "Foo"}, nil)
+		if err == nil {
+			t.Error("expected error from resolvePath rejection")
+		}
+	})
+
+	t.Run("ListSymbols UnmarshalArgs error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: &mockSecurityProvider{}}
+		_, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": make(chan int)}, nil)
+		if err == nil {
+			t.Error("expected error for unserializable args")
+		}
+	})
+
+	t.Run("ListSymbols resolvePath error", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{SP: denyingSP}
+		_, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": "/some/path"}, nil)
+		if err == nil {
+			t.Error("expected error from resolvePath rejection")
+		}
+	})
 }


### PR DESCRIPTION
Closes #429.

## Summary
Error path hardening for the `internal/tools/analysis/` package — the sole sub-90% production package. Added 1,685 lines of table-driven error-path tests across 14 files (2 new, 12 modified).

| Metric | Before | After |
|--------|--------|-------|
| Coverage | 88.8% | **93.1%** |
| ERROR_HANDLING gaps | 95 | 58 (-37) |
| Total gaps | 317 | 212 (-105) |

### Key Functions Hardened
- `health.go`: `runTestsAndCoverage`, `runLint`, `startHeartbeat`
- `dead_code.go`: `identifyModule` → 100%, `analyzeUsages` → 94.4%, `processImplementations` → 100%
- `dependency.go`: `buildGraph` errgroup error propagation
- `types.go`: `FindUsages` → 100%, `FindDefinitions` → 90%, `ListSymbols` → 90%
- `info.go`: `GetFileSkeleton` → 100%, `GetProjectSummary` → 100%
- `mermaid_tool.go`: `coerceGraphMap` → 100%, `normalizeGraphArg` → 100%, `generateMermaidDiagram` → 100%
- `sequence.go`: `resolveStartFunc` → 100%, `isMethodMatch` → 100%
- `refactor_manager.go`: `MoveDefinition` → 95.7%, `RenameSymbol` → 95.2%

## Verification
| Check | Status |
|-------|--------|
| make check-full | **PASS** |
| Lint (golangci-lint) | 0 issues |
| Race detector | Clean |
| Vulncheck | 0 vulnerabilities |
| Dead code | 0 found |
| Test suite | All packages PASS |