### PR TITLE
fix(session): move test-only sessionDependencies to sessiontest package (#525)

### DIFF
--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/agent/session/sessiontest"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
@@ -192,7 +193,7 @@ func TestSessionManager_ConfigError(t *testing.T) {
 	sc := session.NewSessionConfig("", false, 0, 0, false, "test prompt", cfg)
 
 	ic := &mockFailingCapturer{}
-	sd := session.NewSessionDependencies(&persistence.Paths{}, nil, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, nil, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	sd := sessiontest.New(&persistence.Paths{}, nil, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, nil, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	err := o.Run(context.Background(), sc, sd, ic)
 	if err == nil || err.Error() != "failed to apply configuration: config failed" {

--- a/internal/agent/session/entropy_test.go
+++ b/internal/agent/session/entropy_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	"github.com/gosharplite/tell-me-go/internal/agent/session/sessiontest"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
@@ -55,7 +56,7 @@ func TestSessionManager_SessionID_DegradationWarning(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()

--- a/internal/agent/session/export_test.go
+++ b/internal/agent/session/export_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/session/sessiontest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/stretchr/testify/mock"
@@ -15,7 +16,7 @@ import (
 // Exported for external tests
 type SessionManagerInternal = sessionManager
 type SessionConfigInternal = sessionConfig
-type SessionDependenciesInternal = sessionDependencies
+type SessionDependenciesInternal = sessiontest.Deps
 
 func (o *sessionManager) ApplyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.SessionDependencies, capturer ports.Capturer) (*ui.Bridge, error) {
 	return o.applyConfiguration(ctx, chatAgent, sCfg, sd, capturer)

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -14,12 +14,8 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
-	domain_llm "github.com/gosharplite/tell-me-go/internal/domain/llm"
-	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
-	domaintools "github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"golang.org/x/sync/errgroup"
 )
@@ -66,70 +62,6 @@ func NewSessionConfig(configPath string, newSession bool, lastN, backN int, rawO
 		RawOutput:  rawOutput,
 		Prompt:     prompt,
 		Config:     cfg,
-	}
-}
-
-// sessionDependencies holds the required components for a session.
-type sessionDependencies struct {
-	Paths            *persistence.Paths
-	HistoryManager   ports.HistoryManager
-	Client           domain_llm.LLMClient
-	Gateway          domain_llm.LLMGateway
-	Registry         domaintools.Registry
-	SecurityManager  domain_security.Manager
-	Tracker          domain_pricing.CostTracker
-	PricingData      domain_pricing.PricingData
-	PricingOverrides map[string]domain_pricing.ModelPricing
-	EventBus         events.EventBus
-	Logger           ports.Logger
-	TurnsLogger      ports.TurnsLogger
-	SessionProvider  ports.SessionProvider
-	Health           ports.HealthCheckManager
-}
-
-func (d *sessionDependencies) GetGateway() domain_llm.LLMGateway { return d.Gateway }
-func (d *sessionDependencies) GetHistoryManager() ports.HistoryManager {
-	return d.HistoryManager
-}
-func (d *sessionDependencies) GetRegistry() (domaintools.Registry, error) { return d.Registry, nil }
-func (d *sessionDependencies) GetSecurityManager() domain_security.Manager {
-	return d.SecurityManager
-}
-func (d *sessionDependencies) GetEventBus() events.EventBus { return d.EventBus }
-func (d *sessionDependencies) GetLogger() ports.Logger      { return d.Logger }
-func (d *sessionDependencies) GetTurnsLogger() ports.TurnsLogger {
-	return d.TurnsLogger
-}
-func (d *sessionDependencies) GetPaths() *persistence.Paths { return d.Paths }
-func (d *sessionDependencies) GetSessionProvider() ports.SessionProvider {
-	return d.SessionProvider
-}
-func (d *sessionDependencies) GetPricingOverrides() map[string]domain_pricing.ModelPricing {
-	return d.PricingOverrides
-}
-func (d *sessionDependencies) GetTracker() domain_pricing.CostTracker { return d.Tracker }
-func (d *sessionDependencies) GetPricingData() domain_pricing.PricingData {
-	return d.PricingData
-}
-func (d *sessionDependencies) GetHealthManager() ports.HealthCheckManager { return d.Health }
-
-// NewSessionDependencies creates a new sessionDependencies with all required components.
-func NewSessionDependencies(paths *persistence.Paths, hManager ports.HistoryManager, client domain_llm.LLMClient, gw domain_llm.LLMGateway, reg domaintools.Registry, sm domain_security.Manager, tracker domain_pricing.CostTracker, pData domain_pricing.PricingData, overrides map[string]domain_pricing.ModelPricing, bus events.EventBus, logger ports.Logger, turnsLogger ports.TurnsLogger, sessionProvider ports.SessionProvider, health ports.HealthCheckManager) ports.SessionDependencies {
-	return &sessionDependencies{
-		Paths:            paths,
-		HistoryManager:   hManager,
-		Client:           client,
-		Gateway:          gw,
-		Registry:         reg,
-		SecurityManager:  sm,
-		Tracker:          tracker,
-		PricingData:      pData,
-		PricingOverrides: overrides,
-		EventBus:         bus,
-		Logger:           logger,
-		TurnsLogger:      turnsLogger,
-		SessionProvider:  sessionProvider,
-		Health:           health,
 	}
 }
 

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	"github.com/gosharplite/tell-me-go/internal/agent/session/sessiontest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
@@ -54,7 +55,7 @@ func TestSessionManager_Run_Success(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), mTurnsLogger, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), mTurnsLogger, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -95,7 +96,7 @@ func TestSessionManager_Run_Error(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -138,7 +139,7 @@ func TestSessionManager_Run_NoPrompt_WithLastN(t *testing.T) {
 		Prompt:          "",
 		LastN:           5,
 		Config:          &config.Config{},
-		Deps:            session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
+		Deps:            sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
 		Capturer:        mCapturer,
 	}
 
@@ -173,7 +174,7 @@ func TestSessionManager_ApplyConfiguration_Error(t *testing.T) {
 	mChatter.On("Subscribe", mock.Anything).Return()
 	mChatter.On("SetLimits", mock.Anything, 10, mock.Anything, mock.Anything).Return(fmt.Errorf("limits error"))
 
-	deps := session.NewSessionDependencies(paths, nil, nil, nil, nil, nil, nil, pData, nil, nil, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(paths, nil, nil, nil, nil, nil, nil, pData, nil, nil, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	bridge, err := session.AsSessionManagerInternal(orch).ApplyConfiguration(context.Background(), mChatter, sCfg, deps, mCapturer)
 	require.Error(t, err)
@@ -399,7 +400,7 @@ func TestSessionManager_Run_BehaviorSequence(t *testing.T) {
 			Mode:             "mode",
 			SelectedProvider: "provider",
 		},
-		Deps:     session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
+		Deps:     sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
 		Capturer: mCapturer,
 	}
 
@@ -587,7 +588,7 @@ func TestRun_Routing(t *testing.T) {
 			AgentFactory:    factory(mChatter),
 			HistoryRenderer: mHistoryRenderer,
 			UIRenderer:      mUIRenderer,
-			Deps:            session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
+			Deps:            sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil),
 			Capturer:        mCapturer,
 			Config: &config.Config{
 				Model: "model",
@@ -727,7 +728,7 @@ func TestSessionManager_Run_ErrorPropagation(t *testing.T) {
 				Model: "model",
 				Mode:  "mode",
 			})
-			deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+			deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 			mCapturer.On("IsTTY", io.Discard).Return(true)
 			mUIRenderer.On("SetUseColor", true).Return()
@@ -799,7 +800,7 @@ func TestSessionManager_Run_ShutdownError(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -838,7 +839,7 @@ func TestSessionManager_Run_ApplyConfigError(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -888,7 +889,7 @@ func TestSessionManager_SessionID_Fallback(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -938,7 +939,7 @@ func TestSessionManager_SessionID_DeterministicEntropy(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -997,7 +998,7 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 		Model: "model",
 		Mode:  "mode",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	mCapturer.On("IsTTY", io.Discard).Return(true)
 	mUIRenderer.On("SetUseColor", true).Return()
@@ -1102,7 +1103,7 @@ func TestSessionManager_SetupUIRendering_HandleEventError(t *testing.T) {
 			sCfg := &session.SessionConfigInternal{
 				Config: &config.Config{},
 			}
-			deps := session.NewSessionDependencies(
+			deps := sessiontest.New(
 				&persistence.Paths{}, nil, nil, nil, nil, nil, nil,
 				domain_pricing.PricingData{}, nil, nil,
 				mockLogger,

--- a/internal/agent/session/sessiontest/sessiontest.go
+++ b/internal/agent/session/sessiontest/sessiontest.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package sessiontest
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	domain_llm "github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	domaintools "github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// Deps holds the required components for a session.
+type Deps struct {
+	Paths            *persistence.Paths
+	HistoryManager   ports.HistoryManager
+	Client           domain_llm.LLMClient
+	Gateway          domain_llm.LLMGateway
+	Registry         domaintools.Registry
+	SecurityManager  domain_security.Manager
+	Tracker          domain_pricing.CostTracker
+	PricingData      domain_pricing.PricingData
+	PricingOverrides map[string]domain_pricing.ModelPricing
+	EventBus         events.EventBus
+	Logger           ports.Logger
+	TurnsLogger      ports.TurnsLogger
+	SessionProvider  ports.SessionProvider
+	Health           ports.HealthCheckManager
+}
+
+// New creates a new Deps with all required components.
+func New(paths *persistence.Paths, hManager ports.HistoryManager, client domain_llm.LLMClient, gw domain_llm.LLMGateway, reg domaintools.Registry, sm domain_security.Manager, tracker domain_pricing.CostTracker, pData domain_pricing.PricingData, overrides map[string]domain_pricing.ModelPricing, bus events.EventBus, logger ports.Logger, turnsLogger ports.TurnsLogger, sessionProvider ports.SessionProvider, health ports.HealthCheckManager) ports.SessionDependencies {
+	return &Deps{
+		Paths:            paths,
+		HistoryManager:   hManager,
+		Client:           client,
+		Gateway:          gw,
+		Registry:         reg,
+		SecurityManager:  sm,
+		Tracker:          tracker,
+		PricingData:      pData,
+		PricingOverrides: overrides,
+		EventBus:         bus,
+		Logger:           logger,
+		TurnsLogger:      turnsLogger,
+		SessionProvider:  sessionProvider,
+		Health:           health,
+	}
+}
+
+func (d *Deps) GetGateway() domain_llm.LLMGateway { return d.Gateway }
+
+func (d *Deps) GetHistoryManager() ports.HistoryManager {
+	return d.HistoryManager
+}
+
+func (d *Deps) GetRegistry() (domaintools.Registry, error) { return d.Registry, nil }
+
+func (d *Deps) GetSecurityManager() domain_security.Manager {
+	return d.SecurityManager
+}
+
+func (d *Deps) GetEventBus() events.EventBus { return d.EventBus }
+
+func (d *Deps) GetLogger() ports.Logger { return d.Logger }
+
+func (d *Deps) GetTurnsLogger() ports.TurnsLogger {
+	return d.TurnsLogger
+}
+
+func (d *Deps) GetPaths() *persistence.Paths { return d.Paths }
+
+func (d *Deps) GetSessionProvider() ports.SessionProvider {
+	return d.SessionProvider
+}
+
+func (d *Deps) GetPricingOverrides() map[string]domain_pricing.ModelPricing {
+	return d.PricingOverrides
+}
+
+func (d *Deps) GetTracker() domain_pricing.CostTracker { return d.Tracker }
+
+func (d *Deps) GetPricingData() domain_pricing.PricingData {
+	return d.PricingData
+}
+
+func (d *Deps) GetHealthManager() ports.HealthCheckManager { return d.Health }

--- a/tests/integration/agent/session/spinner_integration_test.go
+++ b/tests/integration/agent/session/spinner_integration_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
+	sessiontest "github.com/gosharplite/tell-me-go/internal/agent/session/sessiontest"
 	sessionui "github.com/gosharplite/tell-me-go/internal/agent/session/ui"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
@@ -158,7 +159,7 @@ func TestSpinner_E2E_Visibility(t *testing.T) {
 		Mode:             "mode",
 		SelectedProvider: "provider",
 	})
-	deps := session.NewSessionDependencies(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
+	deps := sessiontest.New(&persistence.Paths{}, mHistory, nil, nil, nil, nil, nil, domain_pricing.PricingData{}, nil, mEventBus, slog.Default(), &ports.NoOpTurnsLogger{}, new(agenttest.MockSessionProvider), nil)
 
 	err := orch.Run(context.Background(), sCfg, deps, mCapturer)
 	assert.NoError(t, err)


### PR DESCRIPTION
Closes #525.

## Summary
Moved the test-only `sessionDependencies` struct and `NewSessionDependencies` constructor from `internal/agent/session/session_manager.go` to a new `internal/agent/session/sessiontest/` package, following the established project convention (`agenttest/`, `eventstest/`, `orchestratortest/`).

### Changes
- **NEW** `session/sessiontest/sessiontest.go` — exported `Deps` struct + `New()` constructor + 14 accessor methods
- **MODIFIED** `session/export_test.go` — alias now points to `sessiontest.Deps`
- **MODIFIED** `session/session_manager.go` — stripped of test-only type (~60 lines removed, imports cleaned)
- **MODIFIED** `session/session_manager_test.go` — 13 calls updated to `sessiontest.New`
- **MODIFIED** `session/entropy_test.go` — 1 call updated
- **MODIFIED** `session/context/gatekeeper_error_test.go` — 1 call updated
- **MODIFIED** `tests/integration/agent/session/spinner_integration_test.go` — 1 call updated

## Verification
| Check | Status |
|-------|--------|
| fmt | PASS |
| tidy | PASS |
| build | PASS |
| lint | Pre-existing issue (persistence_tools.go, not our change) |
| verify-architecture | PASS |
| vulncheck | PASS (0 vulns) |
| test | PASS (all packages) |
| dead-code | PASS |
| test-race | PASS (all packages) |
| test-coverage | PASS |
| `di.sessionDeps` untouched | PASS |