### PR TITLE
fix(session): remove dead Loader field from sessionManager (#523)

### DIFF
--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -184,7 +184,7 @@ func TestSessionManager_ConfigError(t *testing.T) {
 		return &mockFailingChatter{err: errors.New("config failed")}, nil
 	}
 
-	o := session.NewSessionManager("", "", nil, nil, io.Discard, io.Discard, agentFactory, nil, &mockFailingUIRenderer{}, clock.RealClock{}, rand.Reader)
+	o := session.NewSessionManager("", "", nil, io.Discard, io.Discard, agentFactory, nil, &mockFailingUIRenderer{}, clock.RealClock{}, rand.Reader)
 
 	cfg := &config.Config{
 		SelectedProvider: "test",

--- a/internal/agent/session/entropy_test.go
+++ b/internal/agent/session/entropy_test.go
@@ -49,7 +49,7 @@ func TestSessionManager_SessionID_DegradationWarning(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, &stderr, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderr, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -28,7 +28,6 @@ import (
 type sessionManager struct {
 	HomeDir         string
 	Version         string
-	Loader          config.ConfigLoader
 	SM              domain_security.Manager
 	Stdout          io.Writer
 	Stderr          io.Writer
@@ -134,11 +133,10 @@ func NewSessionDependencies(paths *persistence.Paths, hManager ports.HistoryMana
 }
 
 // NewSessionManager creates a new sessionManager.
-func NewSessionManager(homeDir, version string, loader config.ConfigLoader, sm domain_security.Manager, stdout, stderr io.Writer, factory ports.ChatterFactory, historyRenderer ports.HistoryRenderer, uiRenderer ports.UIRenderer, clk clock.Clock, entropy io.Reader) SessionManager {
+func NewSessionManager(homeDir, version string, sm domain_security.Manager, stdout, stderr io.Writer, factory ports.ChatterFactory, historyRenderer ports.HistoryRenderer, uiRenderer ports.UIRenderer, clk clock.Clock, entropy io.Reader) SessionManager {
 	return &sessionManager{
 		HomeDir:         homeDir,
 		Version:         version,
-		Loader:          loader,
 		SM:              sm,
 		Stdout:          stdout,
 		Stderr:          stderr,
@@ -308,7 +306,6 @@ func (o *sessionManager) setupUIRendering(ctx context.Context, chatAgent ports.C
 type RunParams struct {
 	HomeDir         string
 	Version         string
-	Loader          config.ConfigLoader
 	SM              domain_security.Manager
 	Stdout          io.Writer
 	Stderr          io.Writer
@@ -343,7 +340,6 @@ func Run(ctx context.Context, params RunParams) error {
 	orch := NewSessionManager(
 		params.HomeDir,
 		params.Version,
-		params.Loader,
 		params.SM,
 		params.Stdout,
 		params.Stderr,

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -48,7 +48,7 @@ func TestSessionManager_Run_Success(t *testing.T) {
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
 	mTurnsLogger := new(agenttest.MockTurnsLogger)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -89,7 +89,7 @@ func TestSessionManager_Run_Error(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -128,7 +128,6 @@ func TestSessionManager_Run_NoPrompt_WithLastN(t *testing.T) {
 	params := session.RunParams{
 		HomeDir:         "home",
 		Version:         "1.0.0",
-		Loader:          nil,
 		SM:              nil,
 		Stdout:          io.Discard,
 		Stderr:          io.Discard,
@@ -156,7 +155,7 @@ func TestSessionManager_ApplyConfiguration_Error(t *testing.T) {
 	t.Parallel()
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 	mChatter := new(agenttest.MockChatter)
 	mCapturer := new(agenttest.MockCapturer)
 
@@ -385,7 +384,6 @@ func TestSessionManager_Run_BehaviorSequence(t *testing.T) {
 	params := session.RunParams{
 		HomeDir:         "home",
 		Version:         "1.0.0",
-		Loader:          nil,
 		SM:              nil,
 		Stdout:          io.Discard,
 		Stderr:          io.Discard,
@@ -550,7 +548,7 @@ func TestSessionManager_Rollback(t *testing.T) {
 			mHistory.SetInternalContents(make([]*llm.Content, 4)) // 2 turns
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 			mUIRenderer := new(agenttest.MockUIRenderer)
-			orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 			mHistory.SetRollbackErr(tt.rollbackErr)
 			sCfg := &session.SessionConfigInternal{BackN: tt.backN}
@@ -721,7 +719,7 @@ func TestSessionManager_Run_ErrorPropagation(t *testing.T) {
 
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 			mUIRenderer := new(agenttest.MockUIRenderer)
-			orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 			sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 				Model: "model",
@@ -793,7 +791,7 @@ func TestSessionManager_Run_ShutdownError(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, &stderrBuf, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderrBuf, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -832,7 +830,7 @@ func TestSessionManager_Run_ApplyConfigError(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -882,7 +880,7 @@ func TestSessionManager_SessionID_Fallback(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -932,7 +930,7 @@ func TestSessionManager_SessionID_DeterministicEntropy(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -991,7 +989,7 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -1095,7 +1093,7 @@ func TestSessionManager_SetupUIRendering_HandleEventError(t *testing.T) {
 			mCapturer.On("IsTTY", mock.Anything).Return(true)
 
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
-			orch := session.NewSessionManager("home", "1.0.0", nil, nil,
+			orch := session.NewSessionManager("home", "1.0.0", nil,
 				io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer,
 				clock.RealClock{}, rand.Reader)
 

--- a/tests/integration/agent/session/spinner_integration_test.go
+++ b/tests/integration/agent/session/spinner_integration_test.go
@@ -101,7 +101,7 @@ func TestSpinner_E2E_Visibility(t *testing.T) {
 		return mChatter, nil
 	}
 
-	orch := session.NewSessionManager("home", "1.0.0", nil, nil, stdout, stderr, factory, nil, uiRenderer, clock, strings.NewReader("deterministic_entropy"))
+	orch := session.NewSessionManager("home", "1.0.0", nil, stdout, stderr, factory, nil, uiRenderer, clock, strings.NewReader("deterministic_entropy"))
 
 	// 2. Mock Agent Behavior
 	// When Chat is called, it will emit events via the event bus.


### PR DESCRIPTION
Closes #523.

## Summary
Removed the dead `Loader` field from `sessionManager`, `NewSessionManager` constructor, and `RunParams`. The field was stored but never read — verified via static analysis: all call sites already pass `nil`, and `service.go` already omitted the field.

**Changes:**
- `sessionManager.Loader` field removed
- `NewSessionManager` reduced from 11 → 10 parameters
- `RunParams.Loader` field removed (20 → 19 fields)
- 15 test call sites updated across 4 test files

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go test ./... (all packages) | PASS |
| go vet (changed packages) | PASS |
| golangci-lint (agent packages) | 0 issues |
| grep -rn Loader (5 changed files) | 0 matches |

> **Note:** `make check-full` has 1 pre-existing `govet` finding in `internal/tools/workspace/persistence_tools.go` unrelated to this change.