### PR TITLE
fix(ui): strip ANSI codes in TestHistory_RenderTextFallback assertion (#511)

### DIFF
--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -17,6 +18,12 @@ import (
 	infrapersistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/ui"
 )
+
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
+
+func stripANSI(s string) string {
+	return ansiRE.ReplaceAllString(s, "")
+}
 
 func TestHistory_Rendering(t *testing.T) {
 	ctx := context.Background()
@@ -244,8 +251,10 @@ func TestHistory_RenderTextFallback(t *testing.T) {
 	t.Run("raw=false uses glamour renderer", func(t *testing.T) {
 		var buf bytes.Buffer
 		ui.RenderHistory(&buf, h, 10, ports.HistoryRenderOptions{Raw: false})
-		output := buf.String()
+		output := stripANSI(buf.String())
 		// Non-raw path should still contain the content (rendered by glamour)
+		// ANSI escapes are stripped first — glamour may emit color codes
+		// depending on terminal environment state set by prior tests.
 		if !strings.Contains(output, "hello world") {
 			t.Errorf("expected rendered text to contain 'hello world', got %q", output)
 		}


### PR DESCRIPTION
## Summary

Fixes flaky test `TestHistory_RenderTextFallback/raw=false_uses_glamour_renderer` that fails during full suite runs due to ANSI color escape sequences emitted by glamour.

## Root Cause

The glamour renderer uses `WithAutoStyle()`, which detects terminal capabilities at render time. When the full test suite runs, prior packages pollute global state (env vars like `TERM`/`COLORTERM`), causing glamour to emit ANSI CSI sequences. These split `"hello world"` into separate color spans, so `strings.Contains(output, "hello world")` fails.

## Fix

Added a `stripANSI` helper that removes all CSI escape sequences before asserting. This decouples the content assertion from terminal formatting state. Production code (`WithAutoStyle`) is untouched — it remains correct.

## Verification

- `go test -count=1 -run TestHistory_RenderTextFallback ./internal/ui/...` → **PASS**
- `go test -count=1 ./internal/...` → **all 63 packages PASS**

Closes #511