### PR TITLE
fix(domain): change Task ID from float64 to int64 (#574)

### DIFF
--- a/internal/domain/ports/repository.go
+++ b/internal/domain/ports/repository.go
@@ -43,14 +43,14 @@ type ListStore[T any] interface {
 	Count(ctx context.Context) (int, error)
 
 	Append(ctx context.Context, item T) error
-	Update(ctx context.Context, id float64, item T) error
-	Delete(ctx context.Context, id float64) error
+	Update(ctx context.Context, id int64, item T) error
+	Delete(ctx context.Context, id int64) error
 	DeleteAll(ctx context.Context) error
 }
 
 // Task represents a unit of work in the to-do list.
 type Task struct {
-	ID        float64   `json:"id"`
+	ID        int64     `json:"id"`
 	Content   string    `json:"content"`
 	Status    string    `json:"status"` // pending, completed
 	CreatedAt time.Time `json:"created_at"`
@@ -79,8 +79,8 @@ type TaskReader interface {
 // TaskWriter defines the interface for modifying tasks.
 type TaskWriter interface {
 	AddTask(ctx context.Context, content string) (Task, error)
-	UpdateTask(ctx context.Context, id float64, content, status string) (Task, error)
-	DeleteTask(ctx context.Context, id float64) error
+	UpdateTask(ctx context.Context, id int64, content, status string) (Task, error)
+	DeleteTask(ctx context.Context, id int64) error
 	ClearTasks(ctx context.Context) error
 }
 

--- a/internal/domain/services/task_service.go
+++ b/internal/domain/services/task_service.go
@@ -21,15 +21,15 @@ var _ ports.TaskStore = (*taskService)(nil)
 type taskService struct {
 	mu     sync.RWMutex
 	store  ports.ListStore[ports.Task]
-	tasks  map[float64]ports.Task
-	nextID float64
+	tasks  map[int64]ports.Task
+	nextID int64
 }
 
 // NewTaskService creates a new taskService.
 func NewTaskService(store ports.ListStore[ports.Task]) *taskService {
 	return &taskService{
 		store:  store,
-		tasks:  make(map[float64]ports.Task),
+		tasks:  make(map[int64]ports.Task),
 		nextID: 1,
 	}
 }
@@ -81,13 +81,13 @@ func (s *taskService) AddTask(ctx context.Context, content string) (ports.Task, 
 }
 
 // UpdateTask updates an existing task.
-func (s *taskService) UpdateTask(ctx context.Context, id float64, content, status string) (ports.Task, error) {
+func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status string) (ports.Task, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	t, ok := s.tasks[id]
 	if !ok {
-		return ports.Task{}, fmt.Errorf("id %.0f: %w", id, ports.ErrTaskNotFound)
+		return ports.Task{}, fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 	}
 
 	if content != "" {
@@ -106,12 +106,12 @@ func (s *taskService) UpdateTask(ctx context.Context, id float64, content, statu
 }
 
 // DeleteTask removes a task.
-func (s *taskService) DeleteTask(ctx context.Context, id float64) error {
+func (s *taskService) DeleteTask(ctx context.Context, id int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if _, ok := s.tasks[id]; !ok {
-		return fmt.Errorf("id %.0f: %w", id, ports.ErrTaskNotFound)
+		return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 	}
 
 	if err := s.store.Delete(ctx, id); err != nil {
@@ -185,6 +185,6 @@ func (s *taskService) ClearTasks(ctx context.Context) error {
 		return err
 	}
 
-	s.tasks = make(map[float64]ports.Task)
+	s.tasks = make(map[int64]ports.Task)
 	return nil
 }

--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -19,7 +19,7 @@ type mockTaskRepo struct {
 }
 
 func (m *mockTaskRepo) ReadAll(ctx context.Context) ([]ports.Task, error) { return m.tasks, m.readErr }
-func (m *mockTaskRepo) Update(ctx context.Context, id float64, task ports.Task) error {
+func (m *mockTaskRepo) Update(ctx context.Context, id int64, task ports.Task) error {
 	if m.writeErr != nil {
 		return m.writeErr
 	}
@@ -32,7 +32,7 @@ func (m *mockTaskRepo) Update(ctx context.Context, id float64, task ports.Task) 
 	return nil
 }
 
-func (m *mockTaskRepo) Delete(ctx context.Context, id float64) error {
+func (m *mockTaskRepo) Delete(ctx context.Context, id int64) error {
 	if m.writeErr != nil {
 		return m.writeErr
 	}

--- a/internal/infrastructure/persistence/memory_store.go
+++ b/internal/infrastructure/persistence/memory_store.go
@@ -98,12 +98,12 @@ func (s *memoryListStore[T]) ReadAll(ctx context.Context) ([]T, error) {
 	return result, nil
 }
 
-func (s *memoryListStore[T]) getID(item T) float64 {
+func (s *memoryListStore[T]) getID(item T) int64 {
 	val := reflect.ValueOf(item)
 	if val.Kind() == reflect.Struct {
 		field := val.FieldByName("ID")
-		if field.IsValid() && field.CanFloat() {
-			return field.Float()
+		if field.IsValid() && field.CanInt() {
+			return field.Int()
 		}
 	}
 	return 0
@@ -189,7 +189,7 @@ func (s *memoryListStore[T]) Count(ctx context.Context) (int, error) {
 	return len(s.data), nil
 }
 
-func (s *memoryListStore[T]) Update(ctx context.Context, id float64, item T) error {
+func (s *memoryListStore[T]) Update(ctx context.Context, id int64, item T) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, v := range s.data {
@@ -201,7 +201,7 @@ func (s *memoryListStore[T]) Update(ctx context.Context, id float64, item T) err
 	return nil
 }
 
-func (s *memoryListStore[T]) Delete(ctx context.Context, id float64) error {
+func (s *memoryListStore[T]) Delete(ctx context.Context, id int64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for i, v := range s.data {

--- a/internal/infrastructure/persistence/memory_store_test.go
+++ b/internal/infrastructure/persistence/memory_store_test.go
@@ -176,19 +176,19 @@ func runListConcurrency(t *testing.T, ctx context.Context) {
 	// Concurrent appends
 	for i := 0; i < count; i++ {
 		wg.Add(1)
-		go func(val float64) {
+		go func(val int64) {
 			defer wg.Done()
 			_ = store.Append(ctx, ports.Task{ID: val})
-		}(float64(i))
+		}(int64(i))
 	}
 
 	// Concurrent updates
 	for i := 0; i < 5; i++ {
 		wg.Add(1)
-		go func(val float64) {
+		go func(val int64) {
 			defer wg.Done()
 			_ = store.Update(ctx, val, ports.Task{ID: val, Content: "updated"})
-		}(float64(i))
+		}(int64(i))
 	}
 
 	// Concurrent reads

--- a/internal/infrastructure/persistence/sqlite_store.go
+++ b/internal/infrastructure/persistence/sqlite_store.go
@@ -170,19 +170,19 @@ func (s *sqliteTaskStore) Count(ctx context.Context) (int, error) {
 	return count, nil
 }
 
-func (s *sqliteTaskStore) Update(ctx context.Context, id float64, item ports.Task) error {
+func (s *sqliteTaskStore) Update(ctx context.Context, id int64, item ports.Task) error {
 	_, err := s.db.ExecContext(ctx, "UPDATE tasks SET content = ?, status = ? WHERE id = ?",
-		item.Content, item.Status, int64(id))
+		item.Content, item.Status, id)
 	if err != nil {
-		return fmt.Errorf("updating task %d: %w", int(id), err)
+		return fmt.Errorf("updating task %d: %w", id, err)
 	}
 	return nil
 }
 
-func (s *sqliteTaskStore) Delete(ctx context.Context, id float64) error {
-	_, err := s.db.ExecContext(ctx, "DELETE FROM tasks WHERE id = ?", int64(id))
+func (s *sqliteTaskStore) Delete(ctx context.Context, id int64) error {
+	_, err := s.db.ExecContext(ctx, "DELETE FROM tasks WHERE id = ?", id)
 	if err != nil {
-		return fmt.Errorf("deleting task %d: %w", int(id), err)
+		return fmt.Errorf("deleting task %d: %w", id, err)
 	}
 	return nil
 }
@@ -197,9 +197,9 @@ func (s *sqliteTaskStore) DeleteAll(ctx context.Context) error {
 
 func (s *sqliteTaskStore) Append(ctx context.Context, item ports.Task) error {
 	_, err := s.db.ExecContext(ctx, "INSERT INTO tasks (id, content, status, created_at) VALUES (?, ?, ?, ?)",
-		int64(item.ID), item.Content, item.Status, item.CreatedAt.Format(time.RFC3339Nano))
+		item.ID, item.Content, item.Status, item.CreatedAt.Format(time.RFC3339Nano))
 	if err != nil {
-		return fmt.Errorf("appending task %d: %w", int(item.ID), err)
+		return fmt.Errorf("appending task %d: %w", item.ID, err)
 	}
 	return nil
 }

--- a/internal/infrastructure/persistence/sqlite_store_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_test.go
@@ -363,7 +363,7 @@ func TestSQLiteTaskStore_ReadAll_ScanError(t *testing.T) {
 	defer func() { _ = db.Close() }()
 
 	// Create a tasks table with a TEXT id instead of INTEGER.
-	// rows.Scan into float64 will fail for non-numeric TEXT values.
+	// rows.Scan into int64 will fail for non-numeric TEXT values.
 	if _, err := db.Exec("CREATE TABLE tasks (id TEXT PRIMARY KEY, content TEXT NOT NULL, status TEXT NOT NULL, created_at DATETIME NOT NULL);"); err != nil {
 		t.Fatalf("failed to create table: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestSQLiteTaskStore_ErrorPaths(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = db.Close() })
 
-		// Create tasks table with TEXT id so scanning into float64 fails.
+		// Create tasks table with TEXT id so scanning into int64 fails.
 		_, err = db.Exec(`CREATE TABLE tasks (
 			id TEXT PRIMARY KEY,
 			content TEXT NOT NULL,
@@ -875,13 +875,13 @@ func TestSQLiteTaskStore_ReadAll_Bounded(t *testing.T) {
 
 	// Insert 10 pending tasks
 	for i := 1; i <= 10; i++ {
-		task := ports.Task{ID: float64(i), Content: fmt.Sprintf("pending %d", i), Status: "pending", CreatedAt: now}
+		task := ports.Task{ID: int64(i), Content: fmt.Sprintf("pending %d", i), Status: "pending", CreatedAt: now}
 		require.NoError(t, store.Append(ctx, task))
 	}
 
 	// Insert 600 completed tasks
 	for i := 11; i <= 610; i++ {
-		task := ports.Task{ID: float64(i), Content: fmt.Sprintf("completed %d", i), Status: "completed", CreatedAt: now.Add(time.Duration(i) * time.Second)}
+		task := ports.Task{ID: int64(i), Content: fmt.Sprintf("completed %d", i), Status: "completed", CreatedAt: now.Add(time.Duration(i) * time.Second)}
 		require.NoError(t, store.Append(ctx, task))
 	}
 
@@ -921,9 +921,9 @@ func assertPendingCount(t *testing.T, tasks []ports.Task, want int) {
 // assertCompletedRetention verifies that completed tasks in the oldest range
 // [oldestExcludedStart, oldestExcludedEnd] are NOT present and that completed
 // tasks in the newest range [newestIncludedStart, newestIncludedEnd] ARE present.
-func assertCompletedRetention(t *testing.T, tasks []ports.Task, oldestExcludedStart, oldestExcludedEnd, newestIncludedStart, newestIncludedEnd float64) {
+func assertCompletedRetention(t *testing.T, tasks []ports.Task, oldestExcludedStart, oldestExcludedEnd, newestIncludedStart, newestIncludedEnd int64) {
 	t.Helper()
-	completedIDs := make(map[float64]bool)
+	completedIDs := make(map[int64]bool)
 	for _, task := range tasks {
 		if task.Status == "completed" {
 			completedIDs[task.ID] = true
@@ -963,7 +963,7 @@ func seedBenchmarkTasks(b *testing.B, store *sqliteTaskStore, ctx context.Contex
 			status = "in_progress"
 		}
 		task := ports.Task{
-			ID:        float64(i),
+			ID:        int64(i),
 			Content:   fmt.Sprintf("Task %d", i),
 			Status:    status,
 			CreatedAt: now.Add(time.Duration(i) * time.Second),
@@ -1041,7 +1041,7 @@ func seedMixedStatusTasks(t *testing.T, store *sqliteTaskStore, ctx context.Cont
 			status = "in_progress"
 		}
 		task := ports.Task{
-			ID:        float64(i),
+			ID:        int64(i),
 			Content:   fmt.Sprintf("Task %d", i),
 			Status:    status,
 			CreatedAt: now.Add(time.Duration(i) * time.Second),

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -180,10 +180,10 @@ type failingTaskStore struct{}
 func (s *failingTaskStore) ReadAll(ctx context.Context) ([]ports.Task, error) {
 	return nil, errors.New("simulated read failure")
 }
-func (s *failingTaskStore) Update(ctx context.Context, id float64, item ports.Task) error { return nil }
-func (s *failingTaskStore) Delete(ctx context.Context, id float64) error                  { return nil }
-func (s *failingTaskStore) DeleteAll(ctx context.Context) error                           { return nil }
-func (s *failingTaskStore) Append(ctx context.Context, item ports.Task) error             { return nil }
+func (s *failingTaskStore) Update(ctx context.Context, id int64, item ports.Task) error { return nil }
+func (s *failingTaskStore) Delete(ctx context.Context, id int64) error                  { return nil }
+func (s *failingTaskStore) DeleteAll(ctx context.Context) error                         { return nil }
+func (s *failingTaskStore) Append(ctx context.Context, item ports.Task) error           { return nil }
 func (s *failingTaskStore) Query(ctx context.Context, filter ports.ListFilter, limit, offset int) ([]ports.Task, error) {
 	return nil, errors.New("simulated query failure")
 }

--- a/internal/infrastructure/persistence/tasks_bench_test.go
+++ b/internal/infrastructure/persistence/tasks_bench_test.go
@@ -24,7 +24,7 @@ func generateTasks(n int) []ports.Task {
 	now := time.Now()
 	for i := 0; i < n; i++ {
 		tasks[i] = ports.Task{
-			ID:        float64(i + 1),
+			ID:        int64(i + 1),
 			Content:   fmt.Sprintf("Task number %d with some descriptive text for realistic JSON size", i+1),
 			Status:    "pending",
 			CreatedAt: now,

--- a/internal/tools/workspace/persistence_tools.go
+++ b/internal/tools/workspace/persistence_tools.go
@@ -126,9 +126,9 @@ func (t *persistenceTools) ManageTasks(ctx context.Context, args map[string]inte
 	case "add":
 		return t.addTask(ctx, params.Content)
 	case "update":
-		return t.updateTask(ctx, params.TaskID, params.Content, params.Status)
+		return t.updateTask(ctx, int64(params.TaskID), params.Content, params.Status)
 	case "delete":
-		return t.deleteTask(ctx, params.TaskID)
+		return t.deleteTask(ctx, int64(params.TaskID))
 	case "list":
 		return t.listTasks(params.Status, int(params.Limit), int(params.Offset))
 	case "clear":
@@ -143,21 +143,21 @@ func (t *persistenceTools) addTask(ctx context.Context, content string) (tools.T
 	if err != nil {
 		return tools.ToolResult{}, err
 	}
-	return tools.ToolResult{Text: fmt.Sprintf("Task added with ID %.0f", task.ID)}, nil
+	return tools.ToolResult{Text: fmt.Sprintf("Task added with ID %d", task.ID)}, nil
 }
 
-func (t *persistenceTools) updateTask(ctx context.Context, id float64, content, status string) (tools.ToolResult, error) {
+func (t *persistenceTools) updateTask(ctx context.Context, id int64, content, status string) (tools.ToolResult, error) {
 	if _, err := t.tasks.UpdateTask(ctx, id, content, status); err != nil {
 		return tools.ToolResult{}, err
 	}
-	return tools.ToolResult{Text: fmt.Sprintf("Task %.0f updated", id)}, nil
+	return tools.ToolResult{Text: fmt.Sprintf("Task %d updated", id)}, nil
 }
 
-func (t *persistenceTools) deleteTask(ctx context.Context, id float64) (tools.ToolResult, error) {
+func (t *persistenceTools) deleteTask(ctx context.Context, id int64) (tools.ToolResult, error) {
 	if err := t.tasks.DeleteTask(ctx, id); err != nil {
 		return tools.ToolResult{}, err
 	}
-	return tools.ToolResult{Text: fmt.Sprintf("Task %.0f deleted", id)}, nil
+	return tools.ToolResult{Text: fmt.Sprintf("Task %d deleted", id)}, nil
 }
 
 func (t *persistenceTools) listTasks(status string, limit, offset int) (tools.ToolResult, error) {
@@ -185,7 +185,7 @@ func (t *persistenceTools) listTasks(status string, limit, offset int) (tools.To
 		if task.Status == "completed" {
 			icon = "[x]"
 		}
-		_, _ = fmt.Fprintf(&sb, "%.0f. %s %s (%s)\n", task.ID, icon, task.Content, task.Status)
+		_, _ = fmt.Fprintf(&sb, "%d. %s %s (%s)\n", task.ID, icon, task.Content, task.Status)
 	}
 
 	// Pagination hint when there are more pages

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -65,7 +65,7 @@ func (m *mockListStore) Append(ctx context.Context, item ports.Task) error {
 	return nil
 }
 
-func (m *mockListStore) Update(ctx context.Context, id float64, item ports.Task) error {
+func (m *mockListStore) Update(ctx context.Context, id int64, item ports.Task) error {
 	if m.err != nil {
 		return m.err
 	}
@@ -78,7 +78,7 @@ func (m *mockListStore) Update(ctx context.Context, id float64, item ports.Task)
 	return fmt.Errorf("not found")
 }
 
-func (m *mockListStore) Delete(ctx context.Context, id float64) error {
+func (m *mockListStore) Delete(ctx context.Context, id int64) error {
 	if m.err != nil {
 		return m.err
 	}
@@ -245,7 +245,7 @@ func testManageTasksList(t *testing.T) {
 		},
 		{
 			name: "list with limit and offset",
-			args: map[string]interface{}{"action": "list", "offset": 50.0},
+			args: map[string]interface{}{"action": "list", "offset": 50},
 			setup: func(m *mockListStore, ts ports.TaskStore) {
 				ctx := context.Background()
 				for i := 1; i <= 60; i++ {
@@ -293,7 +293,7 @@ func testManageTasksUpdate(t *testing.T) {
 	}{
 		{
 			name: "Successfully update task",
-			args: map[string]interface{}{"action": "update", "task_id": 1.0, "status": "completed"},
+			args: map[string]interface{}{"action": "update", "task_id": 1, "status": "completed"},
 			setup: func(m *mockListStore, ts ports.TaskStore) {
 				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
 				if s, ok := ts.(ports.Initializer); ok {
@@ -325,7 +325,7 @@ func testManageTasksDeleteAndClear(t *testing.T) {
 	}{
 		{
 			name: "delete task",
-			args: map[string]interface{}{"action": "delete", "task_id": 1.0},
+			args: map[string]interface{}{"action": "delete", "task_id": 1},
 			setup: func(m *mockListStore, ts ports.TaskStore) {
 				m.tasks = []ports.Task{{ID: 1, Content: "task 1", Status: "pending"}}
 				if s, ok := ts.(ports.Initializer); ok {
@@ -528,13 +528,13 @@ func TestPersistenceTools_Errors(t *testing.T) {
 	}
 
 	// updateTask error (not found)
-	_, err = pt.ManageTasks(ctx, map[string]interface{}{"action": "update", "task_id": 999.0, "status": "completed"}, nil)
+	_, err = pt.ManageTasks(ctx, map[string]interface{}{"action": "update", "task_id": 999, "status": "completed"}, nil)
 	if err == nil {
 		t.Error("Expected error for non-existent task in updateTask")
 	}
 
 	// deleteTask error (not found)
-	_, err = pt.ManageTasks(ctx, map[string]interface{}{"action": "delete", "task_id": 999.0}, nil)
+	_, err = pt.ManageTasks(ctx, map[string]interface{}{"action": "delete", "task_id": 999}, nil)
 	if err == nil {
 		t.Error("Expected error for non-existent task in deleteTask")
 	}
@@ -655,7 +655,7 @@ func TestManageTasks_ListLastPageNoHint(t *testing.T) {
 	// List with offset=50 (last partial page: tasks 51-60)
 	res, err := pt.ManageTasks(ctx, map[string]interface{}{
 		"action": "list",
-		"offset": 50.0,
+		"offset": 50,
 	}, nil)
 	if err != nil {
 		t.Fatalf("ManageTasks failed: %v", err)

--- a/internal/ui/tui/tasks_model_test.go
+++ b/internal/ui/tui/tasks_model_test.go
@@ -20,8 +20,8 @@ type mockTaskStore struct {
 
 	// TaskWriter methods (unused by taskListModel but needed for interface)
 	AddTaskFunc    func(ctx context.Context, content string) (ports.Task, error)
-	UpdateTaskFunc func(ctx context.Context, id float64, content, status string) (ports.Task, error)
-	DeleteTaskFunc func(ctx context.Context, id float64) error
+	UpdateTaskFunc func(ctx context.Context, id int64, content, status string) (ports.Task, error)
+	DeleteTaskFunc func(ctx context.Context, id int64) error
 	ClearTasksFunc func(ctx context.Context) error
 }
 
@@ -46,14 +46,14 @@ func (m *mockTaskStore) AddTask(ctx context.Context, content string) (ports.Task
 	return ports.Task{}, nil
 }
 
-func (m *mockTaskStore) UpdateTask(ctx context.Context, id float64, content, status string) (ports.Task, error) {
+func (m *mockTaskStore) UpdateTask(ctx context.Context, id int64, content, status string) (ports.Task, error) {
 	if m.UpdateTaskFunc != nil {
 		return m.UpdateTaskFunc(ctx, id, content, status)
 	}
 	return ports.Task{}, nil
 }
 
-func (m *mockTaskStore) DeleteTask(ctx context.Context, id float64) error {
+func (m *mockTaskStore) DeleteTask(ctx context.Context, id int64) error {
 	if m.DeleteTaskFunc != nil {
 		return m.DeleteTaskFunc(ctx, id)
 	}
@@ -539,7 +539,7 @@ func TestTaskListModel_PageNav_NextPage_IncrementsOffset(t *testing.T) {
 			// Return 50 tasks to simulate a full page
 			tasks := make([]ports.Task, 50)
 			for i := range tasks {
-				tasks[i] = ports.Task{ID: float64(offset + i + 1), Content: "task", Status: "pending"}
+				tasks[i] = ports.Task{ID: int64(offset + i + 1), Content: "task", Status: "pending"}
 			}
 			return tasks
 		},
@@ -588,7 +588,7 @@ func TestTaskListModel_PageNav_PrevPage_DecrementsOffset(t *testing.T) {
 			receivedOffset = offset
 			tasks := make([]ports.Task, 50)
 			for i := range tasks {
-				tasks[i] = ports.Task{ID: float64(offset + i + 1), Content: "task", Status: "pending"}
+				tasks[i] = ports.Task{ID: int64(offset + i + 1), Content: "task", Status: "pending"}
 			}
 			return tasks
 		},


### PR DESCRIPTION
Closes #574.

## Summary
Changed `ports.Task.ID` from `float64` to `int64`, removing a JSON-transport bleed from the Domain layer. The `float64 → int64` conversion now occurs strictly at the transport boundary in `persistence_tools.go` (`int64(params.TaskID)`).

### Changes
- **Domain** (`ports/repository.go`): `Task.ID` → `int64`, `ListStore` and `TaskWriter` interfaces updated
- **Service** (`task_service.go`): map key type, `nextID`, method signatures → `int64`
- **Infrastructure** (`sqlite_store.go`, `memory_store.go`): removed redundant `int64(id)` casts, `getID()` uses `CanInt()/Int()`
- **Transport** (`persistence_tools.go`): `int64(params.TaskID)` conversion at edge, format strings `%.0f` → `%d`
- **Tests**: 7 test files updated across 4 packages

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test ./... | PASS |
| go test -race | PASS |
| golangci-lint | 0 issues |
| govulncheck | No vulnerabilities |
