### PR TITLE
fix(test): eliminate time.Sleep synchronization in remaining test files (#580)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ else
     IS_POSIX := true
 endif
 
-.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-architecture lint vulncheck dead-code check check-full bench
+.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-no-test-sleep verify-architecture lint vulncheck dead-code check check-full bench
 
 help:
 	@echo "tell-me-go development tasks:"
@@ -32,6 +32,7 @@ help:
 	@echo "  make test       - Run all tests (standard)"
 	@echo "  make test-race  - Run tests with race detector (AI-SAFE, package-by-package)"
 	@echo "  make verify-architecture - Verify Clean/Hexagonal Architecture layer discipline"
+	@echo "  make verify-no-test-sleep - Verify no time.Sleep for synchronization in tests"
 	@echo "  make test-coverage - Run tests with coverage (excludes mocks/generated)"
 	@echo "  make tidy       - Tidy and vendor dependencies"
 	@echo "  make fmt        - Format code"
@@ -279,6 +280,55 @@ else
 	"
 endif
 
+# Verify no time.Sleep for synchronization in test files (Issue #580 / ADR-XXX).
+# Legitimate I/O simulation and hardware observation sleeps are explicitly allow-listed.
+verify-no-test-sleep:
+ifeq ($(IS_POSIX),true)
+	@echo "Checking for time.Sleep synchronization in test files..."
+	@# ZERO TOLERANCE: internal/ui/ tests must have zero time.Sleep
+	@if grep -rn 'time\.Sleep(' --include='*_test.go' internal/ui/; then \
+		echo ""; \
+		echo "❌ time.Sleep found in internal/ui/ test files."; \
+		echo "   Use deterministic primitives: poll loops, ready channels, or"; \
+		echo "   test-controlled tick channels. See internal/agent/session/doc.go"; \
+		echo "   for canonical patterns."; \
+		exit 1; \
+	fi
+	@# ALLOW-LIST: config/watcher_test.go — only sleeps with 'simulates I/O latency' comment
+	@VIOLATIONS=$$(grep -rn 'time\.Sleep(' --include='*_test.go' internal/infrastructure/config/ | grep -v 'simulates I/O latency'); \
+	if [ -n "$$VIOLATIONS" ]; then \
+		echo ""; \
+		echo "❌ Undocumented time.Sleep in config test files."; \
+		echo "   Allowed: only sleeps with '// simulates I/O latency' comment."; \
+		echo ""; \
+		echo "$$VIOLATIONS"; \
+		exit 1; \
+	fi
+	@# ALLOW-LIST: telemetry/system_metrics_darwin_test.go only (Darwin kernel observation)
+	@VIOLATIONS=$$(grep -rn 'time\.Sleep(' --include='*_test.go' internal/infrastructure/telemetry/ | grep -v 'system_metrics_darwin_test.go'); \
+	if [ -n "$$VIOLATIONS" ]; then \
+		echo ""; \
+		echo "❌ time.Sleep in telemetry test files outside system_metrics_darwin_test.go."; \
+		echo "   Darwin kernel tick observation sleeps are allow-listed in that file only."; \
+		echo ""; \
+		echo "$$VIOLATIONS"; \
+		exit 1; \
+	fi
+	@echo "  ✓ No time.Sleep for synchronization in test files."
+else
+	@echo "Checking for time.Sleep synchronization in test files (Windows)..."
+	@powershell -Command " \
+		$$ErrorActionPreference = 'Stop'; \
+		$$ui = Select-String -Path 'internal/ui/*_test.go' -Pattern 'time\.Sleep' -SimpleMatch:$$false; \
+		if ($$ui) { Write-Host '❌ time.Sleep in internal/ui/ test files'; exit 1 }; \
+		$$cfg = Select-String -Path 'internal/infrastructure/config/*_test.go' -Pattern 'time\.Sleep' -SimpleMatch:$$false | Where-Object { $$_.Line -notmatch 'simulates I/O latency' }; \
+		if ($$cfg) { Write-Host '❌ Undocumented time.Sleep in config test files'; $$cfg | ForEach-Object { Write-Host $$_ }; exit 1 }; \
+		$$tel = Select-String -Path 'internal/infrastructure/telemetry/*_test.go' -Pattern 'time\.Sleep' -SimpleMatch:$$false | Where-Object { $$_.Path -notmatch 'system_metrics_darwin_test\.go' }; \
+		if ($$tel) { Write-Host '❌ time.Sleep in telemetry test files outside allow-list'; $$tel | ForEach-Object { Write-Host $$_ }; exit 1 }; \
+	"
+	@echo "  ✓ No time.Sleep for synchronization in test files."
+endif
+
 verify-architecture:
 ifeq ($(IS_POSIX),true)
 	@ARCH_FAIL_ON_VIOLATION=1 go test -run TestVerifyRealArchitecture ./internal/tools/analysis/...
@@ -341,6 +391,8 @@ check: fmt tidy build
 	@$(MAKE) verify-architecture
 	@echo "=== verify-mock-pattern ==="
 	@$(MAKE) verify-mock-pattern
+	@echo "=== verify-no-test-sleep ==="
+	@$(MAKE) verify-no-test-sleep
 	@echo "=== vulncheck ==="
 	@$(MAKE) vulncheck
 	@echo "=== test ==="
@@ -361,6 +413,8 @@ check-full: fmt tidy build
 	@$(MAKE) verify-architecture
 	@echo "=== verify-mock-pattern ==="
 	@$(MAKE) verify-mock-pattern
+	@echo "=== verify-no-test-sleep ==="
+	@$(MAKE) verify-no-test-sleep
 	@echo "=== vulncheck ==="
 	@$(MAKE) vulncheck
 	@echo "=== test ==="

--- a/internal/infrastructure/config/watcher_test.go
+++ b/internal/infrastructure/config/watcher_test.go
@@ -61,10 +61,12 @@ func (l *testSessionLoader) toIntPtr(val interface{}) *int {
 type sleepingFileStat struct {
 	delay   time.Duration
 	modTime time.Time
+	started chan struct{} // closed when Stat is entered — signals test that I/O has begun
 }
 
 func (s sleepingFileStat) Stat(name string) (os.FileInfo, error) {
-	time.Sleep(s.delay)
+	close(s.started)
+	time.Sleep(s.delay) // simulates I/O latency
 	return stubFileInfo{modTime: s.modTime}, nil
 }
 
@@ -74,7 +76,7 @@ type sleepingConfigLoader struct {
 }
 
 func (l sleepingConfigLoader) Load(path string) (*domain_config.Config, error) {
-	time.Sleep(l.delay)
+	time.Sleep(l.delay) // simulates I/O latency
 	return &domain_config.Config{
 		MaxHistoryTokens: 500,
 		MaxToolTurns:     10,
@@ -92,7 +94,8 @@ func TestFileConfigWatcher_ConcurrentRefreshAndRead(t *testing.T) {
 
 	// Simulate slow disk: 200ms Stat + 100ms Load = 300ms total I/O.
 	futureTime := time.Now().Add(time.Hour)
-	cw.FS = sleepingFileStat{delay: 200 * time.Millisecond, modTime: futureTime}
+	stat := sleepingFileStat{delay: 200 * time.Millisecond, modTime: futureTime, started: make(chan struct{})}
+	cw.FS = stat
 	cw.Loader = sleepingConfigLoader{delay: 100 * time.Millisecond}
 	cw.SetPaths("/fake/main.yaml", "")
 
@@ -107,7 +110,7 @@ func TestFileConfigWatcher_ConcurrentRefreshAndRead(t *testing.T) {
 
 	// Let Refresh enter Phase 2 I/O, then measure GetLimits latency.
 	close(start)
-	time.Sleep(50 * time.Millisecond) // Refresh is now mid-I/O.
+	<-stat.started // Block until sleepingFileStat.Stat is entered — Refresh is now mid-I/O.
 
 	// Measure: GetLimits must NOT block behind Refresh's disk I/O.
 	before := time.Now()

--- a/internal/infrastructure/telemetry/system_metrics_darwin_test.go
+++ b/internal/infrastructure/telemetry/system_metrics_darwin_test.go
@@ -25,7 +25,9 @@ func TestDarwinMetricsProvider_GetCPUStats(t *testing.T) {
 		t.Errorf("GetCPUStats() idle ticks (%d) > total ticks (%d)", idle1, total1)
 	}
 
-	// Wait a short moment and sample again; ticks should increase (or stay the same)
+	// Darwin kernel tick accumulation: waiting for real hardware state change.
+	// This is NOT goroutine synchronization — Mach host_processor_info counters
+	// are updated asynchronously by the kernel scheduler.
 	time.Sleep(10 * time.Millisecond)
 	total2, idle2 := p.GetCPUStats()
 	if total2 < total1 {
@@ -57,6 +59,9 @@ func TestCPUPercentCalculation(t *testing.T) {
 
 	// Take two samples with a small delay, simulating what the UI renderer does
 	total1, idle1 := p.GetCPUStats()
+	// Darwin kernel tick accumulation: waiting for real hardware state change.
+	// This is NOT goroutine synchronization — Mach host_processor_info counters
+	// are updated asynchronously by the kernel scheduler.
 	time.Sleep(100 * time.Millisecond)
 	total2, idle2 := p.GetCPUStats()
 

--- a/internal/ui/renderer_integration_test.go
+++ b/internal/ui/renderer_integration_test.go
@@ -191,9 +191,6 @@ func TestSpinnerWithMetrics(t *testing.T) {
 			stop := renderer.StartSpinnerWithMetrics(ctx, "Testing")
 			defer stop()
 
-			// Wait for the first synchronous draw (already happened, but ensure we receive it)
-			time.Sleep(10 * time.Millisecond) // allow spinner goroutine to start
-
 			// Update the provider to return the second sample
 			provider.SetCPUStats(tt.total2, tt.idle2)
 
@@ -202,8 +199,14 @@ func TestSpinnerWithMetrics(t *testing.T) {
 			// Send a tick to cause the spinner goroutine to draw again
 			c.tick()
 
-			// Wait for the draw that includes updated CPU metrics
-			time.Sleep(50 * time.Millisecond) // allow spinner goroutine to process tick and draw
+			// Wait for the spinner goroutine to process the tick and draw.
+			// Poll stderr for the expected CPU substring instead of guessing with time.Sleep.
+			for i := 0; i < 200; i++ {
+				if strings.Contains(stderr.String(), wantCPU) {
+					break
+				}
+				runtime.Gosched()
+			}
 
 			// Stop the spinner and capture the final stderr output
 			stop()

--- a/internal/ui/renderer_test.go
+++ b/internal/ui/renderer_test.go
@@ -223,8 +223,6 @@ func TestStdUIRenderer_Spinner(t *testing.T) {
 		for i := 0; i < numGoroutines; i++ {
 			go func() {
 				defer wg.Done()
-				// Simulate random arrival of stop calls
-				time.Sleep(time.Millisecond * 10)
 				stop()
 			}()
 		}


### PR DESCRIPTION
Closes #580.

## Summary
Completes Phase 2 of `time.Sleep` elimination from test files, following the patterns established in commit `347f6c45` (Phase 1).

### Changes
| File | Change |
|------|--------|
| `internal/ui/renderer_integration_test.go` | Replaced 50ms blind sleep with deterministic poll loop (`runtime.Gosched()`), removed unnecessary 10ms sleep |
| `internal/ui/renderer_test.go` | Removed cosmetic 10ms sleep from `StartSpinnerRace` |
| `internal/infrastructure/config/watcher_test.go` | Added `started` channel to `sleepingFileStat` for deterministic I/O-entry signal; documented legitimate I/O simulation sleeps |
| `internal/infrastructure/telemetry/system_metrics_darwin_test.go` | Added Darwin kernel tick accumulation documentation comments |
| `Makefile` | Added `verify-no-test-sleep` grep gate wired into `check` and `check-full` with explicit allow-lists |

### Remaining documented exceptions (allow-listed)
- `config/watcher_test.go:69,79` — `// simulates I/O latency`
- `telemetry/system_metrics_darwin_test.go:31,65` — Darwin kernel tick observation

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, verify-mock-pattern, verify-no-test-sleep, vulncheck, test) | PASS |
| `go test -race -count=5 ./internal/ui/... ./internal/infrastructure/config/... ./internal/infrastructure/telemetry/...` | PASS (all 5 iterations, zero race warnings) |
| `go test ./...` | PASS (all 69 packages) |
