### PR TITLE
fix(registry): isolate test state and reduce cyclomatic complexity (#483)

### DIFF
--- a/internal/infrastructure/registry/coverage_test.go
+++ b/internal/infrastructure/registry/coverage_test.go
@@ -21,109 +21,14 @@ func TestRegistry_DuplicateRegistration(t *testing.T) {
 		validate func(t *testing.T, r tools.Registry)
 	}{
 		{
-			name: "update existing tool",
-			actions: func(t *testing.T, r tools.Registry) {
-				def1 := &tools.ToolDeclaration{Name: "tool1", Description: "desc1"}
-				h1 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-					return tools.ToolResult{Text: "v1"}, nil
-				}
-				if err := r.Register(def1, h1); err != nil {
-					t.Fatalf("failed to register tool: %v", err)
-				}
-
-				def2 := &tools.ToolDeclaration{Name: "tool1", Description: "desc2"}
-				h2 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-					return tools.ToolResult{Text: "v2"}, nil
-				}
-				if err := r.RegisterWithOptions(def2, h2, registry.ToolOptions{Serial: true}); err != nil {
-					t.Fatalf("failed to register tool with options: %v", err)
-				}
-			},
-			validate: func(t *testing.T, r tools.Registry) {
-				decls := r.GetDeclarations()
-				if len(decls) != 1 {
-					t.Errorf("expected 1 declaration, got %d", len(decls))
-				}
-				if decls[0].Description != "desc2" {
-					t.Errorf("expected updated description 'desc2', got '%s'", decls[0].Description)
-				}
-				if !r.IsSerial("tool1") {
-					t.Errorf("expected tool1 to be serial after update")
-				}
-				res, _ := r.Execute(context.Background(), "tool1", nil, nil)
-				if res.Text != "v2" {
-					t.Errorf("expected updated handler to return 'v2', got '%s'", res.Text)
-				}
-			},
+			name:     "update existing tool",
+			actions:  registerUpdateExistingTool,
+			validate: validateUpdatedTool,
 		},
 		{
-			name: "re-register to different toolkit",
-			actions: func(t *testing.T, r tools.Registry) {
-				def1 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v1"}
-				h1 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-					return tools.ToolResult{Text: "v1"}, nil
-				}
-				if err := r.RegisterToToolkit("core", def1, h1); err != nil {
-					t.Fatalf("failed to register tool to core: %v", err)
-				}
-
-				def2 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v2"}
-				h2 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-					return tools.ToolResult{Text: "v2"}, nil
-				}
-				if err := r.RegisterToToolkitWithOptions("git", def2, h2, registry.ToolOptions{LongRunning: true}); err != nil {
-					t.Fatalf("failed to re-register tool to git: %v", err)
-				}
-			},
-			validate: func(t *testing.T, r tools.Registry) {
-				// 1. cross_tool remains in core declarations
-				coreDecls := r.GetCoreDeclarations()
-				foundInCore := false
-				for _, d := range coreDecls {
-					if d.Name == "cross_tool" {
-						foundInCore = true
-						break
-					}
-				}
-				if !foundInCore {
-					t.Errorf("expected cross_tool to remain in core declarations")
-				}
-
-				// 2. cross_tool also appears in git toolkit declarations
-				gitDecls := r.GetDeclarationsByToolkits([]string{"git"})
-				foundInGit := false
-				for _, d := range gitDecls {
-					if d.Name == "cross_tool" {
-						foundInGit = true
-						break
-					}
-				}
-				if !foundInGit {
-					t.Errorf("expected cross_tool to appear in git toolkit declarations")
-				}
-
-				// 3. Only one entry (no duplication)
-				decls := r.GetDeclarations()
-				if len(decls) != 1 {
-					t.Errorf("expected 1 declaration, got %d", len(decls))
-				}
-
-				// 4. Declaration was updated
-				if len(decls) > 0 && decls[0].Description != "desc_v2" {
-					t.Errorf("expected updated description 'desc_v2', got '%s'", decls[0].Description)
-				}
-
-				// 5. Options were updated (LongRunning enabled)
-				if !r.IsLongRunning("cross_tool") {
-					t.Errorf("expected cross_tool to be long-running after update")
-				}
-
-				// 6. Handler was updated
-				res, _ := r.Execute(context.Background(), "cross_tool", nil, nil)
-				if res.Text != "v2" {
-					t.Errorf("expected updated handler to return 'v2', got '%s'", res.Text)
-				}
-			},
+			name:     "re-register to different toolkit",
+			actions:  registerCrossToolkitTool,
+			validate: validateCrossToolkitTool,
 		},
 	}
 
@@ -134,6 +39,113 @@ func TestRegistry_DuplicateRegistration(t *testing.T) {
 			tt.actions(t, r)
 			tt.validate(t, r)
 		})
+	}
+}
+
+func registerUpdateExistingTool(t *testing.T, r tools.Registry) {
+	t.Helper()
+	def1 := &tools.ToolDeclaration{Name: "tool1", Description: "desc1"}
+	h1 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "v1"}, nil
+	}
+	if err := r.Register(def1, h1); err != nil {
+		t.Fatalf("failed to register tool: %v", err)
+	}
+
+	def2 := &tools.ToolDeclaration{Name: "tool1", Description: "desc2"}
+	h2 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "v2"}, nil
+	}
+	if err := r.RegisterWithOptions(def2, h2, registry.ToolOptions{Serial: true}); err != nil {
+		t.Fatalf("failed to register tool with options: %v", err)
+	}
+}
+
+func validateUpdatedTool(t *testing.T, r tools.Registry) {
+	t.Helper()
+	decls := r.GetDeclarations()
+	if len(decls) != 1 {
+		t.Errorf("expected 1 declaration, got %d", len(decls))
+	}
+	if decls[0].Description != "desc2" {
+		t.Errorf("expected updated description 'desc2', got '%s'", decls[0].Description)
+	}
+	if !r.IsSerial("tool1") {
+		t.Errorf("expected tool1 to be serial after update")
+	}
+	res, _ := r.Execute(context.Background(), "tool1", nil, nil)
+	if res.Text != "v2" {
+		t.Errorf("expected updated handler to return 'v2', got '%s'", res.Text)
+	}
+}
+
+func registerCrossToolkitTool(t *testing.T, r tools.Registry) {
+	t.Helper()
+	def1 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v1"}
+	h1 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "v1"}, nil
+	}
+	if err := r.RegisterToToolkit("core", def1, h1); err != nil {
+		t.Fatalf("failed to register tool to core: %v", err)
+	}
+
+	def2 := &tools.ToolDeclaration{Name: "cross_tool", Description: "desc_v2"}
+	h2 := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "v2"}, nil
+	}
+	if err := r.RegisterToToolkitWithOptions("git", def2, h2, registry.ToolOptions{LongRunning: true}); err != nil {
+		t.Fatalf("failed to re-register tool to git: %v", err)
+	}
+}
+
+func validateCrossToolkitTool(t *testing.T, r tools.Registry) {
+	t.Helper()
+	// 1. cross_tool remains in core declarations
+	coreDecls := r.GetCoreDeclarations()
+	foundInCore := false
+	for _, d := range coreDecls {
+		if d.Name == "cross_tool" {
+			foundInCore = true
+			break
+		}
+	}
+	if !foundInCore {
+		t.Errorf("expected cross_tool to remain in core declarations")
+	}
+
+	// 2. cross_tool also appears in git toolkit declarations
+	gitDecls := r.GetDeclarationsByToolkits([]string{"git"})
+	foundInGit := false
+	for _, d := range gitDecls {
+		if d.Name == "cross_tool" {
+			foundInGit = true
+			break
+		}
+	}
+	if !foundInGit {
+		t.Errorf("expected cross_tool to appear in git toolkit declarations")
+	}
+
+	// 3. Only one entry (no duplication)
+	decls := r.GetDeclarations()
+	if len(decls) != 1 {
+		t.Errorf("expected 1 declaration, got %d", len(decls))
+	}
+
+	// 4. Declaration was updated
+	if len(decls) > 0 && decls[0].Description != "desc_v2" {
+		t.Errorf("expected updated description 'desc_v2', got '%s'", decls[0].Description)
+	}
+
+	// 5. Options were updated (LongRunning enabled)
+	if !r.IsLongRunning("cross_tool") {
+		t.Errorf("expected cross_tool to be long-running after update")
+	}
+
+	// 6. Handler was updated
+	res, _ := r.Execute(context.Background(), "cross_tool", nil, nil)
+	if res.Text != "v2" {
+		t.Errorf("expected updated handler to return 'v2', got '%s'", res.Text)
 	}
 }
 

--- a/internal/infrastructure/registry/registry_test.go
+++ b/internal/infrastructure/registry/registry_test.go
@@ -259,85 +259,93 @@ func TestRegistry_GetOptions(t *testing.T) {
 
 func TestRegistry_RegisterToToolkit_EmptyDefaultsToCore(t *testing.T) {
 	t.Parallel()
+
+	t.Run("RegisterToToolkit(\"\", def, handler) succeeds", testEmptyDefaultsToCoreSucceeds)
+	t.Run("RegisterToToolkitWithOptions(\"\", def, handler, opts) also defaults to core", testEmptyDefaultsToCoreWithOptions)
+	t.Run("multiple empty-toolkit registrations all go to core", testEmptyDefaultsToCoreMultiple)
+}
+
+func testEmptyDefaultsToCoreSucceeds(t *testing.T) {
+	t.Parallel()
 	r := registry.New()
+	err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: "empty_tk_tool"}, nil)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
 
-	t.Run("RegisterToToolkit(\"\", def, handler) succeeds", func(t *testing.T) {
-		err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: "empty_tk_tool"}, nil)
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
+	decls := r.GetCoreDeclarations()
+	found := false
+	for _, d := range decls {
+		if d.Name == "empty_tk_tool" {
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Errorf("expected 'empty_tk_tool' in core declarations")
+	}
+}
 
-		decls := r.GetCoreDeclarations()
-		found := false
-		for _, d := range decls {
-			if d.Name == "empty_tk_tool" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Errorf("expected 'empty_tk_tool' in core declarations")
-		}
-	})
+func testEmptyDefaultsToCoreWithOptions(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+	err := r.RegisterToToolkitWithOptions("", &tools.ToolDeclaration{Name: "empty_tk_serial"}, nil, registry.ToolOptions{Serial: true})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
 
-	t.Run("RegisterToToolkitWithOptions(\"\", def, handler, opts) also defaults to core", func(t *testing.T) {
-		err := r.RegisterToToolkitWithOptions("", &tools.ToolDeclaration{Name: "empty_tk_serial"}, nil, registry.ToolOptions{Serial: true})
-		if err != nil {
-			t.Fatalf("expected no error, got: %v", err)
-		}
+	if !r.IsSerial("empty_tk_serial") {
+		t.Error("expected empty_tk_serial to be serial")
+	}
 
-		if !r.IsSerial("empty_tk_serial") {
-			t.Error("expected empty_tk_serial to be serial")
+	decls := r.GetCoreDeclarations()
+	found := false
+	for _, d := range decls {
+		if d.Name == "empty_tk_serial" {
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Errorf("expected 'empty_tk_serial' in core declarations")
+	}
 
-		decls := r.GetCoreDeclarations()
-		found := false
-		for _, d := range decls {
-			if d.Name == "empty_tk_serial" {
-				found = true
-				break
-			}
+	toolkits := r.ListAvailableToolkits()
+	for _, tk := range toolkits {
+		if tk == "" {
+			t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
 		}
-		if !found {
-			t.Errorf("expected 'empty_tk_serial' in core declarations")
-		}
+	}
+}
 
-		toolkits := r.ListAvailableToolkits()
-		for _, tk := range toolkits {
-			if tk == "" {
-				t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
-			}
+func testEmptyDefaultsToCoreMultiple(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+	for _, name := range []string{"multi1", "multi2", "multi3"} {
+		if err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: name}, nil); err != nil {
+			t.Fatalf("failed to register %s: %v", name, err)
 		}
-	})
+	}
 
-	t.Run("multiple empty-toolkit registrations all go to core", func(t *testing.T) {
-		for _, name := range []string{"multi1", "multi2", "multi3"} {
-			if err := r.RegisterToToolkit("", &tools.ToolDeclaration{Name: name}, nil); err != nil {
-				t.Fatalf("failed to register %s: %v", name, err)
-			}
-		}
+	decls := r.GetCoreDeclarations()
+	if len(decls) != 3 {
+		t.Errorf("expected 3 declarations, got %d", len(decls))
+	}
 
-		decls := r.GetCoreDeclarations()
-		// Expect 5 total: empty_tk_tool + empty_tk_serial + multi1 + multi2 + multi3
-		if len(decls) != 5 {
-			t.Errorf("expected 5 declarations, got %d", len(decls))
+	names := make(map[string]bool)
+	for _, d := range decls {
+		names[d.Name] = true
+	}
+	for _, name := range []string{"multi1", "multi2", "multi3"} {
+		if !names[name] {
+			t.Errorf("expected %q in core declarations", name)
 		}
+	}
 
-		names := make(map[string]bool)
-		for _, d := range decls {
-			names[d.Name] = true
+	toolkits := r.ListAvailableToolkits()
+	for _, tk := range toolkits {
+		if tk == "" {
+			t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
 		}
-		for _, name := range []string{"multi1", "multi2", "multi3"} {
-			if !names[name] {
-				t.Errorf("expected %q in core declarations", name)
-			}
-		}
-
-		toolkits := r.ListAvailableToolkits()
-		for _, tk := range toolkits {
-			if tk == "" {
-				t.Errorf("expected empty string not to appear in available toolkits, got: %v", toolkits)
-			}
-		}
-	})
+	}
 }


### PR DESCRIPTION
Closes #483.

## Summary

Refactored two test functions in `internal/infrastructure/registry/` that exceeded the complexity threshold (`gocyclo -over 10`):

- **`TestRegistry_DuplicateRegistration`** (coverage_test.go): 21 → **2** — extracted 4 inline closures into named helper functions
- **`TestRegistry_RegisterToToolkit_EmptyDefaultsToCore`** (registry_test.go): 20 → **1** — extracted 3 sub-test bodies into standalone functions with independent registries and `t.Parallel()`

## Changes

| File | Change |
|------|--------|
| `coverage_test.go` | Extracted `registerUpdateExistingTool`, `validateUpdatedTool`, `registerCrossToolkitTool`, `validateCrossToolkitTool` helpers |
| `registry_test.go` | Extracted `testEmptyDefaultsToCoreSucceeds`, `testEmptyDefaultsToCoreWithOptions`, `testEmptyDefaultsToCoreMultiple` helpers with isolated registries |

## Verification

| Check | Status |
|-------|--------|
| `gocyclo -over 10 internal/infrastructure/registry/` | ✅ Neither target function appears |
| `go test -race -count=1 ./internal/infrastructure/registry/...` | ✅ PASS |
| `go test -race -count=1 ./internal/infrastructure/...` | ✅ PASS (all 22 packages) |
| `make check-full` | ✅ PASS (vet, build, test, race, dead-code; lint/vulncheck not installed) |
| Target coverage | ✅ 100.0% |