### PR TITLE
fix(llm): reduce complexity in 5 functions below threshold 10 (#495)

### DIFF
--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -571,35 +571,39 @@ func TestToAnthropicMessages_SkipsEmptyBlocks(t *testing.T) {
 		t.Fatalf("SendChat failed: %v", err)
 	}
 
-	// The model entry with empty text must be skipped.
-	// Consecutive same-role entries (both "user") may be merged
-	// into one message with multiple content blocks.
-	// Either way, we must NOT see a "model" role message.
-	for _, msg := range captured.Messages {
+	assertNoModelRoleMessage(t, captured.Messages)
+	assertUserContentContains(t, captured.Messages, "hello", "world")
+}
+
+// assertNoModelRoleMessage fails if any message in the captured request has role "model".
+func assertNoModelRoleMessage(t *testing.T, msgs []message) {
+	t.Helper()
+	for _, msg := range msgs {
 		if msg.Role == "model" {
 			t.Errorf("empty model entry was not skipped; got model message: %+v", msg)
 		}
 	}
+}
 
-	// Verify the user content is present regardless of merge behaviour
-	var foundHello, foundWorld bool
-	for _, msg := range captured.Messages {
+// assertUserContentContains fails if the given strings are not found in user-role message content blocks.
+func assertUserContentContains(t *testing.T, msgs []message, texts ...string) {
+	t.Helper()
+	found := make(map[string]bool)
+	for _, msg := range msgs {
 		if msg.Role == "user" {
 			for _, block := range msg.Content {
-				if block.Text == "hello" {
-					foundHello = true
-				}
-				if block.Text == "world" {
-					foundWorld = true
+				for _, text := range texts {
+					if block.Text == text {
+						found[text] = true
+					}
 				}
 			}
 		}
 	}
-	if !foundHello {
-		t.Error("expected 'hello' in user content, not found")
-	}
-	if !foundWorld {
-		t.Error("expected 'world' in user content, not found")
+	for _, text := range texts {
+		if !found[text] {
+			t.Errorf("expected %q in user content, not found", text)
+		}
 	}
 }
 

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -200,6 +200,100 @@ func TestSendChat_Scenarios(t *testing.T) {
 	}
 }
 
+// validateDynamicOnlyRequest asserts that:
+// - systemInstruction is present (initialized from nil)                 (Gap 9)
+// - dynamic system parts appear in systemInstruction                    (Gap 7)
+// - system-role entries are excluded from contents                      (Gap 7)
+func validateDynamicOnlyRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("expected bearer token, got '%s'", r.Header.Get("Authorization"))
+	}
+	var req struct {
+		SystemInstruction struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"systemInstruction"`
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Errorf("failed to decode request: %v", err)
+	}
+
+	// Gap 9: systemInstruction must be present (initialized from nil)
+	if len(req.SystemInstruction.Parts) == 0 {
+		t.Fatal("expected systemInstruction to be present with dynamic parts")
+	}
+	// Gap 7: dynamic system parts appear in systemInstruction
+	if req.SystemInstruction.Parts[0].Text != "You are helpful" {
+		t.Errorf("expected systemInstruction.parts[0].text == %q, got %q",
+			"You are helpful", req.SystemInstruction.Parts[0].Text)
+	}
+
+	// Gap 7: system-role entries must NOT appear in contents
+	for i, c := range req.Contents {
+		if c.Role == "system" {
+			t.Errorf("contents[%d] has role 'system', expected it to be excluded", i)
+		}
+	}
+}
+
+// validateStaticAndDynamicRequest asserts that:
+// - Both static and dynamic parts are present in systemInstruction     (Gap 8)
+// - system-role entries are excluded from contents                      (Gap 7)
+func validateStaticAndDynamicRequest(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Header.Get("Authorization") != "Bearer test-token" {
+		t.Errorf("expected bearer token, got '%s'", r.Header.Get("Authorization"))
+	}
+	var req struct {
+		SystemInstruction struct {
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"systemInstruction"`
+		Contents []struct {
+			Role  string `json:"role"`
+			Parts []struct {
+				Text string `json:"text"`
+			} `json:"parts"`
+		} `json:"contents"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		t.Errorf("failed to decode request: %v", err)
+	}
+
+	// Gap 8: Both static and dynamic parts must be present in systemInstruction
+	if len(req.SystemInstruction.Parts) < 2 {
+		t.Fatalf("expected at least 2 systemInstruction parts (static + dynamic), got %d", len(req.SystemInstruction.Parts))
+	}
+
+	// Collect part texts for order-independent comparison
+	texts := make(map[string]bool)
+	for _, p := range req.SystemInstruction.Parts {
+		texts[p.Text] = true
+	}
+	if !texts["Be concise"] {
+		t.Errorf("expected systemInstruction to contain static part %q, got %v", "Be concise", texts)
+	}
+	if !texts["You are helpful"] {
+		t.Errorf("expected systemInstruction to contain dynamic part %q, got %v", "You are helpful", texts)
+	}
+
+	// Gap 7: system-role entries must NOT appear in contents
+	for i, c := range req.Contents {
+		if c.Role == "system" {
+			t.Errorf("contents[%d] has role 'system', expected it to be excluded", i)
+		}
+	}
+}
+
 func TestPrepareRequest_SystemPromptMerging(t *testing.T) {
 	tests := []sendChatTestCase{
 		{
@@ -213,44 +307,7 @@ func TestPrepareRequest_SystemPromptMerging(t *testing.T) {
 				{Role: "system", Parts: []*llm.Part{{Text: "You are helpful"}}},
 				{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}},
 			},
-			validateReq: func(t *testing.T, r *http.Request) {
-				if r.Header.Get("Authorization") != "Bearer test-token" {
-					t.Errorf("expected bearer token, got '%s'", r.Header.Get("Authorization"))
-				}
-				var req struct {
-					SystemInstruction struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"systemInstruction"`
-					Contents []struct {
-						Role  string `json:"role"`
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"contents"`
-				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					t.Errorf("failed to decode request: %v", err)
-				}
-
-				// Gap 9: systemInstruction must be present (initialized from nil)
-				if len(req.SystemInstruction.Parts) == 0 {
-					t.Fatal("expected systemInstruction to be present with dynamic parts")
-				}
-				// Gap 7: dynamic system parts appear in systemInstruction
-				if req.SystemInstruction.Parts[0].Text != "You are helpful" {
-					t.Errorf("expected systemInstruction.parts[0].text == %q, got %q",
-						"You are helpful", req.SystemInstruction.Parts[0].Text)
-				}
-
-				// Gap 7: system-role entries must NOT appear in contents
-				for i, c := range req.Contents {
-					if c.Role == "system" {
-						t.Errorf("contents[%d] has role 'system', expected it to be excluded", i)
-					}
-				}
-			},
+			validateReq: validateDynamicOnlyRequest,
 		},
 		{
 			name: "StaticAndDynamic",
@@ -263,51 +320,7 @@ func TestPrepareRequest_SystemPromptMerging(t *testing.T) {
 				{Role: "system", Parts: []*llm.Part{{Text: "You are helpful"}}},
 				{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}},
 			},
-			validateReq: func(t *testing.T, r *http.Request) {
-				if r.Header.Get("Authorization") != "Bearer test-token" {
-					t.Errorf("expected bearer token, got '%s'", r.Header.Get("Authorization"))
-				}
-				var req struct {
-					SystemInstruction struct {
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"systemInstruction"`
-					Contents []struct {
-						Role  string `json:"role"`
-						Parts []struct {
-							Text string `json:"text"`
-						} `json:"parts"`
-					} `json:"contents"`
-				}
-				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-					t.Errorf("failed to decode request: %v", err)
-				}
-
-				// Gap 8: Both static and dynamic parts must be present in systemInstruction
-				if len(req.SystemInstruction.Parts) < 2 {
-					t.Fatalf("expected at least 2 systemInstruction parts (static + dynamic), got %d", len(req.SystemInstruction.Parts))
-				}
-
-				// Collect part texts for order-independent comparison
-				texts := make(map[string]bool)
-				for _, p := range req.SystemInstruction.Parts {
-					texts[p.Text] = true
-				}
-				if !texts["Be concise"] {
-					t.Errorf("expected systemInstruction to contain static part %q, got %v", "Be concise", texts)
-				}
-				if !texts["You are helpful"] {
-					t.Errorf("expected systemInstruction to contain dynamic part %q, got %v", "You are helpful", texts)
-				}
-
-				// Gap 7: system-role entries must NOT appear in contents
-				for i, c := range req.Contents {
-					if c.Role == "system" {
-						t.Errorf("contents[%d] has role 'system', expected it to be excluded", i)
-					}
-				}
-			},
+			validateReq: validateStaticAndDynamicRequest,
 		},
 	}
 
@@ -891,25 +904,9 @@ func TestParseVertexAI_NoV1Segment(t *testing.T) {
 	t.Run("NoV1InPathSegment", func(t *testing.T) {
 		apiURL := "https://us-central1-aiplatform.googleapis.com/locations/us-central1/publishers/google/models/gemini-1.5-flash"
 		backend, project, location, baseURL, publisherPath := c.parseVertexAI(apiURL)
-
-		if backend != genai.BackendVertexAI {
-			t.Errorf("expected VertexAI backend, got %v", backend)
-		}
-		if project != "" {
-			t.Errorf("expected empty project, got %q", project)
-		}
-		if location != "us-central1" {
-			t.Errorf("expected location us-central1, got %q", location)
-		}
-		// Gap 6: publisherPath is the full segment when no /v1/ exists
-		expectedPath := "publishers/google/models/gemini-1.5-flash"
-		if publisherPath != expectedPath {
-			t.Errorf("expected publisherPath %q, got %q", expectedPath, publisherPath)
-		}
-		// Gap 6: baseURL stays empty when /v1/ not present
-		if baseURL != "" {
-			t.Errorf("expected empty baseURL when no /v1/, got %q", baseURL)
-		}
+		assertParseVertexAIResult(t, backend, project, location, baseURL, publisherPath,
+			genai.BackendVertexAI, "", "us-central1", "",
+			"publishers/google/models/gemini-1.5-flash")
 	})
 
 	// Gap 5: URL where /v1/ appears inside the publisher path segment.
@@ -917,27 +914,32 @@ func TestParseVertexAI_NoV1Segment(t *testing.T) {
 	t.Run("V1InPathSegment", func(t *testing.T) {
 		apiURL := "https://us-central1-aiplatform.googleapis.com/locations/us-central1/publishers/google/models/gemini-1.5-flash/v1/extra"
 		backend, project, location, baseURL, publisherPath := c.parseVertexAI(apiURL)
-
-		if backend != genai.BackendVertexAI {
-			t.Errorf("expected VertexAI backend, got %v", backend)
-		}
-		if project != "" {
-			t.Errorf("expected empty project, got %q", project)
-		}
-		if location != "us-central1" {
-			t.Errorf("expected location us-central1, got %q", location)
-		}
-		// Gap 5: publisherPath is truncated at /v1/
-		expectedPath := "publishers/google/models/gemini-1.5-flash"
-		if publisherPath != expectedPath {
-			t.Errorf("expected publisherPath %q, got %q", expectedPath, publisherPath)
-		}
-		// Gap 5: baseURL is set when /v1/ present in apiURL
-		expectedBaseURL := "https://us-central1-aiplatform.googleapis.com/locations/us-central1/publishers/google/models/gemini-1.5-flash/"
-		if baseURL != expectedBaseURL {
-			t.Errorf("expected baseURL %q, got %q", expectedBaseURL, baseURL)
-		}
+		assertParseVertexAIResult(t, backend, project, location, baseURL, publisherPath,
+			genai.BackendVertexAI, "", "us-central1",
+			"https://us-central1-aiplatform.googleapis.com/locations/us-central1/publishers/google/models/gemini-1.5-flash/",
+			"publishers/google/models/gemini-1.5-flash")
 	})
+}
+
+// assertParseVertexAIResult validates all 5 return values from parseVertexAI.
+func assertParseVertexAIResult(t *testing.T, backend genai.Backend, project, location, baseURL, publisherPath string,
+	wantBackend genai.Backend, wantProject, wantLocation, wantBaseURL, wantPublisherPath string) {
+	t.Helper()
+	if backend != wantBackend {
+		t.Errorf("expected backend %v, got %v", wantBackend, backend)
+	}
+	if project != wantProject {
+		t.Errorf("expected project %q, got %q", wantProject, project)
+	}
+	if location != wantLocation {
+		t.Errorf("expected location %q, got %q", wantLocation, location)
+	}
+	if publisherPath != wantPublisherPath {
+		t.Errorf("expected publisherPath %q, got %q", wantPublisherPath, publisherPath)
+	}
+	if baseURL != wantBaseURL {
+		t.Errorf("expected baseURL %q, got %q", wantBaseURL, baseURL)
+	}
 }
 
 func TestGemini_ModelQualification(t *testing.T) {

--- a/internal/infrastructure/llm/openai/client_test.go
+++ b/internal/infrastructure/llm/openai/client_test.go
@@ -1593,9 +1593,10 @@ func getResponsesAPITextBlockFallbackTestCases(t *testing.T) []responsesAPITestC
 	}
 }
 
-func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
+// getResponsesAPIEdgeGap1And2 covers Gap 1 & 2: Direct content blocks
+// without message wrapper + child blocks.
+func getResponsesAPIEdgeGap1And2(t *testing.T) []responsesAPITestCase {
 	return []responsesAPITestCase{
-		// Gap 1 & 2: Direct content blocks without message wrapper + child blocks
 		{
 			name:    "direct_content_blocks_without_message_wrapper",
 			model:   "gpt-5.4",
@@ -1636,7 +1637,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 				}
 			},
 		},
-		// Gap 3: parseResponseToolCalls error in else-branch
+	}
+}
+
+// getResponsesAPIEdgeGap3 covers Gap 3: parseResponseToolCalls error
+// in else-branch.
+func getResponsesAPIEdgeGap3(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "direct_item_with_invalid_tool_calls",
 			model:   "gpt-5.4",
@@ -1664,7 +1671,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 			},
 			wantErr: "failed to unmarshal tool arguments",
 		},
-		// Gap 4: Top-level Name/Arguments without Function
+	}
+}
+
+// getResponsesAPIEdgeGap4 covers Gap 4: Top-level Name/Arguments
+// without Function.
+func getResponsesAPIEdgeGap4(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "top_level_tool_call_via_name_and_arguments",
 			model:   "gpt-5.4",
@@ -1696,7 +1709,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 				}
 			},
 		},
-		// Gap 4b: Top-level Name/Arguments with invalid JSON — appendToolCall error path
+	}
+}
+
+// getResponsesAPIEdgeGap4b covers Gap 4b: Top-level Name/Arguments
+// with invalid JSON — appendToolCall error path.
+func getResponsesAPIEdgeGap4b(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "top_level_tool_call_via_name_and_invalid_arguments",
 			model:   "gpt-5.4",
@@ -1718,7 +1737,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 			},
 			wantErr: "failed to unmarshal tool arguments",
 		},
-		// Gap 6: extractBlockText with map missing "value" key
+	}
+}
+
+// getResponsesAPIEdgeGap6 covers Gap 6: extractBlockText with map
+// missing "value" key.
+func getResponsesAPIEdgeGap6(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "text_block_with_map_missing_value_key",
 			model:   "gpt-5.4",
@@ -1744,7 +1769,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 				}
 			},
 		},
-		// Gap 7: handleRefusalBlock with empty Refusal
+	}
+}
+
+// getResponsesAPIEdgeGap7 covers Gap 7: handleRefusalBlock with empty
+// Refusal.
+func getResponsesAPIEdgeGap7(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "refusal_block_with_empty_text",
 			model:   "gpt-5.4",
@@ -1778,7 +1809,13 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 				}
 			},
 		},
-		// Unknown content block type must return an error (ADR-022 fail-loud)
+	}
+}
+
+// getResponsesAPIEdgeADR022 covers ADR-022: Unknown content block type
+// must return an error (fail-loud).
+func getResponsesAPIEdgeADR022(t *testing.T) []responsesAPITestCase {
+	return []responsesAPITestCase{
 		{
 			name:    "unknown_content_block_type_returns_error",
 			model:   "gpt-5.4",
@@ -1807,6 +1844,19 @@ func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
 			wantErr: "unhandled content block type",
 		},
 	}
+}
+
+// getResponsesAPIEdgeCases aggregates all edge-case test scenarios.
+func getResponsesAPIEdgeCases(t *testing.T) []responsesAPITestCase {
+	var cases []responsesAPITestCase
+	cases = append(cases, getResponsesAPIEdgeGap1And2(t)...)
+	cases = append(cases, getResponsesAPIEdgeGap3(t)...)
+	cases = append(cases, getResponsesAPIEdgeGap4(t)...)
+	cases = append(cases, getResponsesAPIEdgeGap4b(t)...)
+	cases = append(cases, getResponsesAPIEdgeGap6(t)...)
+	cases = append(cases, getResponsesAPIEdgeGap7(t)...)
+	cases = append(cases, getResponsesAPIEdgeADR022(t)...)
+	return cases
 }
 
 func getStreamingTestCases(t *testing.T) []responsesAPITestCase {

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -114,52 +114,70 @@ func (c *client) processOutputItem(content *llm.Content, out *responseOutputItem
 			return err
 		}
 	} else {
-		// Process as direct content block based on type
-		cb := contentBlock{
-			Type:       out.Type,
-			Text:       out.Text,
-			InputText:  out.InputText,
-			OutputText: out.OutputText,
-			Thought:    out.Thought,
-			Reasoning:  out.Reasoning,
-			Refusal:    out.Refusal,
-		}
-		if err := c.appendPartsFromBlock(content, cb); err != nil {
-			// Output-item types (e.g., "call", "message") are not
-			// content-block types; they are handled by the fallback
-			// logic below. Only propagate errors that are not about
-			// unhandled block types at this level.
-			if !errors.Is(err, errUnhandledBlockType) {
-				return err
-			}
-		}
-
-		// Fallback for items that put blocks in a top-level array
-		for _, childCb := range out.Content {
-			if err := c.appendPartsFromBlock(content, childCb); err != nil {
-				return err
-			}
-		}
-
-		// Top-level tool calls in output item
-		if err := c.parseResponseToolCalls(out.ToolCalls, content); err != nil {
+		if err := c.processDirectOutputItem(content, out); err != nil {
 			return err
 		}
+	}
+	return nil
+}
 
-		// Detection logic for top-level tool call (type: "call")
-		targetName := out.Name
-		targetArgs := out.Arguments
-		if out.Function != nil {
-			targetName = out.Function.Name
-			targetArgs = out.Function.Arguments
+// processDirectOutputItem handles output items that lack a Message wrapper.
+// These items carry content blocks directly (Text, InputText, OutputText, etc.),
+// a top-level Content array for child blocks, ToolCalls, and optionally
+// a top-level function/tool call (type: "call").
+func (c *client) processDirectOutputItem(content *llm.Content, out *responseOutputItem) error {
+	// Process as direct content block based on type
+	cb := contentBlock{
+		Type:       out.Type,
+		Text:       out.Text,
+		InputText:  out.InputText,
+		OutputText: out.OutputText,
+		Thought:    out.Thought,
+		Reasoning:  out.Reasoning,
+		Refusal:    out.Refusal,
+	}
+	if err := c.appendPartsFromBlock(content, cb); err != nil {
+		// Output-item types (e.g., "call", "message") are not
+		// content-block types; they are handled by the fallback
+		// logic below. Only propagate errors that are not about
+		// unhandled block types at this level.
+		if !errors.Is(err, errUnhandledBlockType) {
+			return err
 		}
-		if targetName != "" {
-			if out.ID == "" {
-				return fmt.Errorf("invalid tool payload: missing ID for top-level tool call '%s'", targetName)
-			}
-			if err := c.appendToolCall(content, out.ID, targetName, targetArgs); err != nil {
-				return err
-			}
+	}
+
+	// Fallback for items that put blocks in a top-level array
+	for _, childCb := range out.Content {
+		if err := c.appendPartsFromBlock(content, childCb); err != nil {
+			return err
+		}
+	}
+
+	// Top-level tool calls in output item
+	if err := c.parseResponseToolCalls(out.ToolCalls, content); err != nil {
+		return err
+	}
+
+	// Detection logic for top-level tool call (type: "call")
+	return c.detectTopLevelToolCall(content, out)
+}
+
+// detectTopLevelToolCall checks for a top-level function/tool call in the
+// output item. It resolves the call name and arguments from either the
+// Function field (preferred) or the top-level Name/Arguments fields (fallback).
+func (c *client) detectTopLevelToolCall(content *llm.Content, out *responseOutputItem) error {
+	targetName := out.Name
+	targetArgs := out.Arguments
+	if out.Function != nil {
+		targetName = out.Function.Name
+		targetArgs = out.Function.Arguments
+	}
+	if targetName != "" {
+		if out.ID == "" {
+			return fmt.Errorf("invalid tool payload: missing ID for top-level tool call '%s'", targetName)
+		}
+		if err := c.appendToolCall(content, out.ID, targetName, targetArgs); err != nil {
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
Closes #495.

## Summary

Reduce cyclomatic complexity in 5 functions across llm/ packages below the threshold of 10:

| Function | Package | Before | After | Type |
|----------|---------|--------|-------|------|
| processOutputItem | openai | 14 | 6 | Production |
| TestPrepareRequest_SystemPromptMerging | gemini | 16 | 2 | Test |
| getResponsesAPIEdgeCases | openai | 13 | 1 | Test |
| TestParseVertexAI_NoV1Segment | gemini | 11 | 1 | Test |
| TestToAnthropicMessages_SkipsEmptyBlocks | anthropic | 11 | 2 | Test |

All extracted helpers below threshold.

**Patterns applied:** Extract Method, Extract Helper, Table-Driven Decomposition, Inline Closure Extraction.

## Verification

| Check | Status |
|-------|--------|
| llm package tests (all 3) | PASS |
| llm race detection | PASS |
| llm lint | 0 issues |
| No behavioral changes | Confirmed |