### PR TITLE
fix(persistence): reduce cyclomatic complexity of 11 functions below threshold 10 (#542)

### DIFF
--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -68,30 +68,42 @@ func (m *mockTaskRepo) Query(ctx context.Context, filter ports.ListFilter, limit
 	}
 	var result []ports.Task
 	for _, t := range m.tasks {
-		if filter.Status != "" && t.Status != filter.Status {
-			continue
+		if taskMatchesFilter(t, filter) {
+			result = append(result, t)
 		}
-		if filter.NotStatus != "" && t.Status == filter.NotStatus {
-			continue
-		}
-		if !filter.Since.IsZero() && t.CreatedAt.Before(filter.Since) {
-			continue
-		}
-		if !filter.Before.IsZero() && t.CreatedAt.After(filter.Before) {
-			continue
-		}
-		result = append(result, t)
 	}
+	return applyTaskOffsetLimit(result, limit, offset), nil
+}
+
+// taskMatchesFilter returns true when task satisfies all non-zero filter conditions.
+func taskMatchesFilter(task ports.Task, filter ports.ListFilter) bool {
+	if filter.Status != "" && task.Status != filter.Status {
+		return false
+	}
+	if filter.NotStatus != "" && task.Status == filter.NotStatus {
+		return false
+	}
+	if !filter.Since.IsZero() && task.CreatedAt.Before(filter.Since) {
+		return false
+	}
+	if !filter.Before.IsZero() && task.CreatedAt.After(filter.Before) {
+		return false
+	}
+	return true
+}
+
+// applyTaskOffsetLimit applies offset/limit slicing to a task slice.
+func applyTaskOffsetLimit(tasks []ports.Task, limit, offset int) []ports.Task {
 	if offset > 0 {
-		if offset >= len(result) {
-			return []ports.Task{}, nil
+		if offset >= len(tasks) {
+			return []ports.Task{}
 		}
-		result = result[offset:]
+		tasks = tasks[offset:]
 	}
-	if limit > 0 && limit < len(result) {
-		result = result[:limit]
+	if limit > 0 && limit < len(tasks) {
+		tasks = tasks[:limit]
 	}
-	return result, nil
+	return tasks
 }
 
 func (m *mockTaskRepo) Count(ctx context.Context) (int, error) {
@@ -536,46 +548,68 @@ func TestTaskService_CountTasks(t *testing.T) {
 	}
 }
 
-func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
-	t.Parallel()
+// seedTaskServiceWithN adds n tasks ("Task 1" through "Task N") to the store.
+func seedTaskServiceWithN(t *testing.T, s ports.TaskStore, n int) {
+	t.Helper()
 	ctx := context.Background()
-	s, _ := setupTaskService(t)
-
-	// Add 5 tasks
-	for i := 0; i < 5; i++ {
+	for i := 0; i < n; i++ {
 		_, err := s.AddTask(ctx, fmt.Sprintf("Task %d", i+1))
 		if err != nil {
 			t.Fatalf("failed to add task: %v", err)
 		}
 	}
+}
 
-	// limit=3, offset=0 → first 3
-	first3 := s.ListTasks("", 3, 0)
-	if len(first3) != 3 {
-		t.Errorf("expected 3 tasks, got %d", len(first3))
-	}
-	if first3[0].ID != 1 || first3[2].ID != 3 {
-		t.Errorf("expected IDs 1,2,3, got %v", first3)
-	}
+func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
+	t.Parallel()
 
-	// limit=2, offset=3 → tasks 4,5
-	middle := s.ListTasks("", 2, 3)
-	if len(middle) != 2 {
-		t.Errorf("expected 2 tasks, got %d", len(middle))
-	}
-	if middle[0].ID != 4 || middle[1].ID != 5 {
-		t.Errorf("expected IDs 4,5, got %v", middle)
-	}
+	t.Run("limit3_offset0_returns_first_3", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setupTaskService(t)
+		seedTaskServiceWithN(t, s, 5)
 
-	// offset beyond total → empty
-	beyond := s.ListTasks("", 10, 100)
-	if len(beyond) != 0 {
-		t.Errorf("expected 0 tasks, got %d", len(beyond))
-	}
+		tasks := s.ListTasks("", 3, 0)
+		if len(tasks) != 3 {
+			t.Errorf("expected 3 tasks, got %d", len(tasks))
+		}
+		if tasks[0].ID != 1 || tasks[2].ID != 3 {
+			t.Errorf("expected IDs 1,2,3, got %v", tasks)
+		}
+	})
 
-	// limit=0, offset=0 → all
-	all := s.ListTasks("", 0, 0)
-	if len(all) != 5 {
-		t.Errorf("expected 5 tasks, got %d", len(all))
-	}
+	t.Run("limit2_offset3_returns_tasks_4_5", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setupTaskService(t)
+		seedTaskServiceWithN(t, s, 5)
+
+		tasks := s.ListTasks("", 2, 3)
+		if len(tasks) != 2 {
+			t.Errorf("expected 2 tasks, got %d", len(tasks))
+		}
+		if tasks[0].ID != 4 || tasks[1].ID != 5 {
+			t.Errorf("expected IDs 4,5, got %v", tasks)
+		}
+	})
+
+	t.Run("offset_beyond_total_returns_empty", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setupTaskService(t)
+		seedTaskServiceWithN(t, s, 5)
+
+		tasks := s.ListTasks("", 10, 100)
+		if len(tasks) != 0 {
+			t.Errorf("expected 0 tasks, got %d", len(tasks))
+		}
+	})
+
+	t.Run("limit0_returns_all", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setupTaskService(t)
+		seedTaskServiceWithN(t, s, 5)
+
+		tasks := s.ListTasks("", 0, 0)
+		if len(tasks) != 5 {
+			t.Errorf("expected 5 tasks, got %d", len(tasks))
+		}
+	})
 }

--- a/internal/infrastructure/factory/chatter_test.go
+++ b/internal/infrastructure/factory/chatter_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
-	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -141,41 +140,7 @@ type mockTracker struct {
 }
 
 func TestNewChatter(t *testing.T) {
-	tmpDir := t.TempDir()
-	modeDir := filepath.Join(tmpDir, "modes", "dev")
-	err := os.MkdirAll(modeDir, 0755)
-	if err != nil {
-		t.Fatalf("failed to create mode dir: %v", err)
-	}
-
-	// Create skills dir to satisfy NewFileSkillRepository
-	skillsDir := filepath.Join(tmpDir, "docs", "skills")
-	err = os.MkdirAll(skillsDir, 0755)
-	if err != nil {
-		t.Fatalf("failed to create skills dir: %v", err)
-	}
-
-	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-	eventstest.CleanupBus(t, bus)
-
-	deps := &mockSessionDeps{
-		gw:       &mockGateway{},
-		hManager: &mockHistoryManager{},
-		reg:      &mockRegistry{},
-		sm:       &mockSecurityManager{},
-		bus:      bus,
-		paths: &persistence.Paths{
-			ModeDir: modeDir,
-		},
-		tracker: &mockTracker{},
-	}
-
-	cfg := ports.ChatterConfig{
-		ProviderName: "test-provider",
-		Model:        "test-model",
-		LogPath:      filepath.Join(tmpDir, "trace.log"),
-		TracePath:    filepath.Join(tmpDir, "trace.jsonl"),
-	}
+	deps, cfg := setupNilDepTest(t)
 
 	t.Run("successful initialization", func(t *testing.T) {
 		chatter, err := NewChatter(context.Background(), deps, cfg)
@@ -204,27 +169,26 @@ func TestNewChatter(t *testing.T) {
 			t.Skip("os.Chmod(0000) does not prevent file reads on Windows")
 		}
 
-		deps2, cfg2 := setupNilDepTest(t)
-		// setupNilDepTest creates a docs/skills/ dir. Drop an unreadable
-		// .md file into it to cause NewFileSkillRepository to fail.
-		skillsDir := filepath.Join(filepath.Dir(filepath.Dir(deps2.paths.ModeDir)), "docs", "skills")
+		// Drop an unreadable .md file into the skills dir to cause
+		// NewFileSkillRepository to fail.
+		skillsDir := filepath.Join(filepath.Dir(filepath.Dir(deps.paths.ModeDir)), "docs", "skills")
 		badFile := filepath.Join(skillsDir, "bad.md")
 		require.NoError(t, os.WriteFile(badFile,
 			[]byte("---\nname: Test\ndescription: Test\n---\nContent"), 0644))
 		require.NoError(t, os.Chmod(badFile, 0000))
 		t.Cleanup(func() { _ = os.Chmod(badFile, 0644) })
 
-		_, err := NewChatter(context.Background(), deps2, cfg2)
+		_, err := NewChatter(context.Background(), deps, cfg)
 		if err == nil || !strings.Contains(err.Error(), "failed to initialize skill repository") {
 			t.Errorf("expected 'failed to initialize skill repository' error, got: %v", err)
 		}
 	})
 
 	t.Run("fails when registry cannot be retrieved", func(t *testing.T) {
-		deps2, cfg2 := setupNilDepTest(t)
-		deps2.regErr = errors.New("registry unavailable")
+		deps.regErr = errors.New("registry unavailable")
+		t.Cleanup(func() { deps.regErr = nil })
 
-		_, err := NewChatter(context.Background(), deps2, cfg2)
+		_, err := NewChatter(context.Background(), deps, cfg)
 		if err == nil || !strings.Contains(err.Error(), "failed to retrieve tool registry") {
 			t.Errorf("expected 'failed to retrieve tool registry' error, got: %v", err)
 		}

--- a/internal/infrastructure/persistence/memory_store.go
+++ b/internal/infrastructure/persistence/memory_store.go
@@ -131,57 +131,56 @@ func (s *memoryListStore[T]) getCreatedAt(item T) time.Time {
 	return time.Time{}
 }
 
+// matchesFilter returns true when item satisfies all non-zero filters.
+func (s *memoryListStore[T]) matchesFilter(item T, filter ports.ListFilter) bool {
+	if filter.Status != "" {
+		if s.getStatus(item) != filter.Status {
+			return false
+		}
+	}
+	if filter.NotStatus != "" {
+		if s.getStatus(item) == filter.NotStatus {
+			return false
+		}
+	}
+	if !filter.Since.IsZero() {
+		if s.getCreatedAt(item).Before(filter.Since) {
+			return false
+		}
+	}
+	if !filter.Before.IsZero() {
+		if s.getCreatedAt(item).After(filter.Before) {
+			return false
+		}
+	}
+	return true
+}
+
+// applyOffsetLimit slices result with the given offset and limit.
+func applyOffsetLimit[T any](result []T, offset, limit int) []T {
+	if offset > 0 {
+		if offset >= len(result) {
+			return []T{}
+		}
+		result = result[offset:]
+	}
+	if limit > 0 && limit < len(result) {
+		result = result[:limit]
+	}
+	return result
+}
+
 func (s *memoryListStore[T]) Query(ctx context.Context, filter ports.ListFilter, limit, offset int) ([]T, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
 	var result []T
 	for _, item := range s.data {
-		// Apply status filter
-		if filter.Status != "" {
-			itemStatus := s.getStatus(item)
-			if itemStatus != filter.Status {
-				continue
-			}
+		if s.matchesFilter(item, filter) {
+			result = append(result, item)
 		}
-		// Apply NotStatus exclusion
-		if filter.NotStatus != "" {
-			itemStatus := s.getStatus(item)
-			if itemStatus == filter.NotStatus {
-				continue
-			}
-		}
-		// Apply Since filter
-		if !filter.Since.IsZero() {
-			itemTime := s.getCreatedAt(item)
-			if itemTime.Before(filter.Since) {
-				continue
-			}
-		}
-		// Apply Before filter
-		if !filter.Before.IsZero() {
-			itemTime := s.getCreatedAt(item)
-			if itemTime.After(filter.Before) {
-				continue
-			}
-		}
-		result = append(result, item)
 	}
-
-	// Apply offset
-	if offset > 0 {
-		if offset >= len(result) {
-			return []T{}, nil
-		}
-		result = result[offset:]
-	}
-
-	// Apply limit
-	if limit > 0 && limit < len(result) {
-		result = result[:limit]
-	}
-
-	return result, nil
+	return applyOffsetLimit(result, offset, limit), nil
 }
 
 func (s *memoryListStore[T]) Count(ctx context.Context) (int, error) {

--- a/internal/infrastructure/persistence/sqlite_health_test.go
+++ b/internal/infrastructure/persistence/sqlite_health_test.go
@@ -248,27 +248,32 @@ func TestSQLiteHealthChecker_DBFileStatFails(t *testing.T) {
 	}
 
 	// Verify size_bytes was set to 0 (the else branch).
-	// Note: the untyped 0 literal in the production code is stored as int,
-	// not int64. We accept either representation.
 	details, ok := report.Details.(map[string]any)
 	if !ok {
 		t.Fatal("expected Details to be a map[string]any")
 	}
+	sizeBytes := extractSizeBytes(t, details)
+	if sizeBytes != 0 {
+		t.Errorf("expected size_bytes = 0, got %d", sizeBytes)
+	}
+}
+
+// extractSizeBytes extracts the "size_bytes" value from a details map,
+// accepting both int and int64 representations.
+func extractSizeBytes(t *testing.T, details map[string]any) int64 {
+	t.Helper()
 	raw, exists := details["size_bytes"]
 	if !exists {
 		t.Fatal("expected size_bytes key in details")
 	}
-	var sizeBytes int64
 	switch v := raw.(type) {
 	case int64:
-		sizeBytes = v
+		return v
 	case int:
-		sizeBytes = int64(v)
+		return int64(v)
 	default:
 		t.Fatalf("expected size_bytes to be int or int64, got %T (%v)", raw, raw)
-	}
-	if sizeBytes != 0 {
-		t.Errorf("expected size_bytes = 0, got %d", sizeBytes)
+		return 0
 	}
 }
 
@@ -293,24 +298,6 @@ func TestNoOpHealthChecker_Check(t *testing.T) {
 // in sqliteHealthChecker.Check(). Each subtest exercises a distinct code path.
 func TestSQLiteHealthChecker_Check(t *testing.T) {
 	t.Parallel()
-
-	// Helper to extract size_bytes from details map (handles int and int64).
-	extractSizeBytes := func(t *testing.T, details map[string]any) int64 {
-		t.Helper()
-		raw, exists := details["size_bytes"]
-		if !exists {
-			t.Fatal("expected size_bytes key in details")
-		}
-		switch v := raw.(type) {
-		case int64:
-			return v
-		case int:
-			return int64(v)
-		default:
-			t.Fatalf("expected size_bytes to be int or int64, got %T (%v)", raw, raw)
-			return 0
-		}
-	}
 
 	// ---------------
 	// Baseline: all checks pass on a healthy database.

--- a/internal/infrastructure/persistence/sqlite_store_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_test.go
@@ -871,63 +871,99 @@ func TestSQLiteTaskStore_ReadAll_Bounded(t *testing.T) {
 	db := setupSQLite(t)
 	store := newSQLiteTaskStore(db)
 	ctx := context.Background()
-
 	now := time.Now()
 
 	// Insert 10 pending tasks
 	for i := 1; i <= 10; i++ {
 		task := ports.Task{ID: float64(i), Content: fmt.Sprintf("pending %d", i), Status: "pending", CreatedAt: now}
-		if err := store.Append(ctx, task); err != nil {
-			t.Fatalf("append pending %d: %v", i, err)
-		}
+		require.NoError(t, store.Append(ctx, task))
 	}
 
 	// Insert 600 completed tasks
 	for i := 11; i <= 610; i++ {
 		task := ports.Task{ID: float64(i), Content: fmt.Sprintf("completed %d", i), Status: "completed", CreatedAt: now.Add(time.Duration(i) * time.Second)}
-		if err := store.Append(ctx, task); err != nil {
-			t.Fatalf("append completed %d: %v", i, err)
-		}
+		require.NoError(t, store.Append(ctx, task))
 	}
 
 	tasks, err := store.ReadAll(ctx)
-	if err != nil {
-		t.Fatalf("ReadAll failed: %v", err)
-	}
+	require.NoError(t, err)
 
-	// Expect 10 pending + 500 completed = 510 total
-	if len(tasks) != 510 {
-		t.Errorf("expected 510 tasks (10 pending + 500 completed), got %d", len(tasks))
-	}
+	t.Run("total_count", func(t *testing.T) {
+		if len(tasks) != 510 {
+			t.Errorf("expected 510 tasks (10 pending + 500 completed), got %d", len(tasks))
+		}
+	})
 
-	// Verify all pending tasks are present
-	pendingCount := 0
-	for _, t := range tasks {
-		if t.Status == "pending" {
-			pendingCount++
+	t.Run("pending_present", func(t *testing.T) {
+		assertPendingCount(t, tasks, 10)
+	})
+
+	t.Run("completed_truncation", func(t *testing.T) {
+		assertCompletedRetention(t, tasks, 11, 110, 111, 610)
+	})
+}
+
+// assertPendingCount verifies that exactly want tasks in the slice have
+// Status == "pending".
+func assertPendingCount(t *testing.T, tasks []ports.Task, want int) {
+	t.Helper()
+	count := 0
+	for _, task := range tasks {
+		if task.Status == "pending" {
+			count++
 		}
 	}
-	if pendingCount != 10 {
-		t.Errorf("expected 10 pending tasks, got %d", pendingCount)
+	if count != want {
+		t.Errorf("expected %d pending tasks, got %d", want, count)
 	}
+}
 
-	// Verify completed tasks are the most recent 500 (IDs 111–610, not 11–110)
+// assertCompletedRetention verifies that completed tasks in the oldest range
+// [oldestExcludedStart, oldestExcludedEnd] are NOT present and that completed
+// tasks in the newest range [newestIncludedStart, newestIncludedEnd] ARE present.
+func assertCompletedRetention(t *testing.T, tasks []ports.Task, oldestExcludedStart, oldestExcludedEnd, newestIncludedStart, newestIncludedEnd float64) {
+	t.Helper()
 	completedIDs := make(map[float64]bool)
-	for _, t := range tasks {
-		if t.Status == "completed" {
-			completedIDs[t.ID] = true
+	for _, task := range tasks {
+		if task.Status == "completed" {
+			completedIDs[task.ID] = true
 		}
 	}
-	// The oldest 100 completed (IDs 11–110) should be excluded
-	for id := float64(11); id <= 110; id++ {
+	for id := oldestExcludedStart; id <= oldestExcludedEnd; id++ {
 		if completedIDs[id] {
 			t.Errorf("completed task %d should have been truncated", int(id))
 		}
 	}
-	// The newest 500 completed (IDs 111–610) should be included
-	for id := float64(111); id <= 610; id++ {
+	for id := newestIncludedStart; id <= newestIncludedEnd; id++ {
 		if !completedIDs[id] {
 			t.Errorf("completed task %d should have been retained", int(id))
+		}
+	}
+}
+
+// =============================================================================
+// seedBenchmarkTasks inserts 10,000 tasks with a fixed status distribution:
+// 3000 pending, 1000 in_progress, 6000 completed.
+// =============================================================================
+
+func seedBenchmarkTasks(b *testing.B, store *sqliteTaskStore, ctx context.Context, now time.Time) {
+	b.Helper()
+	b.Log("inserting 10,000 tasks...")
+	for i := 1; i <= 10000; i++ {
+		status := "completed"
+		if i <= 3000 {
+			status = "pending"
+		} else if i <= 4000 {
+			status = "in_progress"
+		}
+		task := ports.Task{
+			ID:        float64(i),
+			Content:   fmt.Sprintf("Task %d", i),
+			Status:    status,
+			CreatedAt: now.Add(time.Duration(i) * time.Second),
+		}
+		if err := store.Append(ctx, task); err != nil {
+			b.Fatalf("append task %d: %v", i, err)
 		}
 	}
 }
@@ -953,27 +989,8 @@ func BenchmarkSQLiteQuery_10000Tasks(b *testing.B) {
 	ctx := context.Background()
 	now := time.Now()
 
-	// Insert 10,000 tasks: 3000 pending, 1000 in_progress, 6000 completed
-	b.Log("inserting 10,000 tasks...")
-	for i := 1; i <= 10000; i++ {
-		status := "completed"
-		if i <= 3000 {
-			status = "pending"
-		} else if i <= 4000 {
-			status = "in_progress"
-		}
-		task := ports.Task{
-			ID:        float64(i),
-			Content:   fmt.Sprintf("Task %d", i),
-			Status:    status,
-			CreatedAt: now.Add(time.Duration(i) * time.Second),
-		}
-		if err := store.Append(ctx, task); err != nil {
-			b.Fatalf("append task %d: %v", i, err)
-		}
-	}
+	seedBenchmarkTasks(b, store, ctx, now)
 
-	// Verify count
 	count, err := store.Count(ctx)
 	if err != nil {
 		b.Fatalf("count failed: %v", err)
@@ -985,7 +1002,6 @@ func BenchmarkSQLiteQuery_10000Tasks(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		// Query with status filter + limit — must allocate proportionally to result, not total
 		tasks, err := store.Query(ctx, ports.ListFilter{Status: "pending"}, 100, 0)
 		if err != nil {
 			b.Fatalf("query failed: %v", err)
@@ -993,7 +1009,6 @@ func BenchmarkSQLiteQuery_10000Tasks(b *testing.B) {
 		if len(tasks) > 100 {
 			b.Fatalf("expected at most 100 tasks, got %d", len(tasks))
 		}
-		// Ensure results are not retained across iterations
 		_ = tasks
 	}
 
@@ -1001,20 +1016,13 @@ func BenchmarkSQLiteQuery_10000Tasks(b *testing.B) {
 }
 
 // =============================================================================
-// TestSQLiteTaskStore_Query_BoundedMemory proves that Query's memory
-// allocation is proportional to the result set, not the total DB size.
+// seedMixedStatusTasks inserts count tasks into the store with a status
+// distribution: first 500 pending, next 500 in_progress, rest completed.
 // =============================================================================
 
-func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
-	t.Parallel()
-
-	db := setupSQLite(t)
-	store := newSQLiteTaskStore(db)
-	ctx := context.Background()
-	now := time.Now()
-
-	// Insert 5000 tasks with mixed statuses
-	for i := 1; i <= 5000; i++ {
+func seedMixedStatusTasks(t *testing.T, store *sqliteTaskStore, ctx context.Context, now time.Time, count int) {
+	t.Helper()
+	for i := 1; i <= count; i++ {
 		status := "completed"
 		if i <= 500 {
 			status = "pending"
@@ -1031,8 +1039,10 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 			t.Fatalf("append task %d: %v", i, err)
 		}
 	}
+}
 
-	// Query with limit=10 — result must have exactly 10 items
+func testTaskStoreQueryLimitEnforced(t *testing.T, store *sqliteTaskStore) {
+	ctx := context.Background()
 	tasks, err := store.Query(ctx, ports.ListFilter{}, 10, 0)
 	if err != nil {
 		t.Fatalf("Query failed: %v", err)
@@ -1040,8 +1050,10 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 	if len(tasks) != 10 {
 		t.Errorf("expected 10 tasks with limit=10, got %d", len(tasks))
 	}
+}
 
-	// Query pending tasks only — must return all 500 (no limit)
+func testTaskStoreQueryStatusFilterPending(t *testing.T, store *sqliteTaskStore) {
+	ctx := context.Background()
 	pending, err := store.Query(ctx, ports.ListFilter{Status: "pending"}, 0, 0)
 	if err != nil {
 		t.Fatalf("Query pending failed: %v", err)
@@ -1049,8 +1061,10 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 	if len(pending) != 500 {
 		t.Errorf("expected 500 pending tasks, got %d", len(pending))
 	}
+}
 
-	// Query with offset beyond total — must return empty
+func testTaskStoreQueryOffsetBeyondTotal(t *testing.T, store *sqliteTaskStore) {
+	ctx := context.Background()
 	empty, err := store.Query(ctx, ports.ListFilter{}, 10, 10000)
 	if err != nil {
 		t.Fatalf("Query beyond range failed: %v", err)
@@ -1058,8 +1072,10 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 	if len(empty) != 0 {
 		t.Errorf("expected 0 tasks with offset beyond total, got %d", len(empty))
 	}
+}
 
-	// Verify Count
+func testTaskStoreQueryCountAccurate(t *testing.T, store *sqliteTaskStore) {
+	ctx := context.Background()
 	count, err := store.Count(ctx)
 	if err != nil {
 		t.Fatalf("Count failed: %v", err)
@@ -1067,18 +1083,18 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 	if count != 5000 {
 		t.Errorf("expected 5000 total tasks, got %d", count)
 	}
+}
 
-	// Verify ReadAll bounded behavior (should return 500 pending + 1000 in_progress + 500 completed = 2000)
+func testTaskStoreQueryReadallBounded(t *testing.T, store *sqliteTaskStore) {
+	ctx := context.Background()
 	all, err := store.ReadAll(ctx)
 	if err != nil {
 		t.Fatalf("ReadAll failed: %v", err)
 	}
-	// 500 pending + 1000 in_progress + 500 (most recent completed) = 2000
 	expectedMax := 500 + 1000 + 500
 	if len(all) > expectedMax {
 		t.Errorf("ReadAll returned %d tasks, expected at most %d", len(all), expectedMax)
 	}
-	// All pending should be present
 	pendingInAll := 0
 	for _, task := range all {
 		if task.Status == "pending" {
@@ -1088,4 +1104,26 @@ func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
 	if pendingInAll != 500 {
 		t.Errorf("expected 500 pending tasks in ReadAll, got %d", pendingInAll)
 	}
+}
+
+// =============================================================================
+// TestSQLiteTaskStore_Query_BoundedMemory proves that Query's memory
+// allocation is proportional to the result set, not the total DB size.
+// =============================================================================
+
+func TestSQLiteTaskStore_Query_BoundedMemory(t *testing.T) {
+	t.Parallel()
+
+	db := setupSQLite(t)
+	store := newSQLiteTaskStore(db)
+	ctx := context.Background()
+	now := time.Now()
+
+	seedMixedStatusTasks(t, store, ctx, now, 5000)
+
+	t.Run("limit_enforced", func(t *testing.T) { testTaskStoreQueryLimitEnforced(t, store) })
+	t.Run("status_filter_pending", func(t *testing.T) { testTaskStoreQueryStatusFilterPending(t, store) })
+	t.Run("offset_beyond_total", func(t *testing.T) { testTaskStoreQueryOffsetBeyondTotal(t, store) })
+	t.Run("count_accurate", func(t *testing.T) { testTaskStoreQueryCountAccurate(t, store) })
+	t.Run("readall_bounded", func(t *testing.T) { testTaskStoreQueryReadallBounded(t, store) })
 }

--- a/internal/infrastructure/persistence/sqlite_store_where_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_where_test.go
@@ -79,31 +79,32 @@ func TestBuildWhereClause(t *testing.T) {
 				t.Errorf("args len = %d; want %d", len(wc.args), tt.wantArgLen)
 			}
 
-			// Verify args are in correct order matching the SQL ? placeholders
-			argIdx := 0
-			if tt.filter.Status != "" {
-				if wc.args[argIdx] != tt.filter.Status {
-					t.Errorf("args[%d] = %v; want Status %q", argIdx, wc.args[argIdx], tt.filter.Status)
-				}
-				argIdx++
-			}
-			if tt.filter.NotStatus != "" {
-				if wc.args[argIdx] != tt.filter.NotStatus {
-					t.Errorf("args[%d] = %v; want NotStatus %q", argIdx, wc.args[argIdx], tt.filter.NotStatus)
-				}
-				argIdx++
-			}
-			if !tt.filter.Since.IsZero() {
-				if wc.args[argIdx] != tt.filter.Since.Format(time.RFC3339Nano) {
-					t.Errorf("args[%d] = %v; want Since %q", argIdx, wc.args[argIdx], tt.filter.Since.Format(time.RFC3339Nano))
-				}
-				argIdx++
-			}
-			if !tt.filter.Before.IsZero() {
-				if wc.args[argIdx] != tt.filter.Before.Format(time.RFC3339Nano) {
-					t.Errorf("args[%d] = %v; want Before %q", argIdx, wc.args[argIdx], tt.filter.Before.Format(time.RFC3339Nano))
-				}
-			}
+			verifyWhereArgs(t, wc, tt.filter)
 		})
 	}
+}
+
+// verifyWhereArgs checks that wc.args contains the correct values matching
+// the non-zero fields of f, in the same order that buildWhereClause places them.
+func verifyWhereArgs(t *testing.T, wc whereClause, f ports.ListFilter) {
+	t.Helper()
+
+	argIdx := 0
+	checkArg(t, wc.args, &argIdx, "Status", f.Status, f.Status != "")
+	checkArg(t, wc.args, &argIdx, "NotStatus", f.NotStatus, f.NotStatus != "")
+	checkArg(t, wc.args, &argIdx, "Since", f.Since.Format(time.RFC3339Nano), !f.Since.IsZero())
+	checkArg(t, wc.args, &argIdx, "Before", f.Before.Format(time.RFC3339Nano), !f.Before.IsZero())
+}
+
+// checkArg verifies a single argument at args[*idx] if isSet is true,
+// then advances idx. Skips verification when isSet is false.
+func checkArg(t *testing.T, args []any, idx *int, fieldName, want string, isSet bool) {
+	t.Helper()
+	if !isSet {
+		return
+	}
+	if args[*idx] != want {
+		t.Errorf("args[%d] = %v; want %s %q", *idx, args[*idx], fieldName, want)
+	}
+	*idx++
 }

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -16,6 +16,34 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 )
 
+// taskMatchesFilter returns true if task matches the given filter.
+func taskMatchesFilter(task ports.Task, filter ports.ListFilter) bool {
+	if filter.NotStatus != "" && task.Status == filter.NotStatus {
+		return false
+	}
+	if filter.Status != "" && task.Status != filter.Status {
+		return false
+	}
+	if !filter.Since.IsZero() && task.CreatedAt.Before(filter.Since) {
+		return false
+	}
+	if !filter.Before.IsZero() && task.CreatedAt.After(filter.Before) {
+		return false
+	}
+	return true
+}
+
+// applyTaskOffsetLimit applies offset and limit to a slice of tasks.
+func applyTaskOffsetLimit(tasks []ports.Task, limit, offset int) []ports.Task {
+	if offset >= len(tasks) {
+		return []ports.Task{}
+	}
+	if limit > 0 {
+		return tasks[offset:min(offset+limit, len(tasks))]
+	}
+	return tasks[offset:]
+}
+
 // mockListStore implements ports.ListStore[ports.Task]
 type mockListStore struct {
 	tasks []ports.Task
@@ -77,30 +105,11 @@ func (m *mockListStore) Query(ctx context.Context, filter ports.ListFilter, limi
 	}
 	var result []ports.Task
 	for _, t := range m.tasks {
-		if filter.Status != "" && t.Status != filter.Status {
-			continue
+		if taskMatchesFilter(t, filter) {
+			result = append(result, t)
 		}
-		if filter.NotStatus != "" && t.Status == filter.NotStatus {
-			continue
-		}
-		if !filter.Since.IsZero() && t.CreatedAt.Before(filter.Since) {
-			continue
-		}
-		if !filter.Before.IsZero() && t.CreatedAt.After(filter.Before) {
-			continue
-		}
-		result = append(result, t)
 	}
-	if offset > 0 {
-		if offset >= len(result) {
-			return []ports.Task{}, nil
-		}
-		result = result[offset:]
-	}
-	if limit > 0 && limit < len(result) {
-		result = result[:limit]
-	}
-	return result, nil
+	return applyTaskOffsetLimit(result, limit, offset), nil
 }
 
 func (m *mockListStore) Count(ctx context.Context) (int, error) {
@@ -172,20 +181,48 @@ func TestPersistenceTools_GetSessionInfo(t *testing.T) {
 }
 
 func TestPersistenceTools_ManageTasks(t *testing.T) {
+	t.Run("add", testManageTasksAdd)
+	t.Run("list", testManageTasksList)
+	t.Run("update", testManageTasksUpdate)
+	t.Run("delete_and_clear", testManageTasksDeleteAndClear)
+	t.Run("completed_filter", testManageTasksCompletedFilter)
+	t.Run("error", testManageTasksError)
+}
+
+func testManageTasksAdd(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           map[string]interface{}
-		setup          func(*mockListStore, ports.TaskStore)
 		expectedResult string
-		expectError    bool
 	}{
 		{
 			name:           "Successfully add task",
 			args:           map[string]interface{}{"action": "add", "content": "task 1"},
 			expectedResult: "Task added with ID 1",
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			setupManageTasks(t, nil, provider)
+
+			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
+
+			assertManageTasksResult(t, res, err, tt.expectedResult, false)
+		})
+	}
+}
+
+func testManageTasksList(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		setup          func(*mockListStore, ports.TaskStore)
+		expectedResult string
+	}{
 		{
-			name: "Successfully list tasks",
+			name: "list basic",
 			args: map[string]interface{}{"action": "list"},
 			setup: func(m *mockListStore, ts ports.TaskStore) {
 				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
@@ -194,59 +231,6 @@ func TestPersistenceTools_ManageTasks(t *testing.T) {
 				}
 			},
 			expectedResult: "task 1",
-		},
-		{
-			name: "Successfully update task",
-			args: map[string]interface{}{"action": "update", "task_id": 1.0, "status": "completed"},
-			setup: func(m *mockListStore, ts ports.TaskStore) {
-				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
-				if s, ok := ts.(ports.Initializer); ok {
-					_ = s.Initialize(context.Background())
-				}
-			},
-			expectedResult: "Task 1 updated",
-		},
-		{
-			name: "Successfully list completed tasks",
-			args: map[string]interface{}{"action": "list", "status": "completed"},
-			setup: func(m *mockListStore, ts ports.TaskStore) {
-				// Use AddTask + UpdateTask to get a completed task into
-				// the in-memory map (Initialize no longer loads completed tasks).
-				ctx := context.Background()
-				t1, err := ts.AddTask(ctx, "task 1")
-				if err != nil {
-					t.Fatalf("AddTask failed: %v", err)
-				}
-				if _, err := ts.UpdateTask(ctx, t1.ID, "", "completed"); err != nil {
-					t.Fatalf("UpdateTask failed: %v", err)
-				}
-				if _, err := ts.AddTask(ctx, "task 2"); err != nil {
-					t.Fatalf("AddTask failed: %v", err)
-				}
-			},
-			expectedResult: "[x]",
-		},
-		{
-			name: "Successfully delete task",
-			args: map[string]interface{}{"action": "delete", "task_id": 1.0},
-			setup: func(m *mockListStore, ts ports.TaskStore) {
-				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
-				if s, ok := ts.(ports.Initializer); ok {
-					_ = s.Initialize(context.Background())
-				}
-			},
-			expectedResult: "Task 1 deleted",
-		},
-		{
-			name: "Successfully clear tasks",
-			args: map[string]interface{}{"action": "clear"},
-			setup: func(m *mockListStore, ts ports.TaskStore) {
-				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
-				if s, ok := ts.(ports.Initializer); ok {
-					_ = s.Initialize(context.Background())
-				}
-			},
-			expectedResult: "All tasks cleared",
 		},
 		{
 			name: "list with default limit",
@@ -286,8 +270,143 @@ func TestPersistenceTools_ManageTasks(t *testing.T) {
 			},
 			expectedResult: "Use offset=50 for next page.",
 		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			setupManageTasks(t, tt.setup, provider)
+
+			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
+
+			assertManageTasksResult(t, res, err, tt.expectedResult, false)
+		})
+	}
+}
+
+func testManageTasksUpdate(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		setup          func(*mockListStore, ports.TaskStore)
+		expectedResult string
+	}{
 		{
-			name:           "Error on unknown action",
+			name: "Successfully update task",
+			args: map[string]interface{}{"action": "update", "task_id": 1.0, "status": "completed"},
+			setup: func(m *mockListStore, ts ports.TaskStore) {
+				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
+				if s, ok := ts.(ports.Initializer); ok {
+					_ = s.Initialize(context.Background())
+				}
+			},
+			expectedResult: "Task 1 updated",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			setupManageTasks(t, tt.setup, provider)
+
+			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
+
+			assertManageTasksResult(t, res, err, tt.expectedResult, false)
+		})
+	}
+}
+
+func testManageTasksDeleteAndClear(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		setup          func(*mockListStore, ports.TaskStore)
+		expectedResult string
+	}{
+		{
+			name: "delete task",
+			args: map[string]interface{}{"action": "delete", "task_id": 1.0},
+			setup: func(m *mockListStore, ts ports.TaskStore) {
+				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
+				if s, ok := ts.(ports.Initializer); ok {
+					_ = s.Initialize(context.Background())
+				}
+			},
+			expectedResult: "Task 1 deleted",
+		},
+		{
+			name: "clear tasks",
+			args: map[string]interface{}{"action": "clear"},
+			setup: func(m *mockListStore, ts ports.TaskStore) {
+				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
+				if s, ok := ts.(ports.Initializer); ok {
+					_ = s.Initialize(context.Background())
+				}
+			},
+			expectedResult: "All tasks cleared",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			setupManageTasks(t, tt.setup, provider)
+
+			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
+
+			assertManageTasksResult(t, res, err, tt.expectedResult, false)
+		})
+	}
+}
+
+func testManageTasksCompletedFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		setup          func(*mockListStore, ports.TaskStore)
+		expectedResult string
+	}{
+		{
+			name: "list completed",
+			args: map[string]interface{}{"action": "list", "status": "completed"},
+			setup: func(m *mockListStore, ts ports.TaskStore) {
+				ctx := context.Background()
+				t1, err := ts.AddTask(ctx, "task 1")
+				if err != nil {
+					t.Fatalf("AddTask failed: %v", err)
+				}
+				if _, err := ts.UpdateTask(ctx, t1.ID, "", "completed"); err != nil {
+					t.Fatalf("UpdateTask failed: %v", err)
+				}
+				if _, err := ts.AddTask(ctx, "task 2"); err != nil {
+					t.Fatalf("AddTask failed: %v", err)
+				}
+			},
+			expectedResult: "[x]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			setupManageTasks(t, tt.setup, provider)
+
+			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
+
+			assertManageTasksResult(t, res, err, tt.expectedResult, false)
+		})
+	}
+}
+
+func testManageTasksError(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           map[string]interface{}
+		expectedResult string
+		expectError    bool
+	}{
+		{
+			name:           "unknown action",
 			args:           map[string]interface{}{"action": "unknown"},
 			expectedResult: "Error: unknown action: unknown",
 		},
@@ -296,7 +415,7 @@ func TestPersistenceTools_ManageTasks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pt, provider := setupPersistenceTools()
-			setupManageTasks(t, tt.setup, provider)
+			setupManageTasks(t, nil, provider)
 
 			res, err := pt.ManageTasks(context.Background(), tt.args, nil)
 


### PR DESCRIPTION
Closes #542.

## Summary
Refactored all 11 functions exceeding the cyclomatic complexity threshold of 10:

| # | Function | File | Before | After |
|---|---|---|---|---|
| 1 | `(*memoryListStore[T]).Query` | memory_store.go | 14 | 3 |
| 2 | `TestSQLiteTaskStore_Query_BoundedMemory` | sqlite_store_test.go | 18 | 1 |
| 3 | `TestSQLiteTaskStore_ReadAll_Bounded` | sqlite_store_test.go | 16 | 4 |
| 4 | `(*mockTaskRepo).Query` | task_service_test.go | 15 | 4 |
| 5 | `(*mockListStore).Query` | persistence_tools_test.go | 15 | 4 |
| 6 | `BenchmarkSQLiteQuery_10000Tasks` | sqlite_store_test.go | 12 | 8 |
| 7 | `TestBuildWhereClause` | sqlite_store_where_test.go | 12 | 4 |
| 8 | `TestPersistenceTools_ManageTasks` | persistence_tools_test.go | 12 | 1 |
| 9 | `TestNewChatter` | chatter_test.go | 11 | 9 |
| 10 | `TestSQLiteHealthChecker_DBFileStatFails` | sqlite_health_test.go | 11 | 7 |
| 11 | `TestTaskService_ListTasks_LimitOffset` | task_service_test.go | 11 | 9 |

**Techniques used**: extract-to-helper, split-into-subtests, promote-local-closure, extract-predicate.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | PASS |
| `get_code_health` complexity alerts | 0 |
| `go test -race ./...` | PASS (70 packages) |
| Coverage | 94.0% (no regression) |
| `golangci-lint run` | 0 issues |
| `verify_architecture` | No cycles |