### PR TITLE
fix(tools): align LLM tool schemas with int64 Task ID type (#581)

### DIFF
--- a/internal/agent/session/internal_tools.go
+++ b/internal/agent/session/internal_tools.go
@@ -71,15 +71,14 @@ func (t *InternalTools) emitHeartbeats(done <-chan struct{}, hb chan<- struct{})
 // SummarizeHistory wraps ContextManager.SummarizeRange as a tool.
 func (t *InternalTools) SummarizeHistory(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
-		Turns float64 `json:"turns"`
-		Focus string  `json:"focus"`
+		Turns int    `json:"turns"`
+		Focus string `json:"focus"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
 		return tools.ToolResult{}, err
 	}
 
-	targetTurns := int(params.Turns)
-	if targetTurns <= 0 {
+	if params.Turns <= 0 {
 		return tools.ToolResult{}, fmt.Errorf("invalid 'turns' parameter: must be > 0")
 	}
 
@@ -88,7 +87,7 @@ func (t *InternalTools) SummarizeHistory(ctx context.Context, args map[string]in
 	defer close(done)
 	go t.emitHeartbeats(done, hb)
 
-	res, metrics, err := t.ctxManager.SummarizeRange(ctx, targetTurns, params.Focus)
+	res, metrics, err := t.ctxManager.SummarizeRange(ctx, params.Turns, params.Focus)
 	if err != nil {
 		return tools.ToolResult{}, err
 	}
@@ -102,15 +101,14 @@ func (t *InternalTools) SummarizeHistory(ctx context.Context, args map[string]in
 // ManageHistory manages conversation history by pinning or unpinning specific turns.
 func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
-		Action string  `json:"action"`
-		Index  float64 `json:"index"`
+		Action string `json:"action"`
+		Index  int    `json:"index"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
 		return tools.ToolResult{}, err
 	}
 
-	index := int(params.Index)
-	if index < 0 {
+	if params.Index < 0 {
 		return tools.ToolResult{}, fmt.Errorf("invalid 'index' parameter: must be >= 0")
 	}
 	var pinned bool
@@ -124,7 +122,7 @@ func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]inter
 		return tools.ToolResult{}, fmt.Errorf("unsupported action: %s", params.Action)
 	}
 
-	if err := t.ctxManager.History.SetPinned(ctx, index, pinned); err != nil {
+	if err := t.ctxManager.History.SetPinned(ctx, params.Index, pinned); err != nil {
 		return tools.ToolResult{}, err
 	}
 
@@ -132,7 +130,7 @@ func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]inter
 	if pinned {
 		status = "pinned"
 	}
-	return tools.ToolResult{Text: fmt.Sprintf("turn %d has been successfully %s", index, status)}, nil
+	return tools.ToolResult{Text: fmt.Sprintf("turn %d has been successfully %s", params.Index, status)}, nil
 }
 
 // RegisterInternal registers the internal tools with the provided registrar.
@@ -146,7 +144,7 @@ func RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager, logger ports.L
 			Type: "OBJECT",
 			Properties: map[string]*tools.Schema{
 				"turns": {
-					Type:        "NUMBER",
+					Type:        "INTEGER",
 					Description: "The number of turns (user+model pairs) to summarize from the beginning of history.",
 				},
 				"focus": {
@@ -175,7 +173,7 @@ func RegisterInternal(r tools.ToolRegistrar, cm *sessctx.Manager, logger ports.L
 					Enum:        []string{"pin", "unpin"},
 				},
 				"index": {
-					Type:        "NUMBER",
+					Type:        "INTEGER",
 					Description: "The 0-based index of the turn to manage.",
 				},
 			},

--- a/internal/tools/workspace/persistence_tools.go
+++ b/internal/tools/workspace/persistence_tools.go
@@ -80,7 +80,7 @@ func (t *persistenceTools) Register(r tools.ToolRegistrar) error {
 					Enum:        []string{"add", "update", "list", "delete", "clear"},
 				},
 				"task_id": {
-					Type:        "NUMBER",
+					Type:        "INTEGER",
 					Description: "The ID of the task to update or delete.",
 				},
 				"content": {
@@ -92,11 +92,11 @@ func (t *persistenceTools) Register(r tools.ToolRegistrar) error {
 					Description: "The new status (e.g., 'completed', 'pending') for 'update' or filter for 'list'.",
 				},
 				"limit": {
-					Type:        "NUMBER",
+					Type:        "INTEGER",
 					Description: "Maximum tasks to return for the 'list' action. Default: 50. Use 0 for unlimited.",
 				},
 				"offset": {
-					Type:        "NUMBER",
+					Type:        "INTEGER",
 					Description: "Number of tasks to skip for the 'list' action. Default: 0. Use with limit for pagination.",
 				},
 			},
@@ -111,12 +111,12 @@ func (t *persistenceTools) Register(r tools.ToolRegistrar) error {
 // ManageTasks handles the manage_tasks tool.
 func (t *persistenceTools) ManageTasks(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
-		Action  string  `json:"action"`
-		Content string  `json:"content"`
-		Status  string  `json:"status"`
-		TaskID  float64 `json:"task_id"`
-		Limit   float64 `json:"limit"`
-		Offset  float64 `json:"offset"`
+		Action  string `json:"action"`
+		Content string `json:"content"`
+		Status  string `json:"status"`
+		TaskID  int64  `json:"task_id"`
+		Limit   int    `json:"limit"`
+		Offset  int    `json:"offset"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
 		return tools.ToolResult{}, err
@@ -126,11 +126,11 @@ func (t *persistenceTools) ManageTasks(ctx context.Context, args map[string]inte
 	case "add":
 		return t.addTask(ctx, params.Content)
 	case "update":
-		return t.updateTask(ctx, int64(params.TaskID), params.Content, params.Status)
+		return t.updateTask(ctx, params.TaskID, params.Content, params.Status)
 	case "delete":
-		return t.deleteTask(ctx, int64(params.TaskID))
+		return t.deleteTask(ctx, params.TaskID)
 	case "list":
-		return t.listTasks(params.Status, int(params.Limit), int(params.Offset))
+		return t.listTasks(params.Status, params.Limit, params.Offset)
 	case "clear":
 		return t.clearTasks(ctx)
 	default:

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -680,3 +680,37 @@ func TestManageTasks_UnmarshalError(t *testing.T) {
 		t.Fatal("expected error from unmarshal args")
 	}
 }
+
+// TestManageTasks_SchemaTaskIDIsInteger verifies that the LLM-facing JSON
+// schema for the manage_tasks tool declares task_id as "INTEGER", not
+// "NUMBER". This prevents LLMs from emitting fractional IDs (e.g., 3.5)
+// that would fail validation at the domain boundary (ports.Task.ID is int64).
+func TestManageTasks_SchemaTaskIDIsInteger(t *testing.T) {
+	pt, _ := setupPersistenceTools()
+	reg := registry.New()
+	if err := pt.Register(reg); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+
+	var manageDecl *tools.ToolDeclaration
+	for _, d := range reg.GetDeclarations() {
+		if d.Name == "manage_tasks" {
+			manageDecl = d
+			break
+		}
+	}
+	if manageDecl == nil {
+		t.Fatal("manage_tasks not found in declarations")
+	}
+	if manageDecl.Parameters == nil {
+		t.Fatal("manage_tasks has no parameters schema")
+	}
+
+	taskIDProp := manageDecl.Parameters.Properties["task_id"]
+	if taskIDProp == nil {
+		t.Fatal("task_id parameter not found in manage_tasks schema")
+	}
+	if taskIDProp.Type != "INTEGER" {
+		t.Errorf("task_id schema type = %q; want %q", taskIDProp.Type, "INTEGER")
+	}
+}


### PR DESCRIPTION
Closes #581.

## Summary
Changed LLM-facing JSON schema types from `"NUMBER"` to `"INTEGER"` for all integer-domain parameters, and aligned Go unmarshal types from `float64` to `int64`/`int`. This prevents LLMs from emitting fractional IDs that would silently truncate at the `ports.Task.ID` (`int64`) domain boundary.

### Files changed
- `internal/tools/workspace/persistence_tools.go` — `task_id`, `limit`, `offset` schemas + struct fields + removed casts
- `internal/tools/workspace/persistence_tools_test.go` — regression test `TestManageTasks_SchemaTaskIDIsInteger`
- `internal/agent/session/internal_tools.go` — `turns`, `index` schemas + struct fields + removed casts

## Verification
| Check | Status |
|-------|--------|
| `go fmt` | PASS |
| `go mod tidy` | PASS |
| `go build` | PASS |
| `golangci-lint` | 0 issues |
| `go test -race ./internal/tools/workspace/...` | PASS |
| `go test -race ./internal/agent/session/...` | PASS |
| `go test -race ./internal/tools/...` | PASS |
| Target coverage (`workspace` package) | 94.1% |
| Zero `"NUMBER"` schema types remaining | ✅ |