### PR TITLE
fix(cross-platform): add Windows skip guards and path normalization fixes (#535)

### DIFF
--- a/internal/infrastructure/factory/chatter_test.go
+++ b/internal/infrastructure/factory/chatter_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -199,6 +200,10 @@ func TestNewChatter(t *testing.T) {
 	})
 
 	t.Run("fails when skill repo cannot load", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("os.Chmod(0000) does not prevent file reads on Windows")
+		}
+
 		deps2, cfg2 := setupNilDepTest(t)
 		// setupNilDepTest creates a docs/skills/ dir. Drop an unreadable
 		// .md file into it to cause NewFileSkillRepository to fail.

--- a/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
+++ b/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -22,6 +23,10 @@ import (
 // permission checks.
 func makeUnwritableDir(t *testing.T) (dir string, fileInside string) {
 	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file creation on Windows")
+	}
 
 	if os.Geteuid() == 0 {
 		t.Skip("skipping permission test: running as root")

--- a/internal/infrastructure/persistence/sqlite_health_test.go
+++ b/internal/infrastructure/persistence/sqlite_health_test.go
@@ -229,6 +229,7 @@ func TestSQLiteHealthChecker_DBFileStatFails(t *testing.T) {
 	}
 	// Force file creation on disk by creating a table.
 	if _, err := db.Exec("CREATE TABLE test (id INTEGER);"); err != nil {
+		_ = db.Close()
 		t.Fatalf("failed to create table: %v", err)
 	}
 	_ = db.Close()

--- a/internal/infrastructure/persistence/sqlite_health_test.go
+++ b/internal/infrastructure/persistence/sqlite_health_test.go
@@ -8,6 +8,7 @@ import (
 	"database/sql"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -174,6 +175,10 @@ func TestSQLiteHealthChecker_IntegrityCheckExecFailure(t *testing.T) {
 func TestSQLiteHealthChecker_DirNotWritable(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file creation on Windows")
+	}
+
 	if os.Geteuid() == 0 {
 		t.Skip("skipping permission test: running as root")
 	}
@@ -210,27 +215,33 @@ func TestSQLiteHealthChecker_DBFileStatFails(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	// Create a symlink to a path in a non-existent directory.
-	// The parent directory (tmpDir) exists and is writable, so the filesystem
-	// checks pass, but os.Stat follows the symlink and fails because the
-	// target directory does not exist → size_bytes = 0.
-	dbPath := filepath.Join(tmpDir, "dangling")
-	if err := os.Symlink("/nonexistent_dir/test.db", dbPath); err != nil {
-		t.Fatal(err)
-	}
+	// Open the database so the file is created on disk, then close and
+	// delete it. The directory still exists and is writable, but os.Stat
+	// on the DB file fails (file gone) → size_bytes = 0. PingContext
+	// then fails because the connection is closed, resulting in
+	// StatusUnhealthy — same behavior as the dangling symlink approach,
+	// without requiring symlink privileges.
+	dbPath := filepath.Join(tmpDir, "test.db")
 
 	db, err := sql.Open("sqlite", dbPath)
 	if err != nil {
 		t.Fatalf("failed to open database: %v", err)
 	}
-	defer func() { _ = db.Close() }()
+	// Force file creation on disk by creating a table.
+	if _, err := db.Exec("CREATE TABLE test (id INTEGER);"); err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+	_ = db.Close()
+
+	if err := os.Remove(dbPath); err != nil {
+		t.Fatalf("failed to remove database file: %v", err)
+	}
 
 	checker := newSQLiteHealthChecker(db, dbPath)
 	report, _ := checker.Check(context.Background())
 
-	// os.Stat follows the dangling symlink and fails → size_bytes = 0.
-	// Then PingContext fails because SQLite cannot create the DB file
-	// in the non-existent directory.
+	// os.Stat fails because the file was removed → size_bytes = 0.
+	// PingContext fails because the connection is closed.
 	if report.Status != ports.StatusUnhealthy {
 		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
 	}
@@ -355,6 +366,10 @@ func TestSQLiteHealthChecker_Check(t *testing.T) {
 	// ---------------
 	t.Run("dir_not_writable", func(t *testing.T) {
 		t.Parallel()
+
+		if runtime.GOOS == "windows" {
+			t.Skip("os.Chmod does not prevent file creation on Windows")
+		}
 
 		if os.Geteuid() == 0 {
 			t.Skip("skipping permission test: running as root")

--- a/internal/infrastructure/security/paths.go
+++ b/internal/infrastructure/security/paths.go
@@ -200,13 +200,14 @@ func (p *pathPolicy) isExemptedDirectory(absPath string) bool {
 	// Explicitly exempt the evaluated OS temporary directory
 	if p.resolvedTempDir != "" {
 		temp := filepath.ToSlash(p.resolvedTempDir)
+		absNormalized := filepath.ToSlash(absPath)
 		if !isCaseSensitive() {
 			temp = strings.ToLower(temp)
-			abs := strings.ToLower(absPath)
+			abs := strings.ToLower(absNormalized)
 			if strings.HasPrefix(abs, temp) {
 				return true
 			}
-		} else if strings.HasPrefix(absPath, temp) {
+		} else if strings.HasPrefix(absNormalized, temp) {
 			return true
 		}
 	}

--- a/internal/infrastructure/security/paths_test.go
+++ b/internal/infrastructure/security/paths_test.go
@@ -497,11 +497,12 @@ func TestNewPathPolicy_ResolvedTempDir(t *testing.T) {
 	// resolvedTempDir must be populated during construction
 	require.NotEmpty(t, p.resolvedTempDir, "resolvedTempDir should be populated by newPathPolicy")
 
-	// Verify a file under the real OS temp dir is considered exempted
-	tempFile := filepath.Join(os.TempDir(), "test-exempted-file.txt")
-	tempFile = p.resolveSymlinks(tempFile)
+	// Use the resolved temp dir from the policy itself as the reference,
+	// rather than os.TempDir() directly, to avoid normalization mismatches
+	// (e.g., short vs long paths, symlink resolution, case differences on Windows).
+	tempFile := filepath.Join(p.resolvedTempDir, "test-exempted-file.txt")
 	exempted := p.isExemptedDirectory(tempFile)
-	assert.True(t, exempted, "path in os.TempDir() should be exempted by isExemptedDirectory")
+	assert.True(t, exempted, "path in resolvedTempDir should be exempted by isExemptedDirectory")
 }
 
 func TestRegisterPath_EmptyPath(t *testing.T) {

--- a/internal/infrastructure/skills/file_repo_test.go
+++ b/internal/infrastructure/skills/file_repo_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -170,6 +171,10 @@ func TestFileSkillRepository_GetAll(t *testing.T) {
 }
 
 func TestNewFileSkillRepository_ErrorPaths_UnreadableSkillFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent reads on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	skillsDir := filepath.Join(tmpDir, "docs", "skills")
 	if err := os.MkdirAll(skillsDir, 0755); err != nil {
@@ -214,6 +219,10 @@ func TestNewFileSkillRepository_ErrorPaths_MissingName(t *testing.T) {
 }
 
 func TestNewFileSkillRepository_ErrorPaths_UnreadableSubdirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	skillsDir := filepath.Join(tmpDir, "docs", "skills")
 	if err := os.MkdirAll(skillsDir, 0755); err != nil {

--- a/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
+++ b/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -612,6 +613,10 @@ func TestOpenLogFileForAppend_MkdirAllSucceeds(t *testing.T) {
 func TestOpenLogFileForAppend_MkdirAllFails(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file creation on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	// Create a read+execute (no write) parent directory.
 	// This allows path lookup (ENOENT for the first OpenFile) but
@@ -641,6 +646,10 @@ func TestOpenLogFileForAppend_MkdirAllFails(t *testing.T) {
 
 func TestOpenLogFileForAppend_PermissionDenied(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file creation on Windows")
+	}
 
 	tmpDir := t.TempDir()
 	// Create the parent directory but make it non-writable.
@@ -830,6 +839,10 @@ func TestResolveUsageForSummary_SuccessWithOverrides(t *testing.T) {
 func TestAppendSummaryToLog_OpenError(t *testing.T) {
 	t.Parallel()
 
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file creation on Windows")
+	}
+
 	tmpDir := t.TempDir()
 
 	// Create a read-only parent directory (no write permission).
@@ -900,6 +913,11 @@ func setupFindLogFilesWithUnreadableSubdir(t *testing.T) string {
 
 func TestFindLogFiles_UnreadableSubdirectory_CallbackError(t *testing.T) {
 	// NOT parallel — chmod on temp dirs can interfere.
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
+
 	tempDir := setupFindLogFilesWithUnreadableSubdir(t)
 
 	ls := &ledgerStore{}

--- a/internal/tools/analysis/astutil_test.go
+++ b/internal/tools/analysis/astutil_test.go
@@ -787,8 +787,8 @@ func TestASTCache_AbsPath(t *testing.T) {
 		t.Parallel()
 		cache := newASTCache("/base")
 		abs := cache.absPath("/absolute/path/file.go")
-		if abs != "/absolute/path/file.go" {
-			t.Errorf("expected /absolute/path/file.go, got %s", abs)
+		if filepath.ToSlash(abs) != "/absolute/path/file.go" {
+			t.Errorf("expected /absolute/path/file.go, got %s", filepath.ToSlash(abs))
 		}
 	})
 

--- a/internal/tools/analysis/complexity_test.go
+++ b/internal/tools/analysis/complexity_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -351,6 +352,11 @@ func (s S) ValueMethod() {}
 // is covered by TestGatherComplexities_ContextCancelledDuringProcessing.
 func TestGatherComplexities_WalkError(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
+
 	tmpDir := t.TempDir()
 	// Create an unreadable directory to trigger Walk error
 	unreadableDir := filepath.Join(tmpDir, "unreadable")

--- a/internal/tools/analysis/dependency_test.go
+++ b/internal/tools/analysis/dependency_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -272,6 +273,9 @@ func TestBuildGraph_ErrorPaths(t *testing.T) {
 		{
 			name: "listInternalPackages error (unreadable directory)",
 			workspaceSetup: func(t *testing.T) (string, *mockAnalysisGoRunner) {
+				if runtime.GOOS == "windows" {
+					t.Skip("os.Chmod(0000) does not make directory unreadable on Windows")
+				}
 				dir := setupWorkspace(t)
 
 				// Create a subdirectory with 0000 permissions so that
@@ -390,6 +394,11 @@ func TestBuildGraph_GetImportsError(t *testing.T) {
 
 func TestListInternalPackages_ErrorPath(t *testing.T) {
 	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not make directory unreadable on Windows")
+	}
+
 	tmpDir := t.TempDir()
 
 	subdir := filepath.Join(tmpDir, "subdir")

--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -1223,10 +1224,21 @@ func TestRunLinter_AuthorizationError(t *testing.T) {
 	}
 }
 
+// echoCommand returns the platform-appropriate command name and arguments
+// to produce text output. On Windows, echo is a cmd.exe built-in, not a
+// standalone binary.
+func echoCommand(text string) (string, []string) {
+	if runtime.GOOS == "windows" {
+		return "cmd", []string{"/c", "echo", text}
+	}
+	return "echo", []string{text}
+}
+
 func TestRealExecutor_Execute(t *testing.T) {
 	t.Parallel()
 	e := &realExecutor{}
-	out, err := e.Execute(context.Background(), "echo", "hello")
+	name, args := echoCommand("hello")
+	out, err := e.Execute(context.Background(), name, args...)
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "hello")
 }

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -909,6 +909,10 @@ func TestOpenOutputFile_Sanitization(t *testing.T) {
 }
 
 func TestOpenOutputFile_MkdirAllError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent MkdirAll on Windows")
+	}
+
 	executor := newprocessExecutor()
 	tmpDir := t.TempDir()
 

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -655,14 +655,20 @@ func TestShellTool_PrepareCommand_ValidateStructureAfterWrap(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
 
+	// shellPrefix returns the expected shell command prefix after wrapping.
+	shellPrefix := "sh"
+	if runtime.GOOS == "windows" {
+		shellPrefix = "cmd"
+	}
+
 	// HasShellFeatures returns true so Wrap is called, then ValidateStructure fails on wrapped parts
 	validator := &toolstest.MockCommandValidator{
 		HasShellFeaturesFunc: func(parts []string) bool {
 			return true
 		},
 		ValidateStructureFunc: func(parts []string) error {
-			// Fail specifically for shell-wrapped parts ("sh", "-c", ...)
-			if len(parts) > 0 && parts[0] == "sh" {
+			// Fail specifically for shell-wrapped parts (shellPrefix, "-c", ...)
+			if len(parts) > 0 && parts[0] == shellPrefix {
 				return fmt.Errorf("shell wrapping validation failed")
 			}
 			return nil

--- a/internal/ui/tui/logger_test.go
+++ b/internal/ui/tui/logger_test.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -47,6 +48,10 @@ func TestInitLogger(t *testing.T) {
 // TestInitLogger_ErrorPath verifies InitLogger returns an error when the
 // log file cannot be created (e.g., when TMPDIR points to a file, not a directory).
 func TestInitLogger_ErrorPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("setting TMPDIR to a file path does not produce expected error on Windows")
+	}
+
 	// Create a regular file and set it as TMPDIR. Since it's a file
 	// and not a directory, tea.LogToFile will fail trying to create
 	// a log file inside it.


### PR DESCRIPTION
Closes #535.

## Summary
Resolves 27 Windows-specific test failures across 10 packages by:
- **Category A (Permissions)**: Added `runtime.GOOS == "windows"` skip guards to 11 tests using `os.Chmod`
- **Category B (Handle Leaks)**: Already guarded; verified no leaks on skip path
- **Category C (Symlinks)**: Refactored `TestSQLiteHealthChecker_DBFileStatFails` to close+delete approach (no symlink privilege needed)
- **Category D (Path Separators)**: Added `filepath.ToSlash()` normalization in `TestASTCache_AbsPath`
- **Category E (Shell Built-ins)**: Added `echoCommand()` platform helper returning `cmd /c echo` on Windows
- **Category F (Error Paths)**: Added skip guards for chmod-based tests; fixed production bug in `isExemptedDirectory` (missing `filepath.ToSlash` on absPath); platform-aware shell prefix in `TestShellTool_PrepareCommand_ValidateStructureAfterWrap`

**Bonus**: Fixed a real production bug in `isExemptedDirectory` — slash normalization gap on Windows.

## Files Changed
14 files, +119 / -23

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `golangci-lint run ./...` | PASS (0 issues) |
| All 10 affected packages | PASS |
