### PR TITLE
fix(persistence): wrap 10K SQLite seed inserts in transaction (#568)

### DIFF
--- a/internal/infrastructure/persistence/sqlite_store_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_test.go
@@ -948,7 +948,13 @@ func assertCompletedRetention(t *testing.T, tasks []ports.Task, oldestExcludedSt
 
 func seedBenchmarkTasks(b *testing.B, store *sqliteTaskStore, ctx context.Context, now time.Time) {
 	b.Helper()
-	b.Log("inserting 10,000 tasks...")
+	b.Log("inserting 10,000 tasks (single transaction)...")
+
+	// BEGIN transaction — avoids per-INSERT disk sync (205s → <1s)
+	if _, err := store.db.ExecContext(ctx, "BEGIN"); err != nil {
+		b.Fatalf("begin transaction: %v", err)
+	}
+
 	for i := 1; i <= 10000; i++ {
 		status := "completed"
 		if i <= 3000 {
@@ -965,6 +971,11 @@ func seedBenchmarkTasks(b *testing.B, store *sqliteTaskStore, ctx context.Contex
 		if err := store.Append(ctx, task); err != nil {
 			b.Fatalf("append task %d: %v", i, err)
 		}
+	}
+
+	// COMMIT — flush all INSERTs to disk atomically
+	if _, err := store.db.ExecContext(ctx, "COMMIT"); err != nil {
+		b.Fatalf("commit transaction: %v", err)
 	}
 }
 


### PR DESCRIPTION
Closes #568.

## Summary
Wrapped the 10,000-insert loop in `seedBenchmarkTasks` (`sqlite_store_test.go`) with a single SQLite BEGIN/COMMIT transaction. This eliminates the per-INSERT disk sync overhead, reducing benchmark setup from ~205s to <1s.

## Changes
- `internal/infrastructure/persistence/sqlite_store_test.go`: Added `BEGIN` before the insert loop and `COMMIT` after, with `b.Fatalf` error handling on both.
- Updated `b.Log` message to reflect single-transaction usage.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| `go test ./internal/infrastructure/persistence/` | ✅ PASS |
| `go test -bench=BenchmarkSQLiteQuery_10000Tasks` | ✅ ~3.5s (was ~205s) |
| Benchmark measurement unchanged | ✅ Same data, queries, assertions |
| Race detection | ✅ Clean |