### PR TITLE
fix(agenttest): fix data race in MockClock with sync.Mutex (#578)

### DIFF
--- a/internal/agent/agenttest/mock_clock.go
+++ b/internal/agent/agenttest/mock_clock.go
@@ -8,6 +8,7 @@
 package agenttest
 
 import (
+	"sync"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
@@ -20,18 +21,23 @@ import (
 // it never blocks. NewTicker() returns a *MockTicker fed from the
 // same After() channel.
 type MockClock struct {
+	mu            sync.Mutex
 	CurrentTime   time.Time
 	CalledNow     int
 	CalledMethods []string
 }
 
 func (m *MockClock) Now() time.Time {
+	m.mu.Lock()
 	m.CalledNow++
 	m.CalledMethods = append(m.CalledMethods, "Now")
-	if m.CurrentTime.IsZero() {
+	t := m.CurrentTime
+	m.mu.Unlock()
+
+	if t.IsZero() {
 		return time.Now()
 	}
-	return m.CurrentTime
+	return t
 }
 
 func (m *MockClock) Since(t time.Time) time.Duration {
@@ -39,24 +45,36 @@ func (m *MockClock) Since(t time.Time) time.Duration {
 }
 
 func (m *MockClock) Sleep(d time.Duration) {
+	m.mu.Lock()
 	m.CalledMethods = append(m.CalledMethods, "Sleep")
 	m.CurrentTime = m.CurrentTime.Add(d)
+	m.mu.Unlock()
 }
 
 func (m *MockClock) After(d time.Duration) <-chan time.Time {
+	m.mu.Lock()
 	m.CalledMethods = append(m.CalledMethods, "After")
+	t := m.CurrentTime.Add(d)
+	m.mu.Unlock()
+
 	c := make(chan time.Time, 1)
-	c <- m.CurrentTime.Add(d)
+	c <- t
 	return c
 }
 
 func (m *MockClock) NewTicker(d time.Duration) clock.Ticker {
+	m.mu.Lock()
 	m.CalledMethods = append(m.CalledMethods, "NewTicker")
+	m.mu.Unlock()
+
 	return &MockTicker{CVal: m.After(d)}
 }
 
 func (m *MockClock) Jitter(base float64) float64 {
+	m.mu.Lock()
 	m.CalledMethods = append(m.CalledMethods, "Jitter")
+	m.mu.Unlock()
+
 	return base
 }
 

--- a/internal/agent/agenttest/mock_clock_test.go
+++ b/internal/agent/agenttest/mock_clock_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agenttest
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestMockClock_RaceDetection verifies that concurrent writes to
+// CalledMethods and CalledNow on MockClock do not trigger the race
+// detector. This test is a precondition for adding sync.Mutex.
+func TestMockClock_RaceDetection(t *testing.T) {
+	m := &MockClock{}
+
+	var wg sync.WaitGroup
+	const goroutines = 5
+	const iterations = 20
+
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				// Mix of all mutating methods
+				m.Now()
+				m.Sleep(1 * time.Millisecond)
+				m.After(1 * time.Millisecond)
+				m.NewTicker(1 * time.Millisecond)
+				m.Jitter(1.0)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// CalledMethods should have goroutines*iterations*6 entries
+	// (NewTicker also appends "After" via its internal call to After)
+	expected := goroutines * iterations * 6
+	if len(m.CalledMethods) != expected {
+		t.Errorf("got %d entries, want %d", len(m.CalledMethods), expected)
+	}
+}


### PR DESCRIPTION
Closes #578.

## Summary
Added `sync.Mutex` to `MockClock` and guarded all mutations to `CalledMethods` and `CalledNow` in all 5 writer methods (`Now`, `Sleep`, `After`, `NewTicker`, `Jitter`). Added a new concurrency regression test that exercises all methods under `-race`. The fix aligns `MockClock` with existing patterns in the same package (`MockCostTracker`, `MockHistoryManager`).

## Changes
| File | Change |
|------|--------|
| `internal/agent/agenttest/mock_clock.go` | Added `sync.Mutex`, guarded `CalledNow`/`CalledMethods` in 5 methods |
| `internal/agent/agenttest/mock_clock_test.go` | New concurrency regression test (5 goroutines × 20 iterations) |

## Verification
| Check | Status |
|-------|--------|
| `go test -race ./tests/integration/agent/orchestrator/` | PASS — all 8 affected tests |
| `go test -race ./internal/agent/... ./tests/integration/agent/...` | PASS — 15 packages |
| `make check-full` (fmt, tidy, build, lint, arch, vulncheck, test, dead-code) | PASS |
| `test-race` (agent packages) | PASS |
| `test-race` (tools/analysis) | Pre-existing timeout — unrelated to this change |
| Target coverage | N/A — test infrastructure fix |
