### PR TITLE
fix(persistence): push coverage from 94.5% to 96.9% (#439)

### DIFF
--- a/internal/infrastructure/persistence/atomic_error_test.go
+++ b/internal/infrastructure/persistence/atomic_error_test.go
@@ -519,6 +519,118 @@ func TestIsTransientRenameError_DirectoryTarget(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Context-cancellation error‑path tests for select/case <-ctx.Done() blocks
+// ---------------------------------------------------------------------------
+
+// TestAtomicWrite_CancelBeforeWrite covers line 46-47 in atomic.go:
+//
+//	select { case <-ctx.Done(): return ctx.Err() }  – after prepareTempFile, before Write.
+//
+// The mock FS does NOT check context in MkdirAll or CreateTemp, so
+// prepareTempFile succeeds and the cancellation is detected at the
+// first explicit select.
+func TestAtomicWrite_CancelBeforeWrite(t *testing.T) {
+	t.Parallel()
+	m := newMockFS()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before AtomicWrite starts
+
+	err := AtomicWrite(ctx, m, "/test", []byte("data"), 0644)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestAtomicWrite_CancelAfterWrite covers line 57-58 in atomic.go:
+//
+//	select { case <-ctx.Done(): return ctx.Err() }  – after Write, before commitTempFile.
+//
+// The WriteFunc blocks until the test cancels the context, guaranteeing
+// that when Write returns the context is already cancelled.  Line 57's
+// select then catches the cancellation.
+func TestAtomicWrite_CancelAfterWrite(t *testing.T) {
+	m := newMockFS()
+	writeHappened := make(chan struct{})
+	unblockWrite := make(chan struct{})
+
+	m.CreateTempFunc = func(ctx context.Context, dir, pattern string) (File, error) {
+		return &mockFile{
+			name: dir + "/temp123",
+			data: new(bytes.Buffer),
+			WriteFunc: func(p []byte) (n int, err error) {
+				close(writeHappened) // signal that Write was called
+				<-unblockWrite       // block until cancel is done
+				return len(p), nil
+			},
+		}, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- AtomicWrite(ctx, m, "/test", []byte("data"), 0644)
+	}()
+
+	<-writeHappened     // WriteFunc has been entered
+	cancel()            // cancel before Write returns
+	close(unblockWrite) // let Write return
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+}
+
+// TestRenameWithRetry_ContextCancelledDuringBackoff covers line 114-115 in
+// atomic.go:
+//
+//	select { case <-ctx.Done(): return ctx.Err() }  – inside the retry loop.
+//
+// The RenameFunc always returns a transient error ("Access is denied").
+// After the first failure the function enters the backoff select; the
+// test cancels the context during the sleep, causing ctx.Done() to fire.
+func TestRenameWithRetry_ContextCancelledDuringBackoff(t *testing.T) {
+	m := newMockFS()
+	callCount := 0
+
+	m.RenameFunc = func(ctx context.Context, oldpath, newpath string) error {
+		callCount++
+		return errors.New("Access is denied") // always transient
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- renameWithRetry(ctx, m, "/tmp/src", "/tmp/dst", 0644)
+	}()
+
+	// Let the first rename attempt happen, then cancel during the backoff.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got %v", err)
+	}
+	// Should NOT exhaust all 5 retries
+	if callCount >= 5 {
+		t.Errorf("expected < 5 rename attempts, got %d", callCount)
+	}
+}
+
 // mockDirEntry implements os.DirEntry for testing.
 type mockDirEntry struct {
 	name  string

--- a/internal/infrastructure/persistence/memory_store_test.go
+++ b/internal/infrastructure/persistence/memory_store_test.go
@@ -205,3 +205,65 @@ func runListConcurrency(t *testing.T, ctx context.Context) {
 	// Final read to ensure no panic or race
 	_, _ = store.ReadAll(ctx)
 }
+
+// =============================================================================
+// getID edge case — non-struct type falls back to 0
+// =============================================================================
+
+func TestMemoryListStore_GetID_NonStruct(t *testing.T) {
+	t.Parallel()
+
+	// getID on a non-struct type (string) should return 0
+	store := newMemoryListStore[string]()
+	id := store.getID("not-a-struct")
+	if id != 0 {
+		t.Errorf("expected 0 for non-struct type, got %v", id)
+	}
+}
+
+// =============================================================================
+// Update with non-existent ID — no-op, returns nil
+// =============================================================================
+
+func TestMemoryListStore_Update_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newMemoryListStore[ports.Task]()
+
+	// Append one item, then try to update a non-existent ID
+	_ = store.Append(ctx, ports.Task{ID: 1, Content: "existing"})
+
+	err := store.Update(ctx, 999, ports.Task{ID: 999, Content: "not found"})
+	if err != nil {
+		t.Errorf("Update for non-existent ID should not error, got: %v", err)
+	}
+
+	// Verify existing data is unchanged
+	items, _ := store.ReadAll(ctx)
+	if len(items) != 1 || items[0].Content != "existing" {
+		t.Errorf("data was modified by failed update: %v", items)
+	}
+}
+
+// =============================================================================
+// Delete with non-existent ID — no-op, returns nil
+// =============================================================================
+
+func TestMemoryListStore_Delete_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	store := newMemoryListStore[ports.Task]()
+
+	_ = store.Append(ctx, ports.Task{ID: 1, Content: "existing"})
+
+	err := store.Delete(ctx, 999)
+	if err != nil {
+		t.Errorf("Delete for non-existent ID should not error, got: %v", err)
+	}
+
+	// Verify existing data is unchanged
+	items, _ := store.ReadAll(ctx)
+	if len(items) != 1 || items[0].Content != "existing" {
+		t.Errorf("data was lost during failed delete: %v", items)
+	}
+}

--- a/internal/infrastructure/persistence/os_fs_test.go
+++ b/internal/infrastructure/persistence/os_fs_test.go
@@ -257,3 +257,30 @@ func TestOSFileSystem_OpenFile(t *testing.T) {
 		t.Errorf("file should exist: %v", err)
 	}
 }
+
+func TestNewDomainFS(t *testing.T) {
+	t.Parallel()
+
+	fs := NewDomainFS(&OSFileSystem{})
+	if fs == nil {
+		t.Fatal("NewDomainFS returned nil")
+	}
+
+	// Quick smoke test: verify the returned FS works
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	data := []byte("hello")
+
+	if err := fs.WriteFile(ctx, path, data, 0644); err != nil {
+		t.Fatalf("WriteFile via NewDomainFS failed: %v", err)
+	}
+
+	got, err := fs.ReadFile(ctx, path)
+	if err != nil {
+		t.Fatalf("ReadFile via NewDomainFS failed: %v", err)
+	}
+	if string(got) != string(data) {
+		t.Errorf("got %q, want %q", got, data)
+	}
+}

--- a/internal/infrastructure/persistence/session_paths_test.go
+++ b/internal/infrastructure/persistence/session_paths_test.go
@@ -325,3 +325,86 @@ func TestInitializePaths_EnsureDirectoriesFailure(t *testing.T) {
 		t.Error("expected error when EnsureDirectories fails inside initializePaths, got nil")
 	}
 }
+
+// =============================================================================
+// RotateSession with non-nil writer — asserts archival message is written
+// =============================================================================
+
+func TestRotateSession_WithWriter(t *testing.T) {
+	t.Parallel()
+	tmp := t.TempDir()
+	homeDir := tmp
+	mode := "test-mode"
+	ctx := context.Background()
+
+	paths, err := initializePaths(ctx, &OSFileSystem{}, homeDir, mode)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create at least one file so the backup directory is created
+	if err := os.WriteFile(paths.HistoryPath, []byte("test data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	err = RotateSession(ctx, &OSFileSystem{}, &buf, *paths, 30, nil)
+	if err != nil {
+		t.Fatalf("RotateSession failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Archiving existing session files") {
+		t.Errorf("expected archival message in writer output, got: %s", output)
+	}
+}
+
+// =============================================================================
+// cleanupOldBackups with ReadDir non-NotExist error — error propagates
+// =============================================================================
+
+func TestCleanupOldBackups_ReadDirError(t *testing.T) {
+	t.Parallel()
+
+	m := newMockFS()
+	m.ReadDirFunc = func(ctx context.Context, name string) ([]os.DirEntry, error) {
+		return nil, os.ErrPermission
+	}
+
+	paths := persistence.ResolvePaths("/home/test", "default")
+	err := cleanupOldBackups(context.Background(), m, *paths, 7, nil)
+	if err == nil {
+		t.Error("expected error from ReadDir failure, got nil")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("expected os.ErrPermission, got %v", err)
+	}
+}
+
+// =============================================================================
+// RotateSession with cleanupOldBackups returning an error
+// =============================================================================
+
+func TestRotateSession_CleanupError(t *testing.T) {
+	t.Parallel()
+
+	m := newMockFS()
+	// Make the files exist so the archive loop proceeds.
+	m.StatFunc = func(ctx context.Context, name string) (os.FileInfo, error) {
+		return &mockFileInfo{name: name}, nil
+	}
+	// ReadDir returns a non-NotExist error so cleanupOldBackups fails.
+	m.ReadDirFunc = func(ctx context.Context, name string) ([]os.DirEntry, error) {
+		return nil, os.ErrPermission
+	}
+
+	paths := persistence.ResolvePaths("/home/test", "default")
+	var buf bytes.Buffer
+	err := RotateSession(context.Background(), m, &buf, *paths, 7, slog.Default())
+	if err == nil {
+		t.Error("expected error when cleanupOldBackups fails inside RotateSession, got nil")
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		t.Errorf("expected os.ErrPermission, got %v", err)
+	}
+}

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -278,6 +279,45 @@ func TestMigrateFromJSON_CountQueryFailure(t *testing.T) {
 	}
 }
 
+func TestMigrateFromJSON_MigrateTasksError(t *testing.T) {
+	// Platform-sensitive: mode 0000 reliably causes ReadFile to fail with EACCES on Linux/macOS.
+	if runtime.GOOS == "windows" {
+		t.Skip("file permission test not reliable on Windows")
+	}
+
+	ctx := context.Background()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	tasksPath := filepath.Join(tmpDir, "tasks.json")
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Create a valid-looking tasks file with mode 0000 — no read permission.
+	if err := os.WriteFile(tasksPath, []byte(`[{"id":1,"content":"T","status":"pending","created_at":"2025-01-01T00:00:00Z"}]`), 0000); err != nil {
+		t.Fatal(err)
+	}
+	// Restore permission at test end so TempDir cleanup works.
+	defer func() { _ = os.Chmod(tasksPath, 0644) }()
+
+	// Open DB and create tasks table — COUNT query must succeed (returns 0).
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	if _, err := db.ExecContext(ctx, "CREATE TABLE IF NOT EXISTS tasks (id INTEGER PRIMARY KEY, content TEXT NOT NULL, status TEXT NOT NULL, created_at DATETIME NOT NULL);"); err != nil {
+		t.Fatal(err)
+	}
+
+	// migrateFromJSON: COUNT returns 0 → calls migrateTasks
+	// migrateTasks: Stat succeeds (file exists, IsDir=false) → ReadFile fails (EACCES)
+	// → migrateTasks returns error → migrateFromJSON logs it → returns nil
+	err = migrateFromJSON(ctx, db, fs, tasksPath, slog.Default())
+	if err != nil {
+		t.Fatalf("migrateFromJSON should return nil even when migrateTasks fails: %v", err)
+	}
+}
+
 func TestMigrateTasks_TxBeginFailure(t *testing.T) {
 	t.Parallel()
 
@@ -344,5 +384,31 @@ func TestExecuteBatchInsert_PartialFailure(t *testing.T) {
 	err = executeBatchInsert(ctx, tx, rows)
 	if err == nil {
 		t.Error("expected error from cancelled context during batch insert, got nil")
+	}
+}
+
+func TestMigrateTasks_EmptyTasksArray(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	tasksPath := filepath.Join(tmpDir, "empty_tasks.json")
+	dbPath := filepath.Join(tmpDir, "test.db")
+
+	// Write a valid JSON file containing an empty array
+	if err := fs.WriteFile(ctx, tasksPath, []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+
+	// migrateTasks reads the empty array, gets len(tasks)==0, returns nil early
+	err = migrateTasks(ctx, db, fs, tasksPath, slog.Default())
+	if err != nil {
+		t.Fatalf("migrateTasks with empty array returned error: %v", err)
 	}
 }

--- a/internal/infrastructure/persistence/sqlite_health_test.go
+++ b/internal/infrastructure/persistence/sqlite_health_test.go
@@ -203,6 +203,61 @@ func TestSQLiteHealthChecker_DirNotWritable(t *testing.T) {
 	}
 }
 
+func TestSQLiteHealthChecker_DBFileStatFails(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a symlink to a path in a non-existent directory.
+	// The parent directory (tmpDir) exists and is writable, so the filesystem
+	// checks pass, but os.Stat follows the symlink and fails because the
+	// target directory does not exist → size_bytes = 0.
+	dbPath := filepath.Join(tmpDir, "dangling")
+	if err := os.Symlink("/nonexistent_dir/test.db", dbPath); err != nil {
+		t.Fatal(err)
+	}
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("failed to open database: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	checker := newSQLiteHealthChecker(db, dbPath)
+	report, _ := checker.Check(context.Background())
+
+	// os.Stat follows the dangling symlink and fails → size_bytes = 0.
+	// Then PingContext fails because SQLite cannot create the DB file
+	// in the non-existent directory.
+	if report.Status != ports.StatusUnhealthy {
+		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
+	}
+
+	// Verify size_bytes was set to 0 (the else branch).
+	// Note: the untyped 0 literal in the production code is stored as int,
+	// not int64. We accept either representation.
+	details, ok := report.Details.(map[string]any)
+	if !ok {
+		t.Fatal("expected Details to be a map[string]any")
+	}
+	raw, exists := details["size_bytes"]
+	if !exists {
+		t.Fatal("expected size_bytes key in details")
+	}
+	var sizeBytes int64
+	switch v := raw.(type) {
+	case int64:
+		sizeBytes = v
+	case int:
+		sizeBytes = int64(v)
+	default:
+		t.Fatalf("expected size_bytes to be int or int64, got %T (%v)", raw, raw)
+	}
+	if sizeBytes != 0 {
+		t.Errorf("expected size_bytes = 0, got %d", sizeBytes)
+	}
+}
+
 func TestNoOpHealthChecker_Check(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -5,7 +5,9 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -169,5 +171,29 @@ func TestNewSessionState_InitRepositoriesFailure(t *testing.T) {
 	_, err := NewSessionState(ctx, badDir)
 	if err == nil {
 		t.Error("expected error from NewSessionState with invalid path, got nil")
+	}
+}
+
+// failingTaskStore is a ListStore[ports.Task] whose ReadAll always fails.
+type failingTaskStore struct{}
+
+func (s *failingTaskStore) ReadAll(ctx context.Context) ([]ports.Task, error) {
+	return nil, errors.New("simulated read failure")
+}
+func (s *failingTaskStore) Update(ctx context.Context, id float64, item ports.Task) error { return nil }
+func (s *failingTaskStore) Delete(ctx context.Context, id float64) error                  { return nil }
+func (s *failingTaskStore) DeleteAll(ctx context.Context) error                           { return nil }
+func (s *failingTaskStore) Append(ctx context.Context, item ports.Task) error             { return nil }
+
+func TestInitServices_InitializeFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	_, err := initServices(ctx, &failingTaskStore{})
+	if err == nil {
+		t.Fatal("expected error from initServices when Initialize fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "simulated read failure") {
+		t.Errorf("expected error to contain 'simulated read failure', got: %v", err)
 	}
 }

--- a/internal/infrastructure/persistence/tasks_test.go
+++ b/internal/infrastructure/persistence/tasks_test.go
@@ -6,6 +6,7 @@ package persistence
 import (
 	"context"
 	"log/slog"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -133,4 +134,116 @@ func setupTaskRepoWithLogger(t *testing.T, logger *slog.Logger) (*taskRepository
 	tasksFile := filepath.Join(tempDir, "tasks.json")
 	repo := newTaskRepository(NewOSFileSystem(), tasksFile, logger)
 	return repo, ctx, tasksFile, tempDir
+}
+
+func TestTaskRepository_ReadFileError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	// Create a DIRECTORY at the tasks file path.
+	// Stat will succeed (directory exists), but ReadFile will fail.
+	tasksFile := filepath.Join(tempDir, "tasks_is_a_dir")
+	if err := os.MkdirAll(tasksFile, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	fs := NewOSFileSystem()
+	repo := newTaskRepository(fs, tasksFile, nil)
+
+	_, err := repo.ReadAll(ctx)
+	if err == nil {
+		t.Fatal("expected error when reading a directory as a tasks file, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading tasks file") {
+		t.Errorf("expected error to contain 'reading tasks file', got: %v", err)
+	}
+}
+
+func TestTaskRepository_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	tasksFile := filepath.Join(tempDir, "tasks.json")
+	fs := NewOSFileSystem()
+
+	// Write an empty file
+	if err := fs.WriteFile(ctx, tasksFile, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newTaskRepository(fs, tasksFile, nil)
+	tasks, err := repo.ReadAll(ctx)
+	if err != nil {
+		t.Fatalf("ReadAll should not error on empty file: %v", err)
+	}
+	if tasks != nil {
+		t.Errorf("expected nil tasks for empty file, got %v", tasks)
+	}
+}
+
+func TestTaskRepository_JSONArrayUnmarshalFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	tasksFile := filepath.Join(tempDir, "tasks.json")
+	fs := NewOSFileSystem()
+
+	// Content starts with '[' but is NOT valid JSON — not an array, not an object.
+	// This triggers the json.Unmarshal failure path, falling through to JSONL parsing.
+	content := `[this is not valid json at all`
+	if err := fs.WriteFile(ctx, tasksFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := newTaskRepository(fs, tasksFile, nil)
+	tasks, err := repo.ReadAll(ctx)
+	if err != nil {
+		t.Fatalf("ReadAll should not error on fallthrough to JSONL: %v", err)
+	}
+	// JSONL parsing finds zero valid lines, so result is empty.
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks from invalid JSON array, got %d", len(tasks))
+	}
+}
+
+func TestParseJSONLTasks_BlankLine(t *testing.T) {
+	t.Parallel()
+
+	trimmed := `{"id": 1, "content": "Task 1"}
+
+{"id": 2, "content": "Task 2"}
+`
+	result := parseJSONLTasks(trimmed, "/test/tasks.json", slog.Default())
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tasks (blank line skipped), got %d", len(result))
+	}
+}
+
+func TestParseJSONLTasks_CorruptedLineNoDebug(t *testing.T) {
+	// NOTE: t.Parallel() is incompatible with t.Setenv(); this test runs serially.
+
+	// Ensure TELL_ME_DEBUG does NOT contain "migration"
+	t.Setenv("TELL_ME_DEBUG", "")
+
+	var buf testfixtures.SyncWriter
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	trimmed := `{"id": 1, "content": "Task 1"}
+not valid json
+{"id": 2, "content": "Task 2"}
+`
+	result := parseJSONLTasks(trimmed, "/test/tasks.json", testLogger)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tasks, got %d", len(result))
+	}
+
+	// Verify NO debug message was logged (since TELL_ME_DEBUG doesn't contain migration)
+	output := buf.String()
+	if strings.Contains(output, "corrupted task line during migration") {
+		t.Error("expected no debug log when TELL_ME_DEBUG does not contain 'migration'")
+	}
 }


### PR DESCRIPTION
Closes #439.

## Summary
Pushed `infrastructure/persistence/` coverage from **94.5% → 96.9%** by adding error-path tests for mock FS error injection paths and uncovered edge cases. 544 lines of test code across 8 test files.

### Functions pushed to 100% (11 total)
| Function | Before | After |
|---|---|---|
| `AtomicWrite` | 90.0% | **100%** |
| `renameWithRetry` | 92.3% | **100%** |
| `getID` | 83.3% | **100%** |
| `Update` (memory_store) | 85.7% | **100%** |
| `Delete` (memory_store) | 85.7% | **100%** |
| `RotateSession` | 95.5% | **100%** |
| `cleanupOldBackups` | 93.8% | **100%** |
| `parseJSONLTasks` | 92.3% | **100%** |
| `readAllInternal` | 85.7% | **100%** |
| `NewDomainFS` | 0.0% | **100%** |
| `initServices` | 75.0% | **100%** |
| `migrateFromJSON` | 87.5% | **100%** |

### Remaining TECHNICAL DEBT gaps (~0.1% short of 97%)
All remaining gaps require mocking `database/sql` internals (concrete struct, not interface) or DI refactoring — categorically untestable without broader refactoring.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| Package coverage | 96.9% |
| Race detector | ✅ Clean |
| Linter | ✅ 0 issues |
