### PR TITLE
fix(orchestrator): cover context cancellation in select branch (#600)

### DIFF
--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -619,6 +619,22 @@ func (c *blockingClock) After(d time.Duration) <-chan time.Time {
 func (c *blockingClock) Now() time.Time              { return time.Now() }
 func (c *blockingClock) Jitter(base float64) float64 { return base }
 
+// syncClock is a Clock whose After() returns an unbuffered channel that never fires,
+// and also closes calledCh to signal that After() was invoked — allowing tests to
+// deterministically wait for a goroutine to reach the select block before calling cancel().
+type syncClock struct {
+	clock.Clock
+	ch       chan time.Time
+	calledCh chan struct{}
+}
+
+func (c *syncClock) After(d time.Duration) <-chan time.Time {
+	close(c.calledCh)
+	return c.ch
+}
+func (c *syncClock) Now() time.Time              { return time.Now() }
+func (c *syncClock) Jitter(base float64) float64 { return base }
+
 func TestRecoveryStep_AttemptRetry_SelectContextCancelled(t *testing.T) {
 	policy := &DefaultRetryPolicy{MaxRetries: 5, Backoff: 1 * time.Hour}
 	step := &RecoveryStep{Policy: policy}

--- a/internal/agent/orchestrator/engine_phases_test.go
+++ b/internal/agent/orchestrator/engine_phases_test.go
@@ -425,10 +425,15 @@ func TestRecoveryStep_Process(t *testing.T) {
 		// this test cancels AFTER the goroutine has entered attemptRetry and
 		// started blocking in the select.
 		//
-		// blockingClock.After() returns an unbuffered channel that never fires,
-		// forcing the select to block on ctx.Done().
+		// syncClock.After() closes calledCh on entry and returns an unbuffered
+		// channel that never fires, forcing the select to block on ctx.Done().
+		// The main goroutine waits on calledCh for a deterministic signal that
+		// the spawned goroutine has reached the select boundary before calling cancel().
 		bus := &passThroughEventBus{}
-		clk := &blockingClock{ch: make(chan time.Time)}
+		clk := &syncClock{
+			ch:       make(chan time.Time),
+			calledCh: make(chan struct{}),
+		}
 		step := &RecoveryStep{Policy: &DefaultRetryPolicy{MaxRetries: 5, Backoff: 1 * time.Hour}}
 		turn := &Turn{
 			State: &TurnState{
@@ -440,7 +445,7 @@ func TestRecoveryStep_Process(t *testing.T) {
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		// NOTE: cancel() is deliberately called in a goroutine below,
+		// NOTE: cancel() is called below after the goroutine enters the select,
 		// NOT here — the context must be alive when Process() starts.
 
 		type procResult struct {
@@ -454,11 +459,9 @@ func TestRecoveryStep_Process(t *testing.T) {
 			resultCh <- procResult{res: res, err: err}
 		}()
 
-		// Yield briefly so the goroutine can enter attemptRetry and block
-		// in the select. 1ms is generous; even if the goroutine hasn't
-		// reached the select yet, cancel() will hit the ctx.Err() guard
-		// at line 147 instead — both paths produce the same result.
-		time.Sleep(time.Millisecond)
+		// Block until the goroutine has entered the select (After() was called),
+		// then cancel. This deterministically hits line 154: case <-ctx.Done().
+		<-clk.calledCh
 		cancel()
 		r := <-resultCh
 

--- a/internal/agent/orchestrator/engine_phases_test.go
+++ b/internal/agent/orchestrator/engine_phases_test.go
@@ -417,4 +417,53 @@ func TestRecoveryStep_Process(t *testing.T) {
 		// the ctx.Err() guard, not the select case
 		assert.Equal(t, 1, turn.State.RetryCount)
 	})
+
+	t.Run("context cancelled during select wait", func(t *testing.T) {
+		// This test covers the select { case <-ctx.Done(): ... } branch at line 154
+		// in attemptRetry. Unlike the "cancelled during retry wait" and
+		// "cancelled before select" tests which cancel before calling Process(),
+		// this test cancels AFTER the goroutine has entered attemptRetry and
+		// started blocking in the select.
+		//
+		// blockingClock.After() returns an unbuffered channel that never fires,
+		// forcing the select to block on ctx.Done().
+		bus := &passThroughEventBus{}
+		clk := &blockingClock{ch: make(chan time.Time)}
+		step := &RecoveryStep{Policy: &DefaultRetryPolicy{MaxRetries: 5, Backoff: 1 * time.Hour}}
+		turn := &Turn{
+			State: &TurnState{
+				LastError:  llm.ErrTransient,
+				RetryCount: 0,
+			},
+			Clock:  clk,
+			Events: bus,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// NOTE: cancel() is deliberately called in a goroutine below,
+		// NOT here — the context must be alive when Process() starts.
+
+		type procResult struct {
+			res ProcessResult
+			err error
+		}
+		resultCh := make(chan procResult, 1)
+
+		go func() {
+			res, err := step.Process(ctx, turn)
+			resultCh <- procResult{res: res, err: err}
+		}()
+
+		// Yield briefly so the goroutine can enter attemptRetry and block
+		// in the select. 1ms is generous; even if the goroutine hasn't
+		// reached the select yet, cancel() will hit the ctx.Err() guard
+		// at line 147 instead — both paths produce the same result.
+		time.Sleep(time.Millisecond)
+		cancel()
+		r := <-resultCh
+
+		assert.Equal(t, ProcessResult{}, r.res)
+		assert.ErrorIs(t, r.err, context.Canceled)
+		assert.Equal(t, 1, turn.State.RetryCount)
+	})
 }


### PR DESCRIPTION
Closes #600.

## Summary
Added a new subtest `"context cancelled during select wait"` to `TestRecoveryStep_Process` in `engine_phases_test.go`. This covers the previously untested `select { case <-ctx.Done(): ... }` branch at line 154 in `attemptRetry()`.

The existing tests cancelled the context **before** calling `Process()`, hitting the early `ctx.Err()` guard instead of the `select` case. The new test cancels the context **during** the select block by using `blockingClock` (unbuffered channel that never fires), forcing the select to wait on `ctx.Done()`.

## Verification
| Check | Status |
|-------|--------|
| make check-full (fmt, tidy, build, lint, verify-architecture) | PASS |
| vulncheck | Pre-existing GO-2026-4985 (unrelated) |
| test | PASS |
| test-race | PASS |
| test-coverage (orchestrator) | 98.5% |
| No production code changes | ✓ |
