### PR TITLE
fix(toolstest): decompose mock monoliths below complexity threshold (#481)

### DIFF
--- a/internal/tools/toolstest/mock_command_validator_test.go
+++ b/internal/tools/toolstest/mock_command_validator_test.go
@@ -9,158 +9,65 @@ import (
 	"testing"
 )
 
-func TestMockCommandValidator(t *testing.T) {
+// --- Split (4 subtests) ---
+
+// assertParts compares got parts against want, handling nil expectations.
+func assertParts(t *testing.T, parts, want []string) {
+	t.Helper()
+	if want != nil {
+		if len(parts) != len(want) {
+			t.Errorf("got len %d; want %d", len(parts), len(want))
+			return
+		}
+		for i := range want {
+			if parts[i] != want[i] {
+				t.Errorf("got %v; want %v", parts, want)
+				break
+			}
+		}
+	} else if parts != nil {
+		t.Errorf("expected nil parts, got %v", parts)
+	}
+}
+
+func TestMockCommandValidator_Split(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		setup func() *MockCommandValidator
-		check func(t *testing.T, m *MockCommandValidator)
+		name    string
+		mock    *MockCommandValidator
+		cmd     string
+		want    []string
+		wantErr string
 	}{
 		{
-			name: "Split_default",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				parts, err := m.Split("echo hello")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if len(parts) != 2 || parts[0] != "echo" || parts[1] != "hello" {
-					t.Errorf("got %v; want [echo hello]", parts)
-				}
-			},
+			name: "default",
+			mock: &MockCommandValidator{},
+			cmd:  "echo hello",
+			want: []string{"echo", "hello"},
 		},
 		{
-			name: "Split_unclosed_single_quote",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				parts, err := m.Split("echo 'unclosed")
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if !strings.Contains(err.Error(), "unclosed quote") {
-					t.Errorf("error %q does not contain 'unclosed quote'", err.Error())
-				}
-				if parts != nil {
-					t.Errorf("expected nil parts, got %v", parts)
-				}
-			},
+			name:    "unclosed_single_quote",
+			mock:    &MockCommandValidator{},
+			cmd:     "echo 'unclosed",
+			wantErr: "unclosed quote",
 		},
 		{
-			name: "Split_unclosed_double_quote",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				parts, err := m.Split(`echo "unclosed`)
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if !strings.Contains(err.Error(), "unclosed quote") {
-					t.Errorf("error %q does not contain 'unclosed quote'", err.Error())
-				}
-				if parts != nil {
-					t.Errorf("expected nil parts, got %v", parts)
-				}
-			},
+			name:    "unclosed_double_quote",
+			mock:    &MockCommandValidator{},
+			cmd:     `echo "unclosed`,
+			wantErr: "unclosed quote",
 		},
 		{
-			name: "Split_with_func_override",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{
-					SplitFunc: func(cmd string) ([]string, error) {
-						return []string{"custom", "result"}, errors.New("custom error")
-					},
-				}
+			name: "with_func_override",
+			mock: &MockCommandValidator{
+				SplitFunc: func(cmd string) ([]string, error) {
+					return []string{"custom", "result"}, errors.New("custom error")
+				},
 			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				parts, err := m.Split("anything")
-				if err == nil || err.Error() != "custom error" {
-					t.Errorf("got error %v; want 'custom error'", err)
-				}
-				if len(parts) != 2 || parts[0] != "custom" || parts[1] != "result" {
-					t.Errorf("got %v; want [custom result]", parts)
-				}
-			},
-		},
-		{
-			name: "IsSafe_default",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				safe, msg := m.IsSafe("any")
-				if !safe {
-					t.Error("expected safe=true")
-				}
-				if msg != "" {
-					t.Errorf("expected empty msg, got %q", msg)
-				}
-			},
-		},
-		{
-			name: "ValidateStructure_default",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				err := m.ValidateStructure([]string{"a"})
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-			},
-		},
-		{
-			name: "CheckPathSafety_default",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				safe, msg := m.CheckPathSafety([]string{"a"})
-				if !safe {
-					t.Error("expected safe=true")
-				}
-				if msg != "" {
-					t.Errorf("expected empty msg, got %q", msg)
-				}
-			},
-		},
-		{
-			name: "HasShellFeatures_powershell_cmdlet",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				if !m.HasShellFeatures([]string{"Get-ChildItem"}) {
-					t.Error("expected true for PowerShell cmdlet")
-				}
-			},
-		},
-		{
-			name: "HasShellFeatures_variable",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				if !m.HasShellFeatures([]string{"$env:PATH"}) {
-					t.Error("expected true for shell variable")
-				}
-			},
-		},
-		{
-			name: "HasShellFeatures_plain",
-			setup: func() *MockCommandValidator {
-				return &MockCommandValidator{}
-			},
-			check: func(t *testing.T, m *MockCommandValidator) {
-				if m.HasShellFeatures([]string{"ls", "-la"}) {
-					t.Error("expected false for plain command")
-				}
-			},
+			cmd:     "anything",
+			want:    []string{"custom", "result"},
+			wantErr: "custom error",
 		},
 	}
 
@@ -168,8 +75,102 @@ func TestMockCommandValidator(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := tt.setup()
-			tt.check(t, m)
+			parts, err := tt.mock.Split(tt.cmd)
+
+			if tt.wantErr != "" {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("error %q does not contain %q", err.Error(), tt.wantErr)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			assertParts(t, parts, tt.want)
+		})
+	}
+}
+
+// --- IsSafe (1 subtest) ---
+
+func TestMockCommandValidator_IsSafe(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockCommandValidator{}
+	safe, msg := mock.IsSafe("any")
+	if !safe {
+		t.Error("expected safe=true")
+	}
+	if msg != "" {
+		t.Errorf("expected empty msg, got %q", msg)
+	}
+}
+
+// --- ValidateStructure (1 subtest) ---
+
+func TestMockCommandValidator_ValidateStructure(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockCommandValidator{}
+	err := mock.ValidateStructure([]string{"a"})
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// --- CheckPathSafety (1 subtest) ---
+
+func TestMockCommandValidator_CheckPathSafety(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockCommandValidator{}
+	safe, msg := mock.CheckPathSafety([]string{"a"})
+	if !safe {
+		t.Error("expected safe=true")
+	}
+	if msg != "" {
+		t.Errorf("expected empty msg, got %q", msg)
+	}
+}
+
+// --- HasShellFeatures (3 subtests) ---
+
+func TestMockCommandValidator_HasShellFeatures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		parts []string
+		want  bool
+	}{
+		{
+			name:  "powershell_cmdlet",
+			parts: []string{"Get-ChildItem"},
+			want:  true,
+		},
+		{
+			name:  "variable",
+			parts: []string{"$env:PATH"},
+			want:  true,
+		},
+		{
+			name:  "plain",
+			parts: []string{"ls", "-la"},
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mock := &MockCommandValidator{}
+			got := mock.HasShellFeatures(tt.parts)
+			if got != tt.want {
+				t.Errorf("got %v; want %v", got, tt.want)
+			}
 		})
 	}
 }

--- a/internal/tools/toolstest/mock_interactor_test.go
+++ b/internal/tools/toolstest/mock_interactor_test.go
@@ -10,143 +10,32 @@ import (
 	"testing"
 )
 
-func TestMockInteractor(t *testing.T) {
+// --- Confirm (3 subtests) ---
+
+func TestMockInteractor_Confirm(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		setup func() *MockInteractor
-		check func(t *testing.T, m *MockInteractor)
+		name    string
+		mock    *MockInteractor
+		wantOk  bool
+		wantErr string
 	}{
 		{
-			name: "Confirm_yes",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Answer: "y"}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				ok, err := m.Confirm(context.Background(), "msg")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if !ok {
-					t.Error("expected true for answer 'y'")
-				}
-			},
+			name:   "yes",
+			mock:   &MockInteractor{Answer: "y"},
+			wantOk: true,
 		},
 		{
-			name: "Confirm_no",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Answer: "n"}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				ok, err := m.Confirm(context.Background(), "msg")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if ok {
-					t.Error("expected false for answer 'n'")
-				}
-			},
+			name:   "no",
+			mock:   &MockInteractor{Answer: "n"},
+			wantOk: false,
 		},
 		{
-			name: "Confirm_with_error",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Err: errors.New("fail")}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				ok, err := m.Confirm(context.Background(), "msg")
-				if err == nil || err.Error() != "fail" {
-					t.Errorf("got error %v; want 'fail'", err)
-				}
-				if ok {
-					t.Error("expected false when Err is set")
-				}
-			},
-		},
-		{
-			name: "ReadLine_with_answer",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Answer: "input"}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				line, err := m.ReadLine(context.Background())
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if line != "input" {
-					t.Errorf("got %q; want 'input'", line)
-				}
-			},
-		},
-		{
-			name: "ReadLine_empty_returns_EOF",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Answer: ""}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				line, err := m.ReadLine(context.Background())
-				if err != io.EOF {
-					t.Errorf("got error %v; want io.EOF", err)
-				}
-				if line != "" {
-					t.Errorf("got %q; want ''", line)
-				}
-			},
-		},
-		{
-			name: "ReadLine_with_error",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Err: errors.New("fail")}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				line, err := m.ReadLine(context.Background())
-				if err == nil || err.Error() != "fail" {
-					t.Errorf("got error %v; want 'fail'", err)
-				}
-				if line != "" {
-					t.Errorf("got %q; want ''", line)
-				}
-			},
-		},
-		{
-			name: "ReadSingleKey",
-			setup: func() *MockInteractor {
-				return &MockInteractor{Answer: "a"}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				key, err := m.ReadSingleKey(context.Background())
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if key != "a" {
-					t.Errorf("got %q; want 'a'", key)
-				}
-			},
-		},
-		{
-			name: "Warn_appends",
-			setup: func() *MockInteractor {
-				return &MockInteractor{}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				m.Warn("a")
-				m.Warn("b")
-				if len(m.Warns) != 2 || m.Warns[0] != "a" || m.Warns[1] != "b" {
-					t.Errorf("got %v; want [a b]", m.Warns)
-				}
-			},
-		},
-		{
-			name: "Prompt_appends",
-			setup: func() *MockInteractor {
-				return &MockInteractor{}
-			},
-			check: func(t *testing.T, m *MockInteractor) {
-				m.Prompt("a")
-				if len(m.Prompts) != 1 || m.Prompts[0] != "a" {
-					t.Errorf("got %v; want [a]", m.Prompts)
-				}
-			},
+			name:    "with_error",
+			mock:    &MockInteractor{Err: errors.New("fail")},
+			wantOk:  false,
+			wantErr: "fail",
 		},
 	}
 
@@ -154,8 +43,112 @@ func TestMockInteractor(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := tt.setup()
-			tt.check(t, m)
+			ok, err := tt.mock.Confirm(context.Background(), "msg")
+
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Errorf("got error %v; want %q", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			if ok != tt.wantOk {
+				t.Errorf("got %v; want %v", ok, tt.wantOk)
+			}
 		})
+	}
+}
+
+// --- ReadLine (3 subtests) ---
+
+func TestMockInteractor_ReadLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mock    *MockInteractor
+		want    string
+		wantErr error
+	}{
+		{
+			name: "with_answer",
+			mock: &MockInteractor{Answer: "input"},
+			want: "input",
+		},
+		{
+			name:    "empty_returns_EOF",
+			mock:    &MockInteractor{Answer: ""},
+			want:    "",
+			wantErr: io.EOF,
+		},
+		{
+			name:    "with_error",
+			mock:    &MockInteractor{Err: errors.New("fail")},
+			want:    "",
+			wantErr: errors.New("fail"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			line, err := tt.mock.ReadLine(context.Background())
+
+			if tt.wantErr != nil {
+				if err == nil || err.Error() != tt.wantErr.Error() {
+					t.Errorf("got error %v; want %v", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			if line != tt.want {
+				t.Errorf("got %q; want %q", line, tt.want)
+			}
+		})
+	}
+}
+
+// --- ReadSingleKey (1 subtest) ---
+
+func TestMockInteractor_ReadSingleKey(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockInteractor{Answer: "a"}
+	key, err := mock.ReadSingleKey(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if key != "a" {
+		t.Errorf("got %q; want 'a'", key)
+	}
+}
+
+// --- Warn (1 subtest) ---
+
+func TestMockInteractor_Warn(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockInteractor{}
+	mock.Warn("a")
+	mock.Warn("b")
+	if len(mock.Warns) != 2 || mock.Warns[0] != "a" || mock.Warns[1] != "b" {
+		t.Errorf("got %v; want [a b]", mock.Warns)
+	}
+}
+
+// --- Prompt (1 subtest) ---
+
+func TestMockInteractor_Prompt(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockInteractor{}
+	mock.Prompt("a")
+	if len(mock.Prompts) != 1 || mock.Prompts[0] != "a" {
+		t.Errorf("got %v; want [a]", mock.Prompts)
 	}
 }

--- a/internal/tools/toolstest/mock_security_manager_test.go
+++ b/internal/tools/toolstest/mock_security_manager_test.go
@@ -9,249 +9,46 @@ import (
 	"testing"
 )
 
-func TestMockSecurityManager(t *testing.T) {
+// --- IsPathSafe (4 subtests) ---
+
+func TestMockSecurityManager_IsPathSafe(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		setup func() *MockSecurityManager
-		check func(t *testing.T, m *MockSecurityManager)
+		name    string
+		mock    *MockSecurityManager
+		path    string
+		want    string
+		wantErr string
 	}{
-		// --- IsPathSafe ---
 		{
-			name: "IsPathSafe_AllowAll",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{AllowAll: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				path, err := m.IsPathSafe("/any")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if path != "/any" {
-					t.Errorf("got %q; want '/any'", path)
-				}
-			},
+			name: "AllowAll",
+			mock: &MockSecurityManager{AllowAll: true},
+			path: "/any",
+			want: "/any",
 		},
 		{
-			name: "IsPathSafe_BypassActive",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{BypassActive: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				path, err := m.IsPathSafe("/any")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if path != "/any" {
-					t.Errorf("got %q; want '/any'", path)
-				}
-			},
+			name: "BypassActive",
+			mock: &MockSecurityManager{BypassActive: true},
+			path: "/any",
+			want: "/any",
 		},
 		{
-			name: "IsPathSafe_default",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				path, err := m.IsPathSafe("/any")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if path != "/any" {
-					t.Errorf("got %q; want '/any'", path)
-				}
-			},
+			name: "default",
+			mock: &MockSecurityManager{},
+			path: "/any",
+			want: "/any",
 		},
 		{
-			name: "IsPathSafe_with_func",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					IsSafeFunc: func(path string) (string, error) {
-						return "safe:" + path, errors.New("custom")
-					},
-				}
+			name: "with_func",
+			mock: &MockSecurityManager{
+				IsSafeFunc: func(path string) (string, error) {
+					return "safe:" + path, errors.New("custom")
+				},
 			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				path, err := m.IsPathSafe("/x")
-				if err == nil || err.Error() != "custom" {
-					t.Errorf("got error %v; want 'custom'", err)
-				}
-				if path != "safe:/x" {
-					t.Errorf("got %q; want 'safe:/x'", path)
-				}
-			},
-		},
-		// --- IsPathWritable ---
-		{
-			name: "IsPathWritable_AllowAll",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{AllowAll: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				path, err := m.IsPathWritable("/any")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if path != "/any" {
-					t.Errorf("got %q; want '/any'", path)
-				}
-			},
-		},
-		// --- Authorize ---
-		{
-			name: "Authorize_AllowAll",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{AllowAll: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				ok, err := m.Authorize(context.Background(), "label", "detail", "reason", true)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if !ok {
-					t.Error("expected true for AllowAll")
-				}
-			},
-		},
-		{
-			name: "Authorize_no_bypass",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				ok, err := m.Authorize(context.Background(), "label", "detail", "reason", true)
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if ok {
-					t.Error("expected false when AllowAll and BypassActive are both false")
-				}
-			},
-		},
-		{
-			name: "Authorize_with_func",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					AuthorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
-						return true, errors.New("auth error")
-					},
-				}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				ok, err := m.Authorize(context.Background(), "label", "detail", "reason", true)
-				if err == nil || err.Error() != "auth error" {
-					t.Errorf("got error %v; want 'auth error'", err)
-				}
-				if !ok {
-					t.Error("expected true from custom func")
-				}
-			},
-		},
-		// --- IsCommandAllowed ---
-		{
-			name: "IsCommandAllowed_AllowAll",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{AllowAll: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				if !m.IsCommandAllowed("rm") {
-					t.Error("expected true for AllowAll")
-				}
-			},
-		},
-		{
-			name: "IsCommandAllowed_in_map",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					AllowedCommands: map[string]bool{"ls": true},
-				}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				if !m.IsCommandAllowed("ls") {
-					t.Error("expected true for 'ls' in AllowedCommands")
-				}
-			},
-		},
-		{
-			name: "IsCommandAllowed_not_in_map",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					AllowedCommands: map[string]bool{"ls": true},
-				}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				if m.IsCommandAllowed("rm") {
-					t.Error("expected false for 'rm' not in AllowedCommands")
-				}
-			},
-		},
-		// --- IsBypassActive / SetBypassActive ---
-		{
-			name: "IsBypassActive",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{BypassActive: true}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				if !m.IsBypassActive() {
-					t.Error("expected true")
-				}
-			},
-		},
-		{
-			name: "SetBypassActive",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				m.SetBypassActive(true)
-				if !m.IsBypassActive() {
-					t.Error("expected true after SetBypassActive(true)")
-				}
-			},
-		},
-		// --- Confirm ---
-		{
-			name: "Confirm_with_interactor",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					Interactor: &MockInteractor{Answer: "y"},
-				}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				ok, err := m.Confirm(context.Background(), "msg")
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if !ok {
-					t.Error("expected true from interactor with Answer='y'")
-				}
-				if !m.ConfirmCalled {
-					t.Error("expected ConfirmCalled to be true")
-				}
-				if m.LastConfirmText != "msg" {
-					t.Errorf("got LastConfirmText %q; want 'msg'", m.LastConfirmText)
-				}
-			},
-		},
-		{
-			name: "Confirm_with_func",
-			setup: func() *MockSecurityManager {
-				return &MockSecurityManager{
-					ConfirmFunc: func(ctx context.Context, message string) (bool, error) {
-						return false, errors.New("confirm error")
-					},
-				}
-			},
-			check: func(t *testing.T, m *MockSecurityManager) {
-				ok, err := m.Confirm(context.Background(), "msg")
-				if err == nil || err.Error() != "confirm error" {
-					t.Errorf("got error %v; want 'confirm error'", err)
-				}
-				if ok {
-					t.Error("expected false from custom ConfirmFunc")
-				}
-			},
+			path:    "/x",
+			want:    "safe:/x",
+			wantErr: "custom",
 		},
 	}
 
@@ -259,8 +56,202 @@ func TestMockSecurityManager(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			m := tt.setup()
-			tt.check(t, m)
+			got, err := tt.mock.IsPathSafe(tt.path)
+
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Errorf("got error %v; want %q", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			if got != tt.want {
+				t.Errorf("got %q; want %q", got, tt.want)
+			}
 		})
 	}
+}
+
+// --- IsPathWritable (1 subtest) ---
+
+func TestMockSecurityManager_IsPathWritable(t *testing.T) {
+	t.Parallel()
+
+	mock := &MockSecurityManager{AllowAll: true}
+	path, err := mock.IsPathWritable("/any")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if path != "/any" {
+		t.Errorf("got %q; want '/any'", path)
+	}
+}
+
+// --- Authorize (3 subtests) ---
+
+func TestMockSecurityManager_Authorize(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mock    *MockSecurityManager
+		wantOk  bool
+		wantErr string
+	}{
+		{
+			name:   "AllowAll",
+			mock:   &MockSecurityManager{AllowAll: true},
+			wantOk: true,
+		},
+		{
+			name:   "no_bypass",
+			mock:   &MockSecurityManager{},
+			wantOk: false,
+		},
+		{
+			name: "with_func",
+			mock: &MockSecurityManager{
+				AuthorizeFunc: func(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
+					return true, errors.New("auth error")
+				},
+			},
+			wantOk:  true,
+			wantErr: "auth error",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ok, err := tt.mock.Authorize(context.Background(), "label", "detail", "reason", true)
+
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Errorf("got error %v; want %q", err, tt.wantErr)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			}
+			if ok != tt.wantOk {
+				t.Errorf("got %v; want %v", ok, tt.wantOk)
+			}
+		})
+	}
+}
+
+// --- IsCommandAllowed (3 subtests) ---
+
+func TestMockSecurityManager_IsCommandAllowed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		mock   *MockSecurityManager
+		cmd    string
+		wantOk bool
+	}{
+		{
+			name:   "AllowAll",
+			mock:   &MockSecurityManager{AllowAll: true},
+			cmd:    "rm",
+			wantOk: true,
+		},
+		{
+			name: "in_map",
+			mock: &MockSecurityManager{
+				AllowedCommands: map[string]bool{"ls": true},
+			},
+			cmd:    "ls",
+			wantOk: true,
+		},
+		{
+			name: "not_in_map",
+			mock: &MockSecurityManager{
+				AllowedCommands: map[string]bool{"ls": true},
+			},
+			cmd:    "rm",
+			wantOk: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ok := tt.mock.IsCommandAllowed(tt.cmd)
+			if ok != tt.wantOk {
+				t.Errorf("got %v; want %v", ok, tt.wantOk)
+			}
+		})
+	}
+}
+
+// --- BypassActive (2 subtests: getter + setter combined) ---
+
+func TestMockSecurityManager_BypassActive(t *testing.T) {
+	t.Parallel()
+
+	t.Run("IsBypassActive", func(t *testing.T) {
+		t.Parallel()
+		mock := &MockSecurityManager{BypassActive: true}
+		if !mock.IsBypassActive() {
+			t.Error("expected true")
+		}
+	})
+
+	t.Run("SetBypassActive", func(t *testing.T) {
+		t.Parallel()
+		mock := &MockSecurityManager{}
+		mock.SetBypassActive(true)
+		if !mock.IsBypassActive() {
+			t.Error("expected true after SetBypassActive(true)")
+		}
+	})
+}
+
+// --- Confirm (2 subtests: interactor + func override) ---
+
+func TestMockSecurityManager_Confirm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with_interactor", func(t *testing.T) {
+		t.Parallel()
+		mock := &MockSecurityManager{
+			Interactor: &MockInteractor{Answer: "y"},
+		}
+		ok, err := mock.Confirm(context.Background(), "msg")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !ok {
+			t.Error("expected true from interactor with Answer='y'")
+		}
+		if !mock.ConfirmCalled {
+			t.Error("expected ConfirmCalled to be true")
+		}
+		if mock.LastConfirmText != "msg" {
+			t.Errorf("got LastConfirmText %q; want 'msg'", mock.LastConfirmText)
+		}
+	})
+
+	t.Run("with_func", func(t *testing.T) {
+		t.Parallel()
+		mock := &MockSecurityManager{
+			ConfirmFunc: func(ctx context.Context, message string) (bool, error) {
+				return false, errors.New("confirm error")
+			},
+		}
+		ok, err := mock.Confirm(context.Background(), "msg")
+		if err == nil || err.Error() != "confirm error" {
+			t.Errorf("got error %v; want 'confirm error'", err)
+		}
+		if ok {
+			t.Error("expected false from custom ConfirmFunc")
+		}
+	})
 }


### PR DESCRIPTION
Closes #481.

## Summary
Decomposed 3 monolithic test functions (80 combined cyclomatic complexity points) into 16 focused per-method test functions, all ≤10 complexity:

| File | Before | After |
|------|--------|-------|
| `mock_interactor_test.go` | 1 function, complexity 23 | 5 functions |
| `mock_command_validator_test.go` | 1 function, complexity 25 | 5 functions |
| `mock_security_manager_test.go` | 1 function, complexity 32 | 6 functions |

**80 combined complexity points eliminated. Zero behavioral changes. Zero new imports.**

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| `gocyclo -over 10 ./internal/tools/toolstest/` | ✅ Empty output |
| `go test ./internal/tools/toolstest/...` | ✅ PASS |
| `go test -race ./internal/tools/toolstest/...` | ✅ PASS |
