### PR TITLE
fix(analysis): reduce cyclomatic complexity of 11 functions below threshold 10 (#494)

### DIFF
--- a/internal/tools/analysis/changes.go
+++ b/internal/tools/analysis/changes.go
@@ -50,24 +50,12 @@ func (a *defaultChangeAnalyzer) SemanticDiff(ctx context.Context, args map[strin
 		return tools.ToolResult{Text: sb.String() + "\n(Could not perform logical analysis)"}, nil
 	}
 
-	sb.WriteString("\nLogical Code Changes:\n")
 	fset := token.NewFileSet()
-	for i, relPath := range changedFiles {
-		if i%5 == 0 && hb != nil {
-			select {
-			case hb <- struct{}{}:
-			default:
-			}
-		}
-		if a.isGoFile(relPath) {
-			changes, changeErr := a.analyzeFileChange(ctx, params.Target, relPath, fset)
-			if changeErr != nil {
-				// Soft-fail: include error in output but continue
-				a.renderChanges(&sb, relPath, []string{"(analysis error: " + changeErr.Error() + ")"})
-			} else {
-				a.renderChanges(&sb, relPath, changes)
-			}
-		}
+	fileChanges := a.analyzeChangedFiles(ctx, params.Target, changedFiles, fset, hb)
+
+	sb.WriteString("\nLogical Code Changes:\n")
+	for relPath, changes := range fileChanges {
+		a.renderChanges(&sb, relPath, changes)
 	}
 
 	return tools.ToolResult{Text: sb.String()}, nil
@@ -104,6 +92,38 @@ func (a *defaultChangeAnalyzer) getDiffMetadata(ctx context.Context, target stri
 	changedFiles := strings.Split(filesRaw, "\n")
 
 	return sb.String(), changedFiles, nil
+}
+
+// analyzeChangedFiles iterates over changed files, sending heartbeats and
+// analyzing Go files. Non-Go files are skipped silently. Analysis errors
+// are captured as soft-fail messages rather than failing the entire diff.
+func (a *defaultChangeAnalyzer) analyzeChangedFiles(
+	ctx context.Context,
+	target string,
+	changedFiles []string,
+	fset *token.FileSet,
+	hb chan<- struct{},
+) map[string][]string {
+	fileChanges := make(map[string][]string, len(changedFiles))
+
+	for i, relPath := range changedFiles {
+		if i%5 == 0 && hb != nil {
+			select {
+			case hb <- struct{}{}:
+			default:
+			}
+		}
+		if !a.isGoFile(relPath) {
+			continue
+		}
+		changes, changeErr := a.analyzeFileChange(ctx, target, relPath, fset)
+		if changeErr != nil {
+			fileChanges[relPath] = []string{"(analysis error: " + changeErr.Error() + ")"}
+		} else {
+			fileChanges[relPath] = changes
+		}
+	}
+	return fileChanges
 }
 
 func (a *defaultChangeAnalyzer) analyzeFileChange(ctx context.Context, target, relPath string, fset *token.FileSet) ([]string, error) {

--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -173,6 +173,49 @@ func (a *defaultDeadCodeAnalyzer) identifyModule(pkgs []*packages.Package) (stri
 	return "", fmt.Errorf("no go.mod found")
 }
 
+// accumulateFirstError stores the first non-nil error into collectedErr.
+func accumulateFirstError(collectedErr *error, err error) {
+	if *collectedErr == nil {
+		*collectedErr = err
+	}
+}
+
+// sendHeartbeat sends a non-blocking pulse on hb every 20th call (when i%20==0).
+// It is a no-op when hb is nil.
+func sendHeartbeat(i int, hb chan<- struct{}) {
+	if i%20 != 0 || hb == nil {
+		return
+	}
+	select {
+	case hb <- struct{}{}:
+	default:
+	}
+}
+
+// analyzeSingleUsage processes one symbol's usage data: tracking external
+// usages, protecting interface contract symbols, and processing
+// implementations. It returns any error from trackExternalUsages for
+// soft-fail accumulation.
+func (a *defaultDeadCodeAnalyzer) analyzeSingleUsage(
+	ctx context.Context,
+	state *scanState,
+	id string,
+	meta *symMeta,
+	fileToPkg map[string]string,
+	resolvedPath string,
+	hb chan<- struct{},
+) error {
+	var trackErr error
+	if err := a.trackExternalUsages(ctx, state, id, meta, fileToPkg, resolvedPath, hb); err != nil {
+		trackErr = err
+	}
+	if a.isInterfaceSymbol(meta) {
+		a.protectContractSymbol(state, id)
+	}
+	a.processImplementations(ctx, state, id, hb)
+	return trackErr
+}
+
 func (a *defaultDeadCodeAnalyzer) analyzeUsages(ctx context.Context, state *scanState, resolvedPath string, hb chan<- struct{}) {
 	fileToPkg := a.buildFileToPkgMap(state.pkgs)
 
@@ -184,24 +227,12 @@ func (a *defaultDeadCodeAnalyzer) analyzeUsages(ctx context.Context, state *scan
 
 	var collectedErr error
 	for i, id := range ids {
-		if i%20 == 0 && hb != nil {
-			select {
-			case hb <- struct{}{}:
-			default:
-			}
-		}
+		sendHeartbeat(i, hb)
 
 		meta := state.declarations[id]
-		if err := a.trackExternalUsages(ctx, state, id, meta, fileToPkg, resolvedPath, hb); err != nil {
-			// soft-fail: collect error, continue processing remaining symbols
-			if collectedErr == nil {
-				collectedErr = err
-			}
+		if err := a.analyzeSingleUsage(ctx, state, id, meta, fileToPkg, resolvedPath, hb); err != nil {
+			accumulateFirstError(&collectedErr, err)
 		}
-		if a.isInterfaceSymbol(meta) {
-			a.protectContractSymbol(state, id)
-		}
-		a.processImplementations(ctx, state, id, hb)
 	}
 	if collectedErr != nil {
 		slog.Warn("usage lookup errors occurred", "error", collectedErr)
@@ -367,12 +398,7 @@ func (a *defaultDeadCodeAnalyzer) propagateInterfaceUsages(ctx context.Context, 
 	snapshotTotal, snapshotExternal, ids := takeUsageSnapshots(state)
 
 	for i, id := range ids {
-		if i%20 == 0 && hb != nil {
-			select {
-			case hb <- struct{}{}:
-			default:
-			}
-		}
+		sendHeartbeat(i, hb)
 
 		if count := snapshotTotal[id]; count > 0 {
 			a.propagateUsageToImplementations(ctx, id, count, snapshotExternal, state, hb)

--- a/internal/tools/analysis/index_harvest_test.go
+++ b/internal/tools/analysis/index_harvest_test.go
@@ -19,158 +19,134 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
-func TestSendResult(t *testing.T) {
+func TestSendResult_ContextAlreadyCancelled(t *testing.T) {
 	t.Parallel()
 
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	results := make(chan pkgResult)
+	hb := make(chan struct{}, 1)
+
+	err := sendResult(ctx, results, pkgResult{
+		symbols: make(map[string][]symbolLocation),
+		usages:  make(map[string][]location),
+	}, hb)
+	assert.ErrorIs(t, err, context.Canceled)
+
+	select {
+	case <-results:
+		t.Error("unexpected result on results channel when context cancelled")
+	default:
+	}
+	select {
+	case <-hb:
+		t.Error("unexpected heartbeat on hb channel when context cancelled")
+	default:
+	}
+}
+
+func TestSendResult_SuccessfulSendWithNilHb(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	results := make(chan pkgResult, 1)
 	emptyResult := pkgResult{
 		symbols: make(map[string][]symbolLocation),
 		usages:  make(map[string][]location),
 	}
 
-	// -------------------------------------------------------------------
-	// EC1: context already cancelled
-	//
-	// Use an unbuffered results channel with no receiver so that
-	// the send branch always blocks.  With only ctx.Done() ready,
-	// select deterministically returns context.Canceled.
-	// -------------------------------------------------------------------
-	t.Run("context already cancelled", func(t *testing.T) {
-		t.Parallel()
+	err := sendResult(ctx, results, emptyResult, nil)
+	assert.NoError(t, err)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // immediately cancel
+	select {
+	case got := <-results:
+		assert.Equal(t, emptyResult, got)
+	default:
+		t.Error("expected result on results channel")
+	}
+}
 
-		results := make(chan pkgResult) // unbuffered, no receiver → send blocks
-		hb := make(chan struct{}, 1)
+func TestSendResult_SuccessfulSendWithNonNilHb(t *testing.T) {
+	t.Parallel()
 
-		err := sendResult(ctx, results, emptyResult, hb)
-		assert.ErrorIs(t, err, context.Canceled)
+	ctx := context.Background()
+	results := make(chan pkgResult, 1)
+	hb := make(chan struct{}, 1)
+	emptyResult := pkgResult{
+		symbols: make(map[string][]symbolLocation),
+		usages:  make(map[string][]location),
+	}
 
-		// Nothing sent on results.
-		select {
-		case <-results:
-			t.Error("unexpected result on results channel when context cancelled")
-		default:
-		}
-		// No heartbeat.
-		select {
-		case <-hb:
-			t.Error("unexpected heartbeat on hb channel when context cancelled")
-		default:
-		}
-	})
+	err := sendResult(ctx, results, emptyResult, hb)
+	assert.NoError(t, err)
 
-	// -------------------------------------------------------------------
-	// EC2: successful send with nil hb
-	// -------------------------------------------------------------------
-	t.Run("successful send with nil hb", func(t *testing.T) {
-		t.Parallel()
+	select {
+	case got := <-results:
+		assert.Equal(t, emptyResult, got)
+	default:
+		t.Error("expected result on results channel")
+	}
+	select {
+	case <-hb:
+	default:
+		t.Error("expected heartbeat on hb channel")
+	}
+}
 
-		ctx := context.Background()
-		results := make(chan pkgResult, 1)
+func TestSendResult_HbChannelFull(t *testing.T) {
+	t.Parallel()
 
-		err := sendResult(ctx, results, emptyResult, nil)
-		assert.NoError(t, err)
+	ctx := context.Background()
+	results := make(chan pkgResult, 1)
+	hb := make(chan struct{})
+	emptyResult := pkgResult{
+		symbols: make(map[string][]symbolLocation),
+		usages:  make(map[string][]location),
+	}
 
-		select {
-		case got := <-results:
-			assert.Equal(t, emptyResult, got)
-		default:
-			t.Error("expected result on results channel")
-		}
-	})
+	err := sendResult(ctx, results, emptyResult, hb)
+	assert.NoError(t, err)
 
-	// -------------------------------------------------------------------
-	// EC3: successful send with non-nil hb
-	// -------------------------------------------------------------------
-	t.Run("successful send with non-nil hb", func(t *testing.T) {
-		t.Parallel()
+	select {
+	case got := <-results:
+		assert.Equal(t, emptyResult, got)
+	default:
+		t.Error("expected result on results channel")
+	}
+	select {
+	case <-hb:
+		t.Error("unexpected heartbeat on unbuffered hb (should have been dropped)")
+	default:
+	}
+}
 
-		ctx := context.Background()
-		results := make(chan pkgResult, 1)
-		hb := make(chan struct{}, 1)
+func TestSendResult_ResultsChannelFull_ContextCancelled(t *testing.T) {
+	t.Parallel()
 
-		err := sendResult(ctx, results, emptyResult, hb)
-		assert.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	results := make(chan pkgResult)
+	emptyResult := pkgResult{
+		symbols: make(map[string][]symbolLocation),
+		usages:  make(map[string][]location),
+	}
 
-		// Result received.
-		select {
-		case got := <-results:
-			assert.Equal(t, emptyResult, got)
-		default:
-			t.Error("expected result on results channel")
-		}
-		// Heartbeat received.
-		select {
-		case <-hb:
-			// ok
-		default:
-			t.Error("expected heartbeat on hb channel")
-		}
-	})
+	ready := make(chan struct{})
+	go func() {
+		ready <- struct{}{}
+		time.Sleep(10 * time.Millisecond)
+		cancel()
+	}()
 
-	// -------------------------------------------------------------------
-	// EC4: hb channel full — no blocking
-	// -------------------------------------------------------------------
-	t.Run("hb channel full — no blocking", func(t *testing.T) {
-		t.Parallel()
+	<-ready
+	err := sendResult(ctx, results, emptyResult, nil)
+	assert.ErrorIs(t, err, context.Canceled)
 
-		ctx := context.Background()
-		results := make(chan pkgResult, 1)
-		// Unbuffered hb with no receiver: send would block without the
-		// default clause in sendResult.
-		hb := make(chan struct{})
-
-		err := sendResult(ctx, results, emptyResult, hb)
-		assert.NoError(t, err)
-
-		// Result must still be delivered (hb drop is silent).
-		select {
-		case got := <-results:
-			assert.Equal(t, emptyResult, got)
-		default:
-			t.Error("expected result on results channel")
-		}
-		// hb must be empty (heartbeat silently dropped via default).
-		select {
-		case <-hb:
-			t.Error("unexpected heartbeat on unbuffered hb (should have been dropped)")
-		default:
-		}
-	})
-
-	// -------------------------------------------------------------------
-	// EC5: results channel full — context cancelled
-	// -------------------------------------------------------------------
-	t.Run("results channel full — context cancelled", func(t *testing.T) {
-		t.Parallel()
-
-		ctx, cancel := context.WithCancel(context.Background())
-		// Unbuffered results with no receiver: sendResult will block on
-		// the send until the context is cancelled.
-		results := make(chan pkgResult)
-
-		// Orchestration pattern from TestGetImplementations_SingleflightCoalescing.
-		ready := make(chan struct{})
-		go func() {
-			ready <- struct{}{} // signal: I've started
-			time.Sleep(10 * time.Millisecond)
-			cancel()
-		}()
-
-		<-ready // wait for goroutine to be ready
-
-		// sendResult will block until the goroutine cancels the context.
-		err := sendResult(ctx, results, emptyResult, nil)
-		assert.ErrorIs(t, err, context.Canceled)
-
-		// Verify nothing was sent on results.
-		select {
-		case <-results:
-			t.Error("unexpected result on unbuffered results channel after cancellation")
-		default:
-		}
-	})
+	select {
+	case <-results:
+		t.Error("unexpected result on unbuffered results channel after cancellation")
+	default:
+	}
 }
 
 // mockFileInfo implements os.FileInfo for shouldIndexFile tests.
@@ -260,226 +236,208 @@ func TestShouldIndexFile(t *testing.T) {
 	}
 }
 
-func TestProcessFile(t *testing.T) {
+// TestProcessFile_ValidGoFile verifies that processFile correctly indexes
+// a valid Go source file: the harvester's currentPath is set to the
+// absolute path of the file, and symbols are collected.
+func TestProcessFile_ValidGoFile(t *testing.T) {
 	t.Parallel()
 	idx := &indexer{resolvePath: filepath.Abs}
 
-	// -------------------------------------------------------------------
-	// EC1: valid Go file, indexed
-	// -------------------------------------------------------------------
-	t.Run("valid Go file, indexed", func(t *testing.T) {
-		t.Parallel()
+	tmpDir := t.TempDir()
+	goFile := filepath.Join(tmpDir, "test.go")
+	content := "package p\n\nvar X = 1\n"
+	if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-		tmpDir := t.TempDir()
-		goFile := filepath.Join(tmpDir, "test.go")
-		content := "package p\n\nvar X = 1\n"
-		if err := os.WriteFile(goFile, []byte(content), 0644); err != nil {
-			t.Fatal(err)
-		}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, goFile, content, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, goFile, content, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
+	h := newHarvester(fset)
+	err = idx.processFile(fset, file, h)
+	if err != nil {
+		t.Fatalf("processFile: %v", err)
+	}
 
-		h := newHarvester(fset)
-		err = idx.processFile(fset, file, h)
-		if err != nil {
-			t.Fatalf("processFile: %v", err)
-		}
-
-		absPath, _ := filepath.Abs(goFile)
-		if h.currentPath != absPath {
-			t.Errorf("currentPath = %q; want %q", h.currentPath, absPath)
-		}
-		if len(h.symbolsByPath) == 0 {
-			t.Error("expected symbols to be collected")
-		}
-	})
-
-	// -------------------------------------------------------------------
-	// EC2: os.Stat fails (file deleted between Load and Refresh) — silent skip
-	// -------------------------------------------------------------------
-	t.Run("os.Stat fails, silent skip", func(t *testing.T) {
-		t.Parallel()
-
-		fset := token.NewFileSet()
-		path := "/nonexistent/deleted_file.go"
-		file, err := parser.ParseFile(fset, path, "package p", 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		h := newHarvester(fset)
-		err = idx.processFile(fset, file, h)
-		if err != nil {
-			t.Errorf("expected nil error for deleted file, got %v", err)
-		}
-		if h.currentPath != "" {
-			t.Errorf("currentPath = %q; want empty", h.currentPath)
-		}
-		if len(h.symbolsByPath) != 0 {
-			t.Error("expected no symbols for deleted file")
-		}
-	})
-
-	// -------------------------------------------------------------------
-	// EC3: shouldIndexFile returns false (non-.go file)
-	// -------------------------------------------------------------------
-	t.Run("shouldIndexFile returns false", func(t *testing.T) {
-		t.Parallel()
-
-		tmpDir := t.TempDir()
-		txtFile := filepath.Join(tmpDir, "test.txt")
-		if err := os.WriteFile(txtFile, []byte("not a go file"), 0644); err != nil {
-			t.Fatal(err)
-		}
-
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, txtFile, "package p", 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		h := newHarvester(fset)
-		err = idx.processFile(fset, file, h)
-		if err != nil {
-			t.Errorf("expected nil error, got %v", err)
-		}
-		if h.currentPath != "" {
-			t.Errorf("currentPath = %q; want empty", h.currentPath)
-		}
-		if len(h.symbolsByPath) != 0 {
-			t.Error("expected no symbols for non-.go file")
-		}
-	})
+	absPath, _ := filepath.Abs(goFile)
+	if h.currentPath != absPath {
+		t.Errorf("currentPath = %q; want %q", h.currentPath, absPath)
+	}
+	if len(h.symbolsByPath) == 0 {
+		t.Error("expected symbols to be collected")
+	}
 }
 
-func TestProcessPackage(t *testing.T) {
-	// All subtests are parallel-safe; DI-based resolvePath injection
-	// replaces the previous OS-level CWD manipulation.
+// TestProcessFile_OsStatFails verifies that processFile silently skips
+// a file when os.Stat fails (e.g. file deleted between Load and Refresh).
+// No error is returned, currentPath stays empty, and no symbols are recorded.
+func TestProcessFile_OsStatFails(t *testing.T) {
+	t.Parallel()
 	idx := &indexer{resolvePath: filepath.Abs}
 
-	// -------------------------------------------------------------------
-	// EC5: empty package, no Syntax
-	// -------------------------------------------------------------------
-	t.Run("empty package, no Syntax", func(t *testing.T) {
-		t.Parallel()
+	fset := token.NewFileSet()
+	path := "/nonexistent/deleted_file.go"
+	file, err := parser.ParseFile(fset, path, "package p", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		fset := token.NewFileSet()
-		pkg := types.NewPackage("example.com/test", "test")
-		manualPkg := &packages.Package{
-			Types:     pkg,
-			TypesInfo: &types.Info{},
-			Syntax:    nil, // zero Syntax files
-		}
+	h := newHarvester(fset)
+	err = idx.processFile(fset, file, h)
+	if err != nil {
+		t.Errorf("expected nil error for deleted file, got %v", err)
+	}
+	if h.currentPath != "" {
+		t.Errorf("currentPath = %q; want empty", h.currentPath)
+	}
+	if len(h.symbolsByPath) != 0 {
+		t.Error("expected no symbols for deleted file")
+	}
+}
 
-		ctx := context.Background()
-		result, err := idx.processPackage(ctx, fset, manualPkg)
-		assert.NoError(t, err)
-		assert.Empty(t, result.symbols)
-		assert.Empty(t, result.usages)
-	})
+// TestProcessFile_ShouldIndexFileReturnsFalse verifies that processFile
+// returns early without error when shouldIndexFile returns false (e.g.
+// for a non-.go file). currentPath stays empty and no symbols are recorded.
+func TestProcessFile_ShouldIndexFileReturnsFalse(t *testing.T) {
+	t.Parallel()
+	idx := &indexer{resolvePath: filepath.Abs}
 
-	// -------------------------------------------------------------------
-	// EC2: context cancelled before loop
-	// -------------------------------------------------------------------
-	t.Run("context cancelled before loop", func(t *testing.T) {
-		t.Parallel()
+	tmpDir := t.TempDir()
+	txtFile := filepath.Join(tmpDir, "test.txt")
+	if err := os.WriteFile(txtFile, []byte("not a go file"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\ngo 1.26\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package test\nvar X = 1\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, txtFile, "package p", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		fset := token.NewFileSet()
-		pkgs, err := packages.Load(&packages.Config{
-			Mode: packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedName,
-			Dir:  tmpDir,
-			Fset: fset,
-		}, ".")
-		if err != nil {
-			t.Fatalf("packages.Load: %v", err)
-		}
-		if len(pkgs) == 0 {
-			t.Fatal("expected at least one package")
-		}
+	h := newHarvester(fset)
+	err = idx.processFile(fset, file, h)
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if h.currentPath != "" {
+		t.Errorf("currentPath = %q; want empty", h.currentPath)
+	}
+	if len(h.symbolsByPath) != 0 {
+		t.Error("expected no symbols for non-.go file")
+	}
+}
 
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
+// EC5: empty package, no Syntax
+func TestProcessPackage_EmptyPackage(t *testing.T) {
+	t.Parallel()
 
-		_, err = idx.processPackage(ctx, fset, pkgs[0])
-		assert.ErrorIs(t, err, context.Canceled)
-	})
+	fset := token.NewFileSet()
+	pkg := types.NewPackage("example.com/test", "test")
+	manualPkg := &packages.Package{
+		Types:     pkg,
+		TypesInfo: &types.Info{},
+		Syntax:    nil,
+	}
 
-	// -------------------------------------------------------------------
-	// EC3: processFile error propagation
-	//
-	// Inject a failing resolvePath via DI to verify that path-resolution
-	// errors from processFile propagate correctly through processPackage.
-	// -------------------------------------------------------------------
-	t.Run("processFile error propagation", func(t *testing.T) {
-		t.Parallel()
+	idx := &indexer{resolvePath: filepath.Abs}
+	ctx := context.Background()
+	result, err := idx.processPackage(ctx, fset, manualPkg)
+	assert.NoError(t, err)
+	assert.Empty(t, result.symbols)
+	assert.Empty(t, result.usages)
+}
 
-		errInjected := errors.New("path resolution failed")
-		idx := &indexer{
-			resolvePath: func(string) (string, error) { return "", errInjected },
-		}
+// EC2: context cancelled before loop
+func TestProcessPackage_ContextCancelled(t *testing.T) {
+	t.Parallel()
 
-		fset := token.NewFileSet()
-		file, err := parser.ParseFile(fset, "any.go", "package test\nvar X = 1\n", 0)
-		if err != nil {
-			t.Fatal(err)
-		}
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\ngo 1.26\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package test\nvar X = 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
-		h := newHarvester(fset)
-		err = idx.processFile(fset, file, h)
-		assert.ErrorIs(t, err, errInjected)
-		assert.Empty(t, h.symbolsByPath)
-		assert.Empty(t, h.currentPath)
-	})
+	fset := token.NewFileSet()
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedName,
+		Dir:  tmpDir,
+		Fset: fset,
+	}, ".")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("expected at least one package")
+	}
 
-	// -------------------------------------------------------------------
-	// EC1: multiple files processed
-	// -------------------------------------------------------------------
-	t.Run("multiple files processed", func(t *testing.T) {
-		t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
 
-		tmpDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\ngo 1.26\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package test\nvar A = 1\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package test\nvar B = 2\n"), 0644); err != nil {
-			t.Fatal(err)
-		}
+	idx := &indexer{resolvePath: filepath.Abs}
+	_, err = idx.processPackage(ctx, fset, pkgs[0])
+	assert.ErrorIs(t, err, context.Canceled)
+}
 
-		fset := token.NewFileSet()
-		pkgs, err := packages.Load(&packages.Config{
-			Mode: packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedName,
-			Dir:  tmpDir,
-			Fset: fset,
-		}, ".")
-		if err != nil {
-			t.Fatalf("packages.Load: %v", err)
-		}
-		if len(pkgs) == 0 {
-			t.Fatal("expected at least one package")
-		}
+// EC3: processFile error propagation
+func TestProcessPackage_ProcessFileError(t *testing.T) {
+	t.Parallel()
 
-		ctx := context.Background()
-		result, err := idx.processPackage(ctx, fset, pkgs[0])
-		assert.NoError(t, err)
+	errInjected := errors.New("path resolution failed")
+	idx := &indexer{
+		resolvePath: func(string) (string, error) { return "", errInjected },
+	}
 
-		// Should have symbols from both files (2 distinct file paths)
-		assert.Len(t, result.symbols, 2, "expected symbols from 2 files")
-	})
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "any.go", "package test\nvar X = 1\n", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h := newHarvester(fset)
+	err = idx.processFile(fset, file, h)
+	assert.ErrorIs(t, err, errInjected)
+	assert.Empty(t, h.symbolsByPath)
+	assert.Empty(t, h.currentPath)
+}
+
+// EC1: multiple files processed
+func TestProcessPackage_MultipleFiles(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\ngo 1.26\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "a.go"), []byte("package test\nvar A = 1\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "b.go"), []byte("package test\nvar B = 2\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	fset := token.NewFileSet()
+	pkgs, err := packages.Load(&packages.Config{
+		Mode: packages.NeedSyntax | packages.NeedTypesInfo | packages.NeedName,
+		Dir:  tmpDir,
+		Fset: fset,
+	}, ".")
+	if err != nil {
+		t.Fatalf("packages.Load: %v", err)
+	}
+	if len(pkgs) == 0 {
+		t.Fatal("expected at least one package")
+	}
+
+	idx := &indexer{resolvePath: filepath.Abs}
+	ctx := context.Background()
+	result, err := idx.processPackage(ctx, fset, pkgs[0])
+	assert.NoError(t, err)
+	assert.Len(t, result.symbols, 2, "expected symbols from 2 files")
 }
 
 func TestHarvestPackages(t *testing.T) {

--- a/internal/tools/analysis/sequence_test.go
+++ b/internal/tools/analysis/sequence_test.go
@@ -504,14 +504,12 @@ func (t *T) Method() {}
 	})
 }
 
-// TestFindStartPackage_ModuleRelativeAndUnexported verifies that the full
-// findStartPackage → resolveStartFunc pipeline resolves both module-relative
-// and fully-qualified paths to unexported methods on unexported types.
-// This is a regression test for Issue #450.
-func TestFindStartPackage_ModuleRelativeAndUnexported(t *testing.T) {
-	t.Parallel()
+// setupRealWorkspaceAnalyzer creates a temporary Go workspace with the given
+// source code and returns a fully initialized sequenceAnalyzer wired to an
+// indexer targeting that workspace, along with a background context.
+func setupRealWorkspaceAnalyzer(t *testing.T, srcCode string) (*defaultSequenceAnalyzer, context.Context) {
+	t.Helper()
 
-	// --- Setup: create a real Go workspace with an unexported type+method ---
 	tmpDir := t.TempDir()
 
 	goMod := []byte("module example.com/test\n\ngo 1.25\n")
@@ -519,28 +517,10 @@ func TestFindStartPackage_ModuleRelativeAndUnexported(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	src := []byte(`package test
-
-type internalCounter struct{ count int }
-
-func logCount(n int) int { return n }
-
-func (c *internalCounter) incrementBy(n int) int {
-	c.count += n
-	logCount(c.count)
-	return c.count
-}
-
-func Start(n int) int {
-	c := &internalCounter{}
-	return c.incrementBy(n)
-}
-`)
-	if err := os.WriteFile(filepath.Join(tmpDir, "test.go"), src, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tmpDir, "test.go"), []byte(srcCode), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	// --- Build the indexer against the real workspace ---
 	idx, err := newIndexer(tmpDir)
 	if err != nil {
 		t.Fatal(err)
@@ -556,52 +536,99 @@ func Start(n int) int {
 		t.Fatal(err)
 	}
 
-	// --- Build the analyzer ---
 	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
-	// Pre-populate the analyzer state so loadPackages is a no-op.
 	analyzer.pkgMu.Lock()
 	analyzer.pkgs = pkgs
 	analyzer.funcMap = analyzer.mapSymbols(pkgs)
 	analyzer.lastLoad = time.Now().Add(1 * time.Hour)
 	analyzer.pkgMu.Unlock()
 
-	tests := []struct {
-		name        string
-		startSymbol string
-		wantFunc    string // expected function name in the diagram
-	}{
-		{
-			name:        "module-relative unexported method",
-			startSymbol: "example.com/test.(*internalCounter).incrementBy",
-			wantFunc:    "logCount",
-		},
-		{
-			name:        "module-relative exported free function",
-			startSymbol: "example.com/test.Start",
-			wantFunc:    "incrementBy",
-		},
-	}
+	return analyzer, ctx
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			res, err := analyzer.AnalyzeSequenceFlow(ctx, map[string]interface{}{
-				"start_symbol": tt.startSymbol,
-				"max_depth":    float64(3),
-			}, nil)
-			if err != nil {
-				t.Fatalf("AnalyzeSequenceFlow failed: %v", err)
-			}
-			if res.Text == "" {
-				t.Fatal("expected non-empty diagram output")
-			}
-			if strings.Contains(res.Text, "Error") {
-				t.Fatalf("unexpected error in output: %s", res.Text)
-			}
-			if !strings.Contains(res.Text, tt.wantFunc) {
-				t.Errorf("diagram missing expected function %q:\n%s", tt.wantFunc, res.Text)
-			}
-		})
+// TestFindStartPackage_UnexportedMethod verifies that a module-relative path
+// to an unexported method on an unexported type is correctly resolved.
+// Regression test for Issue #450.
+func TestFindStartPackage_UnexportedMethod(t *testing.T) {
+	t.Parallel()
+
+	src := `package test
+
+type internalCounter struct{ count int }
+
+func logCount(n int) int { return n }
+
+func (c *internalCounter) incrementBy(n int) int {
+	c.count += n
+	logCount(c.count)
+	return c.count
+}
+
+func Start(n int) int {
+	c := &internalCounter{}
+	return c.incrementBy(n)
+}
+`
+	analyzer, ctx := setupRealWorkspaceAnalyzer(t, src)
+
+	res, err := analyzer.AnalyzeSequenceFlow(ctx, map[string]interface{}{
+		"start_symbol": "example.com/test.(*internalCounter).incrementBy",
+		"max_depth":    float64(3),
+	}, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeSequenceFlow failed: %v", err)
+	}
+	if res.Text == "" {
+		t.Fatal("expected non-empty diagram output")
+	}
+	if strings.Contains(res.Text, "Error") {
+		t.Fatalf("unexpected error in output: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "logCount") {
+		t.Errorf("diagram missing expected function %q:\n%s", "logCount", res.Text)
+	}
+}
+
+// TestFindStartPackage_ExportedFreeFunction verifies that a module-relative
+// path to an exported free function is correctly resolved and traces into
+// method calls within its body.
+func TestFindStartPackage_ExportedFreeFunction(t *testing.T) {
+	t.Parallel()
+
+	src := `package test
+
+type internalCounter struct{ count int }
+
+func logCount(n int) int { return n }
+
+func (c *internalCounter) incrementBy(n int) int {
+	c.count += n
+	logCount(c.count)
+	return c.count
+}
+
+func Start(n int) int {
+	c := &internalCounter{}
+	return c.incrementBy(n)
+}
+`
+	analyzer, ctx := setupRealWorkspaceAnalyzer(t, src)
+
+	res, err := analyzer.AnalyzeSequenceFlow(ctx, map[string]interface{}{
+		"start_symbol": "example.com/test.Start",
+		"max_depth":    float64(3),
+	}, nil)
+	if err != nil {
+		t.Fatalf("AnalyzeSequenceFlow failed: %v", err)
+	}
+	if res.Text == "" {
+		t.Fatal("expected non-empty diagram output")
+	}
+	if strings.Contains(res.Text, "Error") {
+		t.Fatalf("unexpected error in output: %s", res.Text)
+	}
+	if !strings.Contains(res.Text, "incrementBy") {
+		t.Errorf("diagram missing expected function %q:\n%s", "incrementBy", res.Text)
 	}
 }
 
@@ -856,180 +883,174 @@ func parseFuncDecl(t *testing.T, code string) *ast.FuncDecl {
 	return f.Decls[0].(*ast.FuncDecl)
 }
 
-// TestSequenceVisitor_Visit tests the Visit method of sequenceVisitor with
-// table-driven subtests covering all switch branches and guard clauses.
-func TestSequenceVisitor_Visit(t *testing.T) {
+func TestSequenceVisitor_Visit_NilNode(t *testing.T) {
 	t.Parallel()
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		analyzer: &defaultSequenceAnalyzer{},
+	}
+	if got := v.Visit(nil); got != nil {
+		t.Errorf("Visit(nil) = %v, want nil", got)
+	}
+}
 
-	t.Run("nil node returns nil", func(t *testing.T) {
-		t.Parallel()
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			analyzer: &defaultSequenceAnalyzer{},
-		}
-		if got := v.Visit(nil); got != nil {
-			t.Errorf("Visit(nil) = %v, want nil", got)
-		}
-	})
+func TestSequenceVisitor_Visit_CancelledContext(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	v := &sequenceVisitor{
+		ctx:      ctx,
+		analyzer: &defaultSequenceAnalyzer{},
+	}
+	if got := v.Visit(&ast.Ident{Name: "x"}); got != nil {
+		t.Errorf("Visit with cancelled ctx = %v, want nil", got)
+	}
+}
 
-	t.Run("cancelled context returns nil", func(t *testing.T) {
-		t.Parallel()
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		v := &sequenceVisitor{
-			ctx:      ctx,
-			analyzer: &defaultSequenceAnalyzer{},
-		}
-		if got := v.Visit(&ast.Ident{Name: "x"}); got != nil {
-			t.Errorf("Visit with cancelled ctx = %v, want nil", got)
-		}
-	})
+func TestSequenceVisitor_Visit_ForStmt(t *testing.T) {
+	t.Parallel()
+	_, f := parseTestFile(t, "package p; func f() { for i := 0; i < 10; i++ { g() } }")
+	fd := f.Decls[0].(*ast.FuncDecl)
+	forStmt := fd.Body.List[0].(*ast.ForStmt)
 
-	t.Run("ForStmt walks children and returns nil", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, "package p; func f() { for i := 0; i < 10; i++ { g() } }")
-		fd := f.Decls[0].(*ast.FuncDecl)
-		forStmt := fd.Body.List[0].(*ast.ForStmt)
+	pkg := &packages.Package{
+		Name:    "p",
+		PkgPath: "test/pkg",
+		TypesInfo: &types.Info{
+			Uses: make(map[*ast.Ident]types.Object),
+			Defs: make(map[*ast.Ident]types.Object),
+		},
+	}
 
-		pkg := &packages.Package{
-			Name:    "p",
-			PkgPath: "test/pkg",
-			TypesInfo: &types.Info{
-				Uses: make(map[*ast.Ident]types.Object),
-				Defs: make(map[*ast.Ident]types.Object),
-			},
-		}
+	frames := &frameCollector{}
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		pkg:      pkg,
+		analyzer: &defaultSequenceAnalyzer{},
+		frames:   frames,
+		maxDepth: 1,
+	}
 
-		frames := &frameCollector{}
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			pkg:      pkg,
-			analyzer: &defaultSequenceAnalyzer{},
-			frames:   frames,
-			maxDepth: 1,
-		}
+	got := v.Visit(forStmt)
+	if got != nil {
+		t.Errorf("Visit(ForStmt) = %v, want nil", got)
+	}
+	if v.inLoop != 0 {
+		t.Errorf("inLoop = %d, want 0 (restored after ForStmt)", v.inLoop)
+	}
+}
 
-		got := v.Visit(forStmt)
-		if got != nil {
-			t.Errorf("Visit(ForStmt) = %v, want nil", got)
-		}
-		if v.inLoop != 0 {
-			t.Errorf("inLoop = %d, want 0 (restored after ForStmt)", v.inLoop)
-		}
-	})
+func TestSequenceVisitor_Visit_RangeStmt(t *testing.T) {
+	t.Parallel()
+	_, f := parseTestFile(t, "package p; func f() { for _, x := range items { h() } }")
+	fd := f.Decls[0].(*ast.FuncDecl)
+	rangeStmt := fd.Body.List[0].(*ast.RangeStmt)
 
-	t.Run("RangeStmt walks children and returns nil", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, "package p; func f() { for _, x := range items { h() } }")
-		fd := f.Decls[0].(*ast.FuncDecl)
-		rangeStmt := fd.Body.List[0].(*ast.RangeStmt)
+	pkg := &packages.Package{
+		Name:    "p",
+		PkgPath: "test/pkg",
+		TypesInfo: &types.Info{
+			Uses: make(map[*ast.Ident]types.Object),
+			Defs: make(map[*ast.Ident]types.Object),
+		},
+	}
 
-		pkg := &packages.Package{
-			Name:    "p",
-			PkgPath: "test/pkg",
-			TypesInfo: &types.Info{
-				Uses: make(map[*ast.Ident]types.Object),
-				Defs: make(map[*ast.Ident]types.Object),
-			},
-		}
+	frames := &frameCollector{}
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		pkg:      pkg,
+		analyzer: &defaultSequenceAnalyzer{},
+		frames:   frames,
+		maxDepth: 1,
+	}
 
-		frames := &frameCollector{}
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			pkg:      pkg,
-			analyzer: &defaultSequenceAnalyzer{},
-			frames:   frames,
-			maxDepth: 1,
-		}
+	got := v.Visit(rangeStmt)
+	if got != nil {
+		t.Errorf("Visit(RangeStmt) = %v, want nil", got)
+	}
+	if v.inLoop != 0 {
+		t.Errorf("inLoop = %d, want 0 (restored after RangeStmt)", v.inLoop)
+	}
+}
 
-		got := v.Visit(rangeStmt)
-		if got != nil {
-			t.Errorf("Visit(RangeStmt) = %v, want nil", got)
-		}
-		if v.inLoop != 0 {
-			t.Errorf("inLoop = %d, want 0 (restored after RangeStmt)", v.inLoop)
-		}
-	})
+func TestSequenceVisitor_Visit_GoStmt(t *testing.T) {
+	t.Parallel()
+	_, f := parseTestFile(t, "package p; func f() { go async() }")
+	fd := f.Decls[0].(*ast.FuncDecl)
+	goStmt := fd.Body.List[0].(*ast.GoStmt)
 
-	t.Run("GoStmt walks call and returns nil", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, "package p; func f() { go async() }")
-		fd := f.Decls[0].(*ast.FuncDecl)
-		goStmt := fd.Body.List[0].(*ast.GoStmt)
+	pkg := &packages.Package{
+		Name:    "p",
+		PkgPath: "test/pkg",
+		TypesInfo: &types.Info{
+			Uses: make(map[*ast.Ident]types.Object),
+			Defs: make(map[*ast.Ident]types.Object),
+		},
+	}
 
-		pkg := &packages.Package{
-			Name:    "p",
-			PkgPath: "test/pkg",
-			TypesInfo: &types.Info{
-				Uses: make(map[*ast.Ident]types.Object),
-				Defs: make(map[*ast.Ident]types.Object),
-			},
-		}
+	frames := &frameCollector{}
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		pkg:      pkg,
+		analyzer: &defaultSequenceAnalyzer{},
+		frames:   frames,
+		maxDepth: 1,
+	}
 
-		frames := &frameCollector{}
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			pkg:      pkg,
-			analyzer: &defaultSequenceAnalyzer{},
-			frames:   frames,
-			maxDepth: 1,
-		}
+	got := v.Visit(goStmt)
+	if got != nil {
+		t.Errorf("Visit(GoStmt) = %v, want nil", got)
+	}
+	if v.inGo {
+		t.Error("inGo = true, want false (restored after GoStmt)")
+	}
+}
 
-		got := v.Visit(goStmt)
-		if got != nil {
-			t.Errorf("Visit(GoStmt) = %v, want nil", got)
-		}
-		if v.inGo {
-			t.Error("inGo = true, want false (restored after GoStmt)")
-		}
-	})
+func TestSequenceVisitor_Visit_CallExpr(t *testing.T) {
+	t.Parallel()
+	pkgA, _ := setupMockPackages()
 
-	t.Run("CallExpr delegates to handleCall and returns self", func(t *testing.T) {
-		t.Parallel()
-		pkgA, _ := setupMockPackages()
+	var callExpr *ast.CallExpr
+	for _, decl := range pkgA.Syntax[0].Decls {
+		if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
+			callExpr = fd.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
+			break
+		}
+	}
+	if callExpr == nil {
+		t.Fatal("CallExpr not found in StartFunc")
+	}
 
-		var callExpr *ast.CallExpr
-		for _, decl := range pkgA.Syntax[0].Decls {
-			if fd, ok := decl.(*ast.FuncDecl); ok && fd.Name.Name == "StartFunc" {
-				callExpr = fd.Body.List[0].(*ast.ExprStmt).X.(*ast.CallExpr)
-				break
-			}
-		}
-		if callExpr == nil {
-			t.Fatal("CallExpr not found in StartFunc")
-		}
+	frames := &frameCollector{}
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		pkg:      pkgA,
+		modName:  "github.com/test/mod",
+		analyzer: &defaultSequenceAnalyzer{modName: "github.com/test/mod"},
+		frames:   frames,
+		visited:  make(map[string]bool),
+		maxDepth: 1,
+	}
 
-		frames := &frameCollector{}
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			pkg:      pkgA,
-			modName:  "github.com/test/mod",
-			analyzer: &defaultSequenceAnalyzer{modName: "github.com/test/mod"},
-			frames:   frames,
-			visited:  make(map[string]bool),
-			maxDepth: 1,
-		}
+	got := v.Visit(callExpr)
+	if got != v {
+		t.Errorf("Visit(CallExpr) = %v, want self (%v)", got, v)
+	}
+	if len(frames.frames) == 0 {
+		t.Error("expected at least one frame from CallExpr")
+	}
+}
 
-		got := v.Visit(callExpr)
-		if got != v {
-			t.Errorf("Visit(CallExpr) = %v, want self (%v)", got, v)
-		}
-		if len(frames.frames) == 0 {
-			t.Error("expected at least one frame from CallExpr")
-		}
-	})
-
-	t.Run("unhandled node type returns self", func(t *testing.T) {
-		t.Parallel()
-		v := &sequenceVisitor{
-			ctx:      context.Background(),
-			analyzer: &defaultSequenceAnalyzer{},
-		}
-		got := v.Visit(&ast.BasicLit{Kind: token.INT, Value: "0"})
-		if got != v {
-			t.Errorf("Visit(BasicLit) = %v, want self (%v)", got, v)
-		}
-	})
+func TestSequenceVisitor_Visit_UnhandledNode(t *testing.T) {
+	t.Parallel()
+	v := &sequenceVisitor{
+		ctx:      context.Background(),
+		analyzer: &defaultSequenceAnalyzer{},
+	}
+	got := v.Visit(&ast.BasicLit{Kind: token.INT, Value: "0"})
+	if got != v {
+		t.Errorf("Visit(BasicLit) = %v, want self (%v)", got, v)
+	}
 }
 
 // TestSequenceVisitor_HandleCall exercises all uncovered branches in handleCall
@@ -1299,201 +1320,202 @@ func TestGetTypeName(t *testing.T) {
 	}
 }
 
-// TestResolveSelectorCall exercises every branch of sequenceVisitor.resolveSelectorCall.
-func TestResolveSelectorCall(t *testing.T) {
+// TestResolveSelectorCall_PkgNameResolution exercises the PkgName branch of
+// sequenceVisitor.resolveSelectorCall where sel.X is an *ast.Ident that
+// resolves to a *types.PkgName (an import).
+func TestResolveSelectorCall_PkgNameResolution(t *testing.T) {
 	t.Parallel()
-
-	t.Run("sel.X is Ident with PkgName resolution", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, `package p
+	_, f := parseTestFile(t, `package p
 import "fmt"
 func f() { fmt.Println() }`)
-		fd := f.Decls[1].(*ast.FuncDecl)
-		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
-		call := exprStmt.X.(*ast.CallExpr)
-		sel := call.Fun.(*ast.SelectorExpr)
+	fd := f.Decls[1].(*ast.FuncDecl)
+	exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+	call := exprStmt.X.(*ast.CallExpr)
+	sel := call.Fun.(*ast.SelectorExpr)
 
-		fmtPkg := types.NewPackage("fmt", "fmt")
-		pkgTypes := types.NewPackage("example.com/local/pkg", "p")
+	fmtPkg := types.NewPackage("fmt", "fmt")
+	pkgTypes := types.NewPackage("example.com/local/pkg", "p")
 
-		// PkgName for the import
-		pkgName := types.NewPkgName(token.NoPos, pkgTypes, "fmt", fmtPkg)
+	pkgName := types.NewPkgName(token.NoPos, pkgTypes, "fmt", fmtPkg)
 
-		// Println function in fmt
-		printlnSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
-		printlnFunc := types.NewFunc(token.NoPos, fmtPkg, "Println", printlnSig)
+	printlnSig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	printlnFunc := types.NewFunc(token.NoPos, fmtPkg, "Println", printlnSig)
 
-		uses := make(map[*ast.Ident]types.Object)
-		uses[sel.X.(*ast.Ident)] = pkgName
-		uses[sel.Sel] = printlnFunc
+	uses := make(map[*ast.Ident]types.Object)
+	uses[sel.X.(*ast.Ident)] = pkgName
+	uses[sel.Sel] = printlnFunc
 
-		v := &sequenceVisitor{
-			ctx: context.Background(),
-			pkg: &packages.Package{
-				PkgPath:   "example.com/local/pkg",
-				Types:     pkgTypes,
-				TypesInfo: &types.Info{Uses: uses},
-			},
-			analyzer: &defaultSequenceAnalyzer{},
-		}
+	v := &sequenceVisitor{
+		ctx: context.Background(),
+		pkg: &packages.Package{
+			PkgPath:   "example.com/local/pkg",
+			Types:     pkgTypes,
+			TypesInfo: &types.Info{Uses: uses},
+		},
+		analyzer: &defaultSequenceAnalyzer{},
+	}
 
-		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
-		if gotFunc != "Println" {
-			t.Errorf("func = %q, want %q", gotFunc, "Println")
-		}
-		if gotPkgPath != "fmt" {
-			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "fmt")
-		}
-		if gotId != "fmt.Println" {
-			t.Errorf("id = %q, want %q", gotId, "fmt.Println")
-		}
-	})
+	gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+	if gotFunc != "Println" {
+		t.Errorf("func = %q, want %q", gotFunc, "Println")
+	}
+	if gotPkgPath != "fmt" {
+		t.Errorf("pkgPath = %q, want %q", gotPkgPath, "fmt")
+	}
+	if gotId != "fmt.Println" {
+		t.Errorf("id = %q, want %q", gotId, "fmt.Println")
+	}
+}
 
-	t.Run("sel.X is Ident with non-PkgName object", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, `package p
+// TestResolveSelectorCall_NonPkgNameObject exercises the non-PkgName branch
+// where sel.X is an *ast.Ident that resolves to a non-PkgName object (e.g.
+// a *types.Var), so the code falls into the else branch to derive the
+// package path from the variable's type.
+func TestResolveSelectorCall_NonPkgNameObject(t *testing.T) {
+	t.Parallel()
+	_, f := parseTestFile(t, `package p
 type S struct{}
 func (s S) Method() {}
 func f() { var s S; s.Method() }`)
-		fd := f.Decls[2].(*ast.FuncDecl)            // f
-		exprStmt := fd.Body.List[1].(*ast.ExprStmt) // s.Method()
-		call := exprStmt.X.(*ast.CallExpr)
-		sel := call.Fun.(*ast.SelectorExpr)
+	fd := f.Decls[2].(*ast.FuncDecl)
+	exprStmt := fd.Body.List[1].(*ast.ExprStmt)
+	call := exprStmt.X.(*ast.CallExpr)
+	sel := call.Fun.(*ast.SelectorExpr)
 
-		// sel.X is *ast.Ident "s" — resolves to a *types.Var (not PkgName)
-		pkgTypes := types.NewPackage("example.com/pkg", "p")
-		namedS := types.NewNamed(
-			types.NewTypeName(token.NoPos, pkgTypes, "S", types.NewStruct(nil, nil)),
-			types.NewStruct(nil, nil),
-			nil,
-		)
-		methodFunc := types.NewFunc(
-			token.NoPos,
-			pkgTypes,
-			"Method",
-			types.NewSignatureType(
-				types.NewVar(token.NoPos, nil, "s", namedS),
-				nil, nil, nil, nil, false,
-			),
-		)
-		varS := types.NewVar(token.NoPos, pkgTypes, "s", namedS)
+	pkgTypes := types.NewPackage("example.com/pkg", "p")
+	namedS := types.NewNamed(
+		types.NewTypeName(token.NoPos, pkgTypes, "S", types.NewStruct(nil, nil)),
+		types.NewStruct(nil, nil),
+		nil,
+	)
+	methodFunc := types.NewFunc(
+		token.NoPos,
+		pkgTypes,
+		"Method",
+		types.NewSignatureType(
+			types.NewVar(token.NoPos, nil, "s", namedS),
+			nil, nil, nil, nil, false,
+		),
+	)
+	varS := types.NewVar(token.NoPos, pkgTypes, "s", namedS)
 
-		uses := make(map[*ast.Ident]types.Object)
-		uses[sel.X.(*ast.Ident)] = varS // NOT a PkgName → hits else branch
-		uses[sel.Sel] = methodFunc
+	uses := make(map[*ast.Ident]types.Object)
+	uses[sel.X.(*ast.Ident)] = varS
+	uses[sel.Sel] = methodFunc
 
-		v := &sequenceVisitor{
-			ctx: context.Background(),
-			pkg: &packages.Package{
-				PkgPath:   "example.com/local/pkg",
-				TypesInfo: &types.Info{Uses: uses},
-			},
-			analyzer: &defaultSequenceAnalyzer{},
-		}
+	v := &sequenceVisitor{
+		ctx: context.Background(),
+		pkg: &packages.Package{
+			PkgPath:   "example.com/local/pkg",
+			TypesInfo: &types.Info{Uses: uses},
+		},
+		analyzer: &defaultSequenceAnalyzer{},
+	}
 
-		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
-		if gotFunc != "Method" {
-			t.Errorf("func = %q, want %q", gotFunc, "Method")
-		}
-		if gotPkgPath != "example.com/pkg" {
-			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
-		}
-		if gotId != "example.com/pkg.S.Method" {
-			t.Errorf("id = %q, want %q", gotId, "example.com/pkg.S.Method")
-		}
-	})
+	gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+	if gotFunc != "Method" {
+		t.Errorf("func = %q, want %q", gotFunc, "Method")
+	}
+	if gotPkgPath != "example.com/pkg" {
+		t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
+	}
+	if gotId != "example.com/pkg.S.Method" {
+		t.Errorf("id = %q, want %q", gotId, "example.com/pkg.S.Method")
+	}
+}
 
-	t.Run("sel.X not Ident, resolved via TypesInfo.Types", func(t *testing.T) {
-		t.Parallel()
-		_, f := parseTestFile(t, `package p
+// TestResolveSelectorCall_NonIdentX exercises the branch where sel.X is
+// not an *ast.Ident (e.g. a composite literal like T{}), forcing the
+// resolver to fall back to TypesInfo.Types to obtain the receiver type.
+func TestResolveSelectorCall_NonIdentX(t *testing.T) {
+	t.Parallel()
+	_, f := parseTestFile(t, `package p
 type T struct{}
 func (t T) Method() {}
 func f() { (T{}).Method() }`)
-		fd := f.Decls[2].(*ast.FuncDecl)
-		exprStmt := fd.Body.List[0].(*ast.ExprStmt)
-		call := exprStmt.X.(*ast.CallExpr)
-		sel := call.Fun.(*ast.SelectorExpr)
+	fd := f.Decls[2].(*ast.FuncDecl)
+	exprStmt := fd.Body.List[0].(*ast.ExprStmt)
+	call := exprStmt.X.(*ast.CallExpr)
+	sel := call.Fun.(*ast.SelectorExpr)
 
-		// sel.X is *ast.CompositeLit (T{}) — NOT an *ast.Ident
-		pkgTypes := types.NewPackage("example.com/pkg", "p")
-		namedT := types.NewNamed(
-			types.NewTypeName(token.NoPos, pkgTypes, "T", types.NewStruct(nil, nil)),
-			types.NewStruct(nil, nil),
-			nil,
-		)
-		methodFunc := types.NewFunc(
-			token.NoPos,
-			pkgTypes,
-			"Method",
-			types.NewSignatureType(
-				types.NewVar(token.NoPos, nil, "t", namedT),
-				nil, nil, nil, nil, false,
-			),
-		)
+	pkgTypes := types.NewPackage("example.com/pkg", "p")
+	namedT := types.NewNamed(
+		types.NewTypeName(token.NoPos, pkgTypes, "T", types.NewStruct(nil, nil)),
+		types.NewStruct(nil, nil),
+		nil,
+	)
+	methodFunc := types.NewFunc(
+		token.NoPos,
+		pkgTypes,
+		"Method",
+		types.NewSignatureType(
+			types.NewVar(token.NoPos, nil, "t", namedT),
+			nil, nil, nil, nil, false,
+		),
+	)
 
-		uses := make(map[*ast.Ident]types.Object)
-		uses[sel.Sel] = methodFunc
+	uses := make(map[*ast.Ident]types.Object)
+	uses[sel.Sel] = methodFunc
 
-		typesMap := make(map[ast.Expr]types.TypeAndValue)
-		typesMap[sel.X] = types.TypeAndValue{Type: namedT}
+	typesMap := make(map[ast.Expr]types.TypeAndValue)
+	typesMap[sel.X] = types.TypeAndValue{Type: namedT}
 
-		v := &sequenceVisitor{
-			ctx: context.Background(),
-			pkg: &packages.Package{
-				PkgPath: "example.com/local/pkg",
-				TypesInfo: &types.Info{
-					Uses:  uses,
-					Types: typesMap,
-				},
+	v := &sequenceVisitor{
+		ctx: context.Background(),
+		pkg: &packages.Package{
+			PkgPath: "example.com/local/pkg",
+			TypesInfo: &types.Info{
+				Uses:  uses,
+				Types: typesMap,
 			},
-			analyzer: &defaultSequenceAnalyzer{},
-		}
+		},
+		analyzer: &defaultSequenceAnalyzer{},
+	}
 
-		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
-		if gotFunc != "Method" {
-			t.Errorf("func = %q, want %q", gotFunc, "Method")
-		}
-		if gotPkgPath != "example.com/pkg" {
-			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
-		}
-		if gotId != "example.com/pkg.T.Method" {
-			t.Errorf("id = %q, want %q", gotId, "example.com/pkg.T.Method")
-		}
-	})
+	gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+	if gotFunc != "Method" {
+		t.Errorf("func = %q, want %q", gotFunc, "Method")
+	}
+	if gotPkgPath != "example.com/pkg" {
+		t.Errorf("pkgPath = %q, want %q", gotPkgPath, "example.com/pkg")
+	}
+	if gotId != "example.com/pkg.T.Method" {
+		t.Errorf("id = %q, want %q", gotId, "example.com/pkg.T.Method")
+	}
+}
 
-	t.Run("both resolution paths fail, returns empty", func(t *testing.T) {
-		t.Parallel()
-		// sel.X is *ast.BasicLit — NOT *ast.Ident, so the first branch
-		// is skipped. TypesInfo.Types has no entry for it, so the second
-		// branch also fails. TypesInfo.Uses has no entry for sel.Sel.
-		sel := &ast.SelectorExpr{
-			X:   &ast.BasicLit{Kind: token.INT, Value: "1"},
-			Sel: &ast.Ident{Name: "Foo"},
-		}
+// TestResolveSelectorCall_BothPathsFail exercises the fallback path where
+// neither the Ident-based nor the TypesInfo.Types-based resolution succeeds
+// and the function returns only the selector name with empty pkgPath/id.
+func TestResolveSelectorCall_BothPathsFail(t *testing.T) {
+	t.Parallel()
+	sel := &ast.SelectorExpr{
+		X:   &ast.BasicLit{Kind: token.INT, Value: "1"},
+		Sel: &ast.Ident{Name: "Foo"},
+	}
 
-		v := &sequenceVisitor{
-			ctx: context.Background(),
-			pkg: &packages.Package{
-				PkgPath: "example.com/local/pkg",
-				TypesInfo: &types.Info{
-					Uses:  make(map[*ast.Ident]types.Object),
-					Types: make(map[ast.Expr]types.TypeAndValue),
-				},
+	v := &sequenceVisitor{
+		ctx: context.Background(),
+		pkg: &packages.Package{
+			PkgPath: "example.com/local/pkg",
+			TypesInfo: &types.Info{
+				Uses:  make(map[*ast.Ident]types.Object),
+				Types: make(map[ast.Expr]types.TypeAndValue),
 			},
-			analyzer: &defaultSequenceAnalyzer{},
-		}
+		},
+		analyzer: &defaultSequenceAnalyzer{},
+	}
 
-		gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
-		if gotFunc != "Foo" {
-			t.Errorf("func = %q, want %q", gotFunc, "Foo")
-		}
-		if gotPkgPath != "" {
-			t.Errorf("pkgPath = %q, want %q", gotPkgPath, "")
-		}
-		if gotId != "" {
-			t.Errorf("id = %q, want %q", gotId, "")
-		}
-	})
+	gotFunc, gotPkgPath, gotId := v.resolveSelectorCall(sel)
+	if gotFunc != "Foo" {
+		t.Errorf("func = %q, want %q", gotFunc, "Foo")
+	}
+	if gotPkgPath != "" {
+		t.Errorf("pkgPath = %q, want %q", gotPkgPath, "")
+	}
+	if gotId != "" {
+		t.Errorf("id = %q, want %q", gotId, "")
+	}
 }
 
 // TestResolveCallDetails exercises every branch of sequenceVisitor.resolveCallDetails.
@@ -1790,96 +1812,88 @@ func TestNormalizeSymbolName_EdgeCases(t *testing.T) {
 	}
 }
 
-// TestAnalyzeSequenceFlow_ErrorPaths exercises error paths and edge cases in
-// AnalyzeSequenceFlow: type-switch branches for max_depth, missing start_symbol,
-// and traceFlow error propagation.
-func TestAnalyzeSequenceFlow_ErrorPaths(t *testing.T) {
+func TestAnalyzeSequenceFlow_MaxDepthInt(t *testing.T) {
 	t.Parallel()
+	pkgA, pkgB := setupMockPackages()
+	idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
 
-	t.Run("max_depth as int type", func(t *testing.T) {
-		t.Parallel()
-		pkgA, pkgB := setupMockPackages()
-		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
-		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+	res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+		"start_symbol": pkgA.PkgPath + ".StartFunc",
+		"max_depth":    2,
+	}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if res.Text == "" {
+		t.Error("expected non-empty diagram with max_depth=2 (int)")
+	}
+}
 
-		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
-			"start_symbol": pkgA.PkgPath + ".StartFunc",
-			"max_depth":    2, // int, not float64 → case int:
-		}, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if res.Text == "" {
-			t.Error("expected non-empty diagram with max_depth=2 (int)")
-		}
-	})
+func TestAnalyzeSequenceFlow_MaxDepthUnexpectedType(t *testing.T) {
+	t.Parallel()
+	pkgA, pkgB := setupMockPackages()
+	idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
 
-	t.Run("max_depth unexpected type defaults to 5", func(t *testing.T) {
-		t.Parallel()
-		pkgA, pkgB := setupMockPackages()
-		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
-		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+	res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+		"start_symbol": pkgA.PkgPath + ".StartFunc",
+		"max_depth":    "invalid",
+	}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if res.Text == "" {
+		t.Error("expected non-empty diagram with default depth 5")
+	}
+}
 
-		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
-			"start_symbol": pkgA.PkgPath + ".StartFunc",
-			"max_depth":    "invalid", // string → default: maxDepth = 5
-		}, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if res.Text == "" {
-			t.Error("expected non-empty diagram with default depth 5")
-		}
-	})
+func TestAnalyzeSequenceFlow_MaxDepthAbsent(t *testing.T) {
+	t.Parallel()
+	pkgA, pkgB := setupMockPackages()
+	idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
+	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
 
-	t.Run("max_depth absent defaults to 5", func(t *testing.T) {
-		t.Parallel()
-		pkgA, pkgB := setupMockPackages()
-		idx := &mockIndexer{pkgs: []*packages.Package{pkgA, pkgB}}
-		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
+	res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+		"start_symbol": pkgA.PkgPath + ".StartFunc",
+	}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if res.Text == "" {
+		t.Error("expected non-empty diagram with default depth 5")
+	}
+}
 
-		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
-			"start_symbol": pkgA.PkgPath + ".StartFunc",
-			// max_depth omitted → maxDepth = 5
-		}, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if res.Text == "" {
-			t.Error("expected non-empty diagram with default depth 5")
-		}
-	})
+func TestAnalyzeSequenceFlow_EmptyStartSymbol(t *testing.T) {
+	t.Parallel()
+	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
 
-	t.Run("empty start_symbol", func(t *testing.T) {
-		t.Parallel()
-		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, &mockIndexer{})
+	res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+		"start_symbol": "",
+	}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Error: missing") {
+		t.Errorf("expected 'Error: missing' in result, got: %s", res.Text)
+	}
+}
 
-		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
-			"start_symbol": "",
-		}, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !strings.Contains(res.Text, "Error: missing") {
-			t.Errorf("expected 'Error: missing' in result, got: %s", res.Text)
-		}
-	})
+func TestAnalyzeSequenceFlow_TraceFlowError(t *testing.T) {
+	t.Parallel()
+	idx := &mockIndexer{err: fmt.Errorf("index failure")}
+	analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
 
-	t.Run("traceFlow error propagates", func(t *testing.T) {
-		t.Parallel()
-		idx := &mockIndexer{err: fmt.Errorf("index failure")}
-		analyzer := newSequenceAnalyzer(&mockExecutor{}, &mockSecurityProvider{}, idx)
-
-		res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
-			"start_symbol": "example.com/pkg.Func",
-		}, nil)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !strings.Contains(res.Text, "Error tracing flow") {
-			t.Errorf("expected 'Error tracing flow' in result, got: %s", res.Text)
-		}
-	})
+	res, err := analyzer.AnalyzeSequenceFlow(context.Background(), map[string]interface{}{
+		"start_symbol": "example.com/pkg.Func",
+	}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Error tracing flow") {
+		t.Errorf("expected 'Error tracing flow' in result, got: %s", res.Text)
+	}
 }
 
 // TestLoadPackages_ErrorPaths exercises error paths in loadPackages:
@@ -1920,112 +1934,104 @@ func TestLoadPackages_ErrorPaths(t *testing.T) {
 	})
 }
 
-// TestTraceFlow_ErrorPaths exercises error paths in traceFlow:
-// symbol-not-found with various hint generation branches, and
-// resolveStartFunc error wrapping.
-func TestTraceFlow_ErrorPaths(t *testing.T) {
+func TestTraceFlow_SymbolNotFound_NoSlash(t *testing.T) {
 	t.Parallel()
+	a := &defaultSequenceAnalyzer{
+		pkgs:     []*packages.Package{},
+		funcMap:  make(map[string]funcInfo),
+		lastLoad: time.Now(),
+		cacheTTL: 5 * time.Minute,
+	}
 
-	t.Run("symbol not found, no slash", func(t *testing.T) {
-		t.Parallel()
-		a := &defaultSequenceAnalyzer{
-			pkgs:     []*packages.Package{},
-			funcMap:  make(map[string]funcInfo),
-			lastLoad: time.Now(),
-			cacheTTL: 5 * time.Minute,
+	_, err := a.traceFlow(context.Background(), "MissingFunc", 5, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "start symbol not found: MissingFunc") {
+			t.Errorf("expected 'start symbol not found', got: %v", err)
 		}
-
-		_, err := a.traceFlow(context.Background(), "MissingFunc", 5, nil)
-		if err == nil {
-			t.Error("expected error, got nil")
-		} else {
-			if !strings.Contains(err.Error(), "start symbol not found: MissingFunc") {
-				t.Errorf("expected 'start symbol not found', got: %v", err)
-			}
-			// No slash in symbol → no hint
-			if strings.Contains(err.Error(), "try ") {
-				t.Errorf("expected no hint for symbol without slash, got: %v", err)
-			}
+		if strings.Contains(err.Error(), "try ") {
+			t.Errorf("expected no hint for symbol without slash, got: %v", err)
 		}
-	})
+	}
+}
 
-	t.Run("symbol not found, with slash, has module prefix", func(t *testing.T) {
-		t.Parallel()
-		a := &defaultSequenceAnalyzer{
-			pkgs:     []*packages.Package{},
-			funcMap:  make(map[string]funcInfo),
-			modName:  "example.com/mod",
-			lastLoad: time.Now(),
-			cacheTTL: 5 * time.Minute,
+func TestTraceFlow_SymbolNotFound_WithSlash_ModulePrefix(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{
+		pkgs:     []*packages.Package{},
+		funcMap:  make(map[string]funcInfo),
+		modName:  "example.com/mod",
+		lastLoad: time.Now(),
+		cacheTTL: 5 * time.Minute,
+	}
+
+	_, err := a.traceFlow(context.Background(), "example.com/mod/pkg.Func", 5, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "start symbol not found") {
+			t.Errorf("expected 'start symbol not found', got: %v", err)
 		}
-
-		_, err := a.traceFlow(context.Background(), "example.com/mod/pkg.Func", 5, nil)
-		if err == nil {
-			t.Error("expected error, got nil")
-		} else {
-			if !strings.Contains(err.Error(), "start symbol not found") {
-				t.Errorf("expected 'start symbol not found', got: %v", err)
-			}
-			if !strings.Contains(err.Error(), "try 'pkg/path.(*Type).Method'") {
-				t.Errorf("expected module-relative hint, got: %v", err)
-			}
+		if !strings.Contains(err.Error(), "try 'pkg/path.(*Type).Method'") {
+			t.Errorf("expected module-relative hint, got: %v", err)
 		}
-	})
+	}
+}
 
-	t.Run("symbol not found, with slash, no module prefix", func(t *testing.T) {
-		t.Parallel()
-		a := &defaultSequenceAnalyzer{
-			pkgs:     []*packages.Package{},
-			funcMap:  make(map[string]funcInfo),
-			modName:  "",
-			lastLoad: time.Now(),
-			cacheTTL: 5 * time.Minute,
+func TestTraceFlow_SymbolNotFound_WithSlash_NoModulePrefix(t *testing.T) {
+	t.Parallel()
+	a := &defaultSequenceAnalyzer{
+		pkgs:     []*packages.Package{},
+		funcMap:  make(map[string]funcInfo),
+		modName:  "",
+		lastLoad: time.Now(),
+		cacheTTL: 5 * time.Minute,
+	}
+
+	_, err := a.traceFlow(context.Background(), "github.com/foo/pkg.Func", 5, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "start symbol not found") {
+			t.Errorf("expected 'start symbol not found', got: %v", err)
 		}
-
-		_, err := a.traceFlow(context.Background(), "github.com/foo/pkg.Func", 5, nil)
-		if err == nil {
-			t.Error("expected error, got nil")
-		} else {
-			if !strings.Contains(err.Error(), "start symbol not found") {
-				t.Errorf("expected 'start symbol not found', got: %v", err)
-			}
-			if !strings.Contains(err.Error(), "try the full module path") {
-				t.Errorf("expected full-module-path hint, got: %v", err)
-			}
+		if !strings.Contains(err.Error(), "try the full module path") {
+			t.Errorf("expected full-module-path hint, got: %v", err)
 		}
-	})
+	}
+}
 
-	t.Run("resolveStartFunc error", func(t *testing.T) {
-		t.Parallel()
-		fset := token.NewFileSet()
-		code := `package p
+func TestTraceFlow_ResolveStartFuncError(t *testing.T) {
+	t.Parallel()
+	fset := token.NewFileSet()
+	code := `package p
 func OtherFunc() {}`
-		f, _ := parser.ParseFile(fset, "test.go", code, 0)
+	f, _ := parser.ParseFile(fset, "test.go", code, 0)
 
-		pkg := &packages.Package{
-			PkgPath: "example.com/pkg",
-			Syntax:  []*ast.File{f},
-		}
+	pkg := &packages.Package{
+		PkgPath: "example.com/pkg",
+		Syntax:  []*ast.File{f},
+	}
 
-		a := &defaultSequenceAnalyzer{
-			pkgs:     []*packages.Package{pkg},
-			funcMap:  make(map[string]funcInfo),
-			lastLoad: time.Now(),
-			cacheTTL: 5 * time.Minute,
-		}
+	a := &defaultSequenceAnalyzer{
+		pkgs:     []*packages.Package{pkg},
+		funcMap:  make(map[string]funcInfo),
+		lastLoad: time.Now(),
+		cacheTTL: 5 * time.Minute,
+	}
 
-		_, err := a.traceFlow(context.Background(), "example.com/pkg.WrongName", 5, nil)
-		if err == nil {
-			t.Error("expected error, got nil")
-		} else {
-			if !strings.Contains(err.Error(), "start symbol not found") {
-				t.Errorf("expected 'start symbol not found', got: %v", err)
-			}
-			if !strings.Contains(err.Error(), "WrongName") {
-				t.Errorf("expected 'WrongName' in error, got: %v", err)
-			}
+	_, err := a.traceFlow(context.Background(), "example.com/pkg.WrongName", 5, nil)
+	if err == nil {
+		t.Error("expected error, got nil")
+	} else {
+		if !strings.Contains(err.Error(), "start symbol not found") {
+			t.Errorf("expected 'start symbol not found', got: %v", err)
 		}
-	})
+		if !strings.Contains(err.Error(), "WrongName") {
+			t.Errorf("expected 'WrongName' in error, got: %v", err)
+		}
+	}
 }
 
 // TestIsMethodMatch_Remaining exercises the remaining branch in isMethodMatch

--- a/internal/tools/analysis/types_error_test.go
+++ b/internal/tools/analysis/types_error_test.go
@@ -30,13 +30,13 @@ func (m *mockTypeIndex) Lookup(ctx context.Context, symbol string, hb chan<- str
 // errSentinel is a sentinel error used to verify Lookup error propagation.
 var errSentinel = errors.New("index lookup failure")
 
-// TestGetTypeInfo_ErrorPaths exercises all seven error/early-return paths in
-// defaultTypeManager.GetTypeInfo. It uses a mock symbolIndex to control each
-// decision point in isolation.
-func TestGetTypeInfo_ErrorPaths(t *testing.T) {
-	t.Parallel()
-
-	// Pre-create shared temp files for findTypeSpec-nil and findMethodsInPackage-error cases.
+// setupErrorPathTmpDir creates two Go source files in a temp directory:
+//   - mismatch.go: contains OtherType (not MyStruct)
+//   - hastype.go: contains MyStruct with method Foo
+//
+// Returns the temp directory path.
+func setupErrorPathTmpDir(t *testing.T) string {
+	t.Helper()
 	tmpDir := t.TempDir()
 
 	mismatchFile := filepath.Join(tmpDir, "mismatch.go")
@@ -58,127 +58,145 @@ func (s *MyStruct) Foo() string { return "" }
 		t.Fatal(err)
 	}
 
+	return tmpDir
+}
+
+// TestGetTypeInfo_UnmarshalArgsError verifies that an unmarshalable argument
+// (a channel) produces an error and a zero-valued ToolResult.
+func TestGetTypeInfo_UnmarshalArgsError(t *testing.T) {
+	t.Parallel()
+	m := analysis.NewTypeManager(&mockTypeIndex{}, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	ch := make(chan struct{})
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": ch}, nil)
+	if err == nil {
+		t.Fatal("expected error for channel value, got nil")
+	}
+	if res.Text != "" {
+		t.Errorf("expected empty Text on UnmarshalArgs error, got %q", res.Text)
+	}
+	if res.Metadata != nil || res.BinaryData != nil || res.Error != nil {
+		t.Errorf("expected zero-valued ToolResult fields, got Metadata=%v BinaryData=%v Error=%v",
+			res.Metadata, res.BinaryData, res.Error)
+	}
+}
+
+// TestGetTypeInfo_EmptyTypename verifies that an empty typename returns
+// a guidance message without error.
+func TestGetTypeInfo_EmptyTypename(t *testing.T) {
+	t.Parallel()
+	m := analysis.NewTypeManager(&mockTypeIndex{}, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": ""}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Please provide a typename.") {
+		t.Errorf("expected guidance message, got: %s", res.Text)
+	}
+}
+
+// TestGetTypeInfo_LookupError verifies that when Lookup returns an error,
+// the method returns a "Type not found." message without surfacing the error.
+func TestGetTypeInfo_LookupError(t *testing.T) {
+	t.Parallel()
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return nil, errSentinel
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "Foo"}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Type not found.") {
+		t.Errorf("expected 'Type not found.', got: %s", res.Text)
+	}
+}
+
+// TestGetTypeInfo_LookupEmpty verifies that when Lookup returns zero locations
+// without an error, the method returns a "Type not found." message.
+func TestGetTypeInfo_LookupEmpty(t *testing.T) {
+	t.Parallel()
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return nil, nil
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "Foo"}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Type not found.") {
+		t.Errorf("expected 'Type not found.', got: %s", res.Text)
+	}
+}
+
+// TestGetTypeInfo_CacheGetError verifies that when the AST cache cannot
+// retrieve a file (missing on disk), an error is propagated.
+func TestGetTypeInfo_CacheGetError(t *testing.T) {
+	t.Parallel()
+	tmpDir := setupErrorPathTmpDir(t)
+
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return []analysis.Location{{Path: filepath.Join(tmpDir, "does_not_exist.go"), Line: 1, Column: 1}}, nil
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	_, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "Foo"}, nil)
+	if err == nil {
+		t.Error("expected error for cache get failure, got nil")
+	}
+}
+
+// TestGetTypeInfo_FindTypeSpecNil verifies that when findTypeSpec returns nil
+// (the file parses but lacks the requested type), the method returns a
+// "Type not found." message.
+func TestGetTypeInfo_FindTypeSpecNil(t *testing.T) {
+	t.Parallel()
+	tmpDir := setupErrorPathTmpDir(t)
+
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return []analysis.Location{{Path: filepath.Join(tmpDir, "mismatch.go"), Line: 2, Column: 6}}, nil
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "MissingType"}, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(res.Text, "Type not found.") {
+		t.Errorf("expected 'Type not found.', got: %s", res.Text)
+	}
+}
+
+// TestGetTypeInfo_FindMethodsError verifies that a cancelled context causes
+// findMethodsInPackage to fail, propagating an error.
+func TestGetTypeInfo_FindMethodsError(t *testing.T) {
+	t.Parallel()
+	tmpDir := setupErrorPathTmpDir(t)
+
 	cancelCtx, cancel := context.WithCancel(context.Background())
-	cancel() // immediately canceled
+	cancel()
 
-	type testCase struct {
-		name     string
-		args     map[string]interface{}
-		lookupFn func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error)
-		ctx      context.Context
-		wantErr  bool
-		wantText string // if non-empty, must appear in res.Text
-	}
-
-	cases := []testCase{
-		// ── Path 1: UnmarshalArgs fails ──────────────────────────────────────
-		// Channel values cannot be JSON-marshaled, so UnmarshalArgs returns an error.
-		{
-			name:    "path1_UnmarshalArgs_channel",
-			args:    map[string]interface{}{"typename": make(chan int)},
-			wantErr: true,
-		},
-		// ── Path 2: Empty typename ───────────────────────────────────────────
-		{
-			name:     "path2_empty_typename",
-			args:     map[string]interface{}{"typename": ""},
-			wantErr:  false,
-			wantText: "Please provide a typename.",
-		},
-		// ── Path 3: Lookup returns error ─────────────────────────────────────
-		// Code does: if err != nil || len(locs) == 0 → "Type not found."
-		// The error is swallowed; the caller sees nil error.
-		{
-			name: "path3_Lookup_error",
-			args: map[string]interface{}{"typename": "Foo"},
-			lookupFn: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
-				return nil, errSentinel
-			},
-			wantErr:  false,
-			wantText: "Type not found.",
-		},
-		// ── Path 4: Lookup returns empty locations ───────────────────────────
-		{
-			name: "path4_Lookup_empty",
-			args: map[string]interface{}{"typename": "Foo"},
-			lookupFn: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
-				return nil, nil
-			},
-			wantErr:  false,
-			wantText: "Type not found.",
-		},
-		// ── Path 5: Cache.Get fails ──────────────────────────────────────────
-		// Lookup returns a valid location but the file doesn't exist on disk.
-		{
-			name: "path5_CacheGet_error",
-			args: map[string]interface{}{"typename": "Foo"},
-			lookupFn: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
-				return []analysis.Location{{Path: filepath.Join(tmpDir, "does_not_exist.go"), Line: 1, Column: 1}}, nil
-			},
-			wantErr: true,
-		},
-		// ── Path 6: findTypeSpec returns nil ─────────────────────────────────
-		// The file parses successfully but does not contain the requested type.
-		{
-			name: "path6_findTypeSpec_nil",
-			args: map[string]interface{}{"typename": "MissingType"},
-			lookupFn: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
-				return []analysis.Location{{Path: mismatchFile, Line: 2, Column: 6}}, nil
-			},
-			wantErr:  false,
-			wantText: "Type not found.",
-		},
-		// ── Path 7: findMethodsInPackage returns error ───────────────────────
-		// A canceled context causes checkCancellation to return an error inside
-		// the walk function, which filepath.Walk propagates.
-		{
-			name: "path7_findMethodsInPackage_error",
-			args: map[string]interface{}{"typename": "MyStruct"},
-			lookupFn: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
-				return []analysis.Location{{Path: hasTypeFile, Line: 2, Column: 6}}, nil
-			},
-			ctx:     cancelCtx,
-			wantErr: true,
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return []analysis.Location{{Path: filepath.Join(tmpDir, "hastype.go"), Line: 2, Column: 6}}, nil
 		},
 	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
 
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			idx := &mockTypeIndex{}
-			if tc.lookupFn != nil {
-				idx.LookupFunc = tc.lookupFn
-			}
-
-			ctx := tc.ctx
-			if ctx == nil {
-				ctx = context.Background()
-			}
-
-			m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
-			res, err := m.GetTypeInfo(ctx, tc.args, nil)
-
-			if (err != nil) != tc.wantErr {
-				t.Errorf("error = %v, wantErr = %v", err, tc.wantErr)
-			}
-
-			if tc.wantText != "" && !strings.Contains(res.Text, tc.wantText) {
-				t.Errorf("expected result to contain %q, got:\n%s", tc.wantText, res.Text)
-			}
-
-			// On error paths, the ToolResult should be zero-valued.
-			if tc.wantErr && err != nil {
-				if res.Text != "" {
-					t.Errorf("expected empty ToolResult on error, got Text=%q", res.Text)
-				}
-				if res.Metadata != nil || res.BinaryData != nil || res.Error != nil {
-					t.Errorf("expected zero-valued ToolResult fields, got Metadata=%v BinaryData=%v Error=%v",
-						res.Metadata, res.BinaryData, res.Error)
-				}
-			}
-		})
+	_, err := m.GetTypeInfo(cancelCtx, map[string]interface{}{"typename": "MyStruct"}, nil)
+	if err == nil {
+		t.Error("expected error for cancelled context during findMethods, got nil")
 	}
 }
 


### PR DESCRIPTION
Closes #494.

## Summary
Reduced cyclomatic complexity of all 11 functions in `internal/tools/analysis/` from above threshold (11-17) to below threshold 10.

### Test functions (9 of 11) — subtest decomposition:
| Function | File | Before | After |
|---|---|---|---|
| TestSendResult | index_harvest_test.go | 17 | Eliminated → 5 standalone functions |
| TestSequenceVisitor_Visit | sequence_test.go | 16 | Eliminated → 7 standalone functions |
| TestProcessFile | index_harvest_test.go | 15 | Eliminated → 3 standalone functions |
| TestGetTypeInfo_ErrorPaths | types_error_test.go | 15 | Eliminated → 7 standalone functions |
| TestResolveSelectorCall | sequence_test.go | 13 | Eliminated → 4 standalone functions |
| TestTraceFlow_ErrorPaths | sequence_test.go | 13 | Eliminated → 4 standalone functions |
| TestAnalyzeSequenceFlow_ErrorPaths | sequence_test.go | 11 | Eliminated → 5 standalone functions |
| TestFindStartPackage_ModuleRelativeAndUnexported | sequence_test.go | 11 | Eliminated → 2 standalone functions |
| TestProcessPackage | index_harvest_test.go | 11 | Eliminated → 4 standalone functions |

### Production functions (2 of 11) — extract method:
| Function | File | Before | After |
|---|---|---|---|
| (\*defaultChangeAnalyzer).SemanticDiff | changes.go | 12 | 6 (extracted analyzeChangedFiles) |
| (\*defaultDeadCodeAnalyzer).analyzeUsages | dead_code.go | 11 | 5 (extracted analyzeSingleUsage, sendHeartbeat, accumulateFirstError) |

## Verification
| Check | Status |
|-------|--------|
| go test ./... | PASS (all packages) |
| go build ./... | PASS |
| go vet ./internal/tools/analysis/ | PASS |
| golangci-lint | PASS (pre-existing issue in persistence_tools.go only) |
