### PR TITLE
fix(agenttest): encapsulate MockClock fields with mutex-guarded accessors (#583)

### DIFF
--- a/internal/agent/agenttest/mock_clock.go
+++ b/internal/agent/agenttest/mock_clock.go
@@ -14,24 +14,50 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 )
 
-// MockClock is a test double for clock.Clock. CurrentTime, when
-// non-zero, fixes the value returned by Now() and is advanced by
-// Sleep(); when zero, Now() falls through to the real wall clock.
-// After() returns a buffered channel pre-loaded with CurrentTime+d so
+// MockClock is a test double for clock.Clock. When the stored time is
+// non-zero (set via SetCurrentTime), Now() returns that value and Sleep()
+// advances it; when zero, Now() falls through to the real wall clock.
+// After() returns a buffered channel pre-loaded with the stored time+d so
 // it never blocks. NewTicker() returns a *MockTicker fed from the
 // same After() channel.
 type MockClock struct {
 	mu            sync.Mutex
-	CurrentTime   time.Time
-	CalledNow     int
-	CalledMethods []string
+	currentTime   time.Time
+	calledNow     int
+	calledMethods []string
+}
+
+// Snapshot returns a race-safe copy of the observable call state.
+// now is the count of Now() calls; methods is a defensive copy
+// of the called-methods log (ordered by first call).
+func (m *MockClock) Snapshot() (now int, methods []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.calledMethods))
+	copy(out, m.calledMethods)
+	return m.calledNow, out
+}
+
+// SetCurrentTime safely sets the fixed clock time for tests.
+func (m *MockClock) SetCurrentTime(t time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.currentTime = t
+}
+
+// CurrentTime returns the stored fixed time (race-safe).
+// Returns the zero time.Time if never set.
+func (m *MockClock) CurrentTime() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.currentTime
 }
 
 func (m *MockClock) Now() time.Time {
 	m.mu.Lock()
-	m.CalledNow++
-	m.CalledMethods = append(m.CalledMethods, "Now")
-	t := m.CurrentTime
+	m.calledNow++
+	m.calledMethods = append(m.calledMethods, "Now")
+	t := m.currentTime
 	m.mu.Unlock()
 
 	if t.IsZero() {
@@ -46,15 +72,15 @@ func (m *MockClock) Since(t time.Time) time.Duration {
 
 func (m *MockClock) Sleep(d time.Duration) {
 	m.mu.Lock()
-	m.CalledMethods = append(m.CalledMethods, "Sleep")
-	m.CurrentTime = m.CurrentTime.Add(d)
+	m.calledMethods = append(m.calledMethods, "Sleep")
+	m.currentTime = m.currentTime.Add(d)
 	m.mu.Unlock()
 }
 
 func (m *MockClock) After(d time.Duration) <-chan time.Time {
 	m.mu.Lock()
-	m.CalledMethods = append(m.CalledMethods, "After")
-	t := m.CurrentTime.Add(d)
+	m.calledMethods = append(m.calledMethods, "After")
+	t := m.currentTime.Add(d)
 	m.mu.Unlock()
 
 	c := make(chan time.Time, 1)
@@ -64,7 +90,7 @@ func (m *MockClock) After(d time.Duration) <-chan time.Time {
 
 func (m *MockClock) NewTicker(d time.Duration) clock.Ticker {
 	m.mu.Lock()
-	m.CalledMethods = append(m.CalledMethods, "NewTicker")
+	m.calledMethods = append(m.calledMethods, "NewTicker")
 	m.mu.Unlock()
 
 	return &MockTicker{CVal: m.After(d)}
@@ -72,7 +98,7 @@ func (m *MockClock) NewTicker(d time.Duration) clock.Ticker {
 
 func (m *MockClock) Jitter(base float64) float64 {
 	m.mu.Lock()
-	m.CalledMethods = append(m.CalledMethods, "Jitter")
+	m.calledMethods = append(m.calledMethods, "Jitter")
 	m.mu.Unlock()
 
 	return base

--- a/internal/agent/agenttest/mock_clock_test.go
+++ b/internal/agent/agenttest/mock_clock_test.go
@@ -38,7 +38,8 @@ func TestMockClock_RaceDetection(t *testing.T) {
 	// CalledMethods should have goroutines*iterations*6 entries
 	// (NewTicker also appends "After" via its internal call to After)
 	expected := goroutines * iterations * 6
-	if len(m.CalledMethods) != expected {
-		t.Errorf("got %d entries, want %d", len(m.CalledMethods), expected)
+	_, methods := m.Snapshot()
+	if len(methods) != expected {
+		t.Errorf("got %d entries, want %d", len(methods), expected)
 	}
 }

--- a/internal/agent/session/entropy_test.go
+++ b/internal/agent/session/entropy_test.go
@@ -33,7 +33,8 @@ func TestSessionManager_SessionID_DegradationWarning(t *testing.T) {
 	mEventBus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, mEventBus)
 
-	mClock := &agenttest.MockClock{CurrentTime: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	mClock := &agenttest.MockClock{}
+	mClock.SetCurrentTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	mEntropy := new(agenttest.MockEntropySource)
 
 	entropyErr := fmt.Errorf("os entropy exhaustion")

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -866,13 +866,14 @@ func TestSessionManager_SessionID_Fallback(t *testing.T) {
 	mEventBus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, mEventBus)
 
-	mClock := &agenttest.MockClock{CurrentTime: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	mClock := &agenttest.MockClock{}
+	mClock.SetCurrentTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	mEntropy := new(agenttest.MockEntropySource)
 
 	// Entropy source fails
 	mEntropy.On("Read", mock.Anything).Return(nil, 0, fmt.Errorf("entropy failure"))
 
-	expectedSessionID := fmt.Sprintf("session-%d", mClock.CurrentTime.UnixNano())
+	expectedSessionID := fmt.Sprintf("session-%d", mClock.CurrentTime().UnixNano())
 
 	factory := func(ctx context.Context, deps ports.SessionDependencies, cfg ports.ChatterConfig) (ports.Chatter, error) {
 		return mChatter, nil
@@ -903,8 +904,9 @@ func TestSessionManager_SessionID_Fallback(t *testing.T) {
 	err := orch.Run(context.Background(), sCfg, deps, mCapturer)
 	require.NoError(t, err)
 
-	if mClock.CalledNow < 1 {
-		t.Errorf("expected Now() to be called at least once, got %d", mClock.CalledNow)
+	now, _ := mClock.Snapshot()
+	if now < 1 {
+		t.Errorf("expected Now() to be called at least once, got %d", now)
 	}
 	mEntropy.AssertExpectations(t)
 	mChatter.AssertExpectations(t)
@@ -967,7 +969,8 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 	mEventBus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, mEventBus)
 
-	mClock := &agenttest.MockClock{CurrentTime: time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)}
+	mClock := &agenttest.MockClock{}
+	mClock.SetCurrentTime(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
 	mEntropy := new(agenttest.MockEntropySource)
 
 	// Entropy source returns a short read (e.g., only 4 bytes instead of 8)
@@ -980,7 +983,7 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 	mEntropy.On("Read", mock.Anything).Return(nil, 0, io.EOF).Maybe()
 
 	// Since it's a short read, it should fallback to timestamp-based ID
-	expectedSessionID := fmt.Sprintf("session-%d", mClock.CurrentTime.UnixNano())
+	expectedSessionID := fmt.Sprintf("session-%d", mClock.CurrentTime().UnixNano())
 
 	factory := func(ctx context.Context, deps ports.SessionDependencies, cfg ports.ChatterConfig) (ports.Chatter, error) {
 		return mChatter, nil
@@ -1010,8 +1013,9 @@ func TestSessionManager_SessionID_ShortRead_Fallback(t *testing.T) {
 	err := orch.Run(context.Background(), sCfg, deps, mCapturer)
 	require.NoError(t, err)
 
-	if mClock.CalledNow < 1 {
-		t.Errorf("expected Now() to be called at least once, got %d", mClock.CalledNow)
+	now, _ := mClock.Snapshot()
+	if now < 1 {
+		t.Errorf("expected Now() to be called at least once, got %d", now)
 	}
 	mChatter.AssertExpectations(t)
 }

--- a/tests/integration/agent/orchestrator/turn_engine_test.go
+++ b/tests/integration/agent/orchestrator/turn_engine_test.go
@@ -451,7 +451,8 @@ func TestTurnEngine_MiddlewareOrder(t *testing.T) {
 func TestTurnEngine_ClockInjection(t *testing.T) {
 	t.Parallel()
 	fixedTime := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	mockClock := &agenttest.MockClock{CurrentTime: fixedTime}
+	mockClock := &agenttest.MockClock{}
+	mockClock.SetCurrentTime(fixedTime)
 
 	var capturedTime time.Time
 	var Mu sync.Mutex


### PR DESCRIPTION
Closes #583.

## Summary

Unexported the three exported fields on `MockClock` (`CurrentTime`, `CalledNow`, `CalledMethods`) and replaced them with mutex-guarded accessors:

- `Snapshot() (now int, methods []string)` — race-safe copy of call state
- `SetCurrentTime(time.Time)` — safe time seeding
- `CurrentTime() time.Time` — safe stored-time getter (fills gap in issue proposal)

Migrated all ~10 call sites across 4 test files to the new API. ~55 zero-value init sites (`&agenttest.MockClock{}`) required no changes.

## Changes

| File | Changes |
|------|---------|
| `internal/agent/agenttest/mock_clock.go` | Unexported 3 fields, added 3 accessors, updated 11 internal refs |
| `internal/agent/agenttest/mock_clock_test.go` | Replaced `m.CalledMethods` with `m.Snapshot()` |
| `internal/agent/session/session_manager_test.go` | 6 replacements: struct init → SetCurrentTime, field reads → CurrentTime()/Snapshot() |
| `internal/agent/session/entropy_test.go` | 1 replacement: struct init → SetCurrentTime |
| `tests/integration/agent/orchestrator/turn_engine_test.go` | 1 replacement: struct init → SetCurrentTime |

## Verification

| Check | Status |
|-------|--------|
| `make check-full` | PASS |
| `go test -race -count=10 ./internal/agent/...` | PASS (0 warnings) |
| `go test -race -count=5 ./...` | PASS (0 warnings) |
| Target coverage | Maintained |
