### PR TITLE
fix(events): reduce test complexity with helper extraction (#596)

### DIFF
--- a/internal/domain/events/enqueue_backpressure_test.go
+++ b/internal/domain/events/enqueue_backpressure_test.go
@@ -36,6 +36,21 @@ func newReleaseChan(t *testing.T) (ch <-chan struct{}, release func()) {
 	return c, release
 }
 
+// assertDropLogged verifies the structured log output contains the expected
+// drop-warning message, the dropped event type, and the WARN level.
+func assertDropLogged(t *testing.T, logOutput, eventType string) {
+	t.Helper()
+	if !strings.Contains(logOutput, "subscriber queue full, dropping event") {
+		t.Errorf("expected drop warning in log, got: %s", logOutput)
+	}
+	if !strings.Contains(logOutput, eventType) {
+		t.Errorf("expected dropped event type %s in log, got: %s", eventType, logOutput)
+	}
+	if !strings.Contains(logOutput, "level=WARN") {
+		t.Errorf("expected WARN level for drop log, got: %s", logOutput)
+	}
+}
+
 // TestPublish_DropsEventWhenSubscriberQueueIsFull verifies the backpressure
 // "drop" arm of (*SimpleEventBus).enqueueEvent — the `default:` branch of
 // its 3-arm select.
@@ -117,16 +132,7 @@ func TestPublish_DropsEventWhenSubscriberQueueIsFull(t *testing.T) {
 	}
 
 	// Verify the Warn log was emitted for the dropped event.
-	logOutput := buf.String()
-	if !strings.Contains(logOutput, "subscriber queue full, dropping event") {
-		t.Errorf("expected drop warning in log, got: %s", logOutput)
-	}
-	if !strings.Contains(logOutput, "queue_full_e3") {
-		t.Errorf("expected dropped event type queue_full_e3 in log, got: %s", logOutput)
-	}
-	if !strings.Contains(logOutput, "level=WARN") {
-		t.Errorf("expected WARN level for drop log, got: %s", logOutput)
-	}
+	assertDropLogged(t, buf.String(), "queue_full_e3")
 
 	// Indirect pendingCount assertion:
 	// The drop arm calls decPending() to undo its incPending(). If that were

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -1162,6 +1162,19 @@ func TestSimpleEventBus_Shutdown_FlushTimeout(t *testing.T) {
 	<-listenDone
 }
 
+// drainSignals drains exactly count signals from ch, failing the test if
+// any signal does not arrive within the timeout.
+func drainSignals(t *testing.T, ch <-chan struct{}, count int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatal("subscriber did not process event in time")
+		}
+	}
+}
+
 // TestSimpleEventBus_Shutdown_ActiveWorkers exercises the <-done path in
 // Shutdown where the worker goroutines drain successfully before the context
 // expires, and close(done) fires from the normal path (not recover).
@@ -1208,13 +1221,7 @@ func TestSimpleEventBus_Shutdown_ActiveWorkers(t *testing.T) {
 	}
 
 	// Drain processed signals to confirm each event was handled
-	for i := 0; i < numEvents; i++ {
-		select {
-		case <-processed:
-		case <-time.After(2 * time.Second):
-			t.Fatal("subscriber did not process event in time")
-		}
-	}
+	drainSignals(t, processed, numEvents)
 
 	// Flush ensures all events are processed before we stop the listener.
 	flushCtx, flushCancel := context.WithTimeout(ctx, 2*time.Second)


### PR DESCRIPTION
Closes #596.

## Summary
Extracted two shared helper functions to reduce cyclomatic complexity in event bus test functions:

| Function | Before | After | Helper Extracted |
|----------|--------|-------|------------------|
| `TestSimpleEventBus_Shutdown_ActiveWorkers` | 11 | **8** | `drainSignals` |
| `TestPublish_DropsEventWhenSubscriberQueueIsFull` | 12 | **9** | `assertDropLogged` |

Both are now below the threshold of 10.

- `drainSignals(t, ch, count)` — drains exactly N signals from a channel with timeout
- `assertDropLogged(t, logOutput, eventType)` — verifies drop-warning log output

No production code changes. All existing assertions preserved.

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go test -race ./internal/domain/events/...` | PASS |
| `golangci-lint run ./...` | 0 issues |
| `make check-full` | PASS (test-race timeout in analysis package pre-existing/ unrelated) |
| Target coverage | Preserved |