### PR TITLE
fix(auth): harden token caching and workspace error paths (#463)

### DIFF
--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -98,6 +98,7 @@ func (a *VertexAuth) getToken(ctx context.Context) (string, error) {
 				a.Token = strings.TrimSpace(string(content))
 				return a.Token, nil
 			}
+			log.Printf("failed to read auth cache file %s: %v", cacheFile, err)
 		}
 	}
 
@@ -128,7 +129,9 @@ func (a *VertexAuth) Invalidate() {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	a.Token = ""
-	_ = os.Remove(a.getCachePath())
+	if err := os.Remove(a.getCachePath()); err != nil && !os.IsNotExist(err) {
+		log.Printf("failed to remove auth cache file: %v", err)
+	}
 }
 
 // Apply injects the Bearer token into the request headers.
@@ -216,6 +219,9 @@ func (a *ServiceAccountAuth) getToken(ctx context.Context) (string, error) {
 		}
 	} else {
 		// 2. Read the master secret (key.json) from disk
+		if a.KeyFilePath == "" {
+			return "", fmt.Errorf("failed to read service account key: KeyFilePath is empty")
+		}
 		data, err := os.ReadFile(a.KeyFilePath)
 		if err != nil {
 			return "", fmt.Errorf("failed to read service account key: %w", err)

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -61,6 +62,47 @@ func TestVertexAuth_Invalidate(t *testing.T) {
 	if _, err := os.Stat(cachePath); !os.IsNotExist(err) {
 		t.Error("expected cache file to be deleted")
 	}
+}
+
+func TestVertexAuth_Invalidate_RemoveError(t *testing.T) {
+	t.Run("remove failure logs but clears token", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Chmod 0555 on directory not reliable on Windows")
+		}
+
+		tmpDir := t.TempDir()
+		cacheDir := filepath.Join(tmpDir, "cache")
+		auth := &VertexAuth{Token: "some-token", CacheDir: cacheDir}
+		cachePath := auth.getCachePath()
+
+		// Create cache directory and file
+		if err := os.MkdirAll(cacheDir, 0700); err != nil {
+			t.Fatalf("failed to create cache dir: %v", err)
+		}
+		if err := os.WriteFile(cachePath, []byte("token"), 0600); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		// Make parent directory read-only so os.Remove fails
+		if err := os.Chmod(cacheDir, 0555); err != nil {
+			t.Fatalf("failed to chmod cache dir: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chmod(cacheDir, 0700)
+		})
+
+		auth.Invalidate()
+
+		// Primary contract: in-memory token cleared even when file removal fails
+		if auth.Token != "" {
+			t.Error("expected Token to be cleared even when file removal fails")
+		}
+
+		// The cache file should still exist (removal silently failed)
+		if _, err := os.Stat(cachePath); os.IsNotExist(err) {
+			t.Error("expected cache file to still exist when removal fails")
+		}
+	})
 }
 
 func TestVertexAuth_GetToken(t *testing.T) {
@@ -440,6 +482,24 @@ func TestVertexAuth_GetCachePath_UnixFallback(t *testing.T) {
 	}
 }
 
+func TestVertexAuth_GetCachePath_AllFallbacksEmpty(t *testing.T) {
+	originalGetUID := getUID
+	getUID = func() int { return -1 }
+	t.Cleanup(func() { getUID = originalGetUID })
+
+	t.Setenv("USERNAME", "")
+	t.Setenv("USER", "")
+
+	auth := &VertexAuth{}
+	path := auth.getCachePath()
+	if !strings.Contains(path, "tell-me-go-auth--1") {
+		t.Errorf("expected path to contain 'tell-me-go-auth--1', got %s", path)
+	}
+	if !strings.HasSuffix(path, "token.txt") {
+		t.Errorf("expected path to end with 'token.txt', got %s", path)
+	}
+}
+
 func TestVertexAuth_GetToken_GcloudError(t *testing.T) {
 	ctx := context.Background()
 	auth := &VertexAuth{
@@ -571,6 +631,50 @@ func TestVertexAuth_CacheWriteFailure(t *testing.T) {
 	}
 }
 
+func TestVertexAuth_GetToken_AtomicWriteFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Chmod 0555 not reliable on Windows")
+	}
+
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// Compute the cache path to find the directory that needs to exist but be read-only
+	auth := &VertexAuth{CacheDir: tmpDir}
+	cachePath := auth.getCachePath()
+	cacheDir := filepath.Dir(cachePath)
+
+	// Create the cache directory
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+
+	// Make it read-only so that AtomicWrite (CreateTemp) fails inside
+	if err := os.Chmod(cacheDir, 0555); err != nil {
+		t.Fatalf("failed to chmod cache dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chmod(cacheDir, 0700)
+	})
+
+	// Fresh VertexAuth — no preset Token, so code path goes:
+	// cache miss → gcloud → MkdirAll(succeeds) → AtomicWrite(fails)
+	auth2 := &VertexAuth{
+		CacheDir: tmpDir,
+		tokenCmdFunc: func() ([]byte, error) {
+			return []byte("resilient-token"), nil
+		},
+	}
+
+	token, err := auth2.getToken(ctx)
+	if err != nil {
+		t.Fatalf("getToken should return token despite AtomicWrite failure, got error: %v", err)
+	}
+	if token != "resilient-token" {
+		t.Errorf("got %q, want resilient-token", token)
+	}
+}
+
 func TestNewVertexAuth_DefaultTokenCmdFunc(t *testing.T) {
 	a := NewVertexAuth()
 	if a.tokenCmdFunc == nil {
@@ -596,4 +700,109 @@ func TestVertexAuth_NilTokenCmdFunc_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "NewVertexAuth") {
 		t.Errorf("error should mention NewVertexAuth, got: %v", err)
 	}
+}
+
+func TestServiceAccountAuth_EmptyKeyFilePath(t *testing.T) {
+	tests := []struct {
+		name string
+		auth *ServiceAccountAuth
+		want string // expected substring in error, empty means no error expected
+	}{
+		{
+			name: "empty KeyFilePath returns descriptive error",
+			auth: &ServiceAccountAuth{},
+			want: "KeyFilePath is empty",
+		},
+		{
+			name: "empty KeyFilePath with tokenSourceFunc still works",
+			auth: &ServiceAccountAuth{
+				tokenSourceFunc: func() (*oauth2.Token, error) {
+					return &oauth2.Token{
+						AccessToken: "mock-token",
+						Expiry:      time.Now().Add(1 * time.Hour),
+					}, nil
+				},
+			},
+			want: "", // no error expected
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			token, err := tt.auth.getToken(context.Background())
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if token != "mock-token" {
+					t.Errorf("got %q, want %q", token, "mock-token")
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.want) {
+					t.Errorf("expected error containing %q, got %q", tt.want, err.Error())
+				}
+			}
+		})
+	}
+}
+
+func TestVertexAuth_GetToken_CorruptCache(t *testing.T) {
+	t.Run("corrupt cache falls back to gcloud", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Chmod 0000 not reliable on Windows")
+		}
+
+		ctx := context.Background()
+		tmpDir := t.TempDir()
+
+		auth := &VertexAuth{
+			CacheDir: tmpDir,
+			tokenCmdFunc: func() ([]byte, error) {
+				return []byte("fresh-gcloud-token"), nil
+			},
+		}
+
+		cachePath := auth.getCachePath()
+		dir := filepath.Dir(cachePath)
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			t.Fatalf("failed to create cache dir: %v", err)
+		}
+		if err := os.WriteFile(cachePath, []byte("stale-token"), 0600); err != nil {
+			t.Fatalf("failed to write cache file: %v", err)
+		}
+
+		// Make the cache file unreadable to simulate corruption
+		if err := os.Chmod(cachePath, 0000); err != nil {
+			t.Fatalf("failed to chmod cache file: %v", err)
+		}
+
+		// Restore permissions so t.TempDir cleanup can remove the file
+		t.Cleanup(func() {
+			_ = os.Chmod(cachePath, 0600)
+		})
+
+		token, err := auth.getToken(ctx)
+		if err != nil {
+			t.Fatalf("getToken should fall back to gcloud, got error: %v", err)
+		}
+		if token != "fresh-gcloud-token" {
+			t.Errorf("got %q, want fresh-gcloud-token", token)
+		}
+
+		// Verify the corrupt cache was overwritten with the fresh token
+		// (restore readability first)
+		if err := os.Chmod(cachePath, 0600); err != nil {
+			t.Fatalf("failed to restore cache file permissions: %v", err)
+		}
+		content, err := os.ReadFile(cachePath)
+		if err != nil {
+			t.Fatalf("failed to read cache file after getToken: %v", err)
+		}
+		if strings.TrimSpace(string(content)) != "fresh-gcloud-token" {
+			t.Errorf("cache file contains %q, want fresh-gcloud-token", string(content))
+		}
+	})
 }

--- a/internal/tools/workspace/reader_test.go
+++ b/internal/tools/workspace/reader_test.go
@@ -158,6 +158,25 @@ func (m *mockDiffExecutor) RunCommand(ctx context.Context, parts []string, confi
 	return m.processExecutor.RunCommand(ctx, parts, config)
 }
 
+type mockDiffRunErrorExecutor struct {
+	*processExecutor
+	runErr error
+}
+
+func (m *mockDiffRunErrorExecutor) RunCommand(ctx context.Context, parts []string, config executionConfig) (executionResult, error) {
+	if len(parts) > 0 && parts[0] == "diff" {
+		return executionResult{}, m.runErr
+	}
+	return m.processExecutor.RunCommand(ctx, parts, config)
+}
+
+func (m *mockDiffRunErrorExecutor) LookPath(name string) (string, error) {
+	if name == "diff" {
+		return "/usr/bin/diff", nil
+	}
+	return m.processExecutor.LookPath(name)
+}
+
 func TestGetFileDiff(t *testing.T) {
 	tempDir := t.TempDir()
 	f1 := filepath.Join(tempDir, "f1.txt")
@@ -275,6 +294,48 @@ func TestGetFileDiff_Errors(t *testing.T) {
 		}
 		_, _ = r.getFileDiff(ctx, map[string]interface{}{"file1": f1, "file2": fbin, "reason": "testing"}, nil)
 	})
+}
+
+func TestGetFileDiff_RunCommandError(t *testing.T) {
+	tempDir := t.TempDir()
+	f1 := filepath.Join(tempDir, "f1.txt")
+	f2 := filepath.Join(tempDir, "f2.txt")
+	if err := os.WriteFile(f1, []byte("line1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte("line2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	runErr := fmt.Errorf("exec format error")
+	r := &fileReader{
+		sm:     sm,
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+		executor: &mockDiffRunErrorExecutor{
+			processExecutor: newprocessExecutor(),
+			runErr:          runErr,
+		},
+	}
+	ctx := context.Background()
+
+	_, err := r.getFileDiff(ctx, map[string]interface{}{
+		"file1":  f1,
+		"file2":  f2,
+		"reason": "testing run error",
+	}, nil)
+
+	if err == nil {
+		t.Fatal("expected error from RunCommand failure")
+	}
+	if !strings.Contains(err.Error(), "diff failed") {
+		t.Errorf("expected 'diff failed' in error, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "exec format error") {
+		t.Errorf("expected 'exec format error' in error, got: %v", err)
+	}
 }
 
 func TestReadFiles(t *testing.T) {


### PR DESCRIPTION
Closes #463.

## Summary
Hardens ~6 error handling paths across `internal/infrastructure/auth/` (token caching and credential edges) and 1 remaining gap in `internal/tools/workspace/` (getFileDiff RunCommand error path). The remaining ~9 workspace gaps cited in the issue were already comprehensively tested by prior work.

### Changes
| # | Change | Package |
|---|--------|---------|
| 1 | Guard for empty `KeyFilePath` in `ServiceAccountAuth.getToken()` | `auth.go` |
| 2 | Log corrupt cache file read failures (was silent discard) | `auth.go` |
| 3 | Log `Invalidate()` Remove failures with `IsNotExist` guard | `auth.go` |
| 4 | Test all-fallbacks-empty `getCachePath` behavior | `auth_test.go` |
| 5 | Test `AtomicWrite` failure graceful degradation | `auth_test.go` |
| 6 | Test `getFileDiff` RunCommand infrastructure error path | `reader_test.go` |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Auth coverage | 97.8% → 98.9% |
| Workspace coverage | 94.0% (stable) |
| Lint | 0 issues |
| Race detection | PASS |
| Vulncheck | 0 vulnerabilities |