### PR TITLE
fix(agent): add configuration drift detection for applyConfig partial failures (#540)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -416,6 +416,12 @@ type InternalAccessor interface {
 		pricingOverrides map[string]domain_pricing.ModelPricing,
 		limits events.Limits,
 	)
+
+	// DiffConfig compares the canonical intended configuration against
+	// the live engine/context-manager state. Returns a DriftReport
+	// describing any mismatches. Callers should check report.InSync
+	// rather than testing for a nil report — DiffConfig never returns nil.
+	DiffConfig() *DriftReport
 }
 
 // AsInternal wraps a ports.Chatter to provide access to its internal components.

--- a/internal/agent/agentinternal/accessor.go
+++ b/internal/agent/agentinternal/accessor.go
@@ -123,6 +123,13 @@ func (a *AgentInternal) ApplyConfig(ctx context.Context) error {
 	return a.raw.ApplyConfig(ctx)
 }
 
+// DiffConfig compares the canonical intended configuration against
+// the live engine/context-manager state. See agent.DiffConfig for
+// full documentation.
+func (a *AgentInternal) DiffConfig() *agent.DriftReport {
+	return a.raw.DiffConfig()
+}
+
 // Chat invokes the underlying agent's Chat method. Provided for
 // convenience so test code holding an *AgentInternal does not have to
 // call .raw.AsChatter().Chat(...) explicitly.

--- a/internal/agent/agentinternal/accessor_test.go
+++ b/internal/agent/agentinternal/accessor_test.go
@@ -32,6 +32,10 @@ func (m *mockInternalAccessor) ApplyConfig(ctx context.Context) error {
 	return m.Called(ctx).Error(0)
 }
 
+func (m *mockInternalAccessor) DiffConfig() *agent.DriftReport {
+	return m.Called().Get(0).(*agent.DriftReport)
+}
+
 func (m *mockInternalAccessor) AsChatter() ports.Chatter {
 	return m.Called().Get(0).(ports.Chatter)
 }
@@ -278,6 +282,31 @@ func TestAgentInternal_Getters(t *testing.T) {
 				t.Helper()
 				if !reflect.DeepEqual(got, want) {
 					t.Errorf("GetRuntimeConfig() = %+v; want %+v", got, want)
+				}
+			},
+		},
+		{
+			name: "DiffConfig",
+			setup: func(mock *mockInternalAccessor) any {
+				report := &agent.DriftReport{InSync: true}
+				mock.On("DiffConfig").Return(report)
+				return report
+			},
+			call: func(ai *AgentInternal) any {
+				return ai.DiffConfig()
+			},
+			assert: func(t *testing.T, got, want any) {
+				t.Helper()
+				gotReport, ok := got.(*agent.DriftReport)
+				if !ok {
+					t.Fatalf("DiffConfig() returned %T, want *agent.DriftReport", got)
+				}
+				wantReport, ok := want.(*agent.DriftReport)
+				if !ok {
+					t.Fatalf("want is %T, not *agent.DriftReport", want)
+				}
+				if gotReport != wantReport {
+					t.Errorf("DiffConfig() = %+v; want %+v", gotReport, wantReport)
 				}
 			},
 		},

--- a/internal/agent/drift.go
+++ b/internal/agent/drift.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agent
+
+// DriftReport describes configuration mismatches between the canonical
+// intended config (a.config) and the live state of the engine and
+// context manager.
+//
+// A report with InSync == true and all sub-drifts nil means all
+// components match their intended configuration. The zero value
+// (DriftReport{}) correctly represents "no drift detected."
+type DriftReport struct {
+	// InSync is true when all components match the canonical config.
+	InSync bool
+
+	// EngineDrift describes any mismatch in the orchestrator engine.
+	// nil means the engine is in sync (or not initialized).
+	EngineDrift *EngineDrift
+
+	// CtxManagerDrift describes any mismatch in the context manager.
+	// nil means the context manager is in sync (or not initialized).
+	CtxManagerDrift *CtxManagerDrift
+}
+
+// EngineDrift describes a mismatch between the intended runtime
+// configuration and the engine's live state.
+type EngineDrift struct {
+	ExpectedProvider string
+	ActualProvider   string
+	ExpectedModel    string
+	ActualModel      string
+	ExpectedMode     string
+	ActualMode       string
+}
+
+// CtxManagerDrift describes a mismatch between the intended limits
+// and the context manager's live state. Field names match
+// events.Limits for a direct 1:1 mapping to the data source.
+type CtxManagerDrift struct {
+	ExpectedMaxHistoryTokens int
+	ActualMaxHistoryTokens   int
+	ExpectedMaxToolTurns     int
+	ActualMaxToolTurns       int
+	ExpectedMaxHistoryTurns  int
+	ActualMaxHistoryTurns    int
+}
+
+// DiffConfig compares the canonical intended configuration (a.config)
+// against the live state of the engine and context manager. It returns
+// a DriftReport describing any mismatches.
+//
+// A report with InSync == true and all sub-drifts nil means all
+// components match. The caller should check report.InSync rather than
+// testing for a nil report.
+//
+// The returned report is a point-in-time snapshot: between reading
+// a.config and reading live engine/ctx-manager state, a concurrent
+// Reconfigure may change the underlying values. This is acceptable
+// because DiffConfig is a diagnostic tool, not called in the hot path.
+//
+// Nil engine and nil ctxManager (e.g., bare agent before full
+// initialization) are treated as "no drift" for their respective
+// components.
+func (a *agent) DiffConfig() *DriftReport {
+	cfg := a.config.Load()
+	if cfg == nil {
+		return &DriftReport{InSync: true}
+	}
+
+	report := &DriftReport{InSync: true}
+
+	// Compare engine state
+	if a.engine != nil {
+		engineSnap := a.engine.GetConfig()
+		if cfg.ProviderName != engineSnap.ProviderName ||
+			cfg.Model != engineSnap.Model ||
+			cfg.Mode != engineSnap.Mode {
+			report.InSync = false
+			report.EngineDrift = &EngineDrift{
+				ExpectedProvider: cfg.ProviderName,
+				ActualProvider:   engineSnap.ProviderName,
+				ExpectedModel:    cfg.Model,
+				ActualModel:      engineSnap.Model,
+				ExpectedMode:     cfg.Mode,
+				ActualMode:       engineSnap.Mode,
+			}
+		}
+	}
+
+	// Compare context manager state
+	if a.ctxManager != nil {
+		limits := a.ctxManager.GetLimits()
+		if cfg.Limits.MaxHistoryTokens != limits.MaxHistoryTokens ||
+			cfg.Limits.MaxToolTurns != limits.MaxToolTurns ||
+			cfg.Limits.MaxHistoryTurns != limits.MaxHistoryTurns {
+			report.InSync = false
+			report.CtxManagerDrift = &CtxManagerDrift{
+				ExpectedMaxHistoryTokens: cfg.Limits.MaxHistoryTokens,
+				ActualMaxHistoryTokens:   limits.MaxHistoryTokens,
+				ExpectedMaxToolTurns:     cfg.Limits.MaxToolTurns,
+				ActualMaxToolTurns:       limits.MaxToolTurns,
+				ExpectedMaxHistoryTurns:  cfg.Limits.MaxHistoryTurns,
+				ActualMaxHistoryTurns:    limits.MaxHistoryTurns,
+			}
+		}
+	}
+
+	return report
+}

--- a/internal/agent/drift_test.go
+++ b/internal/agent/drift_test.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+)
+
+// TestDiffConfig_AllInSync verifies that a freshly-initialized agent
+// reports InSync after ApplyConfig has been called — the canonical
+// config, engine, and context manager all match.
+func TestDiffConfig_AllInSync(t *testing.T) {
+	chatter, accessor := newTestAgent(t)
+	_ = chatter // keep alive
+
+	if err := accessor.ApplyConfig(context.Background()); err != nil {
+		t.Fatalf("ApplyConfig failed: %v", err)
+	}
+
+	report := accessor.DiffConfig()
+
+	if !report.InSync {
+		t.Error("expected InSync == true after ApplyConfig")
+	}
+	if report.EngineDrift != nil {
+		t.Errorf("expected EngineDrift to be nil, got %+v", report.EngineDrift)
+	}
+	if report.CtxManagerDrift != nil {
+		t.Errorf("expected CtxManagerDrift to be nil, got %+v", report.CtxManagerDrift)
+	}
+}
+
+// TestDiffConfig_EngineDrift verifies that EngineDrift is detected
+// when the canonical config is mutated without calling ApplyConfig,
+// leaving the engine on its original configuration.
+func TestDiffConfig_EngineDrift(t *testing.T) {
+	_, accessor := newTestAgent(t)
+
+	// Mutate the canonical config to values that differ from what
+	// the engine received during NewAgent. Do NOT call ApplyConfig —
+	// this leaves the engine on the original config while a.config
+	// reflects the new values.
+	accessor.SetRuntimeConfigForInternalUse(
+		"different-provider",
+		"different-model",
+		"different-mode",
+		nil, // pricing overrides
+		events.Limits{
+			MaxHistoryTokens: 120000,
+			MaxToolTurns:     200,
+			MaxHistoryTurns:  0,
+		},
+	)
+
+	report := accessor.DiffConfig()
+
+	if report.InSync {
+		t.Error("expected InSync == false when engine has drifted")
+	}
+	if report.EngineDrift == nil {
+		t.Fatal("expected EngineDrift to be non-nil")
+	}
+	if report.EngineDrift.ExpectedProvider != "different-provider" {
+		t.Errorf("ExpectedProvider = %q; want %q", report.EngineDrift.ExpectedProvider, "different-provider")
+	}
+	if report.EngineDrift.ExpectedModel != "different-model" {
+		t.Errorf("ExpectedModel = %q; want %q", report.EngineDrift.ExpectedModel, "different-model")
+	}
+	// ActualProvider/Model/Mode should be the original values from NewAgent
+	if report.EngineDrift.ActualProvider != "test-provider" {
+		t.Errorf("ActualProvider = %q; want %q", report.EngineDrift.ActualProvider, "test-provider")
+	}
+	if report.EngineDrift.ActualModel != "test-model" {
+		t.Errorf("ActualModel = %q; want %q", report.EngineDrift.ActualModel, "test-model")
+	}
+
+	// CtxManager should still be in sync (we didn't change limits
+	// relative to what was already stored; the mutated limits
+	// match the defaults from NewAgent which ApplyConfig propagated)
+	if report.CtxManagerDrift != nil {
+		t.Errorf("expected CtxManagerDrift to be nil, got %+v", report.CtxManagerDrift)
+	}
+}
+
+// TestDiffConfig_CtxManagerDrift verifies that CtxManagerDrift is
+// detected when limits are pushed into the context manager via
+// ApplyConfig with a stubConfigWatcher, then the canonical config is
+// mutated to different limits without re-applying.
+func TestDiffConfig_CtxManagerDrift(t *testing.T) {
+	_, accessor := newTestAgent(t)
+
+	// Step 1: Push limits into ctxManager via ApplyConfig.
+	accessor.SetConfigWatcherForInternalUse(&stubConfigWatcher{
+		tokens:       240000,
+		toolTurns:    400,
+		historyTurns: 100,
+	})
+	if err := accessor.ApplyConfig(context.Background()); err != nil {
+		t.Fatalf("ApplyConfig failed: %v", err)
+	}
+
+	// Step 2: Mutate the canonical config to different limits.
+	// Do NOT call ApplyConfig — ctxManager keeps the old limits.
+	accessor.SetRuntimeConfigForInternalUse(
+		"test-provider",
+		"test-model",
+		"test-mode",
+		nil,
+		events.Limits{
+			MaxHistoryTokens: 120000,
+			MaxToolTurns:     200,
+			MaxHistoryTurns:  0,
+		},
+	)
+
+	report := accessor.DiffConfig()
+
+	if report.InSync {
+		t.Error("expected InSync == false when ctx manager has drifted")
+	}
+	if report.CtxManagerDrift == nil {
+		t.Fatal("expected CtxManagerDrift to be non-nil")
+	}
+	if report.CtxManagerDrift.ExpectedMaxHistoryTokens != 120000 {
+		t.Errorf("ExpectedMaxHistoryTokens = %d; want 120000", report.CtxManagerDrift.ExpectedMaxHistoryTokens)
+	}
+	if report.CtxManagerDrift.ExpectedMaxToolTurns != 200 {
+		t.Errorf("ExpectedMaxToolTurns = %d; want 200", report.CtxManagerDrift.ExpectedMaxToolTurns)
+	}
+	if report.CtxManagerDrift.ActualMaxHistoryTokens != 240000 {
+		t.Errorf("ActualMaxHistoryTokens = %d; want 240000", report.CtxManagerDrift.ActualMaxHistoryTokens)
+	}
+	if report.CtxManagerDrift.ActualMaxToolTurns != 400 {
+		t.Errorf("ActualMaxToolTurns = %d; want 400", report.CtxManagerDrift.ActualMaxToolTurns)
+	}
+
+	// Engine should still be in sync
+	if report.EngineDrift != nil {
+		t.Errorf("expected EngineDrift to be nil, got %+v", report.EngineDrift)
+	}
+}
+
+// TestDiffConfig_BothDrift verifies that both EngineDrift and
+// CtxManagerDrift are detected simultaneously when the canonical
+// config is mutated in both dimensions (engine fields AND limits)
+// without calling ApplyConfig.
+func TestDiffConfig_BothDrift(t *testing.T) {
+	_, accessor := newTestAgent(t)
+
+	// Mutate both engine fields AND limits without ApplyConfig.
+	accessor.SetRuntimeConfigForInternalUse(
+		"different-provider",
+		"different-model",
+		"different-mode",
+		nil, // pricing overrides
+		events.Limits{
+			MaxHistoryTokens: 999000,
+			MaxToolTurns:     999,
+			MaxHistoryTurns:  99,
+		},
+	)
+
+	report := accessor.DiffConfig()
+
+	if report.InSync {
+		t.Error("expected InSync == false when both engine and ctx manager have drifted")
+	}
+	if report.EngineDrift == nil {
+		t.Fatal("expected EngineDrift to be non-nil")
+	}
+	if report.CtxManagerDrift == nil {
+		t.Fatal("expected CtxManagerDrift to be non-nil")
+	}
+
+	// Engine drift: expected from canonical, actual from engine initial.
+	if report.EngineDrift.ExpectedProvider != "different-provider" {
+		t.Errorf("ExpectedProvider = %q; want %q", report.EngineDrift.ExpectedProvider, "different-provider")
+	}
+	if report.EngineDrift.ActualProvider != "test-provider" {
+		t.Errorf("ActualProvider = %q; want %q", report.EngineDrift.ActualProvider, "test-provider")
+	}
+
+	// CtxManager drift: expected from canonical, actual from defaults.
+	if report.CtxManagerDrift.ExpectedMaxHistoryTokens != 999000 {
+		t.Errorf("ExpectedMaxHistoryTokens = %d; want 999000", report.CtxManagerDrift.ExpectedMaxHistoryTokens)
+	}
+	if report.CtxManagerDrift.ExpectedMaxToolTurns != 999 {
+		t.Errorf("ExpectedMaxToolTurns = %d; want 999", report.CtxManagerDrift.ExpectedMaxToolTurns)
+	}
+}
+
+// TestDiffConfig_NilEngineAndCtxManager verifies that a bare agent
+// (nil engine, nil ctxManager) with a seeded config reports InSync
+// — nil components have no drift by definition.
+func TestDiffConfig_NilEngineAndCtxManager(t *testing.T) {
+	accessor := NewBareForInternalUse()
+
+	// Seed config so that DiffConfig has a canonical config to compare
+	// against. Even with a canonical config, nil engine and nil
+	// ctxManager mean there is nothing to drift.
+	accessor.SetRuntimeConfigForInternalUse(
+		"test-provider",
+		"test-model",
+		"test-mode",
+		nil,
+		events.Limits{
+			MaxHistoryTokens: 120000,
+			MaxToolTurns:     200,
+			MaxHistoryTurns:  0,
+		},
+	)
+
+	report := accessor.DiffConfig()
+
+	if !report.InSync {
+		t.Error("expected InSync == true when engine and ctxManager are nil")
+	}
+	if report.EngineDrift != nil {
+		t.Errorf("expected EngineDrift to be nil with nil engine, got %+v", report.EngineDrift)
+	}
+	if report.CtxManagerDrift != nil {
+		t.Errorf("expected CtxManagerDrift to be nil with nil ctxManager, got %+v", report.CtxManagerDrift)
+	}
+}
+
+// TestDiffConfig_NilConfig verifies that a bare agent without any
+// seeded config reports InSync — a nil canonical config means there
+// is nothing to compare against.
+func TestDiffConfig_NilConfig(t *testing.T) {
+	accessor := NewBareForInternalUse()
+
+	// Do NOT seed any config. The atomic pointer is nil.
+
+	report := accessor.DiffConfig()
+
+	if !report.InSync {
+		t.Error("expected InSync == true when canonical config is nil")
+	}
+}

--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -146,6 +146,17 @@ func (e *Engine) Reconfigure(cfg RuntimeConfig, tracker domain_pricing.CostTrack
 	return nil
 }
 
+// GetConfig returns a snapshot of the current engine configuration.
+// This is a diagnostic accessor — not for use in the hot path.
+func (e *Engine) GetConfig() EngineConfigSnapshot {
+	cfg := e.config.Load()
+	return EngineConfigSnapshot{
+		ProviderName: cfg.ProviderName,
+		Model:        cfg.Model,
+		Mode:         cfg.Mode,
+	}
+}
+
 // NewEngine creates a new Engine with a default pipeline.
 func NewEngine(gw llm.LLMGateway, ex ToolExecutor, cm *sessctx.Manager, reg tools.Registry, bus events.EventBus, counter llm.TokenCounter, opts ...engineOption) *Engine {
 	backoff := 2 * time.Second

--- a/internal/agent/orchestrator/engine_types.go
+++ b/internal/agent/orchestrator/engine_types.go
@@ -55,6 +55,15 @@ func (c RuntimeConfig) validate() error {
 	return nil
 }
 
+// EngineConfigSnapshot is a value-type snapshot of the user-facing
+// engine configuration fields. It is returned by Engine.GetConfig()
+// for diagnostic use (drift detection). Not for hot-path use.
+type EngineConfigSnapshot struct {
+	ProviderName string
+	Model        string
+	Mode         string
+}
+
 // engineConfig defines the lock-free runtime state for the Engine.
 type engineConfig struct {
 	ProviderName     string


### PR DESCRIPTION
Closes #540.

## Summary
Adds `DiffConfig()` diagnostic method to detect transient configuration inconsistencies between the canonical intended config and the live engine/context-manager state after partial `applyConfig` failures. This closes the observability gap identified in ADR-029 §4.

### Changes
- `EngineConfigSnapshot` type + `Engine.GetConfig()` accessor
- `DriftReport`, `EngineDrift`, `CtxManagerDrift` types in `drift.go`
- `(*agent).DiffConfig()` method (never-nil, `InSync` as signal)
- `InternalAccessor` interface + `agentinternal` bridge + delegation test
- 6 drift detection tests covering all scenarios

### Intentional deviation
The issue proposed returning `nil` when all components are in sync. The implementation returns `&DriftReport{InSync: true}` instead — safer for callers and follows the existing codebase pattern.

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go test ./internal/agent/...` | PASS |
| `go vet ./...` | PASS |
| `golangci-lint run` | PASS (0 issues) |
| `verify_architecture` | PASS |
