### PR TITLE
fix(session): move Clock/EntropySource defaults to NewSessionManager via options (#524)

### DIFF
--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"testing"
 
-	"crypto/rand"
 	"log/slog"
 	"time"
 
@@ -25,7 +24,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -185,7 +183,7 @@ func TestSessionManager_ConfigError(t *testing.T) {
 		return &mockFailingChatter{err: errors.New("config failed")}, nil
 	}
 
-	o := session.NewSessionManager("", "", nil, io.Discard, io.Discard, agentFactory, nil, &mockFailingUIRenderer{}, clock.RealClock{}, rand.Reader)
+	o := session.NewSessionManager("", "", nil, io.Discard, io.Discard, agentFactory, nil, &mockFailingUIRenderer{})
 
 	cfg := &config.Config{
 		SelectedProvider: "test",

--- a/internal/agent/session/entropy_test.go
+++ b/internal/agent/session/entropy_test.go
@@ -50,7 +50,7 @@ func TestSessionManager_SessionID_DegradationWarning(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderr, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderr, factory, mHistoryRenderer, mUIRenderer, session.WithClock(mClock), session.WithEntropySource(mEntropy))
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -64,9 +64,23 @@ func NewSessionConfig(configPath string, newSession bool, lastN, backN int, rawO
 	}
 }
 
+// SessionManagerOption defines a functional option for configuring a SessionManager.
+type SessionManagerOption func(*sessionManager)
+
+// WithClock sets a custom clock implementation. Defaults to clock.RealClock{}.
+func WithClock(c clock.Clock) SessionManagerOption {
+	return func(sm *sessionManager) { sm.Clock = c }
+}
+
+// WithEntropySource sets a custom entropy source for session ID generation.
+// Defaults to rand.Reader.
+func WithEntropySource(r io.Reader) SessionManagerOption {
+	return func(sm *sessionManager) { sm.EntropySource = r }
+}
+
 // NewSessionManager creates a new sessionManager.
-func NewSessionManager(homeDir, version string, sm domain_security.Manager, stdout, stderr io.Writer, factory ports.ChatterFactory, historyRenderer ports.HistoryRenderer, uiRenderer ports.UIRenderer, clk clock.Clock, entropy io.Reader) SessionManager {
-	return &sessionManager{
+func NewSessionManager(homeDir, version string, sm domain_security.Manager, stdout, stderr io.Writer, factory ports.ChatterFactory, historyRenderer ports.HistoryRenderer, uiRenderer ports.UIRenderer, opts ...SessionManagerOption) SessionManager {
+	s := &sessionManager{
 		HomeDir:         homeDir,
 		Version:         version,
 		SM:              sm,
@@ -75,9 +89,13 @@ func NewSessionManager(homeDir, version string, sm domain_security.Manager, stdo
 		AgentFactory:    factory,
 		HistoryRenderer: historyRenderer,
 		UIRenderer:      uiRenderer,
-		Clock:           clk,
-		EntropySource:   entropy,
+		Clock:           clock.RealClock{},
+		EntropySource:   rand.Reader,
 	}
+	for _, o := range opts {
+		o(s)
+	}
+	return s
 }
 
 // Run executes the session orchestration.
@@ -253,22 +271,11 @@ type RunParams struct {
 	Config          *config.Config
 	Deps            ports.SessionDependencies
 	Capturer        ports.Capturer
-	Clock           clock.Clock
-	EntropySource   io.Reader
 }
 
 // Run is the high-level entry point for running a chat session.
 // It simplifies the public API by encapsulating internal component assembly.
 func Run(ctx context.Context, params RunParams) error {
-	clk := params.Clock
-	if clk == nil {
-		clk = clock.RealClock{}
-	}
-	entropy := params.EntropySource
-	if entropy == nil {
-		entropy = rand.Reader
-	}
-
 	orch := NewSessionManager(
 		params.HomeDir,
 		params.Version,
@@ -278,8 +285,6 @@ func Run(ctx context.Context, params RunParams) error {
 		params.AgentFactory,
 		params.HistoryRenderer,
 		params.UIRenderer,
-		clk,
-		entropy,
 	)
 
 	sCfg := NewSessionConfig(

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -49,7 +49,7 @@ func TestSessionManager_Run_Success(t *testing.T) {
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
 	mTurnsLogger := new(agenttest.MockTurnsLogger)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -90,7 +90,7 @@ func TestSessionManager_Run_Error(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -156,7 +156,7 @@ func TestSessionManager_ApplyConfiguration_Error(t *testing.T) {
 	t.Parallel()
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer)
 	mChatter := new(agenttest.MockChatter)
 	mCapturer := new(agenttest.MockCapturer)
 
@@ -549,7 +549,7 @@ func TestSessionManager_Rollback(t *testing.T) {
 			mHistory.SetInternalContents(make([]*llm.Content, 4)) // 2 turns
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 			mUIRenderer := new(agenttest.MockUIRenderer)
-			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer)
 
 			mHistory.SetRollbackErr(tt.rollbackErr)
 			sCfg := &session.SessionConfigInternal{BackN: tt.backN}
@@ -720,7 +720,7 @@ func TestSessionManager_Run_ErrorPropagation(t *testing.T) {
 
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 			mUIRenderer := new(agenttest.MockUIRenderer)
-			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+			orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer)
 
 			sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 				Model: "model",
@@ -792,7 +792,7 @@ func TestSessionManager_Run_ShutdownError(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderrBuf, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, &stderrBuf, factory, mHistoryRenderer, mUIRenderer)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -831,7 +831,7 @@ func TestSessionManager_Run_ApplyConfigError(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, clock.RealClock{}, rand.Reader)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer)
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -881,7 +881,7 @@ func TestSessionManager_SessionID_Fallback(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, session.WithClock(mClock), session.WithEntropySource(mEntropy))
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -931,7 +931,7 @@ func TestSessionManager_SessionID_DeterministicEntropy(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, session.WithClock(mClock), session.WithEntropySource(mEntropy))
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -990,7 +990,7 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 
 	mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 	mUIRenderer := new(agenttest.MockUIRenderer)
-	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, mClock, mEntropy)
+	orch := session.NewSessionManager("home", "1.0.0", nil, io.Discard, io.Discard, factory, mHistoryRenderer, mUIRenderer, session.WithClock(mClock), session.WithEntropySource(mEntropy))
 
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{
 		Model: "model",
@@ -1095,8 +1095,7 @@ func TestSessionManager_SetupUIRendering_HandleEventError(t *testing.T) {
 
 			mHistoryRenderer := new(agenttest.MockHistoryRenderer)
 			orch := session.NewSessionManager("home", "1.0.0", nil,
-				io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer,
-				clock.RealClock{}, rand.Reader)
+				io.Discard, io.Discard, nil, mHistoryRenderer, mUIRenderer)
 
 			sCfg := &session.SessionConfigInternal{
 				Config: &config.Config{},

--- a/tests/integration/agent/session/spinner_integration_test.go
+++ b/tests/integration/agent/session/spinner_integration_test.go
@@ -102,7 +102,7 @@ func TestSpinner_E2E_Visibility(t *testing.T) {
 		return mChatter, nil
 	}
 
-	orch := session.NewSessionManager("home", "1.0.0", nil, stdout, stderr, factory, nil, uiRenderer, clock, strings.NewReader("deterministic_entropy"))
+	orch := session.NewSessionManager("home", "1.0.0", nil, stdout, stderr, factory, nil, uiRenderer, session.WithClock(clock), session.WithEntropySource(strings.NewReader("deterministic_entropy")))
 
 	// 2. Mock Agent Behavior
 	// When Chat is called, it will emit events via the event bus.


### PR DESCRIPTION
Closes #524.

## Summary
Applied the Functional Options pattern (ADR-007 style) to `NewSessionManager` for Clock and EntropySource, moving safe defaults into the constructor and removing them from RunParams and the nil-defaulting logic in Run().

### Changes
- Added `SessionManagerOption` type + `WithClock`/`WithEntropySource` functions
- Refactored `NewSessionManager` to accept `opts ...SessionManagerOption` with defaults
- Removed `Clock`/`EntropySource` from `RunParams` and nil-defaulting from `Run()`
- Updated 16 call sites across 5 files

### Files Changed (5)
| File | Change |
|------|--------|
| `internal/agent/session/session_manager.go` | Core refactoring |
| `internal/agent/session/session_manager_test.go` | 11 call sites updated |
| `internal/agent/session/entropy_test.go` | 1 call site → options |
| `internal/agent/session/context/gatekeeper_error_test.go` | 1 call site, removed unused imports |
| `tests/integration/agent/session/spinner_integration_test.go` | 1 call site → options |

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go vet (changed packages) | PASS |
| go test ./internal/agent/... (12 packages) | PASS |
| go test ./tests/integration/agent/session/... | PASS |
| make check-full (fmt, tidy, build) | PASS |
| lint | Pre-existing failure in persistence_tools.go (not related) |