### PR TITLE
fix(tui): strip ANSI codes in TestBrowserModel_View assertion (#512)

### DIFF
--- a/internal/ui/tui/browser_test.go
+++ b/internal/ui/tui/browser_test.go
@@ -218,7 +218,12 @@ func TestBrowserModel_View(t *testing.T) {
 
 	_ = m.View()
 
-	// Assertions on the rendered content (directly or via View if height permits)
+	// Strip ANSI escape sequences before asserting — lipgloss may emit
+	// color codes depending on terminal environment state set by prior
+	// test packages in the full suite (same class of bug as #511).
+	rendered = stripANSI(rendered)
+
+	// Assertions on the rendered content
 	expectedSubstrings := []string{
 		"> [USER] - 1",
 		"[PINNED]",


### PR DESCRIPTION
## Summary

Fixes flaky test `TestBrowserModel_View` that fails during full suite runs due to ANSI color escape sequences emitted by lipgloss — same class of bug as #511.

## Root Cause

The browser renderer uses `lipgloss.Style.Render()` for role labels (e.g., `userStyle.Render("[USER] - 1")`). Lipgloss auto-detects terminal color support via environment variables (`TERM`, `COLORTERM`). When the full test suite runs, prior packages pollute this global state, causing lipgloss to emit ANSI CSI sequences that split the expected string into non-contiguous spans. `strings.Contains(rendered, "> [USER] - 1")` fails.

Note: the issue description incorrectly identifies glamour as the source. The browser renderer (`browser_viewport.go`) uses **lipgloss**, not glamour.

## Fix

Applied the existing `stripANSI` helper (already in `browser_test.go`) to the `rendered` variable before assertions. This is the same pattern used in #511 — decouple content assertions from terminal formatting state. Zero production code changes.

## Verification

- `go test -count=1 -run TestBrowserModel_View ./internal/ui/tui/...` → **PASS**
- `go test -count=1 ./internal/...` → **all 63 packages PASS**

Closes #512