### PR TITLE
fix(analysis): decompose resolveCrossPackageMethodUsages to reduce complexity (#571)

### DIFF
--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -435,6 +435,45 @@ func (a *defaultDeadCodeAnalyzer) propagateInterfaceUsages(ctx context.Context, 
 // Performance: walks only packages whose PkgPath differs from the
 // declaring package. Skips packages with nil TypesInfo. Returns early
 // on first confirmed match.
+
+// resolveInPackage walks the AST of a single package looking for a
+// method identifier that type-resolves to targetId. Returns true on
+// first confirmed match.
+//
+// This is the inner loop extracted from resolveCrossPackageMethodUsages
+// to reduce cyclomatic complexity below the project threshold of 10.
+func (a *defaultDeadCodeAnalyzer) resolveInPackage(
+	pkg *packages.Package,
+	methodName string,
+	targetId string,
+) bool {
+	for _, file := range pkg.Syntax {
+		found := false
+		ast.Inspect(file, func(n ast.Node) bool {
+			if found {
+				return false
+			}
+			ident, ok := n.(*ast.Ident)
+			if !ok || ident.Name != methodName {
+				return true
+			}
+			obj, ok := pkg.TypesInfo.Uses[ident]
+			if !ok || obj == nil {
+				return true
+			}
+			if getSymbolIdentity(obj) == targetId {
+				found = true
+				return false
+			}
+			return true
+		})
+		if found {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *defaultDeadCodeAnalyzer) resolveCrossPackageMethodUsages(
 	state *scanState,
 	methodName string,
@@ -444,38 +483,14 @@ func (a *defaultDeadCodeAnalyzer) resolveCrossPackageMethodUsages(
 	declaringBase := getBasePkgPath(declaringPkgPath)
 
 	for _, pkg := range state.pkgs {
-		pkgBase := getBasePkgPath(pkg.PkgPath)
-		if pkgBase == declaringBase {
-			continue // Same package — not cross-package
+		if getBasePkgPath(pkg.PkgPath) == declaringBase {
+			continue
 		}
 		if pkg.TypesInfo == nil {
-			continue // Cannot resolve types
+			continue
 		}
-
-		for _, file := range pkg.Syntax {
-			found := false
-			ast.Inspect(file, func(n ast.Node) bool {
-				if found {
-					return false // Stop walking after first match
-				}
-				ident, ok := n.(*ast.Ident)
-				if !ok || ident.Name != methodName {
-					return true
-				}
-				obj, ok := pkg.TypesInfo.Uses[ident]
-				if !ok || obj == nil {
-					return true
-				}
-				resolvedId := getSymbolIdentity(obj)
-				if resolvedId == targetId {
-					found = true
-					return false
-				}
-				return true
-			})
-			if found {
-				return true
-			}
+		if a.resolveInPackage(pkg, methodName, targetId) {
+			return true
 		}
 	}
 	return false

--- a/internal/tools/analysis/dead_code_deep_test.go
+++ b/internal/tools/analysis/dead_code_deep_test.go
@@ -17,10 +17,12 @@ package analysis
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/go/packages"
 )
 
 // runAnalyzerDeep is a small variant of runAnalyzer that passes deep:true.
@@ -222,4 +224,62 @@ func TestResolveCrossPackageMethodUsages_IdentityResolution(t *testing.T) {
 	assert.False(t, got,
 		"resolveCrossPackageMethodUsages must NOT find Bar anywhere — "+
 			"no such method is called in the fixture.")
+}
+
+// TestResolveInPackage_IdentityResolution is a unit test of the extracted
+// resolveInPackage method. It verifies that the type-aware AST walk
+// correctly resolves identifiers to their full identity within a single
+// *packages.Package.
+//
+// The test extracts the pkgB package from deepIdentFixture (which contains
+// the cross-package call `a.Foo()` where `a` is pkgA.TypeA) and calls
+// resolveInPackage directly with varying targetId values.
+//
+// This satisfies the acceptance criterion: resolveInPackage is
+// independently unit-testable with synthetic *packages.Package fixtures.
+func TestResolveInPackage_IdentityResolution(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	writeFixture(t, tmpDir, deepIdentFixture())
+
+	idx, err := newIndexer(tmpDir)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, idx.Refresh(ctx, nil))
+
+	pkgs, err := idx.Packages(ctx, nil)
+	require.NoError(t, err)
+
+	// Find pkgB — it contains the cross-package call `a.Foo()` where
+	// `a` is pkgA.TypeA. This is the package we test directly.
+	var pkgB *packages.Package
+	for _, pkg := range pkgs {
+		if strings.Contains(pkg.PkgPath, "pkgB") {
+			pkgB = pkg
+			break
+		}
+	}
+	require.NotNil(t, pkgB, "must find pkgB package containing the cross-package call")
+	require.NotNil(t, pkgB.TypesInfo, "pkgB must be type-checked")
+
+	analyzer := newDeadCodeAnalyzer(&deadCodeSecurityProvider{tempDir: tmpDir}, idx)
+
+	// 1. Correct identity — a.Foo() in pkgB resolves to TypeA.Foo.
+	targetId := "example.com/deepident/pkgA.TypeA.Foo"
+	assert.True(t, analyzer.resolveInPackage(pkgB, "Foo", targetId),
+		"resolveInPackage must find TypeA.Foo called from pkgB. "+
+			"The AST walk should resolve a.Foo() to identity %q.", targetId)
+
+	// 2. Wrong type, same method name — no OtherType.Foo is called.
+	wrongId := "example.com/deepident/pkgA.OtherType.Foo"
+	assert.False(t, analyzer.resolveInPackage(pkgB, "Foo", wrongId),
+		"resolveInPackage must NOT match OtherType.Foo — "+
+			"no such type has Foo called in pkgB.")
+
+	// 3. Wrong method name — no identifier "Bar" exists in pkgB.
+	assert.False(t, analyzer.resolveInPackage(pkgB, "Bar", targetId),
+		"resolveInPackage must NOT match Bar — "+
+			"no such method is called in pkgB.")
 }


### PR DESCRIPTION
Closes #571.

## Summary
Extracted the inner `ast.Inspect` closure from `resolveCrossPackageMethodUsages` into a standalone `resolveInPackage` method on `*defaultDeadCodeAnalyzer`. The outer function is now a thin orchestrator loop.

- Cyclomatic complexity: **12 → 5** (below the project threshold of 10)
- New `resolveInPackage` at complexity **9** (under threshold)
- Added `TestResolveInPackage_IdentityResolution` with 3 sub-cases for independent unit testing

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build ./...` | PASS |
| `golangci-lint run` | 0 issues |
| `go test ./...` | PASS (all packages) |
| `go test -race ./internal/tools/analysis/...` | PASS |
| Coverage (`internal/tools/analysis/...`) | 96.1% |
