### PR TITLE
fix(makefile): replace ADR-XXX placeholder with ADR-036 in verify-no-test-sleep (#589)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,7 @@ else
 	"
 endif
 
-# Verify no time.Sleep for synchronization in test files (Issue #580 / ADR-XXX).
+# Verify no time.Sleep for synchronization in test files (Issue #580 / ADR-036).
 # Legitimate I/O simulation and hardware observation sleeps are explicitly allow-listed.
 verify-no-test-sleep:
 ifeq ($(IS_POSIX),true)


### PR DESCRIPTION
Closes #589.

## Summary
Replaces the stale `ADR-XXX` placeholder in the `verify-no-test-sleep` Makefile target comment with the canonical `ADR-036` reference. The corresponding ADR (`docs/adr/2026-05-test-determinism-standards.md`) was finalized before the target landed; this fix updates the cross-reference.

**Change**: Single comment line in `Makefile` line 283.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (10/10 steps; `test-race` flaky timeout in `internal/tools/analysis` is pre-existing, unrelated) |
| grep "ADR-XXX" Makefile | No matches ✓ |
| grep "ADR-036" Makefile | Line 283 only ✓ |
| make verify-no-test-sleep | PASS ✓ |