### PR TITLE
fix(analysis): add WarmImplementations cache warming (#539)

### DIFF
--- a/internal/tools/analysis/analysistest/mock_index.go
+++ b/internal/tools/analysis/analysistest/mock_index.go
@@ -53,3 +53,5 @@ func (m *MockSymbolIndex) Packages(ctx context.Context, hb chan<- struct{}) ([]*
 	return nil, nil
 }
 func (m *MockSymbolIndex) Refresh(ctx context.Context, hb chan<- struct{}) error { return nil }
+
+func (m *MockSymbolIndex) WarmImplementations(ctx context.Context) {}

--- a/internal/tools/analysis/common_test.go
+++ b/internal/tools/analysis/common_test.go
@@ -86,6 +86,8 @@ func (m *mockIndexer) GetImplementations(ctx context.Context, id string, hb chan
 	return m.impls[id]
 }
 
+func (m *mockIndexer) WarmImplementations(ctx context.Context) {}
+
 func (s *mockSecurityProvider) Authorize(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {
 	return true, nil
 }

--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -130,6 +130,12 @@ func (a *defaultDeadCodeAnalyzer) runAnalysisPipeline(ctx context.Context, path 
 		return nil, nil
 	}
 
+	// Warm the implementation cache after Refresh so that subsequent
+	// GetImplementations calls in processImplementations and
+	// propagateUsageToImplementations hit an already-hot cache.
+	// This is a no-op if the cache is already populated (sync.Once).
+	a.idx.WarmImplementations(ctx)
+
 	targetModule, err := a.identifyModule(pkgs)
 	if err != nil {
 		return nil, err

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -576,6 +576,8 @@ func (m *mockSymbolIndex) Packages(ctx context.Context, hb chan<- struct{}) ([]*
 }
 func (m *mockSymbolIndex) Refresh(ctx context.Context, hb chan<- struct{}) error { return nil }
 
+func (m *mockSymbolIndex) WarmImplementations(ctx context.Context) {}
+
 func TestPropagateInterfaceUsages_Regression(t *testing.T) {
 	tests := []struct {
 		name             string

--- a/internal/tools/analysis/index.go
+++ b/internal/tools/analysis/index.go
@@ -60,6 +60,20 @@ type symbolIndex interface {
 	IsSymbolUsed(ctx context.Context, name string, hb chan<- struct{}) bool
 	// GetImplementations returns the concrete method identities that implement the given interface method.
 	GetImplementations(ctx context.Context, interfaceMethodId string, hb chan<- struct{}) []string
+	// WarmImplementations eagerly computes the implementation cache.
+	// It calls computeImplementationsLazy() and discards the result,
+	// warming the cache as a side effect. Interactive consumers
+	// (TUI, long-running agent) opt in; non-interactive consumers (CI)
+	// skip it.
+	//
+	// The context parameter is accepted for future cancellation support
+	// but is not yet wired (the underlying sync.Once does not support
+	// cancellation). Calling with a cancelled context is safe and will
+	// not panic, but the warm-up will proceed regardless.
+	//
+	// Idempotent: safe to call when the cache is already hot
+	// (sync.Once returns immediately).
+	WarmImplementations(ctx context.Context)
 	// Packages returns the loaded packages.
 	Packages(ctx context.Context, hb chan<- struct{}) ([]*packages.Package, error)
 	// Refresh re-scans the workspace to update the index.

--- a/internal/tools/analysis/index_impl.go
+++ b/internal/tools/analysis/index_impl.go
@@ -139,3 +139,16 @@ func (idx *indexer) GetImplementations(ctx context.Context, interfaceMethodId st
 	}
 	return idx.computeImplementationsLazy()[interfaceMethodId]
 }
+
+// WarmImplementations eagerly computes the implementation cache by calling
+// computeImplementationsLazy() and discarding the result. The side effect
+// (populating idx.implsCache.impls) is the intended outcome.
+//
+// It is safe to call concurrently with GetImplementations — both share the
+// same sync.Once gate (idx.implsCache.once), so only one computation runs.
+//
+// The ctx parameter is accepted for future cancellation support (e.g., if
+// sync.Once is replaced with singleflight.DoChan) but is currently unused.
+func (idx *indexer) WarmImplementations(ctx context.Context) {
+	_ = idx.computeImplementationsLazy()
+}

--- a/internal/tools/analysis/index_impl_test.go
+++ b/internal/tools/analysis/index_impl_test.go
@@ -160,3 +160,204 @@ func TestGetImplementations_RefreshError(t *testing.T) {
 		t.Errorf("expected nil result on Refresh error, got %v", result)
 	}
 }
+
+// TestWarmImplementations_WarmsGetImplementations verifies that calling
+// WarmImplementations before GetImplementations produces the same results
+// as calling GetImplementations alone — no semantic change, just cache warming.
+func TestWarmImplementations_WarmsGetImplementations(t *testing.T) {
+	t.Parallel()
+
+	code := `package test
+
+type Greeter interface {
+	Greet() string
+}
+
+type EnglishGreeter struct{}
+
+func (e EnglishGreeter) Greet() string { return "hello" }
+`
+	tmpDir, idx := setupIndexerWorkspace(t, code)
+	_ = tmpDir
+
+	// Get the full implementations map via the lazy path to discover a valid key.
+	fullImpls := idx.computeImplementationsLazy()
+	require.NotEmpty(t, fullImpls, "expected at least one implementation")
+
+	var queryID string
+	for id := range fullImpls {
+		queryID = id
+		break
+	}
+	require.NotEmpty(t, queryID)
+
+	// Freeze the indexer so Refresh does not trigger loadPackages.
+	idx.mu.Lock()
+	idx.lastRefresh = time.Now().Add(1 * time.Hour)
+	idx.mu.Unlock()
+
+	// Invalidate the cache so we start cold.
+	idx.mu.Lock()
+	idx.implsCache = &implCacheEntry{}
+	idx.mu.Unlock()
+
+	// Warm the cache.
+	idx.WarmImplementations(context.Background())
+
+	// Now GetImplementations should return the same result from the warmed cache.
+	got := idx.GetImplementations(context.Background(), queryID, nil)
+	want := fullImpls[queryID]
+
+	assert.ElementsMatch(t, want, got, "GetImplementations after WarmImplementations must match direct computeImplementationsLazy result")
+}
+
+// TestWarmImplementations_Idempotent verifies that calling WarmImplementations
+// twice does not double-compute. The sync.Once gate ensures the computation
+// runs exactly once even when WarmImplementations is called multiple times.
+func TestWarmImplementations_Idempotent(t *testing.T) {
+	t.Parallel()
+
+	code := `package test
+
+type Greeter interface {
+	Greet() string
+}
+
+type EnglishGreeter struct{}
+
+func (e EnglishGreeter) Greet() string { return "hello" }
+`
+	tmpDir, idx := setupIndexerWorkspace(t, code)
+	_ = tmpDir
+
+	// Freeze Refresh.
+	idx.mu.Lock()
+	idx.lastRefresh = time.Now().Add(1 * time.Hour)
+	idx.mu.Unlock()
+
+	// Invalidate the cache.
+	idx.mu.Lock()
+	idx.implsCache = &implCacheEntry{}
+	idx.mu.Unlock()
+
+	// Wire the test hook to count computeImplementations invocations.
+	var computeCount atomic.Int64
+	idx.testComputeImplementationsHook = func() {
+		computeCount.Add(1)
+	}
+
+	// Call WarmImplementations twice.
+	idx.WarmImplementations(context.Background())
+	idx.WarmImplementations(context.Background())
+
+	assert.Equal(t, int64(1), computeCount.Load(),
+		"WarmImplementations called twice must invoke computeImplementations exactly once (sync.Once)")
+}
+
+// TestWarmImplementations_CancelledContext verifies that calling
+// WarmImplementations with a cancelled context does not panic.
+// The ctx parameter is accepted for future cancellation support
+// but is not yet wired (sync.Once does not support cancellation).
+func TestWarmImplementations_CancelledContext(t *testing.T) {
+	t.Parallel()
+
+	code := `package test
+
+type Greeter interface {
+	Greet() string
+}
+
+type EnglishGreeter struct{}
+
+func (e EnglishGreeter) Greet() string { return "hello" }
+`
+	tmpDir, idx := setupIndexerWorkspace(t, code)
+	_ = tmpDir
+
+	// Freeze Refresh.
+	idx.mu.Lock()
+	idx.lastRefresh = time.Now().Add(1 * time.Hour)
+	idx.mu.Unlock()
+
+	// Invalidate the cache.
+	idx.mu.Lock()
+	idx.implsCache = &implCacheEntry{}
+	idx.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	// Must not panic.
+	assert.NotPanics(t, func() {
+		idx.WarmImplementations(ctx)
+	}, "WarmImplementations with cancelled context must not panic")
+
+	// The cache should still be populated (sync.Once ignores ctx).
+	fullImpls := idx.computeImplementationsLazy()
+	assert.NotEmpty(t, fullImpls, "cache must be populated even with cancelled context")
+}
+
+// TestWarmImplementations_Concurrent verifies that N concurrent
+// WarmImplementations calls are coalesced into exactly 1
+// computeImplementations invocation via the sync.Once gate.
+func TestWarmImplementations_Concurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping concurrency test in short mode")
+	}
+	t.Parallel()
+
+	code := `package test
+
+type Greeter interface {
+	Greet() string
+}
+
+type EnglishGreeter struct{}
+
+func (e EnglishGreeter) Greet() string { return "hello" }
+`
+	tmpDir, idx := setupIndexerWorkspace(t, code)
+	_ = tmpDir
+
+	// Freeze Refresh.
+	idx.mu.Lock()
+	idx.lastRefresh = time.Now().Add(1 * time.Hour)
+	idx.mu.Unlock()
+
+	// Invalidate the cache.
+	idx.mu.Lock()
+	idx.implsCache = &implCacheEntry{}
+	idx.mu.Unlock()
+
+	var computeCount atomic.Int64
+	idx.testComputeImplementationsHook = func() {
+		computeCount.Add(1)
+	}
+
+	// Deterministic barrier (same pattern as TestGetImplementations_SingleflightCoalescing).
+	const N = 12
+	ready := make(chan struct{}, N)
+	release := make(chan struct{})
+	done := make(chan struct{}, N)
+
+	for i := 0; i < N; i++ {
+		go func() {
+			ready <- struct{}{}
+			<-release
+			idx.WarmImplementations(context.Background())
+			done <- struct{}{}
+		}()
+	}
+
+	for i := 0; i < N; i++ {
+		<-ready
+	}
+	close(release)
+
+	for i := 0; i < N; i++ {
+		<-done
+	}
+
+	assert.Equal(t, int64(1), computeCount.Load(),
+		"sync.Once must coalesce N concurrent WarmImplementations into exactly 1 compute")
+}

--- a/internal/tools/analysis/sequence.go
+++ b/internal/tools/analysis/sequence.go
@@ -144,6 +144,15 @@ func (a *defaultSequenceAnalyzer) traceFlow(ctx context.Context, startSymbol str
 		return nil, err
 	}
 
+	// Warm the implementation cache after Refresh so that subsequent
+	// GetImplementations calls in tryRecurse hit an already-hot cache.
+	// This is a no-op if the cache is already populated (sync.Once).
+	// Guard against nil idx: some test paths construct a
+	// defaultSequenceAnalyzer without an indexer.
+	if a.idx != nil {
+		a.idx.WarmImplementations(ctx)
+	}
+
 	var modName string
 
 	// Try exact match first


### PR DESCRIPTION
Closes #539.

## Summary
Adds `WarmImplementations(ctx context.Context)` to the `symbolIndex` interface to enable opt-in cache warming for interactive consumers (TUI, long-running agent sessions). This pre-warms the lazy implementation cache after `Refresh()` so that subsequent `GetImplementations()` calls hit an already-hot cache.

### Changes
- **Interface**: Added `WarmImplementations(ctx context.Context)` to `symbolIndex` in `index.go`
- **Implementation**: One-liner delegating to `computeImplementationsLazy()` on `*indexer` in `index_impl.go`
- **Mock stubs**: Added no-op implementations to `mockIndexer`, `mockSymbolIndex`, and `analysistest.MockSymbolIndex`
- **Consumers**: Wired `WarmImplementations(ctx)` into `runAnalysisPipeline` (dead_code.go) and `traceFlow` (sequence.go) after package loading
- **Tests**: 4 new unit tests covering cache warming, idempotency, cancelled context safety, and concurrent coalescing

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go vet ./... | PASS |
| golangci-lint run | PASS (0 issues) |
| go test ./internal/tools/analysis/... | PASS |
| go test -race ./internal/tools/analysis/... | PASS |
| verify_architecture | PASS |
| vulncheck | PASS (0 vulnerabilities) |