### PR TITLE
fix(agenttest): reduce TestMockHistoryManager complexity from 39 to 6 (#471)

### DIFF
--- a/internal/agent/agenttest/mock_history_manager_test.go
+++ b/internal/agent/agenttest/mock_history_manager_test.go
@@ -25,264 +25,246 @@ func seedContents(n int) []*llm.Content {
 	return contents
 }
 
-func TestMockHistoryManager(t *testing.T) {
+// newMockWithContents creates a MockHistoryManager seeded with n content entries.
+func newMockWithContents(n int) *MockHistoryManager {
+	m := &MockHistoryManager{}
+	_ = m.SetContents(context.Background(), seedContents(n))
+	return m
+}
+
+// newMockWithContentsAndWindowErr creates a seeded mock that returns err from GetWindow.
+func newMockWithContentsAndWindowErr(n int, err error) *MockHistoryManager {
+	m := newMockWithContents(n)
+	m.SetGetWindowErr(err)
+	return m
+}
+
+// newMockWithContentsAndRollbackErr creates a seeded mock that returns err from RollbackTurns.
+func newMockWithContentsAndRollbackErr(n int, err error) *MockHistoryManager {
+	m := newMockWithContents(n)
+	m.SetRollbackErr(err)
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// AddContent
+// ---------------------------------------------------------------------------
+
+func TestMockHistoryManager_AddContent_Appends(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name  string
-		setup func() *MockHistoryManager
-		check func(t *testing.T, m *MockHistoryManager)
-	}{
-		{
-			name: "AddContent_appends",
-			setup: func() *MockHistoryManager {
-				return &MockHistoryManager{}
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				content := &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}
-				err := m.AddContent(context.Background(), content)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if m.GetTotalEntries() != 1 {
-					t.Fatalf("got %d entries; want 1", m.GetTotalEntries())
-				}
-				contents := m.GetContents()
-				if len(contents) != 1 || contents[0].Role != "user" || contents[0].Parts[0].Text != "hello" {
-					t.Errorf("got %+v; want role=user, text=hello", contents)
-				}
-			},
-		},
-		{
-			name: "GetWindow_normal_range",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(3))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				window, err := m.GetWindow(context.Background(), 0, 2)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(window) != 2 {
-					t.Fatalf("got %d items; want 2", len(window))
-				}
-				// Verify deep copy: mutating window should not affect internal contents.
-				window[0].Parts[0].Text = "mutated"
-				internal := m.GetContents()
-				if internal[0].Parts[0].Text == "mutated" {
-					t.Error("GetWindow did not deep-copy; internal state was mutated")
-				}
-			},
-		},
-		{
-			name: "GetWindow_endIdx_negative_one",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(3))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				window, err := m.GetWindow(context.Background(), 1, -1)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(window) != 2 {
-					t.Errorf("got %d items; want 2 (indices 1..end)", len(window))
-				}
-			},
-		},
-		{
-			name: "GetWindow_out_of_bounds_start",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(3))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				window, err := m.GetWindow(context.Background(), 10, 20)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(window) != 0 {
-					t.Errorf("got %d items; want 0 (start clamped to total)", len(window))
-				}
-			},
-		},
-		{
-			name: "GetWindow_reversed_range",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(3))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				window, err := m.GetWindow(context.Background(), 2, 1)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(window) != 0 {
-					t.Errorf("got %d items; want 0 (reversed range)", len(window))
-				}
-			},
-		},
-		{
-			name: "GetWindow_with_error",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(3))
-				m.SetGetWindowErr(errors.New("fail"))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				window, err := m.GetWindow(context.Background(), 0, -1)
-				if err == nil || err.Error() != "fail" {
-					t.Errorf("got error %v; want 'fail'", err)
-				}
-				if window != nil {
-					t.Errorf("got %v; want nil", window)
-				}
-			},
-		},
-		{
-			name: "RollbackTurns_normal",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(6))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 1)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if removed != 1 {
-					t.Errorf("got removed=%d; want 1", removed)
-				}
-				if remaining != 2 {
-					t.Errorf("got remaining=%d; want 2", remaining)
-				}
-				if msgs != 4 {
-					t.Errorf("got msgs=%d; want 4", msgs)
-				}
-			},
-		},
-		{
-			name: "RollbackTurns_removes_all",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(4))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 5)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if removed != 2 {
-					t.Errorf("got removed=%d; want 2", removed)
-				}
-				if remaining != 0 {
-					t.Errorf("got remaining=%d; want 0", remaining)
-				}
-				if msgs != 0 {
-					t.Errorf("got msgs=%d; want 0", msgs)
-				}
-				if m.GetTotalEntries() != 0 {
-					t.Error("expected contents to be cleared")
-				}
-			},
-		},
-		{
-			name: "RollbackTurns_zero_turns",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(4))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 0)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if removed != 0 {
-					t.Errorf("got removed=%d; want 0", removed)
-				}
-				if remaining != 2 {
-					t.Errorf("got remaining=%d; want 2", remaining)
-				}
-				if msgs != 4 {
-					t.Errorf("got msgs=%d; want 4", msgs)
-				}
-			},
-		},
-		{
-			name: "RollbackTurns_with_error",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				_ = m.SetContents(context.Background(), seedContents(4))
-				m.SetRollbackErr(errors.New("fail"))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				_, _, _, err := m.RollbackTurns(context.Background(), 1)
-				if err == nil || err.Error() != "fail" {
-					t.Errorf("got error %v; want 'fail'", err)
-				}
-			},
-		},
-		{
-			name: "SetContents_with_func_override",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				m.SetContentsFunc = func(ctx context.Context, contents []*llm.Content) error {
-					// Custom behavior: store only the first content.
-					m.Mu.Lock()
-					if len(contents) > 0 {
-						m.Contents = []*llm.Content{llm.CloneContent(contents[0])}
-					} else {
-						m.Contents = nil
-					}
-					m.Mu.Unlock()
-					return nil
-				}
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				contents := seedContents(3)
-				err := m.SetContents(context.Background(), contents)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				// Func override stores only the first.
-				if m.GetTotalEntries() != 1 {
-					t.Errorf("got %d entries; want 1 (func override)", m.GetTotalEntries())
-				}
-			},
-		},
-		{
-			name: "SetContents_with_error",
-			setup: func() *MockHistoryManager {
-				m := &MockHistoryManager{}
-				m.SetSetContentsErr(errors.New("fail"))
-				return m
-			},
-			check: func(t *testing.T, m *MockHistoryManager) {
-				err := m.SetContents(context.Background(), seedContents(2))
-				if err == nil || err.Error() != "fail" {
-					t.Errorf("got error %v; want 'fail'", err)
-				}
-			},
-		},
+	m := &MockHistoryManager{}
+	content := &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}
+
+	err := m.AddContent(context.Background(), content)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.GetTotalEntries() != 1 {
+		t.Fatalf("got %d entries; want 1", m.GetTotalEntries())
+	}
+	contents := m.GetContents()
+	if len(contents) != 1 || contents[0].Role != "user" || contents[0].Parts[0].Text != "hello" {
+		t.Errorf("got %+v; want role=user, text=hello", contents)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetWindow
+// ---------------------------------------------------------------------------
+
+func TestMockHistoryManager_GetWindow_NormalRange(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(3)
+
+	window, err := m.GetWindow(context.Background(), 0, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(window) != 2 {
+		t.Fatalf("got %d items; want 2", len(window))
+	}
+	// Verify deep copy: mutating window should not affect internal contents.
+	window[0].Parts[0].Text = "mutated"
+	internal := m.GetContents()
+	if internal[0].Parts[0].Text == "mutated" {
+		t.Error("GetWindow did not deep-copy; internal state was mutated")
+	}
+}
+
+func TestMockHistoryManager_GetWindow_EndIdxNegativeOne(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(3)
+
+	window, err := m.GetWindow(context.Background(), 1, -1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(window) != 2 {
+		t.Errorf("got %d items; want 2 (indices 1..end)", len(window))
+	}
+}
+
+func TestMockHistoryManager_GetWindow_OutOfBoundsStart(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(3)
+
+	window, err := m.GetWindow(context.Background(), 10, 20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(window) != 0 {
+		t.Errorf("got %d items; want 0 (start clamped to total)", len(window))
+	}
+}
+
+func TestMockHistoryManager_GetWindow_ReversedRange(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(3)
+
+	window, err := m.GetWindow(context.Background(), 2, 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(window) != 0 {
+		t.Errorf("got %d items; want 0 (reversed range)", len(window))
+	}
+}
+
+func TestMockHistoryManager_GetWindow_WithError(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContentsAndWindowErr(3, errors.New("fail"))
+
+	window, err := m.GetWindow(context.Background(), 0, -1)
+	if err == nil || err.Error() != "fail" {
+		t.Errorf("got error %v; want 'fail'", err)
+	}
+	if window != nil {
+		t.Errorf("got %v; want nil", window)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RollbackTurns
+// ---------------------------------------------------------------------------
+
+func TestMockHistoryManager_RollbackTurns_Normal(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(6)
+
+	removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 1 {
+		t.Errorf("got removed=%d; want 1", removed)
+	}
+	if remaining != 2 {
+		t.Errorf("got remaining=%d; want 2", remaining)
+	}
+	if msgs != 4 {
+		t.Errorf("got msgs=%d; want 4", msgs)
+	}
+}
+
+func TestMockHistoryManager_RollbackTurns_RemovesAll(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(4)
+
+	removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 2 {
+		t.Errorf("got removed=%d; want 2", removed)
+	}
+	if remaining != 0 {
+		t.Errorf("got remaining=%d; want 0", remaining)
+	}
+	if msgs != 0 {
+		t.Errorf("got msgs=%d; want 0", msgs)
+	}
+	if m.GetTotalEntries() != 0 {
+		t.Error("expected contents to be cleared")
+	}
+}
+
+func TestMockHistoryManager_RollbackTurns_ZeroTurns(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(4)
+
+	removed, remaining, msgs, err := m.RollbackTurns(context.Background(), 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("got removed=%d; want 0", removed)
+	}
+	if remaining != 2 {
+		t.Errorf("got remaining=%d; want 2", remaining)
+	}
+	if msgs != 4 {
+		t.Errorf("got msgs=%d; want 4", msgs)
+	}
+}
+
+func TestMockHistoryManager_RollbackTurns_WithError(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContentsAndRollbackErr(4, errors.New("fail"))
+
+	_, _, _, err := m.RollbackTurns(context.Background(), 1)
+	if err == nil || err.Error() != "fail" {
+		t.Errorf("got error %v; want 'fail'", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SetContents
+// ---------------------------------------------------------------------------
+
+func TestMockHistoryManager_SetContents_WithFuncOverride(t *testing.T) {
+	t.Parallel()
+
+	m := &MockHistoryManager{}
+	m.SetContentsFunc = func(ctx context.Context, contents []*llm.Content) error {
+		// Custom behavior: store only the first content.
+		m.Mu.Lock()
+		if len(contents) > 0 {
+			m.Contents = []*llm.Content{llm.CloneContent(contents[0])}
+		} else {
+			m.Contents = nil
+		}
+		m.Mu.Unlock()
+		return nil
 	}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			m := tt.setup()
-			tt.check(t, m)
-		})
+	err := m.SetContents(context.Background(), seedContents(3))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Func override stores only the first.
+	if m.GetTotalEntries() != 1 {
+		t.Errorf("got %d entries; want 1 (func override)", m.GetTotalEntries())
+	}
+}
+
+func TestMockHistoryManager_SetContents_WithError(t *testing.T) {
+	t.Parallel()
+
+	m := &MockHistoryManager{}
+	m.SetSetContentsErr(errors.New("fail"))
+
+	err := m.SetContents(context.Background(), seedContents(2))
+	if err == nil || err.Error() != "fail" {
+		t.Errorf("got error %v; want 'fail'", err)
 	}
 }


### PR DESCRIPTION
Closes #471.

## Summary

Refactored `TestMockHistoryManager` from a monolithic table-driven test (cyclomatic complexity 39) into 12 standalone test functions (max complexity 6) with 3 shared setup helpers. Pure structural refactoring — zero behavioral changes, zero mock changes.

### What Changed
- **12 inline `setup`/`check` closures** → **12 standalone `TestMockHistoryManager_*` functions**, each with `t.Parallel()`
- **3 repeated mock-construction patterns** → **3 named helpers**: `newMockWithContents`, `newMockWithContentsAndWindowErr`, `newMockWithContentsAndRollbackErr`
- **Old `TestMockHistoryManager` wrapper** → deleted

### Per-Function Complexity
| Function | Complexity |
|----------|-----------|
| TestMockHistoryManager_AddContent_Appends | 6 |
| TestMockHistoryManager_RollbackTurns_RemovesAll | 6 |
| TestMockHistoryManager_RollbackTurns_Normal | 5 |
| TestMockHistoryManager_RollbackTurns_ZeroTurns | 5 |
| TestMockHistoryManager_GetWindow_NormalRange | 4 |
| TestMockHistoryManager_GetWindow_WithError | 4 |
| TestMockHistoryManager_SetContents_WithFuncOverride | 4 |
| TestMockHistoryManager_GetWindow_EndIdxNegativeOne | 3 |
| TestMockHistoryManager_GetWindow_OutOfBoundsStart | 3 |
| TestMockHistoryManager_GetWindow_ReversedRange | 3 |
| TestMockHistoryManager_RollbackTurns_WithError | 3 |
| TestMockHistoryManager_SetContents_WithError | 3 |

## Downstream Impact
**Zero.** `mock_history_manager.go` was never touched. All 140+ consumer sites are unaffected.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| All 12 tests | PASS |
| Race detection | PASS |
| Lint (golangci-lint) | 0 issues |
| Architecture (ADR) | PASS |
| Vulnerability scan | 0 CVEs |
| Complexity target (≤10) | ✅ Max 6 |