### PR TITLE
fix(analysis): add error path test coverage to ≥95% (#453)

### DIFF
--- a/internal/tools/analysis/dead_code_anon_interface_test.go
+++ b/internal/tools/analysis/dead_code_anon_interface_test.go
@@ -30,6 +30,9 @@ package analysis
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -409,5 +412,162 @@ func TestCollectMethodNamesFromPackage_NonModuleInternal(t *testing.T) {
 		// So this actually IS module-internal. Test with empty targetModule legitimately.
 		collectMethodNamesFromPackage(pkg, "", names)
 		// Package has nil Syntax, so no names collected — but the guard is exercised
+	})
+}
+
+// TestHasAnonymousInterfaceAssertionMatch_GuardClauses exercises the two
+// guard clauses that return false before the lazy-init/map-lookup path:
+// nil state and empty method name. Without these guards the method
+// would panic on a nil-pointer dereference or a meaningless map lookup.
+func TestHasAnonymousInterfaceAssertionMatch_GuardClauses(t *testing.T) {
+	t.Parallel()
+	analyzer := &defaultDeadCodeAnalyzer{}
+
+	t.Run("nil state returns false", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, analyzer.hasAnonymousInterfaceAssertionMatch(nil, "Foo"),
+			"nil state must return false to prevent nil-pointer dereference")
+	})
+
+	t.Run("empty method name returns false", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			anonymousInterfaceAssertedMethodNames: map[string]struct{}{"Foo": {}},
+		}
+		assert.False(t, analyzer.hasAnonymousInterfaceAssertionMatch(state, ""),
+			"empty method name must return false (short-circuit before map lookup)")
+	})
+}
+
+// TestCollectAnonymousInterfaceAssertedMethodNames_NilState exercises the
+// state == nil guard. The function must return a non-nil empty map so
+// that a subsequent `state.anonymousInterfaceAssertedMethodNames == nil`
+// check correctly distinguishes "not yet populated" from "populated
+// but empty".
+func TestCollectAnonymousInterfaceAssertedMethodNames_NilState(t *testing.T) {
+	t.Parallel()
+
+	result := collectAnonymousInterfaceAssertedMethodNames(nil)
+	require.NotNil(t, result, "must return non-nil map even for nil state")
+	assert.Empty(t, result, "must return empty map for nil state")
+}
+
+// TestCollectNamesFromFile_GuardClauses exercises the nil-file guard
+// and the path through ast.Inspect where getAnonymousInterfaceMethods
+// returns nil for every node (file with no type assertions).
+func TestCollectNamesFromFile_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil file returns immediately", func(t *testing.T) {
+		t.Parallel()
+		names := make(map[string]struct{})
+		// Must not panic
+		collectNamesFromFile(nil, names)
+		assert.Empty(t, names, "nil file must collect no names")
+	})
+
+	t.Run("file with no type assertions collects nothing", func(t *testing.T) {
+		t.Parallel()
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, "test.go", "package p; func f() { _ = 1 + 2 }", 0)
+		require.NoError(t, err)
+		names := make(map[string]struct{})
+		collectNamesFromFile(f, names)
+		assert.Empty(t, names, "file with no type assertions must collect no names")
+	})
+}
+
+// TestGetAnonymousInterfaceMethods_GuardClauses exercises all four
+// nil-return paths in getAnonymousInterfaceMethods:
+//  1. Node is not a *ast.TypeAssertExpr
+//  2. TypeAssertExpr has a nil asserted type
+//  3. Asserted type is not *ast.InterfaceType (e.g., a named type)
+//  4. InterfaceType has nil Methods field
+func TestGetAnonymousInterfaceMethods_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-TypeAssertExpr returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, getAnonymousInterfaceMethods(&ast.Ident{Name: "x"}),
+			"non-TypeAssertExpr node must return nil")
+	})
+
+	t.Run("nil asserted type returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, getAnonymousInterfaceMethods(&ast.TypeAssertExpr{
+			X:    &ast.Ident{Name: "x"},
+			Type: nil,
+		}), "TypeAssertExpr with nil Type must return nil")
+	})
+
+	t.Run("non-interface asserted type returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, getAnonymousInterfaceMethods(&ast.TypeAssertExpr{
+			X:    &ast.Ident{Name: "x"},
+			Type: &ast.Ident{Name: "T"},
+		}), "asserted type that is *ast.Ident (not *ast.InterfaceType) must return nil")
+	})
+
+	t.Run("nil methods returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, getAnonymousInterfaceMethods(&ast.TypeAssertExpr{
+			X:    &ast.Ident{Name: "x"},
+			Type: &ast.InterfaceType{Methods: nil},
+		}), "InterfaceType with nil Methods must return nil")
+	})
+}
+
+// TestCollectNamesFromInterfaceField_GuardClauses exercises the three
+// early-return paths and the nil-name skip in collectNamesFromInterfaceField:
+//  1. Zero names (embedded interface) → return early
+//  2. Non-func type (embedded interface via ident) → return early
+//  3. nil name entry in the Names slice → skip that entry
+//  4. Valid method name → collected into the map
+func TestCollectNamesFromInterfaceField_GuardClauses(t *testing.T) {
+	t.Parallel()
+
+	t.Run("embedded interface (zero names) returns early", func(t *testing.T) {
+		t.Parallel()
+		field := &ast.Field{Names: nil, Type: &ast.FuncType{}}
+		names := make(map[string]struct{})
+		collectNamesFromInterfaceField(field, names)
+		assert.Empty(t, names, "zero-length Names (embedded interface) must collect nothing")
+	})
+
+	t.Run("embedded interface (non-func type) returns early", func(t *testing.T) {
+		t.Parallel()
+		field := &ast.Field{
+			Names: []*ast.Ident{{Name: "M"}},
+			Type:  &ast.Ident{Name: "io.Reader"},
+		}
+		names := make(map[string]struct{})
+		collectNamesFromInterfaceField(field, names)
+		assert.Empty(t, names, "field with non-FuncType Type (embedded ident) must collect nothing")
+	})
+
+	t.Run("nil name in names list skipped", func(t *testing.T) {
+		t.Parallel()
+		field := &ast.Field{
+			Names: []*ast.Ident{nil, {Name: "Valid"}},
+			Type:  &ast.FuncType{},
+		}
+		names := make(map[string]struct{})
+		collectNamesFromInterfaceField(field, names)
+		assert.Len(t, names, 1, "only the non-nil name must be collected")
+		_, ok := names["Valid"]
+		assert.True(t, ok, "Valid must be in the collected names")
+	})
+
+	t.Run("valid method name collected", func(t *testing.T) {
+		t.Parallel()
+		field := &ast.Field{
+			Names: []*ast.Ident{{Name: "Foo"}},
+			Type:  &ast.FuncType{},
+		}
+		names := make(map[string]struct{})
+		collectNamesFromInterfaceField(field, names)
+		assert.Len(t, names, 1, "the single valid name must be collected")
+		_, ok := names["Foo"]
+		assert.True(t, ok, "Foo must be in the collected names")
 	})
 }

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -1437,3 +1437,179 @@ func TestIsEligibleForHarvest_EdgeCases(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildFileToPkgMap_CompiledGoFilesFallback(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+
+	t.Run("CompiledGoFiles duplicates GoFiles skipped", func(t *testing.T) {
+		t.Parallel()
+		pkgs := []*packages.Package{
+			{
+				PkgPath:         "example.com/pkg",
+				GoFiles:         []string{"/a/file.go"},
+				CompiledGoFiles: []string{"/a/file.go"},
+			},
+		}
+		got := analyzer.buildFileToPkgMap(pkgs)
+		assert.Len(t, got, 1)
+		assert.Equal(t, "example.com/pkg", got["/a/file.go"])
+	})
+
+	t.Run("CompiledGoFiles adds new file", func(t *testing.T) {
+		t.Parallel()
+		pkgs := []*packages.Package{
+			{
+				PkgPath:         "example.com/pkg",
+				GoFiles:         []string{"/a/file.go"},
+				CompiledGoFiles: []string{"/a/file.go", "/a/gen.go"},
+			},
+		}
+		got := analyzer.buildFileToPkgMap(pkgs)
+		assert.Len(t, got, 2)
+		assert.Equal(t, "example.com/pkg", got["/a/file.go"])
+		assert.Equal(t, "example.com/pkg", got["/a/gen.go"])
+	})
+}
+
+func TestTrackExternalUsages_SamePackageNoExternal(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	t.Run("same package usage does not increment externalUses", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			targetModule: "example.com/test",
+			declarations: map[string]*symMeta{
+				"example.com/test/pkg.Foo": {
+					id:      "example.com/test/pkg.Foo",
+					pkgPath: "example.com/test/pkg",
+					name:    "Foo",
+					symType: "Function",
+				},
+			},
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		fileToPkg := map[string]string{"/tmp/file.go": "example.com/test/pkg"} // same package
+
+		mockIdx := &mockSymbolIndex{
+			IsSymbolUsedFunc: func(ctx context.Context, name string, hb chan<- struct{}) bool { return true },
+			GetUsagesFunc: func(ctx context.Context, symbol string, path string, hb chan<- struct{}) ([]location, error) {
+				return []location{{Path: "/tmp/file.go", Line: 1, Column: 1}}, nil
+			},
+		}
+
+		analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+		err := analyzer.trackExternalUsages(ctx, state, "example.com/test/pkg.Foo",
+			state.declarations["example.com/test/pkg.Foo"], fileToPkg, "/tmp/proj", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, state.totalUses["example.com/test/pkg.Foo"])
+		assert.Equal(t, 0, state.externalUses["example.com/test/pkg.Foo"])
+	})
+
+	t.Run("usage file not in fileToPkg is skipped", func(t *testing.T) {
+		t.Parallel()
+		state := &scanState{
+			targetModule: "example.com/test",
+			declarations: map[string]*symMeta{
+				"example.com/test/pkg.Foo": {
+					id:      "example.com/test/pkg.Foo",
+					pkgPath: "example.com/test/pkg",
+					name:    "Foo",
+					symType: "Function",
+				},
+			},
+			totalUses:    make(map[string]int),
+			externalUses: make(map[string]int),
+		}
+		// fileToPkg does NOT contain the usage file path
+		fileToPkg := map[string]string{}
+
+		mockIdx := &mockSymbolIndex{
+			IsSymbolUsedFunc: func(ctx context.Context, name string, hb chan<- struct{}) bool { return true },
+			GetUsagesFunc: func(ctx context.Context, symbol string, path string, hb chan<- struct{}) ([]location, error) {
+				return []location{{Path: "/unknown/file.go", Line: 1, Column: 1}}, nil
+			},
+		}
+
+		analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+		err := analyzer.trackExternalUsages(ctx, state, "example.com/test/pkg.Foo",
+			state.declarations["example.com/test/pkg.Foo"], fileToPkg, "/tmp/proj", nil)
+		require.NoError(t, err)
+
+		assert.Equal(t, 1, state.totalUses["example.com/test/pkg.Foo"])
+		assert.Equal(t, 0, state.externalUses["example.com/test/pkg.Foo"])
+	})
+}
+
+func TestIsInterfaceMethod_NonFuncGuard(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+	obj := types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int])
+	assert.False(t, analyzer.isInterfaceMethod(obj))
+}
+
+func TestRunAnalysisPipeline_EmptyPathDefaultsToDot(t *testing.T) {
+	// Not parallel: changes working directory so that "."
+	// resolves inside the security provider's allowed tempDir.
+	tmpDir := t.TempDir()
+	sp := &deadCodeSecurityProvider{tempDir: tmpDir}
+
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module empty.test\n\ngo 1.25"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte("package main\nfunc main() {}"), 0644))
+
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tmpDir))
+	defer func() { require.NoError(t, os.Chdir(origDir)) }()
+
+	idx, err := newIndexer(tmpDir)
+	require.NoError(t, err)
+	require.NoError(t, idx.Refresh(context.Background(), nil))
+
+	analyzer := newDeadCodeAnalyzer(sp, idx)
+	state, err := analyzer.runAnalysisPipeline(context.Background(), "", nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, state)
+}
+
+func TestAnalyzeUsages_Heartbeat(t *testing.T) {
+	t.Parallel()
+
+	state := &scanState{
+		targetModule: "example.com/test",
+		pkgs:         []*packages.Package{},
+		declarations: make(map[string]*symMeta),
+		totalUses:    make(map[string]int),
+		externalUses: make(map[string]int),
+	}
+	for i := 0; i < 21; i++ {
+		id := fmt.Sprintf("example.com/test/pkg.Symbol%d", i)
+		state.declarations[id] = &symMeta{
+			id:      id,
+			pkgPath: "example.com/test/pkg",
+			name:    fmt.Sprintf("Symbol%d", i),
+			symType: "Function",
+		}
+	}
+	mockIdx := &mockSymbolIndex{
+		IsSymbolUsedFunc:       func(ctx context.Context, name string, hb chan<- struct{}) bool { return false },
+		GetImplementationsFunc: func(ctx context.Context, id string) []string { return nil },
+	}
+
+	analyzer := &defaultDeadCodeAnalyzer{idx: mockIdx}
+	hb := make(chan struct{}, 1)
+	analyzer.analyzeUsages(context.Background(), state, "/tmp/proj", hb)
+
+	select {
+	case <-hb:
+		// heartbeat received
+	default:
+		t.Error("expected heartbeat on hb channel")
+	}
+}

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -1557,7 +1557,8 @@ func TestIsInterfaceMethod_NonFuncGuard(t *testing.T) {
 func TestRunAnalysisPipeline_EmptyPathDefaultsToDot(t *testing.T) {
 	// Not parallel: changes working directory so that "."
 	// resolves inside the security provider's allowed tempDir.
-	tmpDir := t.TempDir()
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
 	sp := &deadCodeSecurityProvider{tempDir: tmpDir}
 
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module empty.test\n\ngo 1.25"), 0644))

--- a/internal/tools/analysis/sequence_test.go
+++ b/internal/tools/analysis/sequence_test.go
@@ -5,6 +5,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
@@ -604,6 +605,274 @@ func Start(n int) int {
 	}
 }
 
+func TestFindBySuffix(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{}
+
+	tests := []struct {
+		name    string
+		symbol  string
+		pkgs    []*packages.Package
+		wantPkg string // empty means nil
+		wantRem string
+	}{
+		{
+			name:    "no dot returns nil",
+			symbol:  "NoDot",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/NoDot"}},
+			wantPkg: "",
+			wantRem: "",
+		},
+		{
+			name:    "exact match",
+			symbol:  "example.com/foo.Bar",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/foo"}},
+			wantPkg: "example.com/foo",
+			wantRem: "Bar",
+		},
+		{
+			name:    "suffix match",
+			symbol:  "internal/foo.Bar",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/mod/internal/foo"}},
+			wantPkg: "example.com/mod/internal/foo",
+			wantRem: "Bar",
+		},
+		{
+			name:   "first match wins with multiple suffix candidates",
+			symbol: "pkg/util.Bar",
+			pkgs: []*packages.Package{
+				{PkgPath: "example.com/a/pkg/util"},
+				{PkgPath: "example.com/b/pkg/util"},
+			},
+			wantPkg: "example.com/a/pkg/util",
+			wantRem: "Bar",
+		},
+		{
+			name:   "exact match preferred over suffix when earlier in slice",
+			symbol: "example.com/exact.Bar",
+			pkgs: []*packages.Package{
+				{PkgPath: "x/example.com/exact"},
+				{PkgPath: "example.com/exact"},
+			},
+			wantPkg: "x/example.com/exact",
+			wantRem: "Bar",
+		},
+		{
+			name:    "no matching package",
+			symbol:  "unknown/pkg.Func",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/other"}},
+			wantPkg: "",
+			wantRem: "",
+		},
+		{
+			name:    "empty package list",
+			symbol:  "pkg.Func",
+			pkgs:    []*packages.Package{},
+			wantPkg: "",
+			wantRem: "",
+		},
+		{
+			name:    "single segment package path",
+			symbol:  "pkg.Func",
+			pkgs:    []*packages.Package{{PkgPath: "pkg"}},
+			wantPkg: "pkg",
+			wantRem: "Func",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pkg, rem := a.findBySuffix(tt.symbol, tt.pkgs)
+			if tt.wantPkg == "" {
+				if pkg != nil {
+					t.Errorf("expected nil package, got %v", pkg.PkgPath)
+				}
+			} else {
+				if pkg == nil {
+					t.Errorf("expected package %q, got nil", tt.wantPkg)
+				} else if pkg.PkgPath != tt.wantPkg {
+					t.Errorf("expected PkgPath %q, got %q", tt.wantPkg, pkg.PkgPath)
+				}
+			}
+			if rem != tt.wantRem {
+				t.Errorf("expected remaining %q, got %q", tt.wantRem, rem)
+			}
+		})
+	}
+}
+
+// TestSequenceAnalyzer_WalkGuards exercises every guard clause in walk(...)
+// by calling it directly (not through AnalyzeSequenceFlow).
+func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
+	t.Parallel()
+
+	t.Run("depth at maxDepth returns early", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var startFunc *ast.FuncDecl
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				startFunc = fd
+				break
+			}
+		}
+		if startFunc == nil {
+			t.Fatal("StartFunc not found")
+		}
+
+		a := &defaultSequenceAnalyzer{}
+		frames := &frameCollector{}
+		visited := make(map[string]bool)
+
+		a.walk(context.Background(), pkgA, startFunc, 5, 5, frames, visited, "github.com/test/mod", nil)
+
+		if len(frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(frames.frames))
+		}
+	})
+
+	t.Run("nil function body returns early", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func External()")
+		fd := f.Decls[0].(*ast.FuncDecl)
+
+		pkg := &packages.Package{
+			TypesInfo: &types.Info{Defs: make(map[*ast.Ident]types.Object)},
+		}
+
+		a := &defaultSequenceAnalyzer{}
+		frames := &frameCollector{}
+		visited := make(map[string]bool)
+
+		a.walk(context.Background(), pkg, fd, 0, 5, frames, visited, "", nil)
+
+		if len(frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(frames.frames))
+		}
+	})
+
+	t.Run("nil def object returns early", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var startFunc *ast.FuncDecl
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				startFunc = fd
+				break
+			}
+		}
+		if startFunc == nil {
+			t.Fatal("StartFunc not found")
+		}
+
+		pkg := &packages.Package{
+			PkgPath:   pkgA.PkgPath,
+			Syntax:    pkgA.Syntax,
+			TypesInfo: &types.Info{Defs: make(map[*ast.Ident]types.Object)},
+			Imports:   pkgA.Imports,
+			Module:    pkgA.Module,
+		}
+
+		a := &defaultSequenceAnalyzer{}
+		frames := &frameCollector{}
+		visited := make(map[string]bool)
+
+		a.walk(context.Background(), pkg, startFunc, 0, 5, frames, visited, "github.com/test/mod", nil)
+
+		if len(frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(frames.frames))
+		}
+	})
+
+	t.Run("already visited returns early", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var startFunc *ast.FuncDecl
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				startFunc = fd
+				break
+			}
+		}
+		if startFunc == nil {
+			t.Fatal("StartFunc not found")
+		}
+
+		obj := pkgA.TypesInfo.Defs[startFunc.Name]
+		if obj == nil {
+			t.Fatal("StartFunc object not found in TypesInfo")
+		}
+		key := getSymbolIdentity(obj)
+
+		a := &defaultSequenceAnalyzer{}
+		frames := &frameCollector{}
+		visited := map[string]bool{key: true}
+
+		a.walk(context.Background(), pkgA, startFunc, 0, 5, frames, visited, "github.com/test/mod", nil)
+
+		if len(frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(frames.frames))
+		}
+	})
+
+	t.Run("successful walk adds frames", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var startFunc *ast.FuncDecl
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				startFunc = fd
+				break
+			}
+		}
+		if startFunc == nil {
+			t.Fatal("StartFunc not found")
+		}
+
+		a := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
+		frames := &frameCollector{}
+		visited := make(map[string]bool)
+
+		a.walk(context.Background(), pkgA, startFunc, 0, 5, frames, visited, "github.com/test/mod", nil)
+
+		if len(frames.frames) == 0 {
+			t.Error("expected frames to be added, got none")
+		}
+	})
+
+	t.Run("heartbeat channel receives when non-nil", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var startFunc *ast.FuncDecl
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				startFunc = fd
+				break
+			}
+		}
+		if startFunc == nil {
+			t.Fatal("StartFunc not found")
+		}
+
+		a := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
+		frames := &frameCollector{}
+		visited := make(map[string]bool)
+		hb := make(chan struct{}, 1)
+
+		a.walk(context.Background(), pkgA, startFunc, 0, 5, frames, visited, "github.com/test/mod", hb)
+
+		if len(hb) != 1 {
+			t.Errorf("expected 1 heartbeat, got %d", len(hb))
+		}
+	})
+}
+
 // parseTestFile is a helper that parses Go source into an AST.
 func parseTestFile(t *testing.T, code string) (*token.FileSet, *ast.File) {
 	t.Helper()
@@ -613,4 +882,1198 @@ func parseTestFile(t *testing.T, code string) (*token.FileSet, *ast.File) {
 		t.Fatalf("parse failed: %v", err)
 	}
 	return fset, f
+}
+
+// TestSequenceVisitor_Visit tests the Visit method of sequenceVisitor with
+// table-driven subtests covering all switch branches and guard clauses.
+func TestSequenceVisitor_Visit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil node returns nil", func(t *testing.T) {
+		t.Parallel()
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+		if got := v.Visit(nil); got != nil {
+			t.Errorf("Visit(nil) = %v, want nil", got)
+		}
+	})
+
+	t.Run("cancelled context returns nil", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		v := &sequenceVisitor{
+			ctx:      ctx,
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+		if got := v.Visit(&ast.Ident{Name: "x"}); got != nil {
+			t.Errorf("Visit with cancelled ctx = %v, want nil", got)
+		}
+	})
+
+	t.Run("ForStmt walks children and returns nil", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func f() { for i := 0; i < 10; i++ { g() } }")
+		fd := f.Decls[0].(*ast.FuncDecl)
+		forStmt := fd.Body.List[0].(*ast.ForStmt)
+
+		pkg := &packages.Package{
+			Name:    "p",
+			PkgPath: "test/pkg",
+			TypesInfo: &types.Info{
+				Uses: make(map[*ast.Ident]types.Object),
+				Defs: make(map[*ast.Ident]types.Object),
+			},
+		}
+
+		frames := &frameCollector{}
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			pkg:      pkg,
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   frames,
+			maxDepth: 1,
+		}
+
+		got := v.Visit(forStmt)
+		if got != nil {
+			t.Errorf("Visit(ForStmt) = %v, want nil", got)
+		}
+		if v.inLoop != 0 {
+			t.Errorf("inLoop = %d, want 0 (restored after ForStmt)", v.inLoop)
+		}
+	})
+
+	t.Run("RangeStmt walks children and returns nil", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func f() { for _, x := range items { h() } }")
+		fd := f.Decls[0].(*ast.FuncDecl)
+		rangeStmt := fd.Body.List[0].(*ast.RangeStmt)
+
+		pkg := &packages.Package{
+			Name:    "p",
+			PkgPath: "test/pkg",
+			TypesInfo: &types.Info{
+				Uses: make(map[*ast.Ident]types.Object),
+				Defs: make(map[*ast.Ident]types.Object),
+			},
+		}
+
+		frames := &frameCollector{}
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			pkg:      pkg,
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   frames,
+			maxDepth: 1,
+		}
+
+		got := v.Visit(rangeStmt)
+		if got != nil {
+			t.Errorf("Visit(RangeStmt) = %v, want nil", got)
+		}
+		if v.inLoop != 0 {
+			t.Errorf("inLoop = %d, want 0 (restored after RangeStmt)", v.inLoop)
+		}
+	})
+
+	t.Run("GoStmt walks call and returns nil", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func f() { go async() }")
+		fd := f.Decls[0].(*ast.FuncDecl)
+		goStmt := fd.Body.List[0].(*ast.GoStmt)
+
+		pkg := &packages.Package{
+			Name:    "p",
+			PkgPath: "test/pkg",
+			TypesInfo: &types.Info{
+				Uses: make(map[*ast.Ident]types.Object),
+				Defs: make(map[*ast.Ident]types.Object),
+			},
+		}
+
+		frames := &frameCollector{}
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			pkg:      pkg,
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   frames,
+			maxDepth: 1,
+		}
+
+		got := v.Visit(goStmt)
+		if got != nil {
+			t.Errorf("Visit(GoStmt) = %v, want nil", got)
+		}
+		if v.inGo {
+			t.Error("inGo = true, want false (restored after GoStmt)")
+		}
+	})
+
+	t.Run("CallExpr delegates to handleCall and returns self", func(t *testing.T) {
+		t.Parallel()
+		pkgA, _ := setupMockPackages()
+
+		var callExpr *ast.CallExpr
+		for _, decl := range pkgA.Syntax[0].Decls {
+			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+				callExpr = fd.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
+				break
+			}
+		}
+		if callExpr == nil {
+			t.Fatal("CallExpr not found in StartFunc")
+		}
+
+		frames := &frameCollector{}
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			pkg:      pkgA,
+			modName:  "github.com/test/mod",
+			analyzer: &defaultSequenceAnalyzer{modName: "github.com/test/mod"},
+			frames:   frames,
+			visited:  make(map[string]bool),
+			maxDepth: 1,
+		}
+
+		got := v.Visit(callExpr)
+		if got != v {
+			t.Errorf("Visit(CallExpr) = %v, want self (%v)", got, v)
+		}
+		if len(frames.frames) == 0 {
+			t.Error("expected at least one frame from CallExpr")
+		}
+	})
+
+	t.Run("unhandled node type returns self", func(t *testing.T) {
+		t.Parallel()
+		v := &sequenceVisitor{
+			ctx:      context.Background(),
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+		got := v.Visit(&ast.BasicLit{Kind: token.INT, Value: "0"})
+		if got != v {
+			t.Errorf("Visit(BasicLit) = %v, want self (%v)", got, v)
+		}
+	})
+}
+
+// TestSequenceVisitor_HandleCall exercises all uncovered branches in handleCall
+// via table-driven subtests that each call handleCall directly and assert
+// side effects on v.frames.frames.
+func TestSequenceVisitor_HandleCall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-ident non-selector call returns early", func(t *testing.T) {
+		t.Parallel()
+		// Parse: package p; func f() { func(){}() }
+		// The outer CallExpr has Fun = *ast.FuncLit → hits default case.
+		_, f := parseTestFile(t, "package p; func f() { func(){}() }")
+		fd := f.Decls[0].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   "example.com/local/pkg",
+				TypesInfo: &types.Info{Uses: make(map[*ast.Ident]types.Object)},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   &frameCollector{},
+			modName:  "example.com/local",
+		}
+
+		v.handleCall(call)
+		if len(v.frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(v.frames.frames))
+		}
+	})
+
+	t.Run("empty selector name returns early", func(t *testing.T) {
+		t.Parallel()
+		// Manually construct a CallExpr whose Fun is a SelectorExpr with an
+		// empty Sel.Name. resolveSelectorCall returns targetFunc="" → early
+		// return via targetFunc=="" guard.
+		call := &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.Ident{Name: "x"},
+				Sel: &ast.Ident{Name: ""},
+			},
+		}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   "example.com/local/pkg",
+				TypesInfo: &types.Info{Uses: make(map[*ast.Ident]types.Object)},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   &frameCollector{},
+			modName:  "example.com/local",
+		}
+
+		v.handleCall(call)
+		if len(v.frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(v.frames.frames))
+		}
+	})
+
+	t.Run("external package call returns early", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+import "fmt"
+func f() { fmt.Println() }`)
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+
+		sel := call.Fun.(*ast.SelectorExpr)
+		fmtIdent := sel.X.(*ast.Ident) // "fmt" identifier
+		printlnIdent := sel.Sel        // "Println" identifier
+
+		// Build the "fmt" standard library package.
+		fmtPkg := types.NewPackage("fmt", "fmt")
+		pkgTypes := types.NewPackage("example.com/local/pkg", "p")
+
+		// The PkgName representing the import statement.
+		pkgName := types.NewPkgName(token.NoPos, pkgTypes, "fmt", fmtPkg)
+
+		// Println function in the fmt package.
+		// The signature is irrelevant for this test — we only need the
+		// object to exist so resolveSelectorCall can map targetPkgPath.
+		printlnSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+		printlnFunc := types.NewFunc(token.NoPos, fmtPkg, "Println", printlnSig)
+
+		uses := make(map[*ast.Ident]types.Object)
+		uses[fmtIdent] = pkgName
+		uses[printlnIdent] = printlnFunc
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   "example.com/local/pkg",
+				Types:     pkgTypes,
+				TypesInfo: &types.Info{Uses: uses},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   &frameCollector{},
+			modName:  "example.com/local",
+		}
+
+		// handleCall resolves fmt.Println → targetPkgPath="fmt".
+		// isInternal("fmt") returns false because "fmt" does not have
+		// prefix "example.com/local".
+		v.handleCall(call)
+		if len(v.frames.frames) != 0 {
+			t.Errorf("expected 0 frames, got %d", len(v.frames.frames))
+		}
+	})
+
+	t.Run("duplicate consecutive call skipped", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func f() { g(); g() }")
+		fd := f.Decls[0].(*ast.FuncDecl)
+		call1 := fd.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
+		call2 := fd.Body.List[1].(*ast.ExprStmt).X.(*ast.CallExpr)
+
+		ident1 := call1.Fun.(*ast.Ident)
+		ident2 := call2.Fun.(*ast.Ident)
+
+		pkgPath := "example.com/local/pkg"
+		pkgTypes := types.NewPackage(pkgPath, "p")
+
+		gFunc := types.NewFunc(token.NoPos, pkgTypes, "g",
+			types.NewSignatureType(nil, nil, nil, nil, nil, false))
+
+		uses := make(map[*ast.Ident]types.Object)
+		uses[ident1] = gFunc
+		uses[ident2] = gFunc
+
+		defs := make(map[*ast.Ident]types.Object)
+		defs[fd.Name] = types.NewFunc(token.NoPos, pkgTypes, "f",
+			types.NewSignatureType(nil, nil, nil, nil, nil, false))
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   pkgPath,
+				Types:     pkgTypes,
+				TypesInfo: &types.Info{Uses: uses, Defs: defs},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+			frames:   &frameCollector{},
+			modName:  "example.com/local",
+			depth:    0,
+			maxDepth: 1, // prevents tryRecurse from doing real work
+		}
+
+		// First call adds a frame.
+		v.handleCall(call1)
+		// Second call is a duplicate — same From/To/Function — skipped.
+		v.handleCall(call2)
+
+		if len(v.frames.frames) != 1 {
+			t.Errorf("expected 1 frame (duplicate skipped), got %d", len(v.frames.frames))
+		}
+	})
+}
+
+// TestGetTypePkgPath exercises every branch of defaultSequenceAnalyzer.getTypePkgPath.
+func TestGetTypePkgPath(t *testing.T) {
+	t.Parallel()
+
+	// reusable named type for subtests 2-3
+	pkg := types.NewPackage("example.com/pkg", "pkg")
+	tn := types.NewTypeName(token.NoPos, pkg, "T", types.Typ[types.Int])
+	named := types.NewNamed(tn, types.Typ[types.Int], nil)
+	ptr := types.NewPointer(named)
+
+	tests := []struct {
+		name  string
+		input types.Type
+		want  string
+	}{
+		{
+			name:  "nil type returns empty",
+			input: nil,
+			want:  "",
+		},
+		{
+			name:  "pointer unwraps to named",
+			input: ptr,
+			want:  "example.com/pkg",
+		},
+		{
+			name:  "named type returns package path",
+			input: named,
+			want:  "example.com/pkg",
+		},
+		{
+			name:  "non-named non-pointer returns empty",
+			input: types.NewSlice(types.Typ[types.Int]),
+			want:  "",
+		},
+		{
+			name: "named type with nil package",
+			input: types.NewNamed(
+				types.NewTypeName(token.NoPos, nil, "T", types.Typ[types.Int]),
+				types.Typ[types.Int],
+				nil,
+			),
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &defaultSequenceAnalyzer{}
+			got := a.getTypePkgPath(tt.input)
+			if got != tt.want {
+				t.Errorf("getTypePkgPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetTypeName exercises every branch of defaultSequenceAnalyzer.getTypeName.
+func TestGetTypeName(t *testing.T) {
+	t.Parallel()
+
+	pkg := types.NewPackage("example.com/pkg", "pkg")
+	tn := types.NewTypeName(token.NoPos, pkg, "T", types.Typ[types.Int])
+	named := types.NewNamed(tn, types.Typ[types.Int], nil)
+	ptr := types.NewPointer(named)
+
+	tests := []struct {
+		name  string
+		input types.Type
+		want  string
+	}{
+		{
+			name:  "nil type returns Unknown",
+			input: nil,
+			want:  "Unknown",
+		},
+		{
+			name:  "pointer unwraps to named",
+			input: ptr,
+			want:  "T",
+		},
+		{
+			name:  "named type returns name",
+			input: named,
+			want:  "T",
+		},
+		{
+			name:  "non-named non-pointer returns string representation",
+			input: types.NewSlice(types.Typ[types.Int]),
+			want:  "[]int",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			a := &defaultSequenceAnalyzer{}
+			got := a.getTypeName(tt.input)
+			if got != tt.want {
+				t.Errorf("getTypeName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveSelectorCall exercises every branch of sequenceVisitor.resolveSelectorCall.
+func TestResolveSelectorCall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sel.X is Ident with PkgName resolution", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+import "fmt"
+func f() { fmt.Println() }`)
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+		sel := call.Fun.(*ast.SelectorExpr)
+
+		fmtPkg := types.NewPackage("fmt", "fmt")
+		pkgTypes := types.NewPackage("example.com/local/pkg", "p")
+
+		// PkgName for the import
+		pkgName := types.NewPkgName(token.NoPos, pkgTypes, "fmt", fmtPkg)
+
+		// Println function in fmt
+		printlnSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+		printlnFunc := types.NewFunc(token.NoPos, fmtPkg, "Println", printlnSig)
+
+		uses := make(map[*ast.Ident]types.Object)
+		uses[sel.X.(*ast.Ident)] = pkgName
+		uses[sel.Sel] = printlnFunc
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   "example.com/local/pkg",
+				Types:     pkgTypes,
+				TypesInfo: &types.Info{Uses: uses},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+		if gotFunc != "Println" {
+			t.Errorf("func = %q, want %q", gotFunc, "Println")
+		}
+		if gotPkgPath != "fmt" {
+			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "fmt")
+		}
+		if gotId != "fmt.Println" {
+			t.Errorf("id = %q, want %q", gotId, "fmt.Println")
+		}
+	})
+
+	t.Run("sel.X is Ident with non-PkgName object", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+type S struct{}
+func (s S) Method() {}
+func f() { var s S; s.Method() }`)
+		fd := f.Decls[2].(*ast.FuncDecl)            // f
+		exprStmt := fd.Body.List[1].(*ast.ExprStmt) // s.Method()
+		call := exprStmt.X.(*ast.CallExpr)
+		sel := call.Fun.(*ast.SelectorExpr)
+
+		// sel.X is *ast.Ident "s" — resolves to a *types.Var (not PkgName)
+		pkgTypes := types.NewPackage("example.com/pkg", "p")
+		namedS := types.NewNamed(
+			types.NewTypeName(token.NoPos, pkgTypes, "S", types.NewStruct(nil, nil)),
+			types.NewStruct(nil, nil),
+			nil,
+		)
+		methodFunc := types.NewFunc(
+			token.NoPos,
+			pkgTypes,
+			"Method",
+			types.NewSignatureType(
+				types.NewVar(token.NoPos, nil, "s", namedS),
+				nil, nil, nil, nil, false,
+			),
+		)
+		varS := types.NewVar(token.NoPos, pkgTypes, "s", namedS)
+
+		uses := make(map[*ast.Ident]types.Object)
+		uses[sel.X.(*ast.Ident)] = varS // NOT a PkgName → hits else branch
+		uses[sel.Sel] = methodFunc
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath:   "example.com/local/pkg",
+				TypesInfo: &types.Info{Uses: uses},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+		if gotFunc != "Method" {
+			t.Errorf("func = %q, want %q", gotFunc, "Method")
+		}
+		if gotPkgPath != "example.com/pkg" {
+			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
+		}
+		if gotId != "example.com/pkg.S.Method" {
+			t.Errorf("id = %q, want %q", gotId, "example.com/pkg.S.Method")
+		}
+	})
+
+	t.Run("sel.X not Ident, resolved via TypesInfo.Types", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+type T struct{}
+func (t T) Method() {}
+func f() { (T{}).Method() }`)
+		fd := f.Decls[2].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+		sel := call.Fun.(*ast.SelectorExpr)
+
+		// sel.X is *ast.CompositeLit (T{}) — NOT an *ast.Ident
+		pkgTypes := types.NewPackage("example.com/pkg", "p")
+		namedT := types.NewNamed(
+			types.NewTypeName(token.NoPos, pkgTypes, "T", types.NewStruct(nil, nil)),
+			types.NewStruct(nil, nil),
+			nil,
+		)
+		methodFunc := types.NewFunc(
+			token.NoPos,
+			pkgTypes,
+			"Method",
+			types.NewSignatureType(
+				types.NewVar(token.NoPos, nil, "t", namedT),
+				nil, nil, nil, nil, false,
+			),
+		)
+
+		uses := make(map[*ast.Ident]types.Object)
+		uses[sel.Sel] = methodFunc
+
+		typesMap := make(map[ast.Expr]types.TypeAndValue)
+		typesMap[sel.X] = types.TypeAndValue{Type: namedT}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath: "example.com/local/pkg",
+				TypesInfo: &types.Info{
+					Uses:  uses,
+					Types: typesMap,
+				},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+		if gotFunc != "Method" {
+			t.Errorf("func = %q, want %q", gotFunc, "Method")
+		}
+		if gotPkgPath != "example.com/pkg" {
+			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
+		}
+		if gotId != "example.com/pkg.T.Method" {
+			t.Errorf("id = %q, want %q", gotId, "example.com/pkg.T.Method")
+		}
+	})
+
+	t.Run("both resolution paths fail, returns empty", func(t *testing.T) {
+		t.Parallel()
+		// sel.X is *ast.BasicLit — NOT *ast.Ident, so the first branch
+		// is skipped. TypesInfo.Types has no entry for it, so the second
+		// branch also fails. TypesInfo.Uses has no entry for sel.Sel.
+		sel := &ast.SelectorExpr{
+			X:   &ast.BasicLit{Kind: token.INT, Value: "1"},
+			Sel: &ast.Ident{Name: "Foo"},
+		}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				PkgPath: "example.com/local/pkg",
+				TypesInfo: &types.Info{
+					Uses:  make(map[*ast.Ident]types.Object),
+					Types: make(map[ast.Expr]types.TypeAndValue),
+				},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+		if gotFunc != "Foo" {
+			t.Errorf("func = %q, want %q", gotFunc, "Foo")
+		}
+		if gotPkgPath != "" {
+			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "")
+		}
+		if gotId != "" {
+			t.Errorf("id = %q, want %q", gotId, "")
+		}
+	})
+}
+
+// TestResolveCallDetails exercises every branch of sequenceVisitor.resolveCallDetails.
+func TestResolveCallDetails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("non-interface call returns bare func name", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+func g() int { return 0 }
+func f() { g() }`)
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+
+		typesMap := make(map[ast.Expr]types.TypeAndValue)
+		typesMap[call] = types.TypeAndValue{Type: types.Typ[types.Int]}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				TypesInfo: &types.Info{Types: typesMap},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		displayFunc, retType := v.resolveCallDetails(call, "g")
+		if displayFunc != "g" {
+			t.Errorf("displayFunc = %q, want %q", displayFunc, "g")
+		}
+		if retType != "int" {
+			t.Errorf("retType = %q, want %q", retType, "int")
+		}
+	})
+
+	t.Run("interface call with type name", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, `package p
+type Runner interface { Run() int }
+func f(r Runner) { r.Run() }`)
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+		sel := call.Fun.(*ast.SelectorExpr) // r.Run
+
+		pkgTypes := types.NewPackage("example.com/pkg", "p")
+
+		// Build interface type
+		runMethod := types.NewFunc(
+			token.NoPos,
+			pkgTypes,
+			"Run",
+			types.NewSignatureType(nil, nil, nil, nil,
+				types.NewTuple(types.NewVar(token.NoPos, nil, "", types.Typ[types.Int])),
+				false,
+			),
+		)
+		iface := types.NewInterfaceType([]*types.Func{runMethod}, nil)
+		namedIface := types.NewNamed(
+			types.NewTypeName(token.NoPos, pkgTypes, "Runner", iface),
+			iface,
+			nil,
+		)
+
+		typesMap := make(map[ast.Expr]types.TypeAndValue)
+		// sel.X is *ast.Ident "r" with interface type
+		typesMap[sel.X] = types.TypeAndValue{Type: namedIface}
+		// The call return type
+		typesMap[call] = types.TypeAndValue{Type: types.Typ[types.Int]}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				TypesInfo: &types.Info{Types: typesMap},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		displayFunc, retType := v.resolveCallDetails(call, "Run")
+		if displayFunc != "Runner.Run" {
+			t.Errorf("displayFunc = %q, want %q", displayFunc, "Runner.Run")
+		}
+		if retType != "int" {
+			t.Errorf("retType = %q, want %q", retType, "int")
+		}
+	})
+
+	t.Run("void return cleared", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func g() {}; func f() { g() }")
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+
+		typesMap := make(map[ast.Expr]types.TypeAndValue)
+		// Zero-length tuple → String() == "()"
+		typesMap[call] = types.TypeAndValue{Type: types.NewTuple()}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				TypesInfo: &types.Info{Types: typesMap},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		_, retType := v.resolveCallDetails(call, "g")
+		if retType != "" {
+			t.Errorf("retType = %q, want %q", retType, "")
+		}
+	})
+
+	t.Run("invalid type return cleared", func(t *testing.T) {
+		t.Parallel()
+		_, f := parseTestFile(t, "package p; func g() {}; func f() { g() }")
+		fd := f.Decls[1].(*ast.FuncDecl)
+		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+		call := exprStmt.X.(*ast.CallExpr)
+
+		typesMap := make(map[ast.Expr]types.TypeAndValue)
+		typesMap[call] = types.TypeAndValue{Type: types.Typ[types.Invalid]}
+
+		v := &sequenceVisitor{
+			ctx: context.Background(),
+			pkg: &packages.Package{
+				TypesInfo: &types.Info{Types: typesMap},
+			},
+			analyzer: &defaultSequenceAnalyzer{},
+		}
+
+		_, retType := v.resolveCallDetails(call, "g")
+		if retType != "" {
+			t.Errorf("retType = %q, want %q", retType, "")
+		}
+	})
+}
+
+// TestShortenPkg exercises the shortenPkg helper with table-driven cases.
+func TestShortenPkg(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty string", "", ""},
+		{"single segment", "pkg", "pkg"},
+		{"multi-segment path", "example.com/foo/bar/pkg", "pkg"},
+		{"path with trailing slash", "example.com/foo/", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := a.shortenPkg(tt.input)
+			if got != tt.want {
+				t.Errorf("shortenPkg(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestSequenceExprToString_Default exercises the default branch of the
+// defaultSequenceAnalyzer.exprToString method (not the astutil.go standalone).
+func TestSequenceExprToString_Default(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{}
+
+	tests := []struct {
+		name string
+		expr ast.Expr
+		want string
+	}{
+		{"default case returns empty", &ast.BasicLit{Kind: token.INT, Value: "42"}, ""},
+		{"array type returns empty", &ast.ArrayType{Elt: &ast.Ident{Name: "byte"}}, ""},
+		{"map type returns empty", &ast.MapType{Key: &ast.Ident{Name: "string"}, Value: &ast.Ident{Name: "int"}}, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := a.exprToString(tt.expr)
+			if got != tt.want {
+				t.Errorf("exprToString(%T) = %q, want %q", tt.expr, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFindByPrefix exercises the two-pass prefix-matching logic in findByPrefix.
+func TestFindByPrefix(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{}
+
+	tests := []struct {
+		name    string
+		symbol  string
+		pkgs    []*packages.Package
+		modName string
+		wantPkg string // empty string means nil
+		wantRem string
+	}{
+		{
+			name:    "longest prefix wins",
+			symbol:  "example.com/foo/bar.Baz",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/foo"}, {PkgPath: "example.com/foo/bar"}},
+			modName: "",
+			wantPkg: "example.com/foo/bar",
+			wantRem: "Baz",
+		},
+		{
+			name:    "first pass success skips second pass",
+			symbol:  "example.com/foo.Bar",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/foo"}},
+			modName: "example.com",
+			wantPkg: "example.com/foo",
+			wantRem: "Bar",
+		},
+		{
+			name:    "second pass no-trim skip",
+			symbol:  "other.com/pkg.Func",
+			pkgs:    []*packages.Package{{PkgPath: "unrelated.com/x"}},
+			modName: "example.com",
+			wantPkg: "",
+			wantRem: "",
+		},
+		{
+			name:    "second pass match when first pass fails",
+			symbol:  "internal/foo.Bar",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/mod/internal/foo"}},
+			modName: "example.com/mod",
+			wantPkg: "example.com/mod/internal/foo",
+			wantRem: "Bar",
+		},
+		{
+			name:    "no match in either pass",
+			symbol:  "unknown/pkg.Func",
+			pkgs:    []*packages.Package{{PkgPath: "example.com/other"}},
+			modName: "example.com",
+			wantPkg: "",
+			wantRem: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pkg, rem := a.findByPrefix(tt.symbol, tt.pkgs, tt.modName)
+			if tt.wantPkg == "" {
+				if pkg != nil {
+					t.Errorf("expected nil package, got %v", pkg.PkgPath)
+				}
+			} else {
+				if pkg == nil {
+					t.Errorf("expected package %q, got nil", tt.wantPkg)
+				} else if pkg.PkgPath != tt.wantPkg {
+					t.Errorf("expected PkgPath %q, got %q", tt.wantPkg, pkg.PkgPath)
+				}
+			}
+			if rem != tt.wantRem {
+				t.Errorf("expected remaining %q, got %q", tt.wantRem, rem)
+			}
+		})
+	}
+}
+
+// TestNormalizeSymbolName_EdgeCases exercises edge cases of normalizeSymbolName
+// not covered by the existing TestNormalizeSymbolName (empty, parens, dots).
+func TestNormalizeSymbolName_EdgeCases(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty string", "", ""},
+		{"just dots", "...", ""},
+		{"double-paren receiver", "((Type)).Method", "Method"},
+		{"receiver only no method", "(Type)", "Type"},
+		{"bare function", "FuncName", "FuncName"},
+		{"prefix plus pointer receiver", "pkg.(*Type).Method", "Method"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := a.normalizeSymbolName(tt.input)
+			if got != tt.want {
+				t.Errorf("normalizeSymbolName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAnalyzeSequenceFlow_ErrorPaths exercises error paths and edge cases in
+// AnalyzeSequenceFlow: type-switch branches for max_depth, missing start_symbol,
+// and traceFlow error propagation.
+func TestAnalyzeSequenceFlow_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("max_depth as int type", func(t *testing.T) {
+		t.Parallel()
+		pkgA, pkgB := setupMockPackages()
+		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+
+		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+			"start_symbol": pkgA.PkgPath + ".StartFunc",
+			"max_depth":    2, // int, not float64 → case int:
+		}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if res.Text == "" {
+			t.Error("expected non-empty diagram with max_depth=2 (int)")
+		}
+	})
+
+	t.Run("max_depth unexpected type defaults to 5", func(t *testing.T) {
+		t.Parallel()
+		pkgA, pkgB := setupMockPackages()
+		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+
+		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+			"start_symbol": pkgA.PkgPath + ".StartFunc",
+			"max_depth":    "invalid", // string → default: maxDepth = 5
+		}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if res.Text == "" {
+			t.Error("expected non-empty diagram with default depth 5")
+		}
+	})
+
+	t.Run("max_depth absent defaults to 5", func(t *testing.T) {
+		t.Parallel()
+		pkgA, pkgB := setupMockPackages()
+		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+
+		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+			"start_symbol": pkgA.PkgPath + ".StartFunc",
+			// max_depth omitted → maxDepth = 5
+		}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if res.Text == "" {
+			t.Error("expected non-empty diagram with default depth 5")
+		}
+	})
+
+	t.Run("empty start_symbol", func(t *testing.T) {
+		t.Parallel()
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
+
+		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+			"start_symbol": "",
+		}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !strings.Contains(res.Text, "Error: missing") {
+			t.Errorf("expected 'Error: missing' in result, got: %s", res.Text)
+		}
+	})
+
+	t.Run("traceFlow error propagates", func(t *testing.T) {
+		t.Parallel()
+		idx := &mockIndexer{err: fmt.Errorf("index failure")}
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+
+		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+			"start_symbol": "example.com/pkg.Func",
+		}, nil)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if !strings.Contains(res.Text, "Error tracing flow") {
+			t.Errorf("expected 'Error tracing flow' in result, got: %s", res.Text)
+		}
+	})
+}
+
+// TestLoadPackages_ErrorPaths exercises error paths in loadPackages:
+// indexer failure and empty package list.
+func TestLoadPackages_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("indexer error propagates", func(t *testing.T) {
+		t.Parallel()
+		idx := &mockIndexer{err: fmt.Errorf("boom")}
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+		// lastLoad is zero, so cache is expired; loadPackages calls idx.Packages.
+
+		err := analyzer.loadPackages(context.Background(), nil)
+		if err == nil {
+			t.Error("expected error from indexer failure, got nil")
+		} else {
+			if !strings.Contains(err.Error(), "getting packages from indexer") {
+				t.Errorf("expected wrapping message, got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "boom") {
+				t.Errorf("expected original error 'boom', got: %v", err)
+			}
+		}
+	})
+
+	t.Run("zero packages returns error", func(t *testing.T) {
+		t.Parallel()
+		idx := &mockIndexer{pkgs: []*packages.Package{}} // empty slice
+		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+
+		err := analyzer.loadPackages(context.Background(), nil)
+		if err == nil {
+			t.Error("expected error for empty packages, got nil")
+		} else if !strings.Contains(err.Error(), "no packages loaded") {
+			t.Errorf("expected 'no packages loaded', got: %v", err)
+		}
+	})
+}
+
+// TestTraceFlow_ErrorPaths exercises error paths in traceFlow:
+// symbol-not-found with various hint generation branches, and
+// resolveStartFunc error wrapping.
+func TestTraceFlow_ErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	t.Run("symbol not found, no slash", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultSequenceAnalyzer{
+			pkgs:     []*packages.Package{},
+			funcMap:  make(map[string]funcInfo),
+			lastLoad: time.Now(),
+			cacheTTL: 5 * time.Minute,
+		}
+
+		_, err := a.traceFlow(context.Background(), "MissingFunc", 5, nil)
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else {
+			if !strings.Contains(err.Error(), "start symbol not found: MissingFunc") {
+				t.Errorf("expected 'start symbol not found', got: %v", err)
+			}
+			// No slash in symbol → no hint
+			if strings.Contains(err.Error(), "try ") {
+				t.Errorf("expected no hint for symbol without slash, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("symbol not found, with slash, has module prefix", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultSequenceAnalyzer{
+			pkgs:     []*packages.Package{},
+			funcMap:  make(map[string]funcInfo),
+			modName:  "example.com/mod",
+			lastLoad: time.Now(),
+			cacheTTL: 5 * time.Minute,
+		}
+
+		_, err := a.traceFlow(context.Background(), "example.com/mod/pkg.Func", 5, nil)
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else {
+			if !strings.Contains(err.Error(), "start symbol not found") {
+				t.Errorf("expected 'start symbol not found', got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "try 'pkg/path.(*Type).Method'") {
+				t.Errorf("expected module-relative hint, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("symbol not found, with slash, no module prefix", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultSequenceAnalyzer{
+			pkgs:     []*packages.Package{},
+			funcMap:  make(map[string]funcInfo),
+			modName:  "",
+			lastLoad: time.Now(),
+			cacheTTL: 5 * time.Minute,
+		}
+
+		_, err := a.traceFlow(context.Background(), "github.com/foo/pkg.Func", 5, nil)
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else {
+			if !strings.Contains(err.Error(), "start symbol not found") {
+				t.Errorf("expected 'start symbol not found', got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "try the full module path") {
+				t.Errorf("expected full-module-path hint, got: %v", err)
+			}
+		}
+	})
+
+	t.Run("resolveStartFunc error", func(t *testing.T) {
+		t.Parallel()
+		fset := token.NewFileSet()
+		code := `package p
+func OtherFunc() {}`
+		f, _ := parser.ParseFile(fset, "test.go", code, 0)
+
+		pkg := &packages.Package{
+			PkgPath: "example.com/pkg",
+			Syntax:  []*ast.File{f},
+		}
+
+		a := &defaultSequenceAnalyzer{
+			pkgs:     []*packages.Package{pkg},
+			funcMap:  make(map[string]funcInfo),
+			lastLoad: time.Now(),
+			cacheTTL: 5 * time.Minute,
+		}
+
+		_, err := a.traceFlow(context.Background(), "example.com/pkg.WrongName", 5, nil)
+		if err == nil {
+			t.Error("expected error, got nil")
+		} else {
+			if !strings.Contains(err.Error(), "start symbol not found") {
+				t.Errorf("expected 'start symbol not found', got: %v", err)
+			}
+			if !strings.Contains(err.Error(), "WrongName") {
+				t.Errorf("expected 'WrongName' in error, got: %v", err)
+			}
+		}
+	})
+}
+
+// TestIsMethodMatch_Remaining exercises the remaining branch in isMethodMatch
+// where the symbol contains a receiver pattern but the *ast.FuncDecl has no
+// receiver (plain function), causing getReceiverTypeName to return "".
+func TestIsMethodMatch_Remaining(t *testing.T) {
+	t.Parallel()
+
+	t.Run("symbol has receiver but func is plain", func(t *testing.T) {
+		t.Parallel()
+		code := `package p
+func Method() {}`
+		_, f := parseTestFile(t, code)
+		fd := f.Decls[0].(*ast.FuncDecl)
+		// fd.Recv is nil (plain function, no receiver).
+		// remaining has receiver notation → matches != nil, symbolRecv = "T",
+		// but getReceiverTypeName(fd.Recv) returns "" → returns false.
+		a := &defaultSequenceAnalyzer{}
+		if a.isMethodMatch(fd, "(*T).Method") {
+			t.Error("isMethodMatch should return false when symbol has receiver but func is plain")
+		}
+	})
 }


### PR DESCRIPTION
Closes #453.

## Summary
Added ~1,800 lines of table-driven tests across 4 test files, raising the `internal/tools/analysis` package from 93.7% to **95.8%** coverage. All 23 target functions now meet or exceed the 90% per-function threshold.

### Key improvements
- `findBySuffix`: 33.3% → **100.0%** (largest single gap)
- `walk`: 69.2% → **100.0%**
- `Visit`: 70.4% → **100.0%**
- `handleCall`: 78.6% → **100.0%**
- All dead_code_anon_interface functions: → **100.0%**
- All remaining functions: ≥90%

### Files changed
| File | Change |
|------|--------|
| `dead_code_anon_interface_test.go` | +160 lines (guard clause & nil-state coverage) |
| `dead_code_test.go` | +177 lines (CompiledGoFiles fallback, error accumulation, heartbeat, edge cases) |
| `sequence_test.go` | +1,463 lines (findBySuffix, walk guards, Visit, handleCall) |
| `index.go` | +1 line (formatting) |
| No production logic changed | ✅ |

### Review corrections applied
- Fixed symlink issue in `TestRunAnalysisPipeline_EmptyPathDefaultsToDot` (`filepath.EvalSymlinks`)
- Restored `resolvePath` DI field in `indexer` (testability preserved)
- Restored `index_harvest_test.go` (776 lines — accidentally deleted)
- Reverted unrelated deletions in `events_test.go` and `mock_fs_test.go`

## Verification
| Check | Status |
|-------|--------|
| `go test ./...` | PASS |
| Package coverage | 95.8% (≥95%) |
| Race detector | PASS |
| Production logic unchanged | ✅ |
