### PR TITLE
fix(test): reduce complexity in 6 test functions across 6 packages (#497)

### DIFF
--- a/internal/agent/agenttest/panic_registry_test.go
+++ b/internal/agent/agenttest/panic_registry_test.go
@@ -8,112 +8,80 @@ import (
 	"testing"
 )
 
-func TestPanicRegistry(t *testing.T) {
+func TestPanicRegistry_GetDeclarations_Normal(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct {
-		name  string
-		setup func() *PanicRegistry
-		check func(t *testing.T, r *PanicRegistry)
-	}{
-		{
-			name: "GetDeclarations_normal",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{PanicOnGet: false}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				decls := r.GetDeclarations()
-				if len(decls) != 1 {
-					t.Fatalf("got %d declarations; want 1", len(decls))
-				}
-				if decls[0].Name != "any" {
-					t.Errorf("got name %q; want %q", decls[0].Name, "any")
-				}
-			},
-		},
-		{
-			name: "GetDeclarations_panics",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{PanicOnGet: true}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				defer func() {
-					recovered := recover()
-					if recovered == nil {
-						t.Fatal("expected panic, but none occurred")
-					}
-					msg, ok := recovered.(string)
-					if !ok || msg != "registry GetDeclarations panic" {
-						t.Errorf("got panic %v; want 'registry GetDeclarations panic'", recovered)
-					}
-				}()
-				r.GetDeclarations()
-			},
-		},
-		{
-			name: "Execute_normal",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{PanicOnExec: false}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				result, err := r.Execute(context.Background(), "any", nil, nil)
-				if err != nil {
-					t.Errorf("unexpected error: %v", err)
-				}
-				if result.Text != "" {
-					t.Errorf("got Text %q; want empty", result.Text)
-				}
-			},
-		},
-		{
-			name: "Execute_panics",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{PanicOnExec: true}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				defer func() {
-					recovered := recover()
-					if recovered == nil {
-						t.Fatal("expected panic, but none occurred")
-					}
-					msg, ok := recovered.(string)
-					if !ok || msg != "registry Execute panic" {
-						t.Errorf("got panic %v; want 'registry Execute panic'", recovered)
-					}
-				}()
-				_, _ = r.Execute(context.Background(), "any", nil, nil)
-			},
-		},
-		{
-			name: "IsSerial",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{Serial: true}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				if !r.IsSerial("any") {
-					t.Error("expected IsSerial=true")
-				}
-			},
-		},
-		{
-			name: "IsLongRunning",
-			setup: func() *PanicRegistry {
-				return &PanicRegistry{}
-			},
-			check: func(t *testing.T, r *PanicRegistry) {
-				if r.IsLongRunning("any") {
-					t.Error("expected IsLongRunning=false")
-				}
-			},
-		},
+	r := &PanicRegistry{PanicOnGet: false}
+	decls := r.GetDeclarations()
+	if len(decls) != 1 {
+		t.Fatalf("got %d declarations; want 1", len(decls))
 	}
+	if decls[0].Name != "any" {
+		t.Errorf("got name %q; want %q", decls[0].Name, "any")
+	}
+}
 
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			r := tt.setup()
-			tt.check(t, r)
-		})
+func TestPanicRegistry_GetDeclarations_Panics(t *testing.T) {
+	t.Parallel()
+
+	r := &PanicRegistry{PanicOnGet: true}
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic, but none occurred")
+		}
+		msg, ok := recovered.(string)
+		if !ok || msg != "registry GetDeclarations panic" {
+			t.Errorf("got panic %v; want 'registry GetDeclarations panic'", recovered)
+		}
+	}()
+	r.GetDeclarations()
+}
+
+func TestPanicRegistry_Execute_Normal(t *testing.T) {
+	t.Parallel()
+
+	r := &PanicRegistry{PanicOnExec: false}
+	result, err := r.Execute(context.Background(), "any", nil, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if result.Text != "" {
+		t.Errorf("got Text %q; want empty", result.Text)
+	}
+}
+
+func TestPanicRegistry_Execute_Panics(t *testing.T) {
+	t.Parallel()
+
+	r := &PanicRegistry{PanicOnExec: true}
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Fatal("expected panic, but none occurred")
+		}
+		msg, ok := recovered.(string)
+		if !ok || msg != "registry Execute panic" {
+			t.Errorf("got panic %v; want 'registry Execute panic'", recovered)
+		}
+	}()
+	_, _ = r.Execute(context.Background(), "any", nil, nil)
+}
+
+func TestPanicRegistry_IsSerial(t *testing.T) {
+	t.Parallel()
+
+	r := &PanicRegistry{Serial: true}
+	if !r.IsSerial("any") {
+		t.Error("expected IsSerial=true")
+	}
+}
+
+func TestPanicRegistry_IsLongRunning(t *testing.T) {
+	t.Parallel()
+
+	r := &PanicRegistry{}
+	if r.IsLongRunning("any") {
+		t.Error("expected IsLongRunning=false")
 	}
 }

--- a/internal/agent/orchestrator/orchestratortest/helpers_test.go
+++ b/internal/agent/orchestrator/orchestratortest/helpers_test.go
@@ -62,93 +62,95 @@ func TestMockHook(t *testing.T) {
 	})
 }
 
-// ─────────────────────────── MockRetryPolicy ───────────────────────────
+// ──────────────────────── TestMockRetryPolicy_RetryWithDuration ─────────
 
-func TestMockRetryPolicy(t *testing.T) {
+func TestMockRetryPolicy_RetryWithDuration(t *testing.T) {
 	t.Parallel()
+	p := &MockRetryPolicy{
+		Retry:              true,
+		ShouldRetryResults: []time.Duration{5 * time.Second},
+	}
+	c := &clock.RealClock{}
+	d, ok := p.ShouldRetry(c, fmt.Errorf("some error"), 0, false)
+	if d != 5*time.Second {
+		t.Errorf("duration = %v; want 5s", d)
+	}
+	if !ok {
+		t.Error("ShouldRetry returned false; want true")
+	}
+	if !p.ShouldRetryCalled {
+		t.Error("ShouldRetryCalled = false; want true")
+	}
+}
 
-	t.Run("retry_with_duration", func(t *testing.T) {
-		t.Parallel()
-		p := &MockRetryPolicy{
-			Retry:              true,
-			ShouldRetryResults: []time.Duration{5 * time.Second},
-		}
-		c := &clock.RealClock{}
-		d, ok := p.ShouldRetry(c, fmt.Errorf("some error"), 0, false)
-		if d != 5*time.Second {
-			t.Errorf("duration = %v; want 5s", d)
+// ──────────────────────── TestMockRetryPolicy_NoRetry ──────────────────
+
+func TestMockRetryPolicy_NoRetry(t *testing.T) {
+	t.Parallel()
+	p := &MockRetryPolicy{Retry: false}
+	c := &clock.RealClock{}
+	d, ok := p.ShouldRetry(c, fmt.Errorf("some error"), 0, false)
+	if d != 0 {
+		t.Errorf("duration = %v; want 0", d)
+	}
+	if ok {
+		t.Error("ShouldRetry returned true; want false")
+	}
+}
+
+// ──────────────────────── TestMockRetryPolicy_ExhaustedResults ─────────
+
+func TestMockRetryPolicy_ExhaustedResults(t *testing.T) {
+	t.Parallel()
+	p := &MockRetryPolicy{
+		Retry:              true,
+		ShouldRetryResults: []time.Duration{1 * time.Second},
+	}
+	c := &clock.RealClock{}
+
+	// First call: attempt 0, within results slice
+	d, ok := p.ShouldRetry(c, fmt.Errorf("err"), 0, false)
+	if d != 1*time.Second {
+		t.Errorf("first duration = %v; want 1s", d)
+	}
+	if !ok {
+		t.Error("first ShouldRetry returned false; want true")
+	}
+
+	// Second call: attempt 1, exhausted results → returns (0, true)
+	d, ok = p.ShouldRetry(c, fmt.Errorf("err"), 1, false)
+	if d != 0 {
+		t.Errorf("exhausted duration = %v; want 0", d)
+	}
+	if !ok {
+		t.Error("exhausted ShouldRetry returned false; want true")
+	}
+}
+
+// ──────────────────────── TestMockRetryPolicy_AttemptIndexes ───────────
+
+func TestMockRetryPolicy_AttemptIndexes(t *testing.T) {
+	t.Parallel()
+	p := &MockRetryPolicy{
+		Retry: true,
+		ShouldRetryResults: []time.Duration{
+			1 * time.Second,
+			2 * time.Second,
+			3 * time.Second,
+		},
+	}
+	c := &clock.RealClock{}
+
+	expected := []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second}
+	for i, exp := range expected {
+		d, ok := p.ShouldRetry(c, fmt.Errorf("err"), i, false)
+		if d != exp {
+			t.Errorf("attempt %d: duration = %v; want %v", i, d, exp)
 		}
 		if !ok {
-			t.Error("ShouldRetry returned false; want true")
+			t.Errorf("attempt %d: ShouldRetry returned false; want true", i)
 		}
-		if !p.ShouldRetryCalled {
-			t.Error("ShouldRetryCalled = false; want true")
-		}
-	})
-
-	t.Run("no_retry", func(t *testing.T) {
-		t.Parallel()
-		p := &MockRetryPolicy{Retry: false}
-		c := &clock.RealClock{}
-		d, ok := p.ShouldRetry(c, fmt.Errorf("some error"), 0, false)
-		if d != 0 {
-			t.Errorf("duration = %v; want 0", d)
-		}
-		if ok {
-			t.Error("ShouldRetry returned true; want false")
-		}
-	})
-
-	t.Run("exhausted_results_returns_zero", func(t *testing.T) {
-		t.Parallel()
-		p := &MockRetryPolicy{
-			Retry:              true,
-			ShouldRetryResults: []time.Duration{1 * time.Second},
-		}
-		c := &clock.RealClock{}
-
-		// First call: attempt 0, within results slice
-		d, ok := p.ShouldRetry(c, fmt.Errorf("err"), 0, false)
-		if d != 1*time.Second {
-			t.Errorf("first duration = %v; want 1s", d)
-		}
-		if !ok {
-			t.Error("first ShouldRetry returned false; want true")
-		}
-
-		// Second call: attempt 1, exhausted results → returns (0, true)
-		d, ok = p.ShouldRetry(c, fmt.Errorf("err"), 1, false)
-		if d != 0 {
-			t.Errorf("exhausted duration = %v; want 0", d)
-		}
-		if !ok {
-			t.Error("exhausted ShouldRetry returned false; want true")
-		}
-	})
-
-	t.Run("attempt_indexes_results", func(t *testing.T) {
-		t.Parallel()
-		p := &MockRetryPolicy{
-			Retry: true,
-			ShouldRetryResults: []time.Duration{
-				1 * time.Second,
-				2 * time.Second,
-				3 * time.Second,
-			},
-		}
-		c := &clock.RealClock{}
-
-		expected := []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second}
-		for i, exp := range expected {
-			d, ok := p.ShouldRetry(c, fmt.Errorf("err"), i, false)
-			if d != exp {
-				t.Errorf("attempt %d: duration = %v; want %v", i, d, exp)
-			}
-			if !ok {
-				t.Errorf("attempt %d: ShouldRetry returned false; want true", i)
-			}
-		}
-	})
+	}
 }
 
 // ──────────────────────── CreateProcessorForPhase ─────────────────────

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -917,102 +917,106 @@ func TestSimpleEventBus_FlushCancellations(t *testing.T) {
 	})
 }
 
-func TestSimpleEventBus_ListenDefensive(t *testing.T) {
+func TestSimpleEventBus_ListenDefensive_NilBus(t *testing.T) {
 	t.Parallel()
 
-	t.Run("NilBus", func(t *testing.T) {
-		var bus *events.SimpleEventBus = nil
-		err := bus.Listen(context.Background())
-		if !errors.Is(err, events.ErrBusNotInitialized) {
-			t.Errorf("expected ErrBusNotInitialized, got %v", err)
-		}
-	})
+	var bus *events.SimpleEventBus = nil
+	err := bus.Listen(context.Background())
+	if !errors.Is(err, events.ErrBusNotInitialized) {
+		t.Errorf("expected ErrBusNotInitialized, got %v", err)
+	}
+}
 
-	t.Run("ClosedBus", func(t *testing.T) {
-		ctx := context.Background()
-		bus := events.NewSimpleEventBus(ctx, events.WithAsync(true))
-		_ = bus.Shutdown(ctx)
+func TestSimpleEventBus_ListenDefensive_ClosedBus(t *testing.T) {
+	t.Parallel()
 
-		err := bus.Listen(ctx)
-		if !errors.Is(err, events.ErrBusClosed) {
-			t.Errorf("expected ErrBusClosed, got %v", err)
-		}
-	})
+	ctx := context.Background()
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(true))
+	_ = bus.Shutdown(ctx)
 
-	t.Run("AlreadyRunning", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+	err := bus.Listen(ctx)
+	if !errors.Is(err, events.ErrBusClosed) {
+		t.Errorf("expected ErrBusClosed, got %v", err)
+	}
+}
 
-		bus := events.NewSimpleEventBus(ctx, events.WithAsync(true))
-		eventstest.CleanupBus(t, bus)
+func TestSimpleEventBus_ListenDefensive_AlreadyRunning(t *testing.T) {
+	t.Parallel()
 
-		// Start the first Listen in a background goroutine and wait for
-		// full initialization. After WaitStarted returns, b.running is
-		// guaranteed true under the lock.
-		listenDone := make(chan struct{})
-		go func() {
-			defer close(listenDone)
-			_ = bus.Listen(ctx)
-		}()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(true))
+	eventstest.CleanupBus(t, bus)
+
+	// Start the first Listen in a background goroutine and wait for
+	// full initialization. After WaitStarted returns, b.running is
+	// guaranteed true under the lock.
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		_ = bus.Listen(ctx)
+	}()
+	bus.WaitStarted()
+
+	// Call Listen a second time on an already-running bus.
+	// This exercises the early-return path:
+	//   if b.running { b.mu.Unlock(); return nil }
+	err := bus.Listen(ctx)
+	if err != nil {
+		t.Errorf("expected nil on re-entrant Listen to already-running bus, got %v", err)
+	}
+
+	// Clean shutdown: cancel the context and wait for the first Listen
+	// goroutine to return.
+	cancel()
+	<-listenDone
+}
+
+func TestSimpleEventBus_ListenDefensive_SyncMode(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+
+	// Listen on a sync-mode bus must return nil immediately
+	// and signal started so WaitStarted does not block.
+	err := bus.Listen(ctx)
+	if err != nil {
+		t.Errorf("Listen in sync mode should return nil, got %v", err)
+	}
+
+	// WaitStarted must return immediately — proves signalStarted was called.
+	// Use a channel + timeout to detect deadlock without hanging the test.
+	done := make(chan struct{})
+	go func() {
 		bus.WaitStarted()
+		close(done)
+	}()
+	select {
+	case <-done:
+		// OK — WaitStarted returned
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("WaitStarted blocked after sync-mode Listen — signalStarted was not called")
+	}
 
-		// Call Listen a second time on an already-running bus.
-		// This exercises the early-return path:
-		//   if b.running { b.mu.Unlock(); return nil }
-		err := bus.Listen(ctx)
-		if err != nil {
-			t.Errorf("expected nil on re-entrant Listen to already-running bus, got %v", err)
-		}
-
-		// Clean shutdown: cancel the context and wait for the first Listen
-		// goroutine to return.
-		cancel()
-		<-listenDone
+	// Publish should still work after sync-mode Listen (bus is not closed).
+	received := make(chan events.Event, 1)
+	bus.Subscribe(func(ctx context.Context, e events.Event) {
+		received <- e
 	})
-
-	t.Run("SyncMode", func(t *testing.T) {
-		ctx := context.Background()
-		bus := events.NewSimpleEventBus(ctx, events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
-		// Listen on a sync-mode bus must return nil immediately
-		// and signal started so WaitStarted does not block.
-		err := bus.Listen(ctx)
-		if err != nil {
-			t.Errorf("Listen in sync mode should return nil, got %v", err)
+	if err := bus.Publish(ctx, testEvent{val: "sync-mode"}); err != nil {
+		t.Fatalf("Publish after sync-mode Listen failed: %v", err)
+	}
+	select {
+	case got := <-received:
+		if got.(testEvent).val != "sync-mode" {
+			t.Errorf("expected 'sync-mode', got %v", got.(testEvent).val)
 		}
-
-		// WaitStarted must return immediately — proves signalStarted was called.
-		// Use a channel + timeout to detect deadlock without hanging the test.
-		done := make(chan struct{})
-		go func() {
-			bus.WaitStarted()
-			close(done)
-		}()
-		select {
-		case <-done:
-			// OK — WaitStarted returned
-		case <-time.After(500 * time.Millisecond):
-			t.Fatal("WaitStarted blocked after sync-mode Listen — signalStarted was not called")
-		}
-
-		// Publish should still work after sync-mode Listen (bus is not closed).
-		received := make(chan events.Event, 1)
-		bus.Subscribe(func(ctx context.Context, e events.Event) {
-			received <- e
-		})
-		if err := bus.Publish(ctx, testEvent{val: "sync-mode"}); err != nil {
-			t.Fatalf("Publish after sync-mode Listen failed: %v", err)
-		}
-		select {
-		case got := <-received:
-			if got.(testEvent).val != "sync-mode" {
-				t.Errorf("expected 'sync-mode', got %v", got.(testEvent).val)
-			}
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for event after sync-mode Listen")
-		}
-	})
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event after sync-mode Listen")
+	}
 }
 
 func TestSimpleEventBus_NilAndClosedSubscriptions(t *testing.T) {

--- a/internal/infrastructure/skills/file_repo_test.go
+++ b/internal/infrastructure/skills/file_repo_test.go
@@ -169,79 +169,77 @@ func TestFileSkillRepository_GetAll(t *testing.T) {
 	}
 }
 
-func TestNewFileSkillRepository_ErrorPaths(t *testing.T) {
-	t.Run("unreadable skill file", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		skillsDir := filepath.Join(tmpDir, "docs", "skills")
-		if err := os.MkdirAll(skillsDir, 0755); err != nil {
-			t.Fatalf("failed to create skills dir: %v", err)
-		}
+func TestNewFileSkillRepository_ErrorPaths_UnreadableSkillFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, "docs", "skills")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills dir: %v", err)
+	}
 
-		badFile := filepath.Join(skillsDir, "bad.md")
-		if err := os.WriteFile(badFile, []byte("---\nname: Test\ndescription: Test\n---\nContent"), 0644); err != nil {
-			t.Fatalf("failed to write file: %v", err)
-		}
-		if err := os.Chmod(badFile, 0000); err != nil {
-			t.Fatalf("failed to chmod file: %v", err)
-		}
-		t.Cleanup(func() { _ = os.Chmod(badFile, 0644) })
+	badFile := filepath.Join(skillsDir, "bad.md")
+	if err := os.WriteFile(badFile, []byte("---\nname: Test\ndescription: Test\n---\nContent"), 0644); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := os.Chmod(badFile, 0000); err != nil {
+		t.Fatalf("failed to chmod file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badFile, 0644) })
 
-		_, err := NewFileSkillRepository(skillsDir)
-		if err == nil || !strings.Contains(err.Error(), "read skill file") {
-			t.Errorf("expected 'read skill file' error, got: %v", err)
-		}
-	})
+	_, err := NewFileSkillRepository(skillsDir)
+	if err == nil || !strings.Contains(err.Error(), "read skill file") {
+		t.Errorf("expected 'read skill file' error, got: %v", err)
+	}
+}
 
-	t.Run("parse error - missing name", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		skillsDir := filepath.Join(tmpDir, "docs", "skills")
-		if err := os.MkdirAll(skillsDir, 0755); err != nil {
-			t.Fatalf("failed to create skills dir: %v", err)
-		}
+func TestNewFileSkillRepository_ErrorPaths_MissingName(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, "docs", "skills")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills dir: %v", err)
+	}
 
-		// Valid delimiters, has description, but no name → ErrInvalidFrontmatter
-		if err := os.WriteFile(
-			filepath.Join(skillsDir, "no_name.md"),
-			[]byte("---\ndescription: Has desc but no name\n---\nContent here"),
-			0644,
-		); err != nil {
-			t.Fatalf("failed to write file: %v", err)
-		}
+	// Valid delimiters, has description, but no name → ErrInvalidFrontmatter
+	if err := os.WriteFile(
+		filepath.Join(skillsDir, "no_name.md"),
+		[]byte("---\ndescription: Has desc but no name\n---\nContent here"),
+		0644,
+	); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
 
-		_, err := NewFileSkillRepository(skillsDir)
-		if err == nil || !strings.Contains(err.Error(), "parse skill file") {
-			t.Errorf("expected 'parse skill file' error, got: %v", err)
-		}
-	})
+	_, err := NewFileSkillRepository(skillsDir)
+	if err == nil || !strings.Contains(err.Error(), "parse skill file") {
+		t.Errorf("expected 'parse skill file' error, got: %v", err)
+	}
+}
 
-	t.Run("walk error - unreadable subdirectory", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		skillsDir := filepath.Join(tmpDir, "docs", "skills")
-		if err := os.MkdirAll(skillsDir, 0755); err != nil {
-			t.Fatalf("failed to create skills dir: %v", err)
-		}
+func TestNewFileSkillRepository_ErrorPaths_UnreadableSubdirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+	skillsDir := filepath.Join(tmpDir, "docs", "skills")
+	if err := os.MkdirAll(skillsDir, 0755); err != nil {
+		t.Fatalf("failed to create skills dir: %v", err)
+	}
 
-		// Create a subdirectory with no read permission
-		badSubdir := filepath.Join(skillsDir, "no_access")
-		if err := os.MkdirAll(badSubdir, 0755); err != nil {
-			t.Fatalf("failed to create subdir: %v", err)
-		}
-		// Place a valid skill file so the walk actually enters the directory
-		if err := os.WriteFile(
-			filepath.Join(badSubdir, "valid.md"),
-			[]byte("---\nname: Valid\ndescription: Valid\n---\nContent"),
-			0644,
-		); err != nil {
-			t.Fatalf("failed to write file: %v", err)
-		}
-		if err := os.Chmod(badSubdir, 0000); err != nil {
-			t.Fatalf("failed to chmod subdir: %v", err)
-		}
-		t.Cleanup(func() { _ = os.Chmod(badSubdir, 0755) })
+	// Create a subdirectory with no read permission
+	badSubdir := filepath.Join(skillsDir, "no_access")
+	if err := os.MkdirAll(badSubdir, 0755); err != nil {
+		t.Fatalf("failed to create subdir: %v", err)
+	}
+	// Place a valid skill file so the walk actually enters the directory
+	if err := os.WriteFile(
+		filepath.Join(badSubdir, "valid.md"),
+		[]byte("---\nname: Valid\ndescription: Valid\n---\nContent"),
+		0644,
+	); err != nil {
+		t.Fatalf("failed to write file: %v", err)
+	}
+	if err := os.Chmod(badSubdir, 0000); err != nil {
+		t.Fatalf("failed to chmod subdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(badSubdir, 0755) })
 
-		_, err := NewFileSkillRepository(skillsDir)
-		if err == nil || !strings.Contains(err.Error(), "load skills from") {
-			t.Errorf("expected 'load skills from' error, got: %v", err)
-		}
-	})
+	_, err := NewFileSkillRepository(skillsDir)
+	if err == nil || !strings.Contains(err.Error(), "load skills from") {
+		t.Errorf("expected 'load skills from' error, got: %v", err)
+	}
 }

--- a/internal/pkg/testfixtures/syncwriter_test.go
+++ b/internal/pkg/testfixtures/syncwriter_test.go
@@ -20,99 +20,82 @@ func (w *noStringWriter) Write(p []byte) (int, error) {
 	return w.buf.Write(p)
 }
 
-func TestSyncWriter_Write(t *testing.T) {
-	tests := []struct {
-		name   string
-		sw     *SyncWriter
-		data   []byte
-		verify func(t *testing.T, sw *SyncWriter, n int, err error)
-	}{
-		{
-			name: "writes to external writer",
-			sw:   &SyncWriter{Writer: &bytes.Buffer{}},
-			data: []byte("hello"),
-			verify: func(t *testing.T, sw *SyncWriter, n int, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if n != 5 {
-					t.Errorf("n = %d; want 5", n)
-				}
-				buf := sw.Writer.(*bytes.Buffer)
-				if buf.String() != "hello" {
-					t.Errorf("external buffer = %q; want %q", buf.String(), "hello")
-				}
-			},
-		},
-		{
-			name: "writes to internal buffer when Writer is nil",
-			sw:   &SyncWriter{},
-			data: []byte("hello"),
-			verify: func(t *testing.T, sw *SyncWriter, n int, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if n != 5 {
-					t.Errorf("n = %d; want 5", n)
-				}
-				if sw.String() != "hello" {
-					t.Errorf("String() = %q; want %q", sw.String(), "hello")
-				}
-			},
-		},
-		{
-			name: "sends OnWrite notification",
-			sw:   &SyncWriter{OnWrite: make(chan struct{}, 1)},
-			data: []byte("x"),
-			verify: func(t *testing.T, sw *SyncWriter, n int, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				select {
-				case <-sw.OnWrite:
-					// OK: notification received
-				default:
-					t.Error("expected OnWrite notification but none received")
-				}
-			},
-		},
-		{
-			name: "OnWrite nil does not panic",
-			sw:   &SyncWriter{OnWrite: nil},
-			data: []byte("x"),
-			verify: func(t *testing.T, sw *SyncWriter, n int, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if n != 1 {
-					t.Errorf("n = %d; want 1", n)
-				}
-			},
-		},
-		{
-			name: "OnWrite full does not block",
-			sw:   &SyncWriter{OnWrite: make(chan struct{})},
-			data: []byte("x"),
-			verify: func(t *testing.T, sw *SyncWriter, n int, err error) {
-				if err != nil {
-					t.Fatalf("unexpected error: %v", err)
-				}
-				if n != 1 {
-					t.Errorf("n = %d; want 1", n)
-				}
-				// If we reached here, Write did not block — the default
-				// case in select was taken. That is the expected behaviour.
-			},
-		},
+func TestSyncWriter_Write_ExternalWriter(t *testing.T) {
+	t.Parallel()
+	sw := &SyncWriter{Writer: &bytes.Buffer{}}
+	data := []byte("hello")
+	n, err := sw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+	if n != 5 {
+		t.Errorf("n = %d; want 5", n)
+	}
+	buf := sw.Writer.(*bytes.Buffer)
+	if buf.String() != "hello" {
+		t.Errorf("external buffer = %q; want %q", buf.String(), "hello")
+	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			n, err := tt.sw.Write(tt.data)
-			tt.verify(t, tt.sw, n, err)
-		})
+func TestSyncWriter_Write_InternalBuffer(t *testing.T) {
+	t.Parallel()
+	sw := &SyncWriter{}
+	data := []byte("hello")
+	n, err := sw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
+	if n != 5 {
+		t.Errorf("n = %d; want 5", n)
+	}
+	if sw.String() != "hello" {
+		t.Errorf("String() = %q; want %q", sw.String(), "hello")
+	}
+}
+
+func TestSyncWriter_Write_OnWriteNotification(t *testing.T) {
+	t.Parallel()
+	sw := &SyncWriter{OnWrite: make(chan struct{}, 1)}
+	data := []byte("x")
+	n, err := sw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = n
+	select {
+	case <-sw.OnWrite:
+		// OK: notification received
+	default:
+		t.Error("expected OnWrite notification but none received")
+	}
+}
+
+func TestSyncWriter_Write_OnWriteNil(t *testing.T) {
+	t.Parallel()
+	sw := &SyncWriter{OnWrite: nil}
+	data := []byte("x")
+	n, err := sw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d; want 1", n)
+	}
+}
+
+func TestSyncWriter_Write_OnWriteFull(t *testing.T) {
+	t.Parallel()
+	sw := &SyncWriter{OnWrite: make(chan struct{})}
+	data := []byte("x")
+	n, err := sw.Write(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("n = %d; want 1", n)
+	}
+	// If we reached here, Write did not block — the default
+	// case in select was taken. That is the expected behaviour.
 }
 
 func TestSyncWriter_String(t *testing.T) {

--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -418,91 +418,76 @@ func TestRunLinter(t *testing.T) {
 	}
 }
 
-func TestGoTidy_Errors(t *testing.T) {
+func TestGoTidy_Errors_ModTidyFails(t *testing.T) {
 	t.Parallel()
-	tests := []struct {
-		name       string
-		executeErr error
-		cmdFail    string
-		decline    bool
-	}{
-		{
-			name:       "go mod tidy fails",
-			executeErr: errors.New("tidy error"),
-			cmdFail:    "tidy",
-		},
-		{
-			name:       "go fmt fails",
-			executeErr: errors.New("fmt error"),
-			cmdFail:    "fmt",
-		},
-		{
-			name:    "user declined",
-			decline: true,
-		},
-		{
-			name:       "error with empty output",
-			executeErr: errors.New("tidy error"),
-			cmdFail:    "tidy",
+	m, _, _ := setupDevManager(t)
+	runner := m.runner.(*mockGoRunner)
+	runner.runModTidyFunc = func(ctx context.Context) ([]byte, error) {
+		return []byte("failed"), errors.New("tidy error")
+	}
+
+	res, err := m.goTidy(context.Background(), nil, nil)
+	if err != nil {
+		t.Errorf("expected nil error for go mod tidy fails, got %v", err)
+	}
+	displayName := "Go mod tidy/fmt"
+	if !strings.Contains(res.Text, displayName+" failed or found issues:") {
+		t.Errorf("expected failure text in result, got %q", res.Text)
+	}
+}
+
+func TestGoTidy_Errors_FmtFails(t *testing.T) {
+	t.Parallel()
+	m, _, _ := setupDevManager(t)
+	runner := m.runner.(*mockGoRunner)
+	runner.formatCodeFunc = func(ctx context.Context, path string) ([]byte, error) {
+		return []byte("failed"), errors.New("fmt error")
+	}
+
+	res, err := m.goTidy(context.Background(), nil, nil)
+	if err != nil {
+		t.Errorf("expected nil error for go fmt fails, got %v", err)
+	}
+	displayName := "Go mod tidy/fmt"
+	if !strings.Contains(res.Text, displayName+" failed or found issues:") {
+		t.Errorf("expected failure text in result, got %q", res.Text)
+	}
+}
+
+func TestGoTidy_Errors_UserDeclined(t *testing.T) {
+	t.Parallel()
+	m, _, sm := setupDevManager(t)
+	sm.AllowAll = false
+	m.validator = &mockValidator{
+		CommandValidator: m.validator,
+		isSafeFunc: func(command string) (bool, string) {
+			if strings.Contains(command, "tidy") {
+				return false, "forced prompt for test"
+			}
+			return true, ""
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			m, _, sm := setupDevManager(t)
-			if tt.decline {
-				sm.AllowAll = false
-				m.validator = &mockValidator{
-					CommandValidator: m.validator,
-					isSafeFunc: func(command string) (bool, string) {
-						if strings.Contains(command, "tidy") {
-							return false, "forced prompt for test"
-						}
-						return true, ""
-					},
-				}
-			} else {
-				runner := m.runner.(*mockGoRunner)
-				if tt.cmdFail == "tidy" {
-					runner.runModTidyFunc = func(ctx context.Context) ([]byte, error) {
-						// Return empty output when testing the error+empty path
-						if tt.name == "error with empty output" {
-							return nil, tt.executeErr
-						}
-						return []byte("failed"), tt.executeErr
-					}
-				} else {
-					runner.formatCodeFunc = func(ctx context.Context, path string) ([]byte, error) {
-						return []byte("failed"), tt.executeErr
-					}
-				}
-			}
+	res, err := m.goTidy(context.Background(), nil, nil)
+	if err == nil {
+		t.Error("expected error for user declined, got nil")
+	}
+	if !strings.Contains(res.Text, "Action denied by user.") {
+		t.Errorf("expected 'Action denied by user.', got %q", res.Text)
+	}
+}
 
-			res, err := m.goTidy(context.Background(), nil, nil)
-			if tt.name == "error with empty output" {
-				if err == nil {
-					t.Error("expected error for empty output, got nil")
-				}
-				return
-			}
-			if tt.decline {
-				if err == nil {
-					t.Error("expected error for user declined, got nil")
-				}
-				if !strings.Contains(res.Text, "Action denied by user.") {
-					t.Errorf("expected 'Action denied by user.', got %q", res.Text)
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("expected nil error for %s, got %v", tt.name, err)
-			}
-			displayName := "Go mod tidy/fmt"
-			if !strings.Contains(res.Text, displayName+" failed or found issues:") {
-				t.Errorf("expected failure text in result, got %q", res.Text)
-			}
-		})
+func TestGoTidy_Errors_ModTidyFailsEmptyOutput(t *testing.T) {
+	t.Parallel()
+	m, _, _ := setupDevManager(t)
+	runner := m.runner.(*mockGoRunner)
+	runner.runModTidyFunc = func(ctx context.Context) ([]byte, error) {
+		return nil, errors.New("tidy error")
+	}
+
+	_, err := m.goTidy(context.Background(), nil, nil)
+	if err == nil {
+		t.Error("expected error for empty output, got nil")
 	}
 }
 


### PR DESCRIPTION
Closes #497.

## Summary

Extract `t.Run` subtests and table-driven cases into standalone test functions, eliminating wrapper complexity. All 6 original functions now decomposed into 24 standalone functions, each under complexity threshold 10.

| File | Function | Was | Now (max) |
|------|----------|-----|-----------|
| events_test.go | TestSimpleEventBus_ListenDefensive | 11 | 2–8 |
| helpers_test.go | TestMockRetryPolicy | 13 | 3–5 |
| panic_registry_test.go | TestPanicRegistry | 14 | 2–4 |
| syncwriter_test.go | TestSyncWriter_Write | 15 | 3–4 |
| dev_test.go | TestGoTidy_Errors | 13 | 2–4 |
| file_repo_test.go | TestNewFileSkillRepository_ErrorPaths | 16 | 5–7 |

## Verification

| Check | Status |
|-------|--------|
| go vet | PASS |
| go test -race ./... | PASS (all packages) |
| go build | PASS |
| go fmt | PASS |
| go mod tidy | PASS |
| Assertion preservation | All verbatim |
| Coverage regression | None |