### PR TITLE
fix: replace singleflight with cycle-bound sync.Once for implementations cache (#449)

### DIFF
--- a/internal/tools/analysis/index.go
+++ b/internal/tools/analysis/index.go
@@ -6,12 +6,10 @@ package analysis
 import (
 	"context"
 	"go/token"
+	"golang.org/x/tools/go/packages"
 	"path/filepath"
 	"sync"
 	"time"
-
-	"golang.org/x/sync/singleflight"
-	"golang.org/x/tools/go/packages"
 )
 
 // location represents a position in a source file.
@@ -77,22 +75,29 @@ type indexer struct {
 
 	symbolsByPath                  map[string][]symbolLocation
 	usagesByName                   map[string][]location
-	implementations                map[string][]string // interface method id -> concrete method ids
+	implsCache                     *implCacheEntry // replaced on each Refresh; cycle-bound to prevent stale writeback
 	lastRefresh                    time.Time
-	refreshMu                      sync.Mutex         // For serializing Refresh calls
-	sfGroup                        singleflight.Group // de-dupes concurrent computeImplementations calls
-	testComputeImplementationsHook func()             // Test hook: nil in production (ADR-032)
+	refreshMu                      sync.Mutex // For serializing Refresh calls
+	testComputeImplementationsHook func()     // Test hook: nil in production (ADR-032)
+}
+
+// implCacheEntry bundles a sync.Once gate with its computed result.
+// Each Refresh cycle allocates a fresh entry, ensuring old computations
+// cannot poison the new cycle's cache (see Issue #449).
+type implCacheEntry struct {
+	once  sync.Once
+	impls map[string][]string
 }
 
 const refreshTTL = 5 * time.Second
 
 func newIndexer(dir string) (*indexer, error) {
 	return &indexer{
-		dir:             dir,
-		fset:            token.NewFileSet(),
-		symbolsByPath:   make(map[string][]symbolLocation),
-		usagesByName:    make(map[string][]location),
-		implementations: make(map[string][]string),
+		dir:           dir,
+		fset:          token.NewFileSet(),
+		symbolsByPath: make(map[string][]symbolLocation),
+		usagesByName:  make(map[string][]location),
+		implsCache:    &implCacheEntry{},
 	}, nil
 }
 
@@ -253,7 +258,7 @@ func (idx *indexer) updateState(pkgs []*packages.Package, symbolsByPath map[stri
 	idx.fset = fset
 	idx.symbolsByPath = symbolsByPath
 	idx.usagesByName = usagesByName
-	idx.implementations = nil // invalidated; lazily recomputed by GetImplementations (ADR-029)
+	idx.implsCache = &implCacheEntry{} // fresh cycle gate; old entry abandoned and GC'd (Issue #449)
 	idx.lastRefresh = time.Now()
 }
 

--- a/internal/tools/analysis/index_impl.go
+++ b/internal/tools/analysis/index_impl.go
@@ -114,57 +114,28 @@ func (idx *indexer) computeImplementations(pkgs []*packages.Package) map[string]
 }
 
 func (idx *indexer) computeImplementationsLazy() map[string][]string {
-	// Fast path: if the cache is already populated, return it immediately.
-	// This avoids the singleflight overhead and prevents a race where
-	// the singleflight function completes before all concurrent callers
-	// have registered their DoChan calls (the key is forgotten once the
-	// function returns, causing late callers to start a new execution
-	// instead of receiving the cached result).
+	// Capture the cache entry and pkgs snapshot for this cycle under RLock.
+	// updateState replaces idx.implsCache under Lock, so this captured pointer
+	// is stable for the lifetime of this invocation — no data race.
 	idx.mu.RLock()
-	if impls := idx.implementations; impls != nil {
-		idx.mu.RUnlock()
-		return impls
-	}
+	cache := idx.implsCache
+	pkgs := idx.pkgs
 	idx.mu.RUnlock()
 
-	// Use Do (not DoChan) to guarantee that all concurrent callers
-	// block until the function completes. DoChan runs the function
-	// asynchronously; if it completes before all callers register,
-	// late callers start a redundant second execution.
-	v, err, _ := idx.sfGroup.Do("implementations", func() (any, error) {
-		idx.mu.RLock()
-		pkgs := idx.pkgs
-		idx.mu.RUnlock()
-
-		impls := idx.computeImplementations(pkgs)
-
-		idx.mu.Lock()
-		idx.implementations = impls
-		idx.mu.Unlock()
-
-		return impls, nil
+	// Execute exactly once per cache entry. All concurrent callers that
+	// captured the same cache pointer block here until the winner populates
+	// cache.impls. The sync.Once provides a happens-before edge, so the
+	// read of cache.impls below is safe without additional locking.
+	cache.once.Do(func() {
+		cache.impls = idx.computeImplementations(pkgs)
 	})
 
-	if err != nil || v == nil {
-		return nil
-	}
-	return v.(map[string][]string)
+	return cache.impls
 }
 
 func (idx *indexer) GetImplementations(ctx context.Context, interfaceMethodId string, hb chan<- struct{}) []string {
 	if err := idx.Refresh(ctx, hb); err != nil {
 		return nil
 	}
-	idx.mu.RLock()
-	impls := idx.implementations
-	idx.mu.RUnlock()
-
-	// Lazy gate: Refresh() invalidates implementations (sets to nil).
-	// First caller after TTL expiry triggers the full O(N×M) computation
-	// via singleflight-guarded computeImplementationsLazy(). See ADR-029.
-	if impls == nil {
-		impls = idx.computeImplementationsLazy()
-	}
-
-	return impls[interfaceMethodId]
+	return idx.computeImplementationsLazy()[interfaceMethodId]
 }

--- a/internal/tools/analysis/index_impl_test.go
+++ b/internal/tools/analysis/index_impl_test.go
@@ -45,7 +45,7 @@ func (e EnglishGreeter) Greet() string { return "hello" }
 	// Step 2: Discover a valid interface-method ID by computing
 	// implementations directly. We use computeImplementationsLazy
 	// (same package) to get the full map and pick a key.
-	// This also primes the implementations cache (idx.implementations).
+	// This also primes the implementations cache (idx.implsCache.impls).
 	knownMap := idx.computeImplementationsLazy()
 	require.NotEmpty(t, knownMap, "expected at least one implementation from test workspace")
 
@@ -58,7 +58,7 @@ func (e EnglishGreeter) Greet() string { return "hello" }
 
 	// Freeze the indexer state so subsequent GetImplementations calls
 	// do NOT invoke Refresh → loadPackages → packages.Load.
-	// This isolates the singleflight coalescing test from external
+	// This isolates the coalescing test from external
 	// package-load failures.
 	idx.mu.Lock()
 	idx.lastRefresh = time.Now().Add(1 * time.Hour)
@@ -74,7 +74,7 @@ func (e EnglishGreeter) Greet() string { return "hello" }
 
 	// Step 3: Invalidate the cache and reset counter
 	idx.mu.Lock()
-	idx.implementations = nil
+	idx.implsCache = &implCacheEntry{}
 	idx.mu.Unlock()
 	computeCount.Store(0)
 
@@ -112,7 +112,7 @@ func (e EnglishGreeter) Greet() string { return "hello" }
 
 	// Step 5: Assertions — unchanged
 	assert.Equal(t, int64(1), computeCount.Load(),
-		"singleflight must coalesce N concurrent calls into exactly 1 compute")
+		"sync.Once must coalesce N concurrent calls into exactly 1 compute")
 	for i := 0; i < N; i++ {
 		assert.NotNil(t, results[i])
 	}

--- a/internal/tools/analysis/index_once_test.go
+++ b/internal/tools/analysis/index_once_test.go
@@ -14,11 +14,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestComputeImplementationsLazy_ErrorPath verifies that when the singleflight
-// callback panics (simulated via the ADR-032 test hook), computeImplementationsLazy
-// does not return a partially-computed result. The singleflight.Group.Do re-panics
-// when the callback panics, so we recover in the test and assert the result is nil.
-// After clearing the hook, normal operation is restored.
+// TestComputeImplementationsLazy_ErrorPath verifies that when computeImplementations
+// panics (simulated via the ADR-032 test hook), computeImplementationsLazy does not
+// return a partially-computed result. sync.Once propagates the panic to the caller
+// of Do, so we recover in the test and assert the result is nil. After clearing the
+// hook and creating a fresh cache entry, normal operation is restored.
 func TestComputeImplementationsLazy_ErrorPath(t *testing.T) {
 	t.Parallel()
 
@@ -46,31 +46,30 @@ func TestComputeImplementationsLazy_ErrorPath(t *testing.T) {
 	impls := idx.computeImplementationsLazy()
 	require.NotEmpty(t, impls, "expected at least one implementation in test workspace")
 
-	// Invalidate the cache so the next call enters the singleflight path.
+	// Invalidate the cache so the next call enters the lazy path.
 	idx.mu.Lock()
-	idx.implementations = nil
+	idx.implsCache = &implCacheEntry{}
 	idx.mu.Unlock()
 
 	// Wire the test hook to simulate a failure mid-computation.
-	// It sets a sentinel value into idx.implementations (simulating a partial
-	// write) and then panics. The singleflight.Group.Do catches the panic,
-	// wraps it as a *panicError, and re-panics to the caller.
+	// It sets a sentinel value into idx.implsCache.impls (simulating a partial
+	// write) and then panics.
 	sentinel := map[string][]string{"sentinel": {"value"}}
 	idx.testComputeImplementationsHook = func() {
 		idx.mu.Lock()
-		idx.implementations = sentinel
+		idx.implsCache.impls = sentinel
 		idx.mu.Unlock()
 		panic("test-induced panic in computeImplementations")
 	}
 
 	// Call computeImplementationsLazy with a recover barrier.
-	// The singleflight re-panics, so computeImplementationsLazy never
+	// sync.Once propagates the panic, so computeImplementationsLazy never
 	// returns normally — the result variable stays nil (zero value).
 	var result map[string][]string
 	func() {
 		defer func() {
 			r := recover()
-			require.NotNil(t, r, "expected panic to propagate from singleflight")
+			require.NotNil(t, r, "expected panic to propagate from sync.Once")
 		}()
 		result = idx.computeImplementationsLazy()
 	}()
@@ -81,7 +80,7 @@ func TestComputeImplementationsLazy_ErrorPath(t *testing.T) {
 	// (the sentinel was written by the hook before the panic).
 	idx.testComputeImplementationsHook = nil
 	idx.mu.Lock()
-	idx.implementations = nil
+	idx.implsCache = &implCacheEntry{}
 	idx.mu.Unlock()
 
 	// Third call: normal operation is restored, real implementations are computed.


### PR DESCRIPTION
## Summary

Fixes the flaky `TestGetImplementations_SingleflightCoalescing` test by replacing `singleflight.Group` with a per-refresh-cycle `implCacheEntry` that bundles a `sync.Once` gate with its computed result.

## Root Cause

`singleflight.Do` forgets the key the instant the callback returns. Straggler goroutines that passed the fast-path cache check but haven't yet registered their `Do` call start a redundant second execution. The existing fast path only helps on the second call onward — it cannot close the window between the nil-check and `Do`.

## Fix

Replace the shared mutable `implementations` map + `sfGroup singleflight.Group` with a single `*implCacheEntry` field. Each `Refresh` cycle allocates a fresh entry; old computations write to abandoned entries that get GC'd, never corrupting the current cycle.

```
type implCacheEntry struct {
    once  sync.Once
    impls map[string][]string
}
```

`computeImplementationsLazy` captures the cache entry + pkgs snapshot under `RLock`, then uses `cache.once.Do(...)` — no key-forgetting, no stale writeback.

## Changes

| File | Change |
|------|--------|
| `index.go` | Add `implCacheEntry` struct; replace `implementations`+`sfGroup` with `*implCacheEntry`; update `newIndexer` and `updateState`; remove `singleflight` import |
| `index_impl.go` | Rewrite `computeImplementationsLazy` with cycle-bound cache; simplify `GetImplementations` |
| `index_impl_test.go` | Update cache invalidation and comments |
| `index_singleflight_test.go` → `index_once_test.go` | Rename; update comments |
| `go.mod` / `go.sum` | Remove `golang.org/x/sync/singleflight` |

## Verification

- `make check-full` — all gates pass (fmt, lint, vet, vulncheck, test, test-race, dead-code, coverage)
- `TestGetImplementations_SingleflightCoalescing -count=20 -race` — 20/20 deterministic
- Net −25 lines of code

## Acknowledgements

Co-authored-by: @thptcnec (cycle-bound cache entry design)