### PR TITLE
fix(cli): use capturerOverride for deterministic TTY check in browse test (#515)

### DIFF
--- a/internal/cli/cmd_browse_test.go
+++ b/internal/cli/cmd_browse_test.go
@@ -189,7 +189,17 @@ func TestBrowseCommand_NilInteractorRef_DoesNotPanic(t *testing.T) {
 		Interactor:   nil, // explicit nil
 	}
 
-	err := executeBrowseCommand(cmdCtx, []string{"browse"})
+	// Use capturerOverride to force a deterministic TTY check result.
+	// Without this, prior test packages can pollute TTY detection global
+	// state (os.Stdout, terminal env vars), causing IsTTY to return true
+	// and execution to reach GetUnifiedHistoryProvider on an unprepared
+	// mock — same class of bug as #511/#512.
+	c := &browseCommand{
+		ctx:              cmdCtx,
+		capturerOverride: &mockCapturerInteractor{isTTY: false},
+	}
+
+	err := c.runBrowse(stdctx.Background(), "test-config.yaml")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "requires an interactive TTY")
 	// Should not panic with nil InteractorRef


### PR DESCRIPTION
## Summary

Fixes flaky test `TestBrowseCommand_NilInteractorRef_DoesNotPanic` that panics during full suite runs due to TTY detection state pollution — same class of bug as #511 and #512.

## Root Cause

The test relied on the real capturer's `IsTTY(os.Stdout)` returning `false`. When the full test suite runs, prior packages pollute TTY detection global state (terminal env vars, `os.Stdout` state), causing `IsTTY` to return `true`. Execution proceeds past the TTY guard to `GetUnifiedHistoryProvider` on a mock that never had that expectation set up — panic.

## Fix

Switched from `executeBrowseCommand` (cobra pipeline) to direct `c.runBrowse()` with `capturerOverride: &mockCapturerInteractor{isTTY: false}`. This makes the TTY check deterministic regardless of ambient state. Matches the established pattern in `TestBrowseCommand_RunBrowse_PostTTY` in the same file.

## Verification

- `go test -count=1 -run TestBrowseCommand_NilInteractorRef_DoesNotPanic ./internal/cli/...` → **PASS**
- `go test -count=1 ./internal/...` → **all 63 packages PASS**

Closes #515