### PR TITLE
fix(analysis): decompose evaluateOrphan into evaluator pipeline (#570)

### DIFF
--- a/internal/tools/analysis/orphan_evaluator.go
+++ b/internal/tools/analysis/orphan_evaluator.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// orphanEvalContext carries the full context for a single orphan evaluation step.
+// Read-only fields: id, meta, state, deep, complexity, impact, displayName.
+// Mutable field: report — the *orphanReport being built; nil means "exclude this symbol."
+type orphanEvalContext struct {
+	id          string
+	meta        *symMeta
+	state       *scanState
+	deep        bool
+	complexity  int
+	impact      int
+	displayName string
+	report      *orphanReport
+}
+
+// orphanEvaluator is a single step in the orphan classification pipeline.
+// It receives an eval context and returns the (possibly modified) context.
+// If ctx.report is nil after evaluate returns, the pipeline stops and the
+// symbol is excluded from orphan findings.
+type orphanEvaluator interface {
+	evaluate(ctx *orphanEvalContext) *orphanEvalContext
+}

--- a/internal/tools/analysis/orphan_evaluator_anoniface.go
+++ b/internal/tools/analysis/orphan_evaluator_anoniface.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import "fmt"
+
+// anonInterfaceWarningEvaluator appends a hedge warning when a method
+// name appears in anonymous-interface assertion sites (e.g.,
+// x.(interface{ M() })). This is independent of the text-match warning
+// — both may fire on the same orphan.
+//
+// This is step 7 of the original evaluateOrphan pipeline.
+type anonInterfaceWarningEvaluator struct {
+	analyzer *defaultDeadCodeAnalyzer
+}
+
+func (e *anonInterfaceWarningEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil || ctx.report == nil {
+		return ctx
+	}
+	if !ctx.meta.isMethod {
+		return ctx
+	}
+	if e.analyzer.hasAnonymousInterfaceAssertionMatch(ctx.state, ctx.meta.name) {
+		ctx.report.Reason += fmt.Sprintf(
+			" [WARNING: method name appears in anonymous-interface assertion site(s); verify with: grep -rn \"%s\" --include='*.go' .]",
+			ctx.meta.name,
+		)
+	}
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_complexity.go
+++ b/internal/tools/analysis/orphan_evaluator_complexity.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// complexityReclassifierEvaluator rewrites the Reason field when a
+// PRIVATE-severity orphan has high cyclomatic complexity (≥10).
+// This is step 4 of the original evaluateOrphan pipeline.
+type complexityReclassifierEvaluator struct{}
+
+func (e *complexityReclassifierEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil || ctx.report == nil {
+		return ctx
+	}
+	if ctx.report.Severity == "PRIVATE" && ctx.complexity >= 10 {
+		ctx.report.Reason = "High Priority Refactoring Candidate: can be refactored with zero external impact."
+	}
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_deep.go
+++ b/internal/tools/analysis/orphan_evaluator_deep.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// deepVerificationEvaluator performs type-aware AST verification to
+// confirm whether a method has cross-package callers. This only runs
+// when --deep mode is active.
+//
+// If a cross-package caller is confirmed, ctx.report is set to nil
+// (symbol is alive). Otherwise, deepVerifiedDead is appended to the
+// Reason field, and the text-search warning is suppressed (handled
+// by omitting textMatchWarningEvaluator from the pipeline).
+//
+// This is step 5 of the original evaluateOrphan pipeline.
+type deepVerificationEvaluator struct {
+	analyzer *defaultDeadCodeAnalyzer
+}
+
+func (e *deepVerificationEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil || ctx.report == nil {
+		return ctx
+	}
+	if !ctx.deep || !ctx.meta.isMethod {
+		return ctx
+	}
+
+	if e.analyzer.resolveCrossPackageMethodUsages(ctx.state, ctx.meta.name, ctx.id, ctx.meta.pkgPath) {
+		return nil
+	}
+
+	ctx.report.Reason += deepVerifiedDead
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_nolint.go
+++ b/internal/tools/analysis/orphan_evaluator_nolint.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// nolintGateEvaluator checks whether a symbol is annotated with
+// //nolint:deadcode and, if so, excludes it from orphan findings.
+// This is step 1 of the original evaluateOrphan pipeline.
+type nolintGateEvaluator struct {
+	analyzer *defaultDeadCodeAnalyzer
+}
+
+// evaluate implements orphanEvaluator. If the symbol has a
+// //nolint:deadcode directive, nil is returned to exclude it
+// from findings. Otherwise, the context is passed through unchanged.
+func (e *nolintGateEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil {
+		return nil
+	}
+	if isNolintDeadcode(ctx.meta.obj, ctx.state) {
+		return nil
+	}
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_severity.go
+++ b/internal/tools/analysis/orphan_evaluator_severity.go
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// severityClassifierEvaluator classifies an orphan symbol as DEAD or
+// PRIVATE based on usage counts and populates the initial Reason.
+// This is step 3 of the original evaluateOrphan pipeline.
+type severityClassifierEvaluator struct{}
+
+func (e *severityClassifierEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil {
+		return nil
+	}
+	total := ctx.state.totalUses[ctx.id]
+
+	var severity, reason string
+	if total == 0 {
+		severity = "DEAD"
+		reason = "No references found within the module (including interfaces/tests)."
+	} else {
+		severity = "PRIVATE"
+		reason = "Exported symbol is only used within its own package."
+	}
+
+	ctx.report = &orphanReport{
+		Symbol:     ctx.displayName,
+		Pkg:        ctx.meta.pkgPath,
+		Type:       ctx.meta.symType,
+		Severity:   severity,
+		Reason:     reason,
+		Complexity: ctx.complexity,
+		Impact:     ctx.impact,
+	}
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_textmatch.go
+++ b/internal/tools/analysis/orphan_evaluator_textmatch.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// textMatchWarningEvaluator appends a hedge warning when a raw text
+// search finds the symbol name in source files outside its declaring
+// package. This warning is suppressed when --deep mode is active and
+// the symbol is a method (deepVerificationEvaluator already handled
+// that case with type-aware verification).
+//
+// This is step 6 of the original evaluateOrphan pipeline.
+type textMatchWarningEvaluator struct {
+	analyzer *defaultDeadCodeAnalyzer
+}
+
+func (e *textMatchWarningEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil || ctx.report == nil {
+		return ctx
+	}
+	// Suppressed when deep verification already handled this method.
+	if ctx.deep && ctx.meta.isMethod {
+		return ctx
+	}
+	if e.analyzer.hasTextMatchOutsidePackage(ctx.state, ctx.meta.name, ctx.meta.pkgPath) {
+		ctx.report.Reason += " [WARNING: Text search found potential cross-package usage. Verify this is not a false positive due to structural typing.]"
+	}
+	return ctx
+}

--- a/internal/tools/analysis/orphan_evaluator_usage.go
+++ b/internal/tools/analysis/orphan_evaluator_usage.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// usageGateEvaluator checks whether a symbol has any external usage.
+// If total > 0 AND external > 0, the symbol is alive cross-package
+// and is excluded from orphan findings.
+// This is step 2 of the original evaluateOrphan pipeline.
+type usageGateEvaluator struct{}
+
+// evaluate implements orphanEvaluator. If the symbol has both total
+// and external references > 0, nil is returned to exclude it.
+func (e *usageGateEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if ctx == nil {
+		return ctx
+	}
+	total := ctx.state.totalUses[ctx.id]
+	external := ctx.state.externalUses[ctx.id]
+	if total > 0 && external > 0 {
+		return nil
+	}
+	return ctx
+}

--- a/internal/tools/analysis/report.go
+++ b/internal/tools/analysis/report.go
@@ -61,70 +61,53 @@ func formatDisplayName(id string, meta *symMeta) string {
 }
 
 // evaluateOrphan determines whether a symbol qualifies as dead or effectively
-// private, producing an orphanReport if so.
+// private, producing an orphanReport if so. The logic is decomposed into a
+// pipeline of single-purpose evaluators (see orphan_evaluator.go).
 func (a *defaultDeadCodeAnalyzer) evaluateOrphan(id string, meta *symMeta, state *scanState, deep bool) *orphanReport {
-	// Symbols annotated with //nolint:deadcode are explicitly excluded
-	// from dead-code reporting. This is a co-located, self-documenting
-	// mechanism for suppressing known false positives (e.g., symbols
-	// consumed through the agentinternal bridge pattern, ADR-022).
-	if isNolintDeadcode(meta.obj, state) {
-		return nil
+	ctx := &orphanEvalContext{
+		id:          id,
+		meta:        meta,
+		state:       state,
+		deep:        deep,
+		complexity:  a.calculateSymbolComplexity(meta.obj, state.pkgs),
+		impact:      a.calculateImpactScore(meta.obj, state.pkgs),
+		displayName: formatDisplayName(id, meta),
 	}
+	return a.runOrphanPipeline(ctx)
+}
 
-	total := state.totalUses[id]
-	external := state.externalUses[id]
+// runOrphanPipeline assembles evaluators conditionally based on --deep mode
+// and executes them in sequence. Returns nil when any evaluator excludes the
+// symbol, or the final orphanReport when all evaluators pass.
+func (a *defaultDeadCodeAnalyzer) runOrphanPipeline(ctx *orphanEvalContext) *orphanReport {
+	evaluators := a.buildEvaluatorPipeline(ctx.deep)
 
-	if total > 0 && external > 0 {
-		return nil
-	}
-
-	var severity, reason string
-	if total == 0 {
-		severity = "DEAD"
-		reason = "No references found within the module (including interfaces/tests)."
-	} else {
-		// Implicitly: total > 0 && external == 0
-		severity = "PRIVATE"
-		reason = "Exported symbol is only used within its own package."
-	}
-
-	complexity := a.calculateSymbolComplexity(meta.obj, state.pkgs)
-	impact := a.calculateImpactScore(meta.obj, state.pkgs)
-	displayName := formatDisplayName(id, meta)
-
-	if severity == "PRIVATE" && complexity >= 10 {
-		reason = "High Priority Refactoring Candidate: can be refactored with zero external impact."
-	}
-
-	if deep && meta.isMethod {
-		if a.resolveCrossPackageMethodUsages(state, meta.name, id, meta.pkgPath) {
-			return nil // Confirmed alive cross-package — reclassified
+	for _, ev := range evaluators {
+		ctx = ev.evaluate(ctx)
+		if ctx == nil {
+			return nil
 		}
-		reason += deepVerifiedDead
-		// Skip text-search warning — we verified it's a false positive
-	} else if a.hasTextMatchOutsidePackage(state, meta.name, meta.pkgPath) {
-		reason += " [WARNING: Text search found potential cross-package usage. Verify this is not a false positive due to structural typing.]"
 	}
+	return ctx.report
+}
 
-	// Anonymous-interface-assertion hedge. See
-	// dead_code_anon_interface.go for the full rationale. Methods only:
-	// the pattern `x.(interface{ M() })` invokes a method, never a free
-	// function or a type. Independent of the text-search warning above
-	// — both may legitimately fire on the same orphan, in which case
-	// both appear.
-	if meta.isMethod && a.hasAnonymousInterfaceAssertionMatch(state, meta.name) {
-		reason += fmt.Sprintf(" [WARNING: method name appears in anonymous-interface assertion site(s); verify with: grep -rn \"%s\" --include='*.go' .]", meta.name)
+// buildEvaluatorPipeline returns the ordered list of evaluators for the
+// orphan classification pipeline. When --deep is active, the deep verification
+// evaluator replaces the text-match warning evaluator.
+func (a *defaultDeadCodeAnalyzer) buildEvaluatorPipeline(deep bool) []orphanEvaluator {
+	evaluators := []orphanEvaluator{
+		&nolintGateEvaluator{analyzer: a},
+		&usageGateEvaluator{},
+		&severityClassifierEvaluator{},
+		&complexityReclassifierEvaluator{},
 	}
-
-	return &orphanReport{
-		Symbol:     displayName,
-		Pkg:        meta.pkgPath,
-		Type:       meta.symType,
-		Severity:   severity,
-		Reason:     reason,
-		Complexity: complexity,
-		Impact:     impact,
+	if deep {
+		evaluators = append(evaluators, &deepVerificationEvaluator{analyzer: a})
+	} else {
+		evaluators = append(evaluators, &textMatchWarningEvaluator{analyzer: a})
 	}
+	evaluators = append(evaluators, &anonInterfaceWarningEvaluator{analyzer: a})
+	return evaluators
 }
 
 // buildReport orchestrates the full report-building pipeline from scanState to structured findings.


### PR DESCRIPTION
Closes #570.

## Summary

Decomposed the 13-complexity `evaluateOrphan` function in `internal/tools/analysis/report.go` into a Chain of Responsibility pipeline of 7 single-purpose evaluators.

### New Files (8)
- `orphan_evaluator.go` — interface + context struct
- `orphan_evaluator_nolint.go` — step 1: nolint:deadcode gate
- `orphan_evaluator_usage.go` — step 2: usage-count gate
- `orphan_evaluator_severity.go` — step 3: DEAD/PRIVATE classification
- `orphan_evaluator_complexity.go` — step 4: complexity reclassification
- `orphan_evaluator_deep.go` — step 5: deep cross-package verification
- `orphan_evaluator_textmatch.go` — step 6: text-match hedge warning
- `orphan_evaluator_anoniface.go` — step 7: anonymous-interface warning

### Modified File (1)
- `report.go` — replaced monolithic function with pipeline builder + executor

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build ./...` | PASS |
| `golangci-lint run` | PASS (0 issues) |
| `go test ./internal/tools/analysis/...` | PASS |
| Coverage | 95.9% |
| Complexity: `evaluateOrphan` | 13 → 1 |
| Complexity: `runOrphanPipeline` | 3 |
| Complexity: `buildEvaluatorPipeline` | 2 |