### PR TITLE
fix(workspace): reduce test complexity below threshold of 10 (#493)

### DIFF
--- a/internal/tools/workspace/backup_test.go
+++ b/internal/tools/workspace/backup_test.go
@@ -18,16 +18,19 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
-func TestBackupManager_Undo(t *testing.T) {
+// setupBackupForUndo creates a backupManager with two snapshots:
+// a WRITE snapshot (new file) followed by a REPLACE snapshot (modification).
+// Returns the manager, context, and the file path.
+func setupBackupForUndo(t *testing.T) (*backupManager, context.Context, string) {
+	t.Helper()
 	tempDir := t.TempDir()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.RegisterSafePath(tempDir)
 	bm := newBackupManager(sm, persistencetest.NewPlainOSFileSystem(), 10)
 	ctx := context.Background()
-
 	path := filepath.Join(tempDir, "test.txt")
 
-	// 1. Snapshot new file creation
+	// Step 1: Snapshot new file creation
 	if err := bm.snapshot(ctx, path, "WRITE"); err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +38,7 @@ func TestBackupManager_Undo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 2. Snapshot modification
+	// Step 2: Snapshot modification
 	if err := bm.snapshot(ctx, path, "REPLACE"); err != nil {
 		t.Fatal(err)
 	}
@@ -43,7 +46,14 @@ func TestBackupManager_Undo(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// 3. Undo modification
+	return bm, ctx, path
+}
+
+// TestBackupManager_Undo_Modification verifies that undoing a REPLACE
+// snapshot restores the previous file content.
+func TestBackupManager_Undo_Modification(t *testing.T) {
+	bm, ctx, path := setupBackupForUndo(t)
+
 	res, err := bm.undo(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
@@ -58,9 +68,20 @@ func TestBackupManager_Undo(t *testing.T) {
 	if string(content) != "v1" {
 		t.Errorf("got %s, want v1", content)
 	}
+}
 
-	// 4. Undo creation
-	res, err = bm.undo(ctx, 1)
+// TestBackupManager_Undo_Creation verifies that undoing a WRITE snapshot
+// (after the modification was already undone) removes the created file.
+func TestBackupManager_Undo_Creation(t *testing.T) {
+	bm, ctx, path := setupBackupForUndo(t)
+
+	// Undo the modification first
+	if _, err := bm.undo(ctx, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Then undo the creation
+	res, err := bm.undo(ctx, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +190,11 @@ func TestBackupManager_Undo_Errors(t *testing.T) {
 	}
 }
 
-func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
+// setupUndoErrorTest creates a backupManager with the test case's snapshot
+// already taken. Returns the manager, context, and the mock security manager
+// (needed for cleanup).
+func setupUndoErrorTest(t *testing.T, tc undoErrorTestCase) (*backupManager, context.Context) {
+	t.Helper()
 	tempDir := t.TempDir()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	fs := tc.mockFS
@@ -180,7 +205,7 @@ func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
 	ctx := context.Background()
 
 	cleanup := tc.setup(t, tempDir, sm)
-	defer cleanup()
+	t.Cleanup(cleanup)
 
 	fullPath := tc.snapshotPath
 	if fullPath != "" {
@@ -192,8 +217,14 @@ func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
 		}
 	}
 
-	res, err := bm.undo(ctx, 1)
+	return bm, ctx
+}
 
+// verifyUndoErrorResult asserts the undo result against the test case's
+// expectations. When wantErrSubstr is set, it checks the error; otherwise
+// it checks for success and optional result substring.
+func verifyUndoErrorResult(t *testing.T, res string, err error, tc undoErrorTestCase) {
+	t.Helper()
 	if tc.wantErrSubstr != "" {
 		if err == nil || !strings.Contains(err.Error(), tc.wantErrSubstr) {
 			t.Errorf("expected error containing %q, got %v", tc.wantErrSubstr, err)
@@ -207,6 +238,12 @@ func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
 	if tc.wantResSubstr != "" && !strings.Contains(res, tc.wantResSubstr) {
 		t.Errorf("expected result containing %q, got %q", tc.wantResSubstr, res)
 	}
+}
+
+func runUndoErrorTest(t *testing.T, tc undoErrorTestCase) {
+	bm, ctx := setupUndoErrorTest(t, tc)
+	res, err := bm.undo(ctx, 1)
+	verifyUndoErrorResult(t, res, err, tc)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -934,55 +934,66 @@ func TestOpenOutputFile_MkdirAllError(t *testing.T) {
 	}
 }
 
-func TestProcessExecutor_Output(t *testing.T) {
+// TestProcessExecutor_Output_Success verifies that Output returns stdout
+// with a trailing newline on successful command execution.
+func TestProcessExecutor_Output_Success(t *testing.T) {
 	executor := newprocessExecutor()
 	ctx := context.Background()
+	out, err := executor.Output(ctx, helperPath, "echo", "hello")
+	if err != nil {
+		t.Fatalf("Output failed: %v", err)
+	}
+	if string(out) != "hello\n" {
+		t.Errorf("expected 'hello\\n', got %q", string(out))
+	}
+}
 
-	t.Run("success", func(t *testing.T) {
-		out, err := executor.Output(ctx, helperPath, "echo", "hello")
-		if err != nil {
-			t.Fatalf("Output failed: %v", err)
-		}
-		if string(out) != "hello\n" {
-			t.Errorf("expected 'hello\\n', got %q", string(out))
-		}
-	})
+// TestProcessExecutor_Output_ExitError verifies that Output returns an error
+// containing the exit status when the command exits non-zero.
+func TestProcessExecutor_Output_ExitError(t *testing.T) {
+	executor := newprocessExecutor()
+	ctx := context.Background()
+	out, err := executor.Output(ctx, helperPath, "exit", "1")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "exit status 1") {
+		t.Errorf("expected 'exit status 1' in error, got: %v", err)
+	}
+	if out != nil {
+		t.Logf("partial output on exit error: %q", string(out))
+	}
+}
 
-	t.Run("exit error", func(t *testing.T) {
-		out, err := executor.Output(ctx, helperPath, "exit", "1")
-		if err == nil {
-			t.Fatal("expected error for non-zero exit")
-		}
-		if !strings.Contains(err.Error(), "exit status 1") {
-			t.Errorf("expected 'exit status 1' in error, got: %v", err)
-		}
-		if out != nil {
-			t.Logf("partial output on exit error: %q", string(out))
-		}
-	})
+// TestProcessExecutor_CombinedOutput_Success verifies that CombinedOutput
+// returns combined stdout+stderr on successful command execution.
+func TestProcessExecutor_CombinedOutput_Success(t *testing.T) {
+	executor := newprocessExecutor()
+	ctx := context.Background()
+	out, err := executor.CombinedOutput(ctx, helperPath, "echo", "hello")
+	if err != nil {
+		t.Fatalf("CombinedOutput failed: %v", err)
+	}
+	if string(out) != "hello\n" {
+		t.Errorf("expected 'hello\\n', got %q", string(out))
+	}
+}
 
-	t.Run("CombinedOutput success", func(t *testing.T) {
-		out, err := executor.CombinedOutput(ctx, helperPath, "echo", "hello")
-		if err != nil {
-			t.Fatalf("CombinedOutput failed: %v", err)
-		}
-		if string(out) != "hello\n" {
-			t.Errorf("expected 'hello\\n', got %q", string(out))
-		}
-	})
-
-	t.Run("CombinedOutput exit error", func(t *testing.T) {
-		out, err := executor.CombinedOutput(ctx, helperPath, "exit", "2")
-		if err == nil {
-			t.Fatal("expected error for non-zero exit")
-		}
-		if !strings.Contains(err.Error(), "exit status 2") {
-			t.Errorf("expected 'exit status 2' in error, got: %v", err)
-		}
-		if out != nil {
-			t.Logf("partial output on exit error: %q", string(out))
-		}
-	})
+// TestProcessExecutor_CombinedOutput_ExitError verifies that CombinedOutput
+// returns an error containing the exit status when the command exits non-zero.
+func TestProcessExecutor_CombinedOutput_ExitError(t *testing.T) {
+	executor := newprocessExecutor()
+	ctx := context.Background()
+	out, err := executor.CombinedOutput(ctx, helperPath, "exit", "2")
+	if err == nil {
+		t.Fatal("expected error for non-zero exit")
+	}
+	if !strings.Contains(err.Error(), "exit status 2") {
+		t.Errorf("expected 'exit status 2' in error, got: %v", err)
+	}
+	if out != nil {
+		t.Logf("partial output on exit error: %q", string(out))
+	}
 }
 
 func TestProcessExecutor_Output_RunError(t *testing.T) {
@@ -1071,6 +1082,28 @@ func TestProcessExecutor_LookPath(t *testing.T) {
 // streamProcessor.appendErr tests
 // ---------------------------------------------------------------------------
 
+// verifyAppendErrResult asserts the state of the string builder, truncated flag,
+// and optional feedback buffer against the test case expectations.
+func verifyAppendErrResult(t *testing.T, sb *strings.Builder, sp *streamProcessor, wantEmptySB bool, wantContains string, wantTruncated bool, useFeedback bool, fb io.Writer) {
+	t.Helper()
+	got := sb.String()
+	if wantEmptySB && got != "" {
+		t.Errorf("expected empty sb, got %q", got)
+	}
+	if wantContains != "" && !strings.Contains(got, wantContains) {
+		t.Errorf("expected sb to contain %q, got %q", wantContains, got)
+	}
+	if sp.truncated.Load() != wantTruncated {
+		t.Errorf("truncated = %v, want %v", sp.truncated.Load(), wantTruncated)
+	}
+	if useFeedback && fb != nil {
+		fbStr := fb.(*bytes.Buffer).String()
+		if !strings.Contains(fbStr, wantContains) {
+			t.Errorf("expected feedback to contain %q, got %q", wantContains, fbStr)
+		}
+	}
+}
+
 func TestStreamProcessor_appendErr(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -1156,22 +1189,7 @@ func TestStreamProcessor_appendErr(t *testing.T) {
 			var sb strings.Builder
 			sp.appendErr(&sb, tt.err)
 
-			got := sb.String()
-			if tt.wantEmptySB && got != "" {
-				t.Errorf("expected empty sb, got %q", got)
-			}
-			if tt.wantContains != "" && !strings.Contains(got, tt.wantContains) {
-				t.Errorf("expected sb to contain %q, got %q", tt.wantContains, got)
-			}
-			if sp.truncated.Load() != tt.wantTruncated {
-				t.Errorf("truncated = %v, want %v", sp.truncated.Load(), tt.wantTruncated)
-			}
-			if tt.useFeedback && fb != nil {
-				fbStr := fb.(*bytes.Buffer).String()
-				if !strings.Contains(fbStr, tt.wantContains) {
-					t.Errorf("expected feedback to contain %q, got %q", tt.wantContains, fbStr)
-				}
-			}
+			verifyAppendErrResult(t, &sb, sp, tt.wantEmptySB, tt.wantContains, tt.wantTruncated, tt.useFeedback, fb)
 		})
 	}
 }
@@ -1186,256 +1204,232 @@ func (f *failingWriter) Write(p []byte) (int, error) {
 	return 0, fmt.Errorf("disk full")
 }
 
-func TestWriteTracker_Write(t *testing.T) {
-	t.Run("normal write", func(t *testing.T) {
-		feedback := &bytes.Buffer{}
-		wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
-		var w bytes.Buffer
+func TestWriteTracker_Write_NormalWrite(t *testing.T) {
+	feedback := &bytes.Buffer{}
+	wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
+	var w bytes.Buffer
+	wt.Write(&w, []byte("data"))
+	if w.String() != "data" {
+		t.Errorf("expected 'data', got %q", w.String())
+	}
+	if feedback.Len() != 0 {
+		t.Errorf("expected no feedback, got %q", feedback.String())
+	}
+	if wt.failed.Load() {
+		t.Error("expected failed=false")
+	}
+}
 
-		wt.Write(&w, []byte("data"))
+func TestWriteTracker_Write_WriteFailure(t *testing.T) {
+	feedback := &bytes.Buffer{}
+	wt := &writeTracker{feedback: feedback, filePath: "important.txt"}
+	wt.Write(&failingWriter{}, []byte("data"))
+	if !wt.failed.Load() {
+		t.Error("expected failed=true after write error")
+	}
+	fb := feedback.String()
+	if !strings.Contains(fb, "[Warning] Failed to write to output file") {
+		t.Errorf("expected warning in feedback, got %q", fb)
+	}
+	if !strings.Contains(fb, "important.txt") {
+		t.Errorf("expected file path in warning, got %q", fb)
+	}
+	if !strings.Contains(fb, "disk full") {
+		t.Errorf("expected error cause in warning, got %q", fb)
+	}
+}
 
-		if w.String() != "data" {
-			t.Errorf("expected 'data', got %q", w.String())
-		}
-		if feedback.Len() != 0 {
-			t.Errorf("expected no feedback, got %q", feedback.String())
-		}
-		if wt.failed.Load() {
-			t.Error("expected failed=false")
-		}
-	})
+func TestWriteTracker_Write_AlreadyFailed(t *testing.T) {
+	feedback := &bytes.Buffer{}
+	wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
+	wt.failed.Store(true)
+	wt.Write(&failingWriter{}, []byte("more data"))
+	if feedback.Len() != 0 {
+		t.Errorf("expected no new feedback, got %q", feedback.String())
+	}
+}
 
-	t.Run("write failure — warning emitted once", func(t *testing.T) {
-		feedback := &bytes.Buffer{}
-		wt := &writeTracker{feedback: feedback, filePath: "important.txt"}
+func TestWriteTracker_Write_TypedNilFile(t *testing.T) {
+	feedback := &bytes.Buffer{}
+	wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
+	var f *os.File = nil
+	var w io.Writer = f
+	wt.Write(w, []byte("data"))
+	if wt.failed.Load() {
+		t.Error("expected failed=false for typed nil")
+	}
+	if feedback.Len() != 0 {
+		t.Errorf("expected no feedback, got %q", feedback.String())
+	}
+}
 
-		wt.Write(&failingWriter{}, []byte("data"))
-
-		if !wt.failed.Load() {
-			t.Error("expected failed=true after write error")
-		}
-		fb := feedback.String()
-		if !strings.Contains(fb, "[Warning] Failed to write to output file") {
-			t.Errorf("expected warning in feedback, got %q", fb)
-		}
-		if !strings.Contains(fb, "important.txt") {
-			t.Errorf("expected file path in warning, got %q", fb)
-		}
-		if !strings.Contains(fb, "disk full") {
-			t.Errorf("expected error cause in warning, got %q", fb)
-		}
-	})
-
-	t.Run("already failed — second write silently skipped", func(t *testing.T) {
-		feedback := &bytes.Buffer{}
-		wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
-		wt.failed.Store(true) // precondition: already failed
-
-		wt.Write(&failingWriter{}, []byte("more data"))
-
-		// Feedback must not grow — the write should be skipped entirely.
-		if feedback.Len() != 0 {
-			t.Errorf("expected no new feedback, got %q", feedback.String())
-		}
-	})
-
-	t.Run("typed nil *os.File — skipped", func(t *testing.T) {
-		feedback := &bytes.Buffer{}
-		wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
-
-		var f *os.File = nil
-		var w io.Writer = f // typed nil: interface is non-nil, concrete is nil
-		wt.Write(w, []byte("data"))
-
-		if wt.failed.Load() {
-			t.Error("expected failed=false for typed nil")
-		}
-		if feedback.Len() != 0 {
-			t.Errorf("expected no feedback, got %q", feedback.String())
-		}
-	})
-
-	t.Run("nil interface — skipped", func(t *testing.T) {
-		feedback := &bytes.Buffer{}
-		wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
-
-		wt.Write(nil, []byte("data"))
-
-		if wt.failed.Load() {
-			t.Error("expected failed=false for nil interface")
-		}
-		if feedback.Len() != 0 {
-			t.Errorf("expected no feedback, got %q", feedback.String())
-		}
-	})
+func TestWriteTracker_Write_NilInterface(t *testing.T) {
+	feedback := &bytes.Buffer{}
+	wt := &writeTracker{feedback: feedback, filePath: "test.txt"}
+	wt.Write(nil, []byte("data"))
+	if wt.failed.Load() {
+		t.Error("expected failed=false for nil interface")
+	}
+	if feedback.Len() != 0 {
+		t.Errorf("expected no feedback, got %q", feedback.String())
+	}
 }
 
 // ---------------------------------------------------------------------------
 // newPipelineCmd tests
 // ---------------------------------------------------------------------------
 
-func TestProcessExecutor_newPipelineCmd(t *testing.T) {
+func TestProcessExecutor_newPipelineCmd_EmptyPartsIndex0(t *testing.T) {
 	e := newprocessExecutor()
 	ctx := context.Background()
+	_, err := e.newPipelineCmd(ctx, []string{}, 0, executionConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty parts")
+	}
+	if !strings.Contains(err.Error(), "empty command at index 0") {
+		t.Errorf("expected 'empty command at index 0', got %q", err.Error())
+	}
+}
 
-	t.Run("empty parts — index 0", func(t *testing.T) {
-		_, err := e.newPipelineCmd(ctx, []string{}, 0, executionConfig{})
-		if err == nil {
-			t.Fatal("expected error for empty parts")
-		}
-		if !strings.Contains(err.Error(), "empty command at index 0") {
-			t.Errorf("expected 'empty command at index 0', got %q", err.Error())
-		}
-	})
+func TestProcessExecutor_newPipelineCmd_EmptyPartsIndex2(t *testing.T) {
+	e := newprocessExecutor()
+	ctx := context.Background()
+	_, err := e.newPipelineCmd(ctx, []string{}, 2, executionConfig{})
+	if err == nil {
+		t.Fatal("expected error for empty parts")
+	}
+	if !strings.Contains(err.Error(), "empty command at index 2") {
+		t.Errorf("expected 'empty command at index 2', got %q", err.Error())
+	}
+}
 
-	t.Run("empty parts — index 2", func(t *testing.T) {
-		_, err := e.newPipelineCmd(ctx, []string{}, 2, executionConfig{})
-		if err == nil {
-			t.Fatal("expected error for empty parts")
-		}
-		if !strings.Contains(err.Error(), "empty command at index 2") {
-			t.Errorf("expected 'empty command at index 2', got %q", err.Error())
-		}
-	})
+func TestProcessExecutor_newPipelineCmd_ValidParts(t *testing.T) {
+	e := newprocessExecutor()
+	ctx := context.Background()
+	cmd, err := e.newPipelineCmd(ctx, []string{"echo", "hello"}, 0, executionConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil *exec.Cmd")
+	}
+	if cmd.Args[0] != "echo" {
+		t.Errorf("expected cmd.Args[0] == 'echo', got %q", cmd.Args[0])
+	}
+}
 
-	t.Run("valid parts — returns *exec.Cmd", func(t *testing.T) {
-		cmd, err := e.newPipelineCmd(ctx, []string{"echo", "hello"}, 0, executionConfig{})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
+func TestProcessExecutor_newPipelineCmd_WithEnv(t *testing.T) {
+	e := newprocessExecutor()
+	ctx := context.Background()
+	config := executionConfig{Env: map[string]string{"GOOS": "linux", "CUSTOM_VAR": "testval"}}
+	cmd, err := e.newPipelineCmd(ctx, []string{"go", "version"}, 0, config)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil *exec.Cmd")
+	}
+	if len(cmd.Env) == 0 {
+		t.Fatal("expected cmd.Env to be non-empty")
+	}
+	foundGOOS, foundCustom := false, false
+	for _, e := range cmd.Env {
+		if e == "GOOS=linux" {
+			foundGOOS = true
 		}
-		if cmd == nil {
-			t.Fatal("expected non-nil *exec.Cmd")
+		if e == "CUSTOM_VAR=testval" {
+			foundCustom = true
 		}
-		if cmd.Args[0] != "echo" {
-			t.Errorf("expected cmd.Args[0] == 'echo', got %q", cmd.Args[0])
-		}
-	})
-
-	t.Run("with env — cmd.Env includes custom var", func(t *testing.T) {
-		config := executionConfig{
-			Env: map[string]string{"GOOS": "linux", "CUSTOM_VAR": "testval"},
-		}
-		cmd, err := e.newPipelineCmd(ctx, []string{"go", "version"}, 0, config)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if cmd == nil {
-			t.Fatal("expected non-nil *exec.Cmd")
-		}
-		if len(cmd.Env) == 0 {
-			t.Fatal("expected cmd.Env to be non-empty")
-		}
-		foundGOOS := false
-		foundCustom := false
-		for _, e := range cmd.Env {
-			if e == "GOOS=linux" {
-				foundGOOS = true
-			}
-			if e == "CUSTOM_VAR=testval" {
-				foundCustom = true
-			}
-		}
-		if !foundGOOS {
-			t.Error("cmd.Env missing GOOS=linux")
-		}
-		if !foundCustom {
-			t.Error("cmd.Env missing CUSTOM_VAR=testval")
-		}
-	})
+	}
+	if !foundGOOS {
+		t.Error("cmd.Env missing GOOS=linux")
+	}
+	if !foundCustom {
+		t.Error("cmd.Env missing CUSTOM_VAR=testval")
+	}
 }
 
 // ---------------------------------------------------------------------------
 // handleCaptureError tests
 // ---------------------------------------------------------------------------
 
-func TestProcessExecutor_handleCaptureError(t *testing.T) {
+func TestProcessExecutor_handleCaptureError_NilError(t *testing.T) {
 	e := newprocessExecutor()
+	var sb strings.Builder
+	var mu sync.Mutex
+	truncated := &atomic.Bool{}
+	e.handleCaptureError(nil, &sb, &mu, executionConfig{}, truncated, 100)
+	if sb.String() != "" {
+		t.Errorf("expected empty sb, got %q", sb.String())
+	}
+	if truncated.Load() {
+		t.Error("expected truncated=false")
+	}
+}
 
-	t.Run("nil error — no-op", func(t *testing.T) {
-		var sb strings.Builder
-		var mu sync.Mutex
-		truncated := &atomic.Bool{}
+func TestProcessExecutor_handleCaptureError_ErrTooLongWithCapacity(t *testing.T) {
+	e := newprocessExecutor()
+	var sb strings.Builder
+	var mu sync.Mutex
+	truncated := &atomic.Bool{}
+	e.handleCaptureError(bufio.ErrTooLong, &sb, &mu, executionConfig{}, truncated, 500)
+	got := sb.String()
+	if !strings.Contains(got, "[Warning] Output line too long") {
+		t.Errorf("expected 'too long' warning, got %q", got)
+	}
+	if truncated.Load() {
+		t.Error("expected truncated=false when capacity remains")
+	}
+}
 
-		e.handleCaptureError(nil, &sb, &mu, executionConfig{}, truncated, 100)
+func TestProcessExecutor_handleCaptureError_ErrTooLongNoCapacity(t *testing.T) {
+	e := newprocessExecutor()
+	var sb strings.Builder
+	sb.WriteString("12345")
+	var mu sync.Mutex
+	truncated := &atomic.Bool{}
+	e.handleCaptureError(bufio.ErrTooLong, &sb, &mu, executionConfig{}, truncated, 5)
+	if sb.String() != "12345" {
+		t.Errorf("expected sb unchanged %q, got %q", "12345", sb.String())
+	}
+	if !truncated.Load() {
+		t.Error("expected truncated=true when at max capacity")
+	}
+}
 
-		if sb.String() != "" {
-			t.Errorf("expected empty sb, got %q", sb.String())
-		}
-		if truncated.Load() {
-			t.Error("expected truncated=false")
-		}
-	})
+func TestProcessExecutor_handleCaptureError_WithFeedback(t *testing.T) {
+	e := newprocessExecutor()
+	var sb strings.Builder
+	var mu sync.Mutex
+	truncated := &atomic.Bool{}
+	feedback := &bytes.Buffer{}
+	config := executionConfig{Feedback: feedback}
+	e.handleCaptureError(fmt.Errorf("test error"), &sb, &mu, config, truncated, 500)
+	if !strings.Contains(sb.String(), "[Warning] Output read error: test error") {
+		t.Errorf("expected error warning in sb, got %q", sb.String())
+	}
+	fb := feedback.String()
+	if !strings.Contains(fb, "[Warning] Output read error: test error") {
+		t.Errorf("expected warning in feedback, got %q", fb)
+	}
+}
 
-	t.Run("ErrTooLong with capacity — warning written", func(t *testing.T) {
-		var sb strings.Builder
-		var mu sync.Mutex
-		truncated := &atomic.Bool{}
-
-		e.handleCaptureError(bufio.ErrTooLong, &sb, &mu, executionConfig{}, truncated, 500)
-
-		got := sb.String()
-		if !strings.Contains(got, "[Warning] Output line too long") {
-			t.Errorf("expected 'too long' warning, got %q", got)
-		}
-		if truncated.Load() {
-			t.Error("expected truncated=false when capacity remains")
-		}
-	})
-
-	t.Run("ErrTooLong no capacity — truncated flag set, sb unchanged", func(t *testing.T) {
-		var sb strings.Builder
-		sb.WriteString("12345") // pre-fill exactly 5 bytes
-		var mu sync.Mutex
-		truncated := &atomic.Bool{}
-
-		e.handleCaptureError(bufio.ErrTooLong, &sb, &mu, executionConfig{}, truncated, 5)
-
-		if sb.String() != "12345" {
-			t.Errorf("expected sb unchanged %q, got %q", "12345", sb.String())
-		}
-		if !truncated.Load() {
-			t.Error("expected truncated=true when at max capacity")
-		}
-	})
-
-	t.Run("error with feedback writer", func(t *testing.T) {
-		var sb strings.Builder
-		var mu sync.Mutex
-		truncated := &atomic.Bool{}
-		feedback := &bytes.Buffer{}
-		config := executionConfig{Feedback: feedback}
-
-		e.handleCaptureError(fmt.Errorf("test error"), &sb, &mu, config, truncated, 500)
-
-		if !strings.Contains(sb.String(), "[Warning] Output read error: test error") {
-			t.Errorf("expected error warning in sb, got %q", sb.String())
-		}
-		fb := feedback.String()
-		if !strings.Contains(fb, "[Warning] Output read error: test error") {
-			t.Errorf("expected warning in feedback, got %q", fb)
-		}
-	})
-
-	t.Run("truncation when message exceeds remaining capacity", func(t *testing.T) {
-		var sb strings.Builder
-		sb.WriteString("abcde") // 5 bytes prefilled
-		var mu sync.Mutex
-		truncated := &atomic.Bool{}
-
-		// maxCapture=10, sb has 5 bytes, remaining=5
-		// The fullMsg "\n[Warning] Output read error: ...\n" is > 5 bytes
-		e.handleCaptureError(fmt.Errorf("truncation test error"), &sb, &mu, executionConfig{}, truncated, 10)
-
-		if !truncated.Load() {
-			t.Error("expected truncated=true when message exceeds remaining capacity")
-		}
-		if sb.Len() > 10 {
-			t.Errorf("expected sb length <= 10, got %d", sb.Len())
-		}
-		if !strings.Contains(sb.String(), "[War") {
-			t.Errorf("expected warning prefix in sb, got %q", sb.String())
-		}
-	})
+func TestProcessExecutor_handleCaptureError_Truncation(t *testing.T) {
+	e := newprocessExecutor()
+	var sb strings.Builder
+	sb.WriteString("abcde")
+	var mu sync.Mutex
+	truncated := &atomic.Bool{}
+	e.handleCaptureError(fmt.Errorf("truncation test error"), &sb, &mu, executionConfig{}, truncated, 10)
+	if !truncated.Load() {
+		t.Error("expected truncated=true when message exceeds remaining capacity")
+	}
+	if sb.Len() > 10 {
+		t.Errorf("expected sb length <= 10, got %d", sb.Len())
+	}
+	if !strings.Contains(sb.String(), "[War") {
+		t.Errorf("expected warning prefix in sb, got %q", sb.String())
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -1740,125 +1734,105 @@ func TestNewPipelineCmd_CancelGuard(t *testing.T) {
 // Task 4 — Command/Pipeline error path hardening
 // ---------------------------------------------------------------------------
 
-// TestPipeline_WirePipesCleanupOnFailure verifies that when wirePipes fails
-// mid-allocation, partially-allocated pipes are properly closed via the
-// deferred closePipes() call, preventing file descriptor leaks.
-func TestPipeline_WirePipesCleanupOnFailure(t *testing.T) {
-	t.Run("stderr pipe failure mid-pipeline", func(t *testing.T) {
-		cmd1 := exec.Command("echo", "hello")
-		cmd2 := exec.Command("echo", "world")
-		cmd3 := exec.Command("echo", "third")
-
-		// Pre-consume cmd3's StderrPipe so wirePipes fails on it
-		if _, err := cmd3.StderrPipe(); err != nil {
-			t.Fatalf("failed to pre-consume StderrPipe: %v", err)
-		}
-
-		p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2, cmd3}}
-		err := p.wirePipes()
-		if err == nil {
-			t.Fatal("expected wirePipes to fail on pre-consumed StderrPipe")
-		}
-		if !strings.Contains(err.Error(), "failed to get stderr pipe for command 2") {
-			t.Errorf("expected stderr pipe error for command 2, got: %v", err)
-		}
-		// Verify cleanup: closePipes should be safe to call (no double-close panic)
-		// The deferred closePipes already ran, so calling again should be a no-op
-		p.closePipes()
-	})
-
-	t.Run("stdout pipe failure mid-pipeline", func(t *testing.T) {
-		cmd1 := exec.Command("echo", "hello")
-		cmd2 := exec.Command("echo", "world")
-		cmd3 := exec.Command("echo", "third")
-
-		// Pre-consume cmd1's StdoutPipe so wirePipes fails on first iteration's stdout
-		if _, err := cmd1.StdoutPipe(); err != nil {
-			t.Fatalf("failed to pre-consume StdoutPipe: %v", err)
-		}
-
-		p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2, cmd3}}
-		err := p.wirePipes()
-		if err == nil {
-			t.Fatal("expected wirePipes to fail on pre-consumed StdoutPipe")
-		}
-		if !strings.Contains(err.Error(), "failed to get stdout pipe for command 0") {
-			t.Errorf("expected stdout pipe error for command 0, got: %v", err)
-		}
-		// Verify cleanup: cmd1's stderr was already obtained → pipes should have 1 entry
-		// The defer already closed it; calling closePipes again is safe
-		if len(p.pipes) != 1 {
-			t.Errorf("expected 1 pipe (cmd1 stderr) before cleanup, got %d", len(p.pipes))
-		}
-		p.closePipes()
-	})
-
-	t.Run("last stdout pipe fails", func(t *testing.T) {
-		cmd1 := exec.Command("echo", "hello")
-		cmd2 := exec.Command("echo", "world")
-
-		// Pre-consume cmd2's StdoutPipe (the last command's stdout)
-		if _, err := cmd2.StdoutPipe(); err != nil {
-			t.Fatalf("failed to pre-consume StdoutPipe: %v", err)
-		}
-
-		p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2}}
-		err := p.wirePipes()
-		if err == nil {
-			t.Fatal("expected wirePipes to fail on pre-consumed last StdoutPipe")
-		}
-		if !strings.Contains(err.Error(), "failed to get stdout pipe for last command") {
-			t.Errorf("expected last stdout pipe error, got: %v", err)
-		}
-		// Verify cleanup: cmd1's stderr, cmd1's stdout, and cmd2's stderr
-		// were all allocated before the failure. The defer should have closed all 3.
-		if len(p.pipes) != 3 {
-			t.Errorf("expected 3 pipes before cleanup, got %d", len(p.pipes))
-		}
-		p.closePipes()
-	})
+func TestPipeline_WirePipesCleanupOnFailure_StderrPipe(t *testing.T) {
+	cmd1 := exec.Command("echo", "hello")
+	cmd2 := exec.Command("echo", "world")
+	cmd3 := exec.Command("echo", "third")
+	if _, err := cmd3.StderrPipe(); err != nil {
+		t.Fatalf("failed to pre-consume StderrPipe: %v", err)
+	}
+	p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2, cmd3}}
+	err := p.wirePipes()
+	if err == nil {
+		t.Fatal("expected wirePipes to fail on pre-consumed StderrPipe")
+	}
+	if !strings.Contains(err.Error(), "failed to get stderr pipe for command 2") {
+		t.Errorf("expected stderr pipe error for command 2, got: %v", err)
+	}
+	p.closePipes()
 }
 
-// TestRunCommand_NonExitError verifies RunCommand behavior when the process
-// is terminated by a signal (non-*exec.ExitError) or when the executable
-// cannot be found at all.
-func TestRunCommand_NonExitError(t *testing.T) {
+func TestPipeline_WirePipesCleanupOnFailure_StdoutPipe(t *testing.T) {
+	cmd1 := exec.Command("echo", "hello")
+	cmd2 := exec.Command("echo", "world")
+	cmd3 := exec.Command("echo", "third")
+	if _, err := cmd1.StdoutPipe(); err != nil {
+		t.Fatalf("failed to pre-consume StdoutPipe: %v", err)
+	}
+	p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2, cmd3}}
+	err := p.wirePipes()
+	if err == nil {
+		t.Fatal("expected wirePipes to fail on pre-consumed StdoutPipe")
+	}
+	if !strings.Contains(err.Error(), "failed to get stdout pipe for command 0") {
+		t.Errorf("expected stdout pipe error for command 0, got: %v", err)
+	}
+	if len(p.pipes) != 1 {
+		t.Errorf("expected 1 pipe (cmd1 stderr) before cleanup, got %d", len(p.pipes))
+	}
+	p.closePipes()
+}
+
+func TestPipeline_WirePipesCleanupOnFailure_LastStdoutPipe(t *testing.T) {
+	cmd1 := exec.Command("echo", "hello")
+	cmd2 := exec.Command("echo", "world")
+	if _, err := cmd2.StdoutPipe(); err != nil {
+		t.Fatalf("failed to pre-consume StdoutPipe: %v", err)
+	}
+	p := &pipeline{cmds: []*exec.Cmd{cmd1, cmd2}}
+	err := p.wirePipes()
+	if err == nil {
+		t.Fatal("expected wirePipes to fail on pre-consumed last StdoutPipe")
+	}
+	if !strings.Contains(err.Error(), "failed to get stdout pipe for last command") {
+		t.Errorf("expected last stdout pipe error, got: %v", err)
+	}
+	if len(p.pipes) != 3 {
+		t.Errorf("expected 3 pipes before cleanup, got %d", len(p.pipes))
+	}
+	p.closePipes()
+}
+
+// TestRunCommand_NonExitError_SignalKill verifies RunCommand behavior when
+// the process is terminated by a signal (via context timeout), producing a
+// non-*exec.ExitError. The exit code must be non-zero and partial output
+// should be preserved.
+func TestRunCommand_NonExitError_SignalKill(t *testing.T) {
 	e := newprocessExecutor()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	res, err := e.RunCommand(ctx, []string{helperPath, "sleep", "10"}, executionConfig{})
+	if err == nil {
+		t.Fatal("expected error from killed command")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Logf("expected context error, got: %v (may vary by OS)", err)
+	}
+	if res.ExitCode == 0 {
+		t.Error("expected non-zero exit code for killed command")
+	}
+	if res.Output == "" {
+		t.Log("no partial output captured (OK — command may not have produced output before kill)")
+	}
+}
 
-	t.Run("command killed by signal", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
-		defer cancel()
-		res, err := e.RunCommand(ctx, []string{helperPath, "sleep", "10"}, executionConfig{})
-		if err == nil {
-			t.Fatal("expected error from killed command")
-		}
-		if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
-			t.Logf("expected context error, got: %v (may vary by OS)", err)
-		}
-		if res.ExitCode == 0 {
-			t.Error("expected non-zero exit code for killed command")
-		}
-		// Partial output should be returned (the process may have produced some)
-		if res.Output == "" {
-			t.Log("no partial output captured (OK — command may not have produced output before kill)")
-		}
-	})
-
-	t.Run("command not found", func(t *testing.T) {
-		ctx := context.Background()
-		res, err := e.RunCommand(ctx, []string{"nonexistent_command_xyz_31415"}, executionConfig{})
-		if err == nil {
-			t.Fatal("expected error for nonexistent command")
-		}
-		if !strings.Contains(err.Error(), "executable file not found") &&
-			!strings.Contains(err.Error(), "not found") &&
-			!strings.Contains(err.Error(), "failed to start") {
-			t.Logf("expected 'not found' or 'failed to start' in error, got: %v", err)
-		}
-		if res.ExitCode != 1 {
-			t.Errorf("expected exit code 1 for nonexistent command, got %d", res.ExitCode)
-		}
-	})
+// TestRunCommand_NonExitError_CommandNotFound verifies RunCommand behavior
+// when the executable cannot be found.
+func TestRunCommand_NonExitError_CommandNotFound(t *testing.T) {
+	e := newprocessExecutor()
+	ctx := context.Background()
+	res, err := e.RunCommand(ctx, []string{"nonexistent_command_xyz_31415"}, executionConfig{})
+	if err == nil {
+		t.Fatal("expected error for nonexistent command")
+	}
+	if !strings.Contains(err.Error(), "executable file not found") &&
+		!strings.Contains(err.Error(), "not found") &&
+		!strings.Contains(err.Error(), "failed to start") {
+		t.Logf("expected 'not found' or 'failed to start' in error, got: %v", err)
+	}
+	if res.ExitCode != 1 {
+		t.Errorf("expected exit code 1 for nonexistent command, got %d", res.ExitCode)
+	}
 }
 
 // TestRunCommand_OutputFileCloseError verifies the Close error propagation

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -292,93 +292,112 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 	})
 }
 
-func TestRegisterGit_PartialFailure(t *testing.T) {
+// TestRegisterGit_PartialFailure_GetGitStatus verifies that registerGit
+// propagates errors when the first RegisterToToolkit call fails.
+func TestRegisterGit_PartialFailure_GetGitStatus(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "get_git_status",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
+}
 
-	t.Run("first RegisterToToolkit fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "get_git_status",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
+// TestRegisterGit_PartialFailure_GetGitBlame verifies that registerGit
+// propagates errors when a mid-sequence RegisterToToolkit call fails.
+func TestRegisterGit_PartialFailure_GetGitBlame(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "get_git_blame",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
+}
 
-	t.Run("mid RegisterToToolkit fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "get_git_blame",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
+// TestRegisterGit_PartialFailure_GitCommit verifies that registerGit
+// propagates errors when RegisterToToolkitWithOptions fails.
+func TestRegisterGit_PartialFailure_GitCommit(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "git_commit",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
+}
 
-	t.Run("RegisterToToolkitWithOptions fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "git_commit",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
+// TestRegisterGit_PartialFailure_GetGitDiff verifies that registerGit
+// propagates errors when the second RegisterToToolkit call fails.
+func TestRegisterGit_PartialFailure_GetGitDiff(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "get_git_diff",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
+}
 
-	t.Run("second RegisterToToolkit fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "get_git_diff",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
+// TestRegisterGit_PartialFailure_GitCreateBranch verifies that registerGit
+// propagates errors when the last RegisterToToolkitWithOptions call fails.
+func TestRegisterGit_PartialFailure_GitCreateBranch(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "git_create_branch",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
+}
 
-	t.Run("last RegisterToToolkitWithOptions fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "git_create_branch",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
-
-	t.Run("third RegisterToToolkit fails", func(t *testing.T) {
-		registry := &failingRegistry{
-			mockToolRegistry: &mockToolRegistry{},
-			failOnTool:       "get_git_log",
-		}
-		err := registerGit(registry, sm, exec)
-		if err == nil {
-			t.Fatal("expected error from registerGit")
-		}
-		if !strings.Contains(err.Error(), "injected failure") {
-			t.Errorf("expected 'injected failure', got %q", err.Error())
-		}
-	})
+// TestRegisterGit_PartialFailure_GetGitLog verifies that registerGit
+// propagates errors when the third RegisterToToolkit call fails.
+func TestRegisterGit_PartialFailure_GetGitLog(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	exec := &toolstest.MockExecutor{}
+	registry := &failingRegistry{
+		mockToolRegistry: &mockToolRegistry{},
+		failOnTool:       "get_git_log",
+	}
+	err := registerGit(registry, sm, exec)
+	if err == nil {
+		t.Fatal("expected error from registerGit")
+	}
+	if !strings.Contains(err.Error(), "injected failure") {
+		t.Errorf("expected 'injected failure', got %q", err.Error())
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/tools/workspace/search_test.go
+++ b/internal/tools/workspace/search_test.go
@@ -251,71 +251,82 @@ func TestSearchFiles_TooManyResults(t *testing.T) {
 // createSearchMatcher tests
 // ---------------------------------------------------------------------------
 
-func TestCreateSearchMatcher(t *testing.T) {
+// TestCreateSearchMatcher_LiteralMatch verifies the literal match
+// path returns true when a line contains the query string.
+func TestCreateSearchMatcher_LiteralMatch(t *testing.T) {
 	s := &fileSearcher{}
+	matcher, err := s.createSearchMatcher("hello", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matcher == nil {
+		t.Fatal("expected non-nil matcher")
+	}
+	_, ok := matcher("ignored-path.txt", "hello world")
+	if !ok {
+		t.Error("expected true for line containing 'hello'")
+	}
+}
 
-	t.Run("literal match", func(t *testing.T) {
-		matcher, err := s.createSearchMatcher("hello", false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if matcher == nil {
-			t.Fatal("expected non-nil matcher")
-		}
-		_, ok := matcher("ignored-path.txt", "hello world")
-		if !ok {
-			t.Error("expected true for line containing 'hello'")
-		}
-	})
+// TestCreateSearchMatcher_LiteralNoMatch verifies the literal match
+// path returns false when a line does not contain the query string.
+func TestCreateSearchMatcher_LiteralNoMatch(t *testing.T) {
+	s := &fileSearcher{}
+	matcher, err := s.createSearchMatcher("hello", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, ok := matcher("ignored-path.txt", "goodbye world")
+	if ok {
+		t.Error("expected false for line not containing 'hello'")
+	}
+}
 
-	t.Run("literal no match", func(t *testing.T) {
-		matcher, err := s.createSearchMatcher("hello", false)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		_, ok := matcher("ignored-path.txt", "goodbye world")
-		if ok {
-			t.Error("expected false for line not containing 'hello'")
-		}
-	})
+// TestCreateSearchMatcher_RegexValidMatch verifies the regex match
+// path returns true when a line matches the pattern.
+func TestCreateSearchMatcher_RegexValidMatch(t *testing.T) {
+	s := &fileSearcher{}
+	matcher, err := s.createSearchMatcher("^func", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if matcher == nil {
+		t.Fatal("expected non-nil matcher")
+	}
+	_, ok := matcher("ignored.go", "func main() {}")
+	if !ok {
+		t.Error("expected true for line starting with 'func'")
+	}
+}
 
-	t.Run("regex valid match", func(t *testing.T) {
-		matcher, err := s.createSearchMatcher("^func", true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if matcher == nil {
-			t.Fatal("expected non-nil matcher")
-		}
-		_, ok := matcher("ignored.go", "func main() {}")
-		if !ok {
-			t.Error("expected true for line starting with 'func'")
-		}
-	})
+// TestCreateSearchMatcher_RegexValidNoMatch verifies the regex match
+// path returns false when a line does not match the pattern.
+func TestCreateSearchMatcher_RegexValidNoMatch(t *testing.T) {
+	s := &fileSearcher{}
+	matcher, err := s.createSearchMatcher("^func", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, ok := matcher("ignored.go", "var x = 1")
+	if ok {
+		t.Error("expected false for line not starting with 'func'")
+	}
+}
 
-	t.Run("regex valid no match", func(t *testing.T) {
-		matcher, err := s.createSearchMatcher("^func", true)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		_, ok := matcher("ignored.go", "var x = 1")
-		if ok {
-			t.Error("expected false for line not starting with 'func'")
-		}
-	})
-
-	t.Run("regex invalid", func(t *testing.T) {
-		matcher, err := s.createSearchMatcher("[invalid", true)
-		if err == nil {
-			t.Fatal("expected error for invalid regex")
-		}
-		if matcher != nil {
-			t.Error("expected nil matcher for invalid regex")
-		}
-		if !strings.Contains(err.Error(), "invalid regex") {
-			t.Errorf("expected 'invalid regex' in error, got %q", err.Error())
-		}
-	})
+// TestCreateSearchMatcher_RegexInvalid verifies that an invalid regex
+// pattern returns an error and a nil matcher.
+func TestCreateSearchMatcher_RegexInvalid(t *testing.T) {
+	s := &fileSearcher{}
+	matcher, err := s.createSearchMatcher("[invalid", true)
+	if err == nil {
+		t.Fatal("expected error for invalid regex")
+	}
+	if matcher != nil {
+		t.Error("expected nil matcher for invalid regex")
+	}
+	if !strings.Contains(err.Error(), "invalid regex") {
+		t.Errorf("expected 'invalid regex' in error, got %q", err.Error())
+	}
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #493.

## Summary
Extract t.Run sub-test closures into top-level test functions across 4 workspace test files. Extract assertion helpers where table-driven tests had inline conditional checks. All 11 targeted functions now below cyclomatic complexity threshold of 10.

| File | Functions | Before | After |
|------|-----------|--------|-------|
| search_test.go | TestCreateSearchMatcher | 14 | 3–4 (×5) |
| registration_test.go | TestRegisterGit_PartialFailure | 13 | 3 (×6) |
| backup_test.go | TestBackupManager_Undo | 12 | 5 (×2) |
| backup_test.go | runUndoErrorTest | 11 | 1 |
| process_executor_test.go | 7 functions | 11–16 | 3–9 |

Zero production code changes. All test assertions preserved verbatim.

## Verification
| Check | Status |
|-------|--------|
| go test -race ./internal/tools/workspace/... | PASS (10.4s) |
| golangci-lint (workspace/) | Only pre-existing persistence_tools.go:32 |
| Complexity (all 11 target fns) | <10 |
