### PR TITLE
docs(adr): refresh ADR-022 MockClock example to match encapsulated pattern (#590)

### DIFF
--- a/docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md
+++ b/docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md
@@ -137,29 +137,53 @@ func (m *MockClock) Now() time.Time {
 #### Spy variant for call-count/call-order assertion
 
 When a test needs to assert that a method was called (or called N times, or
-called in a specific order), add lightweight spy fields to the struct:
+called in a specific order), track call state in **unexported fields guarded
+by `sync.Mutex`** and expose a single `Snapshot()` accessor for race-safe
+inspection. This conforms to [ADR-036: Test Determinism Standards §3](./2026-05-test-determinism-standards.md).
 
 ```go
 type MockClock struct {
-    CurrentTime   time.Time
-    CalledNow     int       // call-count field
-    CalledMethods []string  // call-order field (append method name on each call)
+    mu            sync.Mutex
+    currentTime   time.Time
+    calledNow     int
+    calledMethods []string
+}
+
+// Snapshot returns a race-safe copy of the observable call state.
+func (m *MockClock) Snapshot() (now int, methods []string) {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    out := make([]string, len(m.calledMethods))
+    copy(out, m.calledMethods)
+    return m.calledNow, out
 }
 
 func (m *MockClock) Now() time.Time {
-    m.CalledNow++
-    m.CalledMethods = append(m.CalledMethods, "Now")
-    // ... normal behaviour ...
+    m.mu.Lock()
+    m.calledNow++
+    m.calledMethods = append(m.calledMethods, "Now")
+    t := m.currentTime
+    m.mu.Unlock()
+
+    if t.IsZero() {
+        return time.Now()
+    }
+    return t
 }
 ```
 
-Tests assert directly on the spy fields:
+Tests assert via `Snapshot()` — the only way to read call state:
 
 ```go
-mClock := &agenttest.MockClock{CurrentTime: fixedTime}
+mClock := &agenttest.MockClock{}
+mClock.SetCurrentTime(fixedTime)
 // ... run system under test ...
-if mClock.CalledNow < 1 {
-    t.Errorf("expected Now() to be called at least once, got %d", mClock.CalledNow)
+now, methods := mClock.Snapshot()
+if now < 1 {
+    t.Errorf("expected Now() to be called at least once, got %d", now)
+}
+if len(methods) == 0 || methods[0] != "Now" {
+    t.Errorf("expected first call to be Now(), got %v", methods)
 }
 ```
 
@@ -171,8 +195,10 @@ if mClock.CalledNow < 1 {
 3. **Simpler to read and maintain.** A `MockClock` with a `CurrentTime` field
    is self-documenting. A testify mock requires reading `.On()` calls in each
    test to understand behaviour.
-4. **For call-count assertions, use spy fields** (e.g. `CalledNow int`,
-   `CalledMethods []string`) rather than pulling in `testify/mock`.
+4. **For call-count assertions, use `sync.Mutex`-guarded spy fields**
+   with a `Snapshot()` accessor (e.g. unexported `calledNow int`,
+   `calledMethods []string`) rather than pulling in `testify/mock`.
+   This ensures the mock passes `go test -race` (see ADR-036 §3).
 
 #### Exception: `agentinternal/`
 
@@ -264,6 +290,9 @@ those mocks cannot live in `agenttest/` without creating import cycles.
 
 ## References
 
+- [ADR-036: Test Determinism Standards](./2026-05-test-determinism-standards.md) §3 —
+  mandates `sync.Mutex`-guarded state for all mocks and fakes. The encapsulated
+  spy pattern in this ADR's examples conforms to that requirement.
 - `docs/refactor/testutil-audit.md` — the full 8-session refactor record,
   including the symbol inventory, per-session outcomes, and lessons
   learned.

--- a/docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md
+++ b/docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md
@@ -158,6 +158,13 @@ func (m *MockClock) Snapshot() (now int, methods []string) {
     return m.calledNow, out
 }
 
+// SetCurrentTime safely sets the fixed clock time for tests.
+func (m *MockClock) SetCurrentTime(t time.Time) {
+    m.mu.Lock()
+    defer m.mu.Unlock()
+    m.currentTime = t
+}
+
 func (m *MockClock) Now() time.Time {
     m.mu.Lock()
     m.calledNow++
@@ -192,8 +199,7 @@ if len(methods) == 0 || methods[0] != "Now" {
 1. **Make the zero value useful** (Go proverb). Hand-rolled mocks work without
    `.On()` boilerplate.
 2. **Consistent with `toolstest/`** which already uses this pattern exclusively.
-3. **Simpler to read and maintain.** A `MockClock` with a `CurrentTime` field
-   is self-documenting. A testify mock requires reading `.On()` calls in each
+3. **Simpler to read and maintain.** A `MockClock` with explicit state methods like `SetCurrentTime` is self-documenting. A testify mock requires reading `.On()` calls in each
    test to understand behaviour.
 4. **For call-count assertions, use `sync.Mutex`-guarded spy fields**
    with a `Snapshot()` accessor (e.g. unexported `calledNow int`,

--- a/docs/adr/2026-05-test-determinism-standards.md
+++ b/docs/adr/2026-05-test-determinism-standards.md
@@ -139,6 +139,9 @@ contexts) and leaked a serialization concern into pure domain logic.
 
 - [ADR-011](2026-04-uibridge-actor-model.md) — Defines the original deterministic testing
   rules (Rules 1–3) that this ADR generalizes across the project.
+- [ADR-022](2026-04-test-doubles-in-pkgtest-subpackages.md) — establishes the
+  `<pkg>test` mock construction pattern. The encapsulated spy variant in ADR-022
+  conforms to this ADR's §3 race-safety requirement.
 - [ADR-032](2026-05-test-hook-policy.md) — Defines the test-hook policy that provides the
   legitimate exception mechanism for unexported concrete types where interface mocking is
   impossible.


### PR DESCRIPTION
Closes #590.

## Summary
Updated ADR-022 (Test Doubles in `*test` Sub-Packages) to replace the stale exported-field MockClock pattern with the encapsulated `sync.Mutex` + `Snapshot()` pattern that matches the current canonical implementation in `internal/agent/agenttest/mock_clock.go` and conforms to ADR-036 §3 (Race-Safe Mocks).

### Changes
- **ADR-022** (`docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md`):
  - Replaced the "Spy variant" code example with encapsulated `sync.Mutex`-guarded fields and `Snapshot()` accessor
  - Rewrote Rationale item #4 to reference `sync.Mutex` and `Snapshot()` instead of exported field names
  - Added cross-reference to ADR-036 in the References section
- **ADR-036** (`docs/adr/2026-05-test-determinism-standards.md`):
  - Added cross-reference to ADR-022 in the Cross-References section for bidirectional linking

## Verification
| Check | Status |
|-------|--------|
| `make fmt tidy build` | PASS |
| `make lint` | PASS |
| `make verify-architecture` | PASS |
| `make vulncheck` | PASS |
| `make test` | PASS |
| `make dead-code` | PASS |
| `make test-race` | PASS |
| `make test-coverage` | PASS |
| grep CalledNow/CalledMethods ADR-022 | Zero matches (exit 1) |
