### PR TITLE
fix(persistence): add baseline benchmarks for task migration and history write (#505)

### DIFF
--- a/internal/infrastructure/history/history_bench_test.go
+++ b/internal/infrastructure/history/history_bench_test.go
@@ -25,13 +25,6 @@ func BenchmarkManagerAddContent(b *testing.B) {
 			fs := persistencetest.NewPlainOSFileSystem()
 			filePath := filepath.Join(tmpDir, "history.jsonl")
 			archivePath := filepath.Join(tmpDir, "archive.jsonl")
-			m := NewManager(fs, filePath, archivePath)
-
-			if preSeed > 0 {
-				if err := m.SetContents(ctx, generateContents(preSeed)); err != nil {
-					b.Fatalf("SetContents seed failed: %v", err)
-				}
-			}
 
 			entry := &llm.Content{
 				Role: "user",
@@ -40,9 +33,17 @@ func BenchmarkManagerAddContent(b *testing.B) {
 				},
 			}
 
-			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				m := NewManager(fs, filePath, archivePath)
+				if preSeed > 0 {
+					if err := m.SetContents(ctx, generateContents(preSeed)); err != nil {
+						b.Fatalf("SetContents seed failed: %v", err)
+					}
+				}
+				b.StartTimer()
+
 				_ = m.AddContent(ctx, entry)
 			}
 		})

--- a/internal/infrastructure/history/history_bench_test.go
+++ b/internal/infrastructure/history/history_bench_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package history
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+)
+
+// BenchmarkManagerAddContent measures the end-to-end latency of Manager.AddContent
+// including the lock, clone, store.Append, and in-memory append against
+// a Manager pre-seeded with different amounts of history.
+func BenchmarkManagerAddContent(b *testing.B) {
+	preSeedSizes := []int{0, 1000}
+	for _, preSeed := range preSeedSizes {
+		b.Run(fmt.Sprintf("preSeed=%d", preSeed), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			m := NewManager(fs, filePath, archivePath)
+
+			if preSeed > 0 {
+				if err := m.SetContents(ctx, generateContents(preSeed)); err != nil {
+					b.Fatalf("SetContents seed failed: %v", err)
+				}
+			}
+
+			entry := &llm.Content{
+				Role: "user",
+				Parts: []*llm.Part{
+					{Text: "benchmark append message"},
+				},
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = m.AddContent(ctx, entry)
+			}
+		})
+	}
+}
+
+// BenchmarkManagerSave measures the end-to-end latency of Manager.Save
+// including the lock, store.Save, and store.Sync (fsync) overhead
+// against a Manager pre-loaded with the given number of content entries.
+func BenchmarkManagerSave(b *testing.B) {
+	sizes := []int{100, 1000, 5000}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			m := NewManager(fs, filePath, archivePath)
+
+			if err := m.SetContents(ctx, generateContents(size)); err != nil {
+				b.Fatalf("SetContents seed failed: %v", err)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = m.Save(ctx)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/history/store_bench_test.go
+++ b/internal/infrastructure/history/store_bench_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package history
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+)
+
+// generateContents creates n Content fixtures with alternating roles
+// (user for even indices, model for odd) and a single text Part.
+func generateContents(n int) []*llm.Content {
+	contents := make([]*llm.Content, n)
+	for i := 0; i < n; i++ {
+		role := "user"
+		if i%2 != 0 {
+			role = "model"
+		}
+		contents[i] = &llm.Content{
+			Role: role,
+			Parts: []*llm.Part{
+				{Text: fmt.Sprintf("Message %d: The quick brown fox jumps over the lazy dog.", i)},
+			},
+		}
+	}
+	return contents
+}
+
+// generateContentsWithInlineData creates n Content fixtures with alternating
+// roles, a text Part, and an additional InlineData Part that exercises the
+// prepareForStorage → AssetStore.Put path during Save.
+func generateContentsWithInlineData(n int) []*llm.Content {
+	contents := make([]*llm.Content, n)
+	for i := 0; i < n; i++ {
+		role := "user"
+		if i%2 != 0 {
+			role = "model"
+		}
+		contents[i] = &llm.Content{
+			Role: role,
+			Parts: []*llm.Part{
+				{Text: fmt.Sprintf("Message %d: The quick brown fox jumps over the lazy dog.", i)},
+				{InlineData: &llm.Blob{
+					MIMEType: "image/png",
+					Data:     []byte(fmt.Sprintf("fake-image-data-%d", i)),
+				}},
+			},
+		}
+	}
+	return contents
+}
+
+// BenchmarkJSONLStoreAppend measures incremental append latency of jsonlStore.Append
+// simulating turn-by-turn writes against files pre-seeded with different amounts of history.
+func BenchmarkJSONLStoreAppend(b *testing.B) {
+	preSeedSizes := []int{0, 1000, 5000}
+	for _, preSeed := range preSeedSizes {
+		b.Run(fmt.Sprintf("preSeed=%d", preSeed), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			store := newJSONLStore(fs, filePath, archivePath)
+
+			if preSeed > 0 {
+				seed := generateContents(preSeed)
+				_ = store.Save(ctx, seed)
+			}
+
+			singleEntry := []*llm.Content{{
+				Role: "user",
+				Parts: []*llm.Part{
+					{Text: "Appended turn message"},
+				},
+			}}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = store.Append(ctx, singleEntry)
+			}
+		})
+	}
+}
+
+// BenchmarkJSONLStoreCompact measures the full compaction cycle (Load → Save)
+// against a file pre-seeded with content entries and patches.
+func BenchmarkJSONLStoreCompact(b *testing.B) {
+	sizes := []int{100, 1000, 5000}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			store := newJSONLStore(fs, filePath, archivePath)
+
+			seed := generateContents(size)
+			_ = store.Save(ctx, seed)
+
+			for idx := 0; idx < size; idx++ {
+				_ = store.UpdateMetadata(ctx, idx, map[string]interface{}{"pinned": true})
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = store.Compact(ctx)
+			}
+		})
+	}
+}
+
+// BenchmarkJSONLStoreSave measures compaction write throughput of jsonlStore.Save
+// for both text-only content and content with inline binary data.
+func BenchmarkJSONLStoreSave(b *testing.B) {
+	textSizes := []int{100, 1000, 5000}
+	for _, size := range textSizes {
+		b.Run(fmt.Sprintf("TextOnly/size=%d", size), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			fixture := generateContents(size)
+			store := newJSONLStore(fs, filePath, archivePath)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = store.Save(ctx, fixture)
+			}
+		})
+	}
+
+	inlineSizes := []int{100, 1000}
+	for _, size := range inlineSizes {
+		b.Run(fmt.Sprintf("WithInlineData/size=%d", size), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+			fixture := generateContentsWithInlineData(size)
+			store := newJSONLStore(fs, filePath, archivePath)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = store.Save(ctx, fixture)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/history/store_bench_test.go
+++ b/internal/infrastructure/history/store_bench_test.go
@@ -67,12 +67,6 @@ func BenchmarkJSONLStoreAppend(b *testing.B) {
 			fs := persistencetest.NewPlainOSFileSystem()
 			filePath := filepath.Join(tmpDir, "history.jsonl")
 			archivePath := filepath.Join(tmpDir, "archive.jsonl")
-			store := newJSONLStore(fs, filePath, archivePath)
-
-			if preSeed > 0 {
-				seed := generateContents(preSeed)
-				_ = store.Save(ctx, seed)
-			}
 
 			singleEntry := []*llm.Content{{
 				Role: "user",
@@ -81,9 +75,18 @@ func BenchmarkJSONLStoreAppend(b *testing.B) {
 				},
 			}}
 
-			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				store := newJSONLStore(fs, filePath, archivePath)
+				if preSeed > 0 {
+					seed := generateContents(preSeed)
+					if err := store.Save(ctx, seed); err != nil {
+						b.Fatalf("seed Save failed: %v", err)
+					}
+				}
+				b.StartTimer()
+
 				_ = store.Append(ctx, singleEntry)
 			}
 		})
@@ -101,18 +104,23 @@ func BenchmarkJSONLStoreCompact(b *testing.B) {
 			fs := persistencetest.NewPlainOSFileSystem()
 			filePath := filepath.Join(tmpDir, "history.jsonl")
 			archivePath := filepath.Join(tmpDir, "archive.jsonl")
-			store := newJSONLStore(fs, filePath, archivePath)
-
-			seed := generateContents(size)
-			_ = store.Save(ctx, seed)
-
-			for idx := 0; idx < size; idx++ {
-				_ = store.UpdateMetadata(ctx, idx, map[string]interface{}{"pinned": true})
-			}
-
-			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
+				store := newJSONLStore(fs, filePath, archivePath)
+
+				seed := generateContents(size)
+				if err := store.Save(ctx, seed); err != nil {
+					b.Fatalf("seed Save failed: %v", err)
+				}
+
+				for idx := 0; idx < size; idx++ {
+					if err := store.UpdateMetadata(ctx, idx, map[string]interface{}{"pinned": true}); err != nil {
+						b.Fatalf("UpdateMetadata[%d] failed: %v", idx, err)
+					}
+				}
+				b.StartTimer()
+
 				_ = store.Compact(ctx)
 			}
 		})

--- a/internal/infrastructure/persistence/tasks_bench_test.go
+++ b/internal/infrastructure/persistence/tasks_bench_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package persistence
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+)
+
+// generateTasks creates n realistic Task fixtures for benchmarking.
+func generateTasks(n int) []ports.Task {
+	tasks := make([]ports.Task, n)
+	now := time.Now()
+	for i := 0; i < n; i++ {
+		tasks[i] = ports.Task{
+			ID:        float64(i + 1),
+			Content:   fmt.Sprintf("Task number %d with some descriptive text for realistic JSON size", i+1),
+			Status:    "pending",
+			CreatedAt: now,
+		}
+	}
+	return tasks
+}
+
+// marshalTasksToJSONL marshals a slice of tasks into JSONL format (one JSON object per line).
+func marshalTasksToJSONL(tasks []ports.Task) string {
+	var sb strings.Builder
+	for _, t := range tasks {
+		data, err := json.Marshal(t)
+		if err != nil {
+			panic(fmt.Sprintf("marshalTasksToJSONL: failed to marshal task: %v", err))
+		}
+		sb.Write(data)
+		sb.WriteByte('\n')
+	}
+	return sb.String()
+}
+
+// BenchmarkParseJSONLTasks measures the performance of parseJSONLTasks across
+// realistic input sizes with zero filesystem I/O.
+func BenchmarkParseJSONLTasks(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	sizes := []int{100, 1000, 10000, 50000}
+
+	for _, size := range sizes {
+		tasks := generateTasks(size)
+		fixture := marshalTasksToJSONL(tasks)
+
+		b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				_ = parseJSONLTasks(fixture, "bench.jsonl", logger)
+			}
+		})
+	}
+}
+
+// BenchmarkTaskRepositoryReadAll measures end-to-end read performance of
+// taskRepository.ReadAll with real disk I/O, covering both JSONL and JSON
+// array formats.
+func BenchmarkTaskRepositoryReadAll(b *testing.B) {
+	sizes := []int{1000, 10000, 50000}
+	formats := []struct {
+		name    string
+		marshal func([]ports.Task) []byte
+	}{
+		{
+			name: "jsonl",
+			marshal: func(tasks []ports.Task) []byte {
+				return []byte(marshalTasksToJSONL(tasks))
+			},
+		},
+		{
+			name: "json_array",
+			marshal: func(tasks []ports.Task) []byte {
+				data, err := json.Marshal(tasks)
+				if err != nil {
+					panic(fmt.Sprintf("json.Marshal tasks: %v", err))
+				}
+				return data
+			},
+		},
+	}
+
+	for _, format := range formats {
+		b.Run("format="+format.name, func(b *testing.B) {
+			for _, size := range sizes {
+				b.Run(fmt.Sprintf("size=%d", size), func(b *testing.B) {
+					ctx := context.Background()
+					tmpDir := b.TempDir()
+					fs := persistencetest.NewPlainOSFileSystem()
+					filePath := filepath.Join(tmpDir, "tasks.json")
+
+					tasks := generateTasks(size)
+					content := format.marshal(tasks)
+
+					if err := fs.WriteFile(ctx, filePath, content, 0644); err != nil {
+						b.Fatalf("WriteFile: %v", err)
+					}
+
+					repo := newTaskRepository(fs, filePath, slog.New(slog.NewTextHandler(io.Discard, nil)))
+
+					b.ResetTimer()
+					b.ReportAllocs()
+
+					for i := 0; i < b.N; i++ {
+						_, _ = repo.ReadAll(ctx)
+					}
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #505.

## Summary
Added baseline benchmarks for persistence and history packages as specified in #505:

### Persistence — TaskMigration
- **`BenchmarkParseJSONLTasks`** — pure-function JSONL parsing at sizes 100/1K/10K/50K
- **`BenchmarkTaskRepositoryReadAll`** — end-to-end read throughput (JSONL + JSON array) at sizes 1K/10K/50K

### History — HistoryWrite
- **`BenchmarkJSONLStoreSave`** — compaction write throughput (text-only + inline data) at sizes 100/1K/5K
- **`BenchmarkJSONLStoreAppend`** — incremental append latency at preSeed 0/1K/5K
- **`BenchmarkJSONLStoreCompact`** — full compaction cycle (Load → Save) with patches at sizes 100/1K/5K
- **`BenchmarkManagerAddContent`** — Manager-level append with lock overhead at preSeed 0/1K
- **`BenchmarkManagerSave`** — Manager-level save with Sync/fsync at sizes 100/1K/5K

### Design
- All benchmarks use `b.ReportAllocs()` for B/op and allocs/op
- Baseline only — no optimization targets
- `persistencetest.NewPlainOSFileSystem()` for consistent I/O (avoids AtomicWrite noise)
- Stable, low-variance output; linear scaling confirmed

## Verification
| Check | Status |
|-------|--------|
| go fmt | PASS |
| go vet | PASS |
| go build | PASS |
| go test | PASS |
| Benchmarks (benchmem) | PASS — all produce B/op, allocs/op |
