### PR TITLE
fix(adr): add missing ADR-035 row to index table (#588)

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-032** | Test-Hook Policy for Unexported Concrete Types | 2026-05 | Accepted | [2026-05-test-hook-policy.md](2026-05-test-hook-policy.md) |
 | **ADR-033** | Narrow the `auth.Authenticator` Interface (Remove `getToken`) | 2026-05 | Accepted | [2026-05-narrow-authenticator-interface.md](2026-05-narrow-authenticator-interface.md) |
 | **ADR-034** | Cosmetic Lint Fixes Must Be Submitted as Standalone PRs | 2026-05 | Accepted | [2026-05-cosmetic-lint-fix-pr-separation.md](2026-05-cosmetic-lint-fix-pr-separation.md) |
+| **ADR-035** | Per-Request Goroutine Model for Capturer Reads | 2026-05 | Accepted | [2026-05-capturer-per-request-goroutine.md](2026-05-capturer-per-request-goroutine.md) |
 | **ADR-036** | Test Determinism Standards (No-Sleep, Race-Safe Mocks, Deterministic Time) | 2026-05 | Accepted | [2026-05-test-determinism-standards.md](2026-05-test-determinism-standards.md) |
 
 ## How to Create a New ADR


### PR DESCRIPTION
Closes #588.

## Summary
Added the missing ADR-035 row to the ADR index table in `docs/adr/README.md`. ADR-035 (`2026-05-capturer-per-request-goroutine.md`) already existed as a file but its corresponding row was missing from the index, creating a numbering gap between ADR-034 and ADR-036.

## Change
- `docs/adr/README.md`: Inserted one row for ADR-035 between ADR-034 and ADR-036 in the index table.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, vulncheck, test, dead-code) | ✅ PASS |
| `grep "ADR-035" docs/adr/README.md` | ✅ Hit |
| Link target file exists | ✅ |
| ADR-036 retains its number | ✅ |
| Only `docs/adr/README.md` changed | ✅ |
