### PR TITLE
fix(llm): harden error paths and coverage across provider health, anthropic, and openai (#461)

### DIFF
--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -602,3 +602,117 @@ func TestToAnthropicMessages_SkipsEmptyBlocks(t *testing.T) {
 		t.Error("expected 'world' in user content, not found")
 	}
 }
+
+// customRoundTripper is an http.RoundTripper that is NOT an *http.Transport.
+// Used by TestNewClient_TransportCloneFallback to exercise the else branch
+// in NewClient's transport initialization.
+type customRoundTripper struct{}
+
+func (c *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(`{"id":"msg","content":[{"type":"text","text":"ok"}],"role":"assistant","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+// TestNewClient_TransportCloneFallback closes Gap #1: when
+// http.DefaultTransport is not an *http.Transport (e.g., it has been
+// replaced by a custom RoundTripper), NewClient must fall back to
+// using DefaultTransport directly instead of calling Clone().
+// This test is NOT parallel because it mutates the global
+// http.DefaultTransport.
+func TestNewClient_TransportCloneFallback(t *testing.T) {
+	// Save and restore DefaultTransport
+	orig := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = orig })
+
+	// Replace DefaultTransport with a non-*http.Transport type
+	http.DefaultTransport = &customRoundTripper{}
+
+	c := NewClient("https://api.anthropic.com/v1", "claude-3", &auth.AnthropicAuth{APIKey: "key"})
+	if c.transport == nil {
+		t.Fatal("expected transport to be non-nil")
+	}
+	if c.httpClient == nil {
+		t.Fatal("expected httpClient to be non-nil")
+	}
+}
+
+// TestPrepareAnthropicRequest_ThinkingBudgetIncreasesMaxTokens closes
+// Gap #2 variant: when thinkingBudget > 0 AND the caller explicitly
+// set MaxTokens (via WithMaxTokens) to a value <= thinkingBudget, the
+// code must still bump MaxTokens above the thinking budget. This
+// complements the table-driven test in truncation_test.go by covering
+// the explicit-MaxTokens-but-still-too-low path.
+func TestPrepareAnthropicRequest_ThinkingBudgetIncreasesMaxTokens(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient("https://api.anthropic.com/v1", "claude-3-5-sonnet",
+		&auth.AnthropicAuth{APIKey: "test-key"},
+		WithThinkingBudget(20000), // > defaultMaxTokens (16384)
+		WithMaxTokens(16000),      // < thinkingBudget, triggers increase
+	)
+
+	req, err := c.prepareAnthropicRequest(context.Background(),
+		[]*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The request body should have MaxTokens increased to thinkingBudget + 1024
+	body, _ := io.ReadAll(req.Body)
+	if !strings.Contains(string(body), `"max_tokens":21024`) {
+		t.Errorf("expected max_tokens=21024 (thinkingBudget 20000 + 1024), got body: %s", string(body))
+	}
+}
+
+// TestSendChat_PreCancelledContext closes Gap #3: when the context is
+// already cancelled before SendChat is called, the HTTP client's Do
+// method must return an error before reaching the server. This is
+// distinct from TestSendChat_Timeout which uses a deadline.
+func TestSendChat_PreCancelledContext(t *testing.T) {
+	t.Parallel()
+
+	server, c := setupMockAnthropicServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("HTTP server should not be reached with cancelled context")
+	})
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before the call
+
+	_, _, err := c.SendChat(ctx, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	if !strings.Contains(err.Error(), "request failed") {
+		t.Errorf("expected error containing 'request failed', got: %v", err)
+	}
+}
+
+// TestBuildHTTPRequest_VertexURL closes Gap #7: when isVertex()
+// returns true, buildHTTPRequest must construct a URL ending with
+// the model name followed by ":rawPredict" instead of the standard
+// "/messages" path.
+func TestBuildHTTPRequest_VertexURL(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient("https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/anthropic/models",
+		"claude-3-5-sonnet",
+		&auth.AnthropicAuth{APIKey: "test-key"},
+	)
+
+	req, err := c.buildHTTPRequest(context.Background(), []byte(`{}`))
+	if err != nil {
+		t.Fatalf("buildHTTPRequest failed: %v", err)
+	}
+
+	// Vertex URL must include model name with :rawPredict
+	expectedSuffix := "claude-3-5-sonnet:rawPredict"
+	if !strings.Contains(req.URL.String(), expectedSuffix) {
+		t.Errorf("expected URL to contain %q, got: %s", expectedSuffix, req.URL.String())
+	}
+}

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -1365,6 +1365,7 @@ func getResponsesAPIContentBlockTestCases(t *testing.T) []responsesAPITestCase {
 	cases = append(cases, getResponsesAPIRefusalTestCases(t)...)
 	cases = append(cases, getResponsesAPIMixedInputTestCases(t)...)
 	cases = append(cases, getResponsesAPITextBlockFallbackTestCases(t)...)
+	cases = append(cases, getResponsesAPIEdgeCases(t)...)
 	return cases
 }
 
@@ -1592,6 +1593,222 @@ func getResponsesAPITextBlockFallbackTestCases(t *testing.T) []responsesAPITestC
 	}
 }
 
+func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
+		// Gap 1 & 2: Direct content blocks without message wrapper + child blocks
+		{
+			name:    "direct_content_blocks_without_message_wrapper",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type:       "text",
+							OutputText: "direct output text",
+						},
+						{
+							Type: "custom_block",
+							Content: []contentBlock{
+								{Type: "text", Text: "child block text"},
+							},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			validate: func(t *testing.T, resp *llm.Content, metrics *llm.Metrics) {
+				var foundDirect, foundChild bool
+				for _, part := range resp.Parts {
+					if part.Text == "direct output text" {
+						foundDirect = true
+					}
+					if part.Text == "child block text" {
+						foundChild = true
+					}
+				}
+				if !foundDirect {
+					t.Error("expected 'direct output text' part")
+				}
+				if !foundChild {
+					t.Error("expected 'child block text' part from child Content iteration")
+				}
+			},
+		},
+		// Gap 3: parseResponseToolCalls error in else-branch
+		{
+			name:    "direct_item_with_invalid_tool_calls",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type: "direct_item",
+							ToolCalls: []toolCall{
+								{
+									ID:   "call_1",
+									Type: "function",
+									Function: functionCall{
+										Name:      "test_tool",
+										Arguments: "{invalid json",
+									},
+								},
+							},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "failed to unmarshal tool arguments",
+		},
+		// Gap 4: Top-level Name/Arguments without Function
+		{
+			name:    "top_level_tool_call_via_name_and_arguments",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type:      "call",
+							ID:        "call_name_123",
+							Name:      "test_tool",
+							Arguments: `{"param": "val"}`,
+							// No Function field — uses Name/Arguments directly
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			validate: func(t *testing.T, resp *llm.Content, metrics *llm.Metrics) {
+				if len(resp.Parts) != 1 || resp.Parts[0].FunctionCall == nil {
+					t.Fatal("expected function call part")
+				}
+				if resp.Parts[0].FunctionCall.ID != "call_name_123" {
+					t.Errorf("expected ID 'call_name_123', got %q", resp.Parts[0].FunctionCall.ID)
+				}
+				if resp.Parts[0].FunctionCall.Name != "test_tool" {
+					t.Errorf("expected name 'test_tool', got %q", resp.Parts[0].FunctionCall.Name)
+				}
+			},
+		},
+		// Gap 4b: Top-level Name/Arguments with invalid JSON — appendToolCall error path
+		{
+			name:    "top_level_tool_call_via_name_and_invalid_arguments",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type:      "call",
+							ID:        "call_name_456",
+							Name:      "test_tool",
+							Arguments: "{invalid json",
+							// No Function field — uses Name/Arguments with broken JSON
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "failed to unmarshal tool arguments",
+		},
+		// Gap 6: extractBlockText with map missing "value" key
+		{
+			name:    "text_block_with_map_missing_value_key",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type: "text",
+							Text: map[string]interface{}{"other": "not-value"},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			validate: func(t *testing.T, resp *llm.Content, metrics *llm.Metrics) {
+				// extractBlockText returns "" for map without "value" key
+				// handleTextBlock then checks OutputText (empty) and InputText (empty)
+				// No part should be added
+				if len(resp.Parts) != 0 {
+					t.Errorf("expected 0 parts for map without 'value' key, got %d", len(resp.Parts))
+				}
+			},
+		},
+		// Gap 7: handleRefusalBlock with empty Refusal
+		{
+			name:    "refusal_block_with_empty_text",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type: "message",
+							Message: &struct {
+								Role      string         `json:"role"`
+								Content   []contentBlock `json:"content"`
+								ToolCalls []toolCall     `json:"tool_calls"`
+							}{
+								Role: "assistant",
+								Content: []contentBlock{
+									{Type: "refusal", Refusal: ""},
+									{Type: "text", Text: "fallback text"},
+								},
+							},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			validate: func(t *testing.T, resp *llm.Content, metrics *llm.Metrics) {
+				// Empty refusal should not produce a part; "fallback text" should
+				if len(resp.Parts) != 1 || resp.Parts[0].Text != "fallback text" {
+					t.Errorf("expected 1 part 'fallback text', got %+v", resp.Parts)
+				}
+			},
+		},
+		// Unknown content block type must return an error (ADR-022 fail-loud)
+		{
+			name:    "unknown_content_block_type_returns_error",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type: "message",
+							Message: &struct {
+								Role      string         `json:"role"`
+								Content   []contentBlock `json:"content"`
+								ToolCalls []toolCall     `json:"tool_calls"`
+							}{
+								Role: "assistant",
+								Content: []contentBlock{
+									{Type: "future_block_type_xyz"},
+								},
+							},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "unhandled content block type",
+		},
+	}
+}
+
 func getStreamingTestCases(t *testing.T) []responsesAPITestCase {
 	return []responsesAPITestCase{}
 }
@@ -1623,6 +1840,48 @@ func getToolCallTestCases(t *testing.T) []responsesAPITestCase {
 					t.Errorf("unexpected tool call")
 				}
 			},
+		},
+		{
+			name:    "top_level_tool_call_empty_id_returns_error",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type: "call",
+							ID:   "", // ← empty ID triggers the guard
+							Function: &functionCall{
+								Name:      "test_tool",
+								Arguments: `{"param": "val"}`,
+							},
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "invalid tool payload",
+		},
+		{
+			name:    "top_level_tool_call_empty_id_via_name_args",
+			model:   "gpt-5.4",
+			headers: map[string]string{"reasoning_effort": "high"},
+			tools:   []*tools.ToolDeclaration{getStandardToolDecl()},
+			mockHandler: func(w http.ResponseWriter, r *http.Request) {
+				resp := responsesAPIResponse{
+					Output: []responseOutputItem{
+						{
+							Type:      "call",
+							ID:        "", // ← empty ID
+							Name:      "test_tool",
+							Arguments: `{"param": "val"}`,
+						},
+					},
+				}
+				_ = json.NewEncoder(w).Encode(resp)
+			},
+			wantErr: "invalid tool payload",
 		},
 	}
 }

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -2,9 +2,17 @@ package openai
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 )
+
+// errUnhandledBlockType is a sentinel for appendPartsFromBlock's default
+// case. Callers at the output-item level (not content-block level) ignore
+// this error because output-item types such as "call" and "message" are
+// not content-block types and are handled by fallback logic.
+var errUnhandledBlockType = errors.New("unhandled content block type")
 
 // ---------------------------------------------------------------------------
 // Responses API sink
@@ -98,7 +106,9 @@ func (c *client) fromResponsesAPIResponse(resp *responsesAPIResponse, duration f
 func (c *client) processOutputItem(content *llm.Content, out *responseOutputItem) error {
 	if out.Message != nil {
 		for _, cb := range out.Message.Content {
-			c.appendPartsFromBlock(content, cb)
+			if err := c.appendPartsFromBlock(content, cb); err != nil {
+				return err
+			}
 		}
 		if err := c.parseResponseToolCalls(out.Message.ToolCalls, content); err != nil {
 			return err
@@ -114,11 +124,21 @@ func (c *client) processOutputItem(content *llm.Content, out *responseOutputItem
 			Reasoning:  out.Reasoning,
 			Refusal:    out.Refusal,
 		}
-		c.appendPartsFromBlock(content, cb)
+		if err := c.appendPartsFromBlock(content, cb); err != nil {
+			// Output-item types (e.g., "call", "message") are not
+			// content-block types; they are handled by the fallback
+			// logic below. Only propagate errors that are not about
+			// unhandled block types at this level.
+			if !errors.Is(err, errUnhandledBlockType) {
+				return err
+			}
+		}
 
 		// Fallback for items that put blocks in a top-level array
 		for _, childCb := range out.Content {
-			c.appendPartsFromBlock(content, childCb)
+			if err := c.appendPartsFromBlock(content, childCb); err != nil {
+				return err
+			}
 		}
 
 		// Top-level tool calls in output item
@@ -134,7 +154,12 @@ func (c *client) processOutputItem(content *llm.Content, out *responseOutputItem
 			targetArgs = out.Function.Arguments
 		}
 		if targetName != "" {
-			_ = c.appendToolCall(content, out.ID, targetName, targetArgs)
+			if out.ID == "" {
+				return fmt.Errorf("invalid tool payload: missing ID for top-level tool call '%s'", targetName)
+			}
+			if err := c.appendToolCall(content, out.ID, targetName, targetArgs); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -144,7 +169,7 @@ func (c *client) processOutputItem(content *llm.Content, out *responseOutputItem
 // Content block handlers (Responses API)
 // ---------------------------------------------------------------------------
 
-func (c *client) appendPartsFromBlock(content *llm.Content, cb contentBlock) {
+func (c *client) appendPartsFromBlock(content *llm.Content, cb contentBlock) error {
 	switch cb.Type {
 	case "text", "output_text", "input_text":
 		c.handleTextBlock(content, cb)
@@ -155,8 +180,9 @@ func (c *client) appendPartsFromBlock(content *llm.Content, cb contentBlock) {
 	case "refusal":
 		c.handleRefusalBlock(content, cb)
 	default:
-		c.logger.Debug("unhandled content block type", "type", cb.Type)
+		return fmt.Errorf("%w %q: this provider API change must be addressed", errUnhandledBlockType, cb.Type)
 	}
+	return nil
 }
 
 func (c *client) handleTextBlock(content *llm.Content, cb contentBlock) {

--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -111,7 +111,10 @@ func (c *llmProviderHealthChecker) checkConfiguration(ctx context.Context, repor
 
 // buildRequest creates the HTTP request for health check
 func (c *llmProviderHealthChecker) buildRequest(ctx context.Context, authReq *auth.Request) (*http.Request, error) {
-	method, url := c.getPingEndpoint()
+	method, url, err := c.getPingEndpoint()
+	if err != nil {
+		return nil, err
+	}
 	req, err := http.NewRequestWithContext(ctx, method, url, nil)
 	if err != nil {
 		return nil, err
@@ -137,6 +140,15 @@ func (c *llmProviderHealthChecker) performConnectivityCheck(req *http.Request, d
 
 // handleHTTPResponse analyzes status codes, classifies errors, determines health status
 func (c *llmProviderHealthChecker) handleHTTPResponse(resp *http.Response, err error, report *ports.ComponentReport, details map[string]any) *ports.ComponentReport {
+	// Defensive: net/http guarantees at most one of (resp, err) is non-nil,
+	// but custom RoundTrippers or middleware may return (nil, nil).
+	if resp == nil && err == nil {
+		report.Status = ports.StatusUnhealthy
+		report.Message = "health check returned nil response and nil error"
+		report.Error = fmt.Errorf("health check: nil response and nil error")
+		return report
+	}
+
 	if err != nil {
 		// Transient Failures (DNS, Timeout, etc.)
 		report.Status = ports.StatusDegraded
@@ -165,11 +177,17 @@ func (c *llmProviderHealthChecker) handleHTTPResponse(resp *http.Response, err e
 	return report
 }
 
-// classifyErrorStatus handles provider-specific status code interpretation
+// classifyErrorStatus handles provider-specific status code interpretation.
+//
+// Some providers lack a standard GET ping endpoint. For those, the health
+// checker pings the base URL directly (see getPingEndpoint for routing).
+// A 404 or 405 from the base URL means the server is reachable but the
+// endpoint doesn't exist — this is a successful connectivity check, not a
+// failure. Currently only Anthropic relies on this path.
+//
+// All other 4xx codes indicate the provider returned a client error on a
+// known-good endpoint, which is treated as unhealthy.
 func (c *llmProviderHealthChecker) classifyErrorStatus(statusCode int, report *ports.ComponentReport) *ports.ComponentReport {
-	// For some endpoints, 404 or 405 might just mean the ping path is wrong but the server is up.
-	// However, for OpenAI/Gemini /models, we expect 200.
-	// For Anthropic, we might get 404 on the base URL.
 	if statusCode == http.StatusNotFound || statusCode == http.StatusMethodNotAllowed {
 		report.Status = ports.StatusHealthy
 		report.Message = fmt.Sprintf("%s provider reached (ping returned %d)", c.providerName, statusCode)
@@ -180,24 +198,29 @@ func (c *llmProviderHealthChecker) classifyErrorStatus(statusCode int, report *p
 	return report
 }
 
-func (c *llmProviderHealthChecker) getPingEndpoint() (string, string) {
+func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
 	p := strings.ToLower(c.providerName)
 	switch p {
 	case "openai", "deepseek":
-		return "GET", c.baseURL + "/models"
+		return "GET", c.baseURL + "/models", nil
 	case "google", "gemini":
 		// Gemini API often uses a different base for models or needs the key as a query param.
 		// But if we use the baseURL passed in (which usually includes the key or uses headers),
 		// we try a standard models list.
 		if strings.Contains(c.baseURL, "googleapis.com") {
-			return "GET", c.baseURL + "/models"
+			return "GET", c.baseURL + "/models", nil
 		}
-		return "GET", c.baseURL + "/models"
+		return "GET", c.baseURL + "/models", nil
 	case "anthropic":
-		// Anthropic doesn't have a standard GET /v1/models that works reliably for a ping.
-		// We use the base URL to verify connectivity.
-		return "GET", c.baseURL
+		// Anthropic's Messages API has no standard GET ping endpoint.
+		// GET /v1/messages returns 405; GET /v1/models is not a Messages endpoint.
+		// We ping the base URL directly. The expected response is 404 (Not Found)
+		// or 405 (Method Not Allowed), which classifyErrorStatus interprets as
+		// "provider reached" (StatusHealthy). This is intentional — the server
+		// responded, proving connectivity. See ADR-022 "fail loud" principle:
+		// we do NOT silently succeed; we explicitly document the workaround.
+		return "GET", c.baseURL, nil
 	default:
-		return "GET", c.baseURL
+		return "", "", fmt.Errorf("unknown provider type %q: cannot determine health check endpoint", c.providerName)
 	}
 }

--- a/internal/infrastructure/llm/provider_health_test.go
+++ b/internal/infrastructure/llm/provider_health_test.go
@@ -315,3 +315,183 @@ func TestLLMProviderHealthChecker_GeminiEndpointSelection(t *testing.T) {
 		})
 	}
 }
+
+func TestLLMProviderHealthChecker_UnknownProvider(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("unknown-provider", authMock, server.URL, nil)
+
+	report, err := checker.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if report.Status != ports.StatusUnhealthy {
+		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
+	}
+	if !strings.Contains(report.Message, "unknown provider type") {
+		t.Errorf("expected message to contain 'unknown provider type', got: %s", report.Message)
+	}
+}
+
+func TestLLMProviderHealthChecker_NilResponseNilError(t *testing.T) {
+	t.Parallel()
+	// Call handleHTTPResponse directly with (nil, nil) — this path is reachable
+	// if custom middleware or refactored code bypasses the stdlib's RoundTripper guard.
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+
+	details := make(map[string]any)
+	report := &ports.ComponentReport{
+		Component: ports.CompLLMProvider,
+		Status:    ports.StatusHealthy,
+		Message:   "before",
+	}
+
+	result := checker.handleHTTPResponse(nil, nil, report, details)
+	if result.Status != ports.StatusUnhealthy {
+		t.Errorf("expected StatusUnhealthy, got %s", result.Status)
+	}
+	if !strings.Contains(result.Message, "nil response") {
+		t.Errorf("expected message about nil response, got: %s", result.Message)
+	}
+	if result.Error == nil {
+		t.Error("expected report.Error to be non-nil")
+	}
+}
+
+func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		providerName    string
+		baseURL         string
+		useServer       bool
+		serverHandler   func(w http.ResponseWriter, r *http.Request)
+		cancelCtx       bool
+		authenticator   auth.Authenticator
+		wantStatus      ports.HealthStatus
+		wantMsgContains string
+	}{
+		// Gap 1: Pre-cancelled context — http.NewRequestWithContext succeeds in Go 1.26,
+		// but httpClient.Do fails immediately with "context canceled" → connectivity error.
+		{
+			name:            "pre-cancelled context",
+			providerName:    "openai",
+			baseURL:         "http://127.0.0.1:1",
+			cancelCtx:       true,
+			authenticator:   &auth.BearerAuth{Token: "test-key"},
+			wantStatus:      ports.StatusDegraded,
+			wantMsgContains: "connectivity issue",
+		},
+		// Gap 2: Google/Gemini without googleapis.com in URL — hits the false branch.
+		{
+			name:            "gemini without googleapis in URL",
+			providerName:    "gemini",
+			baseURL:         "http://127.0.0.1:1",
+			authenticator:   &auth.APIKeyAuth{APIKey: "test-key"},
+			wantStatus:      ports.StatusDegraded,
+			wantMsgContains: "connectivity issue",
+		},
+		// Gap 3: Google/Gemini WITH googleapis.com in URL — hits the true branch.
+		{
+			name:            "gemini with googleapis in URL",
+			providerName:    "google",
+			baseURL:         "http://127.0.0.1:1/googleapis.com",
+			authenticator:   &auth.APIKeyAuth{APIKey: "test-key"},
+			wantStatus:      ports.StatusDegraded,
+			wantMsgContains: "connectivity issue",
+		},
+		// Gap 5: 405 MethodNotAllowed → classifyErrorStatus returns StatusHealthy (same as 404).
+		{
+			name:         "method not allowed fallback",
+			providerName: "openai",
+			useServer:    true,
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			},
+			authenticator:   &auth.BearerAuth{Token: "test-key"},
+			wantStatus:      ports.StatusHealthy,
+			wantMsgContains: "provider reached",
+		},
+		// Gap 6a: 502 Bad Gateway → classified as transient → StatusDegraded.
+		{
+			name:         "bad gateway 502",
+			providerName: "openai",
+			useServer:    true,
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusBadGateway)
+			},
+			authenticator:   &auth.BearerAuth{Token: "test-key"},
+			wantStatus:      ports.StatusDegraded,
+			wantMsgContains: "transient",
+		},
+		// Gap 6b: 504 Gateway Timeout → classified as transient → StatusDegraded.
+		{
+			name:         "gateway timeout 504",
+			providerName: "openai",
+			useServer:    true,
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusGatewayTimeout)
+			},
+			authenticator:   &auth.BearerAuth{Token: "test-key"},
+			wantStatus:      ports.StatusDegraded,
+			wantMsgContains: "transient",
+		},
+		// Gap 9: 403 Forbidden → classified as terminal (not auth, not transient) →
+		// falls through to classifyErrorStatus → StatusUnhealthy.
+		{
+			name:         "forbidden 403",
+			providerName: "openai",
+			useServer:    true,
+			serverHandler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusForbidden)
+			},
+			authenticator:   &auth.BearerAuth{Token: "test-key"},
+			wantStatus:      ports.StatusUnhealthy,
+			wantMsgContains: "error status: 403",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var baseURL string
+			if tt.useServer {
+				server := httptest.NewServer(http.HandlerFunc(tt.serverHandler))
+				t.Cleanup(func() { server.Close() })
+				baseURL = server.URL
+			} else {
+				baseURL = tt.baseURL
+			}
+
+			checker := NewLLMProviderHealthChecker(tt.providerName, tt.authenticator, baseURL, nil)
+
+			ctx := context.Background()
+			if tt.cancelCtx {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel() // immediately cancel
+			}
+
+			report, err := checker.Check(ctx)
+			if err != nil {
+				t.Fatalf("Check returned unexpected Go error: %v", err)
+			}
+			if report.Status != tt.wantStatus {
+				t.Errorf("expected status %s, got %s: %s", tt.wantStatus, report.Status, report.Message)
+			}
+			if tt.wantMsgContains != "" && !strings.Contains(report.Message, tt.wantMsgContains) {
+				t.Errorf("expected message to contain %q, got: %s", tt.wantMsgContains, report.Message)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #461.

## Summary

Hardens ~30 error/adapter paths in the `infrastructure/llm/` layer across three files:

### provider_health.go
- **Nil-resp defensive guard** in `handleHTTPResponse` — prevents panic when custom RoundTrippers return `(nil, nil)`
- **Unknown provider rejection** in `getPingEndpoint` — returns error instead of silently passing health checks via 404
- **Enhanced comments** documenting the intentional Anthropic 404-as-healthy workaround with ADR-022 cross-reference

### openai/responses.go
- **Empty-ID guard** in `processOutputItem` Responses API path — prevents silent dispatch of malformed tool calls
- **Fail-loud default case** in `appendPartsFromBlock` — returns error instead of silent debug log for unknown content block types
- **Sentinel `errUnhandledBlockType`** with `errors.Is` filtering at output-item-level call sites

### Test Coverage
- 621 insertions across 5 files, 19 deletions
- New tests: transport clone fallback, thinking budget bumps, pre-cancelled context, Vertex URL path, Gemini routing, 405/502/504 status codes, direct content blocks, tool call ID validation, refusal handling, map-without-value-key

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| `llm` package coverage | ✅ 100.0% (was 98.1%) |
| `anthropic` package coverage | ✅ 99.6% (was 99.2%) |
| `openai` package coverage | ✅ 99.3% |
| Target ≥98.5% overall | ✅ 99.3% |
| ADR-022 compliance | ✅ No prod `testing` imports |
| Race detection | ✅ Clean |