### PR TITLE
fix(analysis): track struct-embed usages in handleIdent, extend buildFileToPkgMap

### DIFF
--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -317,8 +317,25 @@ func (a *defaultDeadCodeAnalyzer) processImplementations(ctx context.Context, st
 func (a *defaultDeadCodeAnalyzer) buildFileToPkgMap(pkgs []*packages.Package) map[string]string {
 	fileToPkg := make(map[string]string)
 	for _, pkg := range pkgs {
+		// GoFiles contains the source files for this package variant.
+		// With Tests:true (set in indexer.loadPackages), synthesized test
+		// packages appear as separate entries: internal test variants share
+		// the production PkgPath, and external test variants use the
+		// PkgPath + "_test" convention. Both populate GoFiles with the
+		// appropriate test files, so a single pass over all pkgs.GoFiles
+		// naturally covers production, internal-test, and external-test
+		// source files.
 		for _, file := range pkg.GoFiles {
 			fileToPkg[file] = pkg.PkgPath
+		}
+		// CompiledGoFiles covers files that are suitable for type-checking.
+		// It is a superset of GoFiles in most configurations, but including
+		// it as a fallback ensures any file processed by the type checker
+		// (and thus appearing in usage locations) has a package mapping.
+		for _, file := range pkg.CompiledGoFiles {
+			if _, exists := fileToPkg[file]; !exists {
+				fileToPkg[file] = pkg.PkgPath
+			}
 		}
 	}
 	return fileToPkg

--- a/internal/tools/analysis/index_harvest.go
+++ b/internal/tools/analysis/index_harvest.go
@@ -234,14 +234,18 @@ func (h *harvester) handleIdent(d *ast.Ident) {
 		return
 	}
 
-	if _, isDef := h.info.Defs[d]; isDef {
-		return
-	}
-
 	obj, ok := h.info.Uses[d]
 	if !ok || obj == nil {
-		return
+		return // Not a usage of any symbol (e.g., pure definition with no simultaneous use)
 	}
+
+	// NOTE: An ident can be both a Def AND a Use simultaneously — the
+	// canonical example is a struct embed like `analysistest.MockSymbolIndex`
+	// where the Sel ident defines the embedded field while also referencing
+	// the type from another package. The previous code unconditionally
+	// returned on any Def match, which silently dropped all struct-embed
+	// usages. We now only gate on the Uses map; a pure Def (e.g., a func
+	// declaration name) has Uses[d] == nil and is correctly skipped above.
 
 	isExported, isMethod, isPackageLevel := h.classifyObject(obj)
 	if !isExported && !isMethod && !isPackageLevel {


### PR DESCRIPTION
## Problem

`dead_code_graph` flagged `[PRIVATE] analysistest.MockSymbolIndex` despite it being used via struct embedding in `types_error_test.go`. Two gaps:

1. **`handleIdent` in `index_harvest.go`**: struct embeds like `analysistest.MockSymbolIndex` create idents in both `TypesInfo.Defs` (field definition) and `TypesInfo.Uses` (type reference). The old code unconditionally returned on any `Defs` match, silently dropping the usage.

2. **`buildFileToPkgMap` in `dead_code.go`**: only indexed `GoFiles`; added `CompiledGoFiles` as a safety-net fallback for any type-checked file not in `GoFiles`.

## Fix

- Removed the premature `Defs` gate in `handleIdent`; relies on the `Uses` map only (pure definitions have `Uses[d] == nil` and are naturally skipped).
- Extended `buildFileToPkgMap` with a `CompiledGoFiles` fallback, with documentation explaining why `GoFiles` already covers test files when `Tests: true`.

## Before vs After

| Before | After |
|--------|-------|
| 3 findings | 2 findings |
| `[PRIVATE] MockSymbolIndex` | Gone |
| `[DEAD] NewDeadCodeAnalyzer` | Remains (true positive) |
| `[DEAD] NewIndexer` | Remains (true positive) |

Closes #446