### PR TITLE
fix(analysis): resolve type aliases in harvestObjectSymbols to restore interface propagation

### DIFF
--- a/internal/tools/analysis/harvest.go
+++ b/internal/tools/analysis/harvest.go
@@ -148,7 +148,11 @@ func (a *defaultDeadCodeAnalyzer) harvestObjectSymbols(obj types.Object, fset *t
 
 	// Capture exported methods
 	if tn, ok := obj.(*types.TypeName); ok {
-		if named, ok := tn.Type().(*types.Named); ok {
+		t := tn.Type()
+		if alias, ok := t.(*types.Alias); ok {
+			t = types.Unalias(alias)
+		}
+		if named, ok := t.(*types.Named); ok {
 			a.harvestNamedMethods(named, fset, state)
 			if itf, ok := named.Underlying().(*types.Interface); ok {
 				a.harvestInterfaceMethods(itf, fset, state)


### PR DESCRIPTION
## Problem

`dead_code_graph` produced false positives for all `MockSymbolIndex` and `MockSecurityProvider` methods (9 findings). The root cause was a type alias blind spot in `harvestObjectSymbols`: Go 1.22+ returns `*types.Alias` from `TypeName.Type()` for declarations like `type SymbolIndex = symbolIndex`, but the code only checked for `*types.Named`.

## Fix

3 lines added to resolve `*types.Alias` via `types.Unalias` before the `*types.Named` type assertion:

```go
t := tn.Type()
if alias, ok := t.(*types.Alias); ok {
    t = types.Unalias(alias)
}
```

## Before vs After

| Before | After |
|--------|-------|
| 11 dead-code findings | 3 dead-code findings |
| 8 `[DEAD] (MockSymbolIndex).*` false positives | 0 — all eliminated |
| `[PRIVATE] MockSymbolIndex` | Remaining (separate issue #446) |
| `[DEAD] NewDeadCodeAnalyzer` / `NewIndexer` | True positives from prior dead code cleanup |

Closes #445