### PR TITLE
fix(analysis): reduce complexity of TestSequenceAnalyzer_WalkGuards from 28 to 8 (#485)

### DIFF
--- a/internal/tools/analysis/sequence_test.go
+++ b/internal/tools/analysis/sequence_test.go
@@ -702,6 +702,20 @@ func TestFindBySuffix(t *testing.T) {
 	}
 }
 
+// setupWalkGuardTest sets up mock packages and locates the named function
+// declaration. It calls t.Fatal if the function is not found.
+func setupWalkGuardTest(t *testing.T, funcName string) (*packages.Package, *ast.FuncDecl) {
+	t.Helper()
+	pkgA, _ := setupMockPackages()
+	for _, decl := range pkgA.Syntax[0].Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == funcName {
+			return pkgA, fd
+		}
+	}
+	t.Fatalf("%s not found in mock package", funcName)
+	return nil, nil
+}
+
 // TestSequenceAnalyzer_WalkGuards exercises every guard clause in walk(...)
 // by calling it directly (not through AnalyzeSequenceFlow).
 func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
@@ -709,18 +723,7 @@ func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
 
 	t.Run("depth at maxDepth returns early", func(t *testing.T) {
 		t.Parallel()
-		pkgA, _ := setupMockPackages()
-
-		var startFunc *ast.FuncDecl
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				startFunc = fd
-				break
-			}
-		}
-		if startFunc == nil {
-			t.Fatal("StartFunc not found")
-		}
+		pkgA, startFunc := setupWalkGuardTest(t, "StartFunc")
 
 		a := &defaultSequenceAnalyzer{}
 		frames := &frameCollector{}
@@ -755,18 +758,7 @@ func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
 
 	t.Run("nil def object returns early", func(t *testing.T) {
 		t.Parallel()
-		pkgA, _ := setupMockPackages()
-
-		var startFunc *ast.FuncDecl
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				startFunc = fd
-				break
-			}
-		}
-		if startFunc == nil {
-			t.Fatal("StartFunc not found")
-		}
+		pkgA, startFunc := setupWalkGuardTest(t, "StartFunc")
 
 		pkg := &packages.Package{
 			PkgPath:   pkgA.PkgPath,
@@ -789,18 +781,7 @@ func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
 
 	t.Run("already visited returns early", func(t *testing.T) {
 		t.Parallel()
-		pkgA, _ := setupMockPackages()
-
-		var startFunc *ast.FuncDecl
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				startFunc = fd
-				break
-			}
-		}
-		if startFunc == nil {
-			t.Fatal("StartFunc not found")
-		}
+		pkgA, startFunc := setupWalkGuardTest(t, "StartFunc")
 
 		obj := pkgA.TypesInfo.Defs[startFunc.Name]
 		if obj == nil {
@@ -821,18 +802,7 @@ func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
 
 	t.Run("successful walk adds frames", func(t *testing.T) {
 		t.Parallel()
-		pkgA, _ := setupMockPackages()
-
-		var startFunc *ast.FuncDecl
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				startFunc = fd
-				break
-			}
-		}
-		if startFunc == nil {
-			t.Fatal("StartFunc not found")
-		}
+		pkgA, startFunc := setupWalkGuardTest(t, "StartFunc")
 
 		a := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
 		frames := &frameCollector{}
@@ -847,18 +817,7 @@ func TestSequenceAnalyzer_WalkGuards(t *testing.T) {
 
 	t.Run("heartbeat channel receives when non-nil", func(t *testing.T) {
 		t.Parallel()
-		pkgA, _ := setupMockPackages()
-
-		var startFunc *ast.FuncDecl
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				startFunc = fd
-				break
-			}
-		}
-		if startFunc == nil {
-			t.Fatal("StartFunc not found")
-		}
+		pkgA, startFunc := setupWalkGuardTest(t, "StartFunc")
 
 		a := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
 		frames := &frameCollector{}


### PR DESCRIPTION
Closes #485.

## Summary
Extracted a `setupWalkGuardTest` helper function to eliminate repeated inline AST/package setup across 5 sub-tests in `TestSequenceAnalyzer_WalkGuards`. This reduces cyclomatic complexity from 28 to 8 (threshold: ≤10).

**Changes:**
- Added `setupWalkGuardTest(t, funcName)` helper that wraps `setupMockPackages()` + function declaration lookup
- Replaced 11-line setup blocks in 5 sub-tests with a single `setupWalkGuardTest(t, "StartFunc")` call
- The "nil function body returns early" sub-test was left untouched (uses different setup pattern)
- No assertion or behavioral changes

## Verification
| Check | Status |
|-------|--------|
| Complexity (gocyclo) | 8 (from 28) |
| `go test ./internal/tools/analysis/...` | PASS |
| `go test ./...` (full suite) | PASS |
| `go test -race ./internal/tools/analysis/...` | PASS |
| Coverage (`internal/tools/analysis`) | 96.2% |
| `dead-code` | No dead code |
| `verify-architecture` | PASS |
