### PR TITLE
fix(test): resolve 3 remaining Windows test failures (#537)

### DIFF
--- a/internal/infrastructure/telemetry/stale_lock_test.go
+++ b/internal/infrastructure/telemetry/stale_lock_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -372,9 +373,8 @@ func TestLedgerStore_AcquireLedgerLock_FreshLock_NotStale(t *testing.T) {
 }
 
 func TestLedgerStore_AcquireLedgerLock_StaleLock_RemoveFails(t *testing.T) {
-	// Skip on Windows — chmod doesn't work the same way
-	if err := os.Chmod(t.TempDir(), 0755); err != nil {
-		t.Skipf("skipping on platform without chmod support: %v", err)
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows: chmod does not prevent file removal")
 	}
 
 	tmpDir, err := os.MkdirTemp("", "ls_acquire_remove_fail_test")
@@ -507,9 +507,8 @@ func TestMetricsManager_AcquireLedgerLock_FreshLock_NotStale(t *testing.T) {
 }
 
 func TestMetricsManager_AcquireLedgerLock_StaleLock_RemoveFails(t *testing.T) {
-	// Skip on Windows — chmod doesn't work the same way
-	if err := os.Chmod(t.TempDir(), 0755); err != nil {
-		t.Skipf("skipping on platform without chmod support: %v", err)
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows: chmod does not prevent file removal")
 	}
 
 	tmpDir, err := os.MkdirTemp("", "mm_acquire_remove_fail_test")

--- a/internal/tools/analysis/astutil.go
+++ b/internal/tools/analysis/astutil.go
@@ -53,10 +53,20 @@ func newASTCache(baseDir string) *astCache {
 }
 
 func (c *astCache) absPath(relPath string) string {
-	if c.baseDir == "" || filepath.IsAbs(relPath) {
+	if c.baseDir == "" || isAbsPath(relPath) {
 		return relPath
 	}
 	return filepath.Join(c.baseDir, relPath)
+}
+
+// isAbsPath returns true if p is absolute on the current OS.
+// On Windows, filepath.IsAbs returns false for Unix-style absolute paths
+// (e.g., "/foo/bar"), so we treat forward-slash-prefixed paths as absolute.
+func isAbsPath(p string) bool {
+	if filepath.IsAbs(p) {
+		return true
+	}
+	return os.PathSeparator == '\\' && strings.HasPrefix(p, "/")
 }
 
 func (cf cachedFile) isValid(info os.FileInfo) bool {

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -658,7 +658,7 @@ func TestShellTool_PrepareCommand_ValidateStructureAfterWrap(t *testing.T) {
 	// shellPrefix returns the expected shell command prefix after wrapping.
 	shellPrefix := "sh"
 	if runtime.GOOS == "windows" {
-		shellPrefix = "cmd"
+		shellPrefix = "cmd.exe"
 	}
 
 	// HasShellFeatures returns true so Wrap is called, then ValidateStructure fails on wrapped parts


### PR DESCRIPTION
Closes #537.

## Summary

Fixes the 3 remaining Windows test failures after cross-platform fixes in #535:

| # | Package | Fix |
|---|---------|-----|
| 1 | `internal/tools/workspace` | Changed `shellPrefix` from `"cmd"` to `"cmd.exe"` to match `windowsShellWrapper.Wrap()` |
| 2 | `internal/infrastructure/telemetry` | Replaced unreliable `os.Chmod` skip-guards with explicit `runtime.GOOS == "windows"` checks |
| 3 | `internal/tools/analysis` | Added `isAbsPath` helper that treats Unix-style absolute paths (`/foo/bar`) as absolute on Windows |

## Verification
| Check | Status |
|-------|--------|
| make check-full (fmt, tidy, build, lint, verify-architecture, vulncheck, test, dead-code) | PASS |
| test-race | Pre-existing timeout in analysis package (unrelated) |
| Changed packages tests | PASS |