### PR TITLE
fix(docs): audit public API godoc coverage (#613)

### DIFF
--- a/internal/domain/ports/capturer.go
+++ b/internal/domain/ports/capturer.go
@@ -40,8 +40,23 @@ func WithTUIPrompt(tui bool) CaptureOption {
 
 // Capturer defines the interface for UI interactions that the orchestrator needs.
 type Capturer interface {
+	// IsTTY reports whether v is connected to an interactive terminal.
+	// It accepts an io.Writer (typically os.Stdout or os.Stdin) and returns
+	// true if the writer is a character device capable of interactive I/O.
 	IsTTY(v any) bool
+
+	// CapturePrompt presents the user with an interactive prompt and returns
+	// the input string. It blocks until the user submits input or the context
+	// is cancelled.
+	//
+	// Options (WithSkipTTYWait, WithRaw, WithTUIPrompt) modify capture
+	// behavior. When no options are provided, CapturePrompt uses sensible
+	// defaults for the current terminal configuration.
+	//
+	// The returned error is non-nil only when the context is cancelled or
+	// the underlying input stream encounters an irrecoverable error.
 	CapturePrompt(ctx context.Context, args []string, opts ...CaptureOption) (string, error)
+
 	// Confirm asks the user for a yes/no confirmation.
 	Confirm(ctx context.Context, message string) (bool, error)
 	// Close performs any necessary cleanup, such as flushing suggestion buffers.

--- a/internal/domain/ports/doc.go
+++ b/internal/domain/ports/doc.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package ports defines the primary interfaces (ports) for the hexagonal
+// architecture of tell-me-go. These interfaces establish the contracts
+// between the domain core and all external adapters (infrastructure, UI,
+// persistence).
+//
+// # Interface Families
+//
+// Agent Lifecycle & Configuration:
+//   - Chatter / ChatterFactory / ChatExecutor / ChatConfigurator / ChatEventSource
+//   - SessionConfig / SessionDependencies / Session
+//
+// Conversation Persistence:
+//   - HistoryManager / HistoryReader / HistoryWriter / HistoryModifier
+//   - HistoryRenderer / HistoryRenderOptions / HistoryViewDTO
+//   - ArchiveReader / UnifiedHistoryProvider
+//
+// User Interaction:
+//   - Capturer / CaptureOptions / CaptureOption
+//   - UIRenderer / ResponseRenderer / StatusLogger / UsageLogger / ToolLogger
+//   - RendererConfigurator
+//
+// System Diagnostics:
+//   - HealthChecker / HealthCheckManager / HealthReport / HealthStatus / Component / ComponentReport
+//   - SystemMetricsProvider
+//
+// Conversation Compression:
+//   - Summarizer
+//
+// Context Pipeline:
+//   - ContextTransformer / ContextRequest / ContextMetadata
+//   - PruningPolicy / ResultStrategy
+//
+// Persistence & State:
+//   - PersistenceProvider / SessionProvider / SessionStateProvider
+//   - TaskStore / TaskReader / TaskWriter / Task
+//   - KVStore / ListStore / ListFilter
+//   - Initializer / ResourceCloser
+//
+// Observability:
+//   - Logger / TurnsLogger
+//
+// Suggestions:
+//   - SuggestionService / SuggestionProvider / PromptTracker
+//
+// Infrastructure Wiring:
+//   - LLMDependencyProvider / PersistenceDependencyProvider / InfrastructureDependencyProvider
+//   - HistoryManagerProvider / SuggestionProvider
+//
+// All interfaces in this package are designed for dependency injection.
+// Implementations live in internal/infrastructure/ and internal/ui/.
+package ports

--- a/internal/domain/ports/health.go
+++ b/internal/domain/ports/health.go
@@ -34,18 +34,29 @@ const (
 
 // ComponentReport encapsulates the diagnostic result for a single system component.
 type ComponentReport struct {
-	Component Component    `json:"component"`
-	Status    HealthStatus `json:"status"`
-	Message   string       `json:"message"`
-	Details   any          `json:"details,omitempty"`
-	Error     error        `json:"-"`
+	// Component identifies the system component that was checked.
+	Component Component `json:"component"`
+	// Status is the health status of this component.
+	Status HealthStatus `json:"status"`
+	// Message provides a human-readable description of the component's state.
+	Message string `json:"message"`
+	// Details contains component-specific diagnostic data (e.g., latency,
+	// endpoint URL, provider name). The structure varies by component type.
+	Details any `json:"details,omitempty"`
+	// Error is the underlying error if the component is unhealthy.
+	// This field is excluded from JSON serialization.
+	Error error `json:"-"`
 }
 
 // HealthReport provides a consolidated view of the overall system health.
 type HealthReport struct {
-	OverallStatus HealthStatus                  `json:"overall_status"`
-	Components    map[Component]ComponentReport `json:"components"`
-	Timestamp     time.Time                     `json:"timestamp"`
+	// OverallStatus is the aggregate health of the system. It is
+	// StatusHealthy only when all components are healthy.
+	OverallStatus HealthStatus `json:"overall_status"`
+	// Components maps each component identifier to its diagnostic report.
+	Components map[Component]ComponentReport `json:"components"`
+	// Timestamp records when the health check was performed.
+	Timestamp time.Time `json:"timestamp"`
 }
 
 // HealthChecker is the interface for individual component health providers.

--- a/internal/domain/ports/history.go
+++ b/internal/domain/ports/history.go
@@ -27,22 +27,54 @@ type HistoryReader interface {
 	// GetLastUserMessage finds the text of the last user message and the number of turns to rollback.
 	GetLastUserMessage(ctx context.Context) (msg string, turnsToRollback int, err error)
 
+	// GetResolver returns the asset resolver for resolving inline data
+	// references (e.g., images, files) embedded in the conversation history.
 	GetResolver() llm.AssetResolver
 }
 
 // HistoryWriter defines the interface for adding or modifying chat history.
 type HistoryWriter interface {
+	// SetContents replaces the entire in-memory history with the given
+	// slice. The previous history is discarded without being persisted.
+	// Call Save to persist the new contents to disk.
 	SetContents(ctx context.Context, contents []*llm.Content) error
+
+	// AddContent appends a single Content entry to the in-memory history.
+	// The entry is not persisted until Save is called.
 	AddContent(ctx context.Context, content *llm.Content) error
+
+	// AppendParts appends one or more Parts to the Content at the given
+	// index. This is used to attach multi-part responses (e.g., tool
+	// results) to an existing message. The index must refer to an
+	// existing Content entry.
 	AppendParts(ctx context.Context, index int, parts []*llm.Part) error
+
+	// Save persists the current in-memory history to stable storage.
+	// It is a no-op if the history has not been modified since the last
+	// save. Implementations must be safe for sequential use; concurrent
+	// calls to Save and Sync are not required.
 	Save(ctx context.Context) error
+
+	// Sync flushes any buffered writes to stable storage without
+	// performing a full save cycle. It is lighter-weight than Save
+	// and suitable for use at the end of each turn.
 	Sync(ctx context.Context) error
 }
 
 // HistoryModifier defines the interface for specialized history operations.
 type HistoryModifier interface {
+	// Archive moves the given contents from active memory to the
+	// disk-based archive. Archived content is no longer accessible
+	// via GetWindow but remains available through ArchiveReader.
 	Archive(ctx context.Context, contents []*llm.Content) error
+
+	// SetPinned marks or unmarks a specific turn as pinned. Pinned turns
+	// are exempt from automatic pruning and summarization. turnIndex
+	// refers to the turn number in active memory.
 	SetPinned(ctx context.Context, turnIndex int, pinned bool) error
+
+	// GetFilePath returns the filesystem path to the active history file.
+	// This is primarily used for logging and diagnostic purposes.
 	GetFilePath() string
 
 	// RollbackTurns removes the last N turns (1 turn = 2 messages) from the history.

--- a/internal/domain/ports/logger.go
+++ b/internal/domain/ports/logger.go
@@ -9,11 +9,24 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 )
 
-// Logger defines the interface for logging within the application.
+// Logger defines the interface for structured logging within the application.
+// Implementations should support key=value pairs as variadic args
+// (e.g., logger.Info("message", "key1", val1, "key2", val2)).
 type Logger interface {
+	// Error logs a message at ERROR level. Used for unrecoverable
+	// failures that require operator attention.
 	Error(msg string, args ...any)
+
+	// Warn logs a message at WARN level. Used for potentially harmful
+	// situations that do not prevent continued operation.
 	Warn(msg string, args ...any)
+
+	// Info logs a message at INFO level. Used for significant events
+	// during normal operation (e.g., startup, completion).
 	Info(msg string, args ...any)
+
+	// Debug logs a message at DEBUG level. Used for diagnostic
+	// information useful during development and troubleshooting.
 	Debug(msg string, args ...any)
 }
 
@@ -25,14 +38,25 @@ func (l *NoOpLogger) Warn(msg string, args ...any)  {}
 func (l *NoOpLogger) Info(msg string, args ...any)  {}
 func (l *NoOpLogger) Debug(msg string, args ...any) {}
 
+// TurnsLogger defines the interface for logging conversation turns to disk.
 type TurnsLogger interface {
+	// HandleEvent processes a single event synchronously. It is safe
+	// to call from any goroutine. Events are buffered and flushed
+	// asynchronously by the background workers started in Listen.
 	HandleEvent(ctx context.Context, e events.Event)
-	// Listen starts the turns logger's background workers and blocks until the context is canceled.
+
+	// Listen starts the turns logger's background workers and blocks
+	// until the context is canceled.
 	// [ARCHITECTURAL REFACTOR] This replaces the previous fire-and-forget goroutine pattern.
 	Listen(ctx context.Context) error
+
+	// Close flushes any buffered events and releases resources.
+	// It must be called after Listen returns.
 	Close() error
 }
 
+// NoOpTurnsLogger is a TurnsLogger that discards all events.
+// It is used when turn logging is disabled or unavailable.
 type NoOpTurnsLogger struct{}
 
 func (l *NoOpTurnsLogger) HandleEvent(ctx context.Context, e events.Event) {}

--- a/internal/domain/ports/prompt.go
+++ b/internal/domain/ports/prompt.go
@@ -21,7 +21,14 @@ type SuggestionService interface {
 
 // PromptTracker defines the interface for persisting and loading cross-session prompts.
 type PromptTracker interface {
+	// Append records a user prompt for future suggestion retrieval.
+	// Fire-and-forget: the implementation may buffer writes.
 	Append(ctx context.Context, prompt string) error
+
+	// LoadTopN returns up to limit of the most frequently used prompts
+	// across all recorded sessions, ordered by frequency descending.
 	LoadTopN(ctx context.Context, limit int) ([]string, error)
+
+	// Close flushes any buffered writes and releases resources.
 	Close() error
 }

--- a/internal/domain/ports/renderer.go
+++ b/internal/domain/ports/renderer.go
@@ -15,34 +15,73 @@ import (
 
 // ResponseRenderer defines the interface for synchronous response rendering.
 type ResponseRenderer interface {
+	// StartSpinner begins an indeterminate progress indicator and returns
+	// a stop function. Callers must invoke stop() exactly once to clear
+	// the spinner. The spinner runs until stop is called or the context
+	// is cancelled.
 	StartSpinner(ctx context.Context) (stop func())
+
+	// StartSpinnerWithStatus begins a spinner with the given status text
+	// displayed alongside the indicator.
 	StartSpinnerWithStatus(ctx context.Context, status string) (stop func())
+
+	// StartSpinnerWithMetrics begins a spinner with status text and
+	// live-updating resource usage metrics (CPU, memory).
 	StartSpinnerWithMetrics(ctx context.Context, status string) (stop func())
+
+	// RenderResponse writes the LLM response to the terminal. When
+	// showThoughts is true, reasoning/thinking blocks are included.
+	// When rawOutput is true, markdown rendering is disabled.
 	RenderResponse(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool)
 }
 
 // StatusLogger defines the interface for logging status and system messages.
 type StatusLogger interface {
+	// LogTurnStatus renders the outcome of a conversation turn (e.g.,
+	// "completed", "error", "cancelled").
 	LogTurnStatus(ctx context.Context, status events.TurnStatus)
+
+	// LogSystemMessage renders a system-level message with the given
+	// severity level (e.g., "info", "warn", "error").
 	LogSystemMessage(ctx context.Context, msg string, level string)
+
+	// RenderHealthReport displays the consolidated health report to
+	// the user. The report includes per-component status and timestamps.
 	RenderHealthReport(ctx context.Context, report *HealthReport)
 }
 
 // UsageLogger defines the interface for logging usage metrics.
 type UsageLogger interface {
+	// LogUsage writes token usage, cost, and latency metrics to the
+	// terminal and optionally to the specified log file. startTime is
+	// the time the LLM request was initiated, used to compute duration.
 	LogUsage(ctx context.Context, m *llm.Metrics, logFile string, startTime time.Time)
 }
 
 // ToolLogger defines the interface for logging tool calls and results.
 type ToolLogger interface {
+	// LogToolCall renders a tool invocation to the user. turn and
+	// maxTurns provide progress context (e.g., "tool 2/5").
+	// When showTools is false, the call is logged at debug level only.
 	LogToolCall(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool)
+
+	// LogToolResult renders the outcome of a tool execution. When
+	// showTools is false, only errors are displayed.
 	LogToolResult(ctx context.Context, name string, result tools.ToolResult, showTools bool)
 }
 
 // RendererConfigurator defines the interface for configuring renderer behavior.
 type RendererConfigurator interface {
+	// SetUseColor enables or disables ANSI color output for subsequent
+	// rendering operations. Safe to call at any time.
 	SetUseColor(use bool)
+
+	// SetForceSpinner forces the spinner to appear even when output is
+	// not a terminal. Useful for testing or when piping to a pager.
 	SetForceSpinner(force bool)
+
+	// IsTerminalContext reports whether the renderer is connected to
+	// an interactive terminal. This determines default spinner behavior.
 	IsTerminalContext() bool
 }
 
@@ -57,14 +96,21 @@ type UIRenderer interface {
 
 // HistoryRenderer defines the interface for rendering chat history.
 type HistoryRenderer interface {
+	// Render writes a formatted representation of the last n entries
+	// from the HistoryReader to w. The options control formatting:
+	// Raw disables markdown rendering, ShowThoughts includes reasoning
+	// blocks, and UseColor enables ANSI color output.
 	Render(w io.Writer, h HistoryReader, n int, options HistoryRenderOptions)
 }
 
 // HistoryRenderOptions defines the options for rendering chat history.
 type HistoryRenderOptions struct {
-	Raw          bool
+	// Raw disables markdown rendering and special formatting.
+	Raw bool
+	// ShowThoughts includes extracted reasoning/thinking blocks in the output.
 	ShowThoughts bool
-	UseColor     bool
+	// UseColor enables ANSI color escape sequences in the output.
+	UseColor bool
 }
 
 // SystemMetricsProvider defines the interface for collecting host resource usage.

--- a/internal/domain/ports/repository.go
+++ b/internal/domain/ports/repository.go
@@ -14,11 +14,23 @@ var (
 	ErrTaskNotFound = errors.New("task not found")
 )
 
-// KVStore defines a generic key-value storage interface.
+// KVStore defines a generic key-value storage interface for persisting
+// simple configuration and settings data.
 type KVStore interface {
+	// Get retrieves the value for the given key. Returns an empty
+	// string if the key does not exist. The implementation determines
+	// whether a missing key is an error.
 	Get(ctx context.Context, key string) (string, error)
+
+	// Set stores a value for the given key, overwriting any existing
+	// value. The change is immediately durable.
 	Set(ctx context.Context, key string, val string) error
+
+	// Delete removes the given key and its value. It is a no-op if
+	// the key does not exist.
 	Delete(ctx context.Context, key string) error
+
+	// GetAll returns a copy of all key-value pairs currently stored.
 	GetAll(ctx context.Context) (map[string]string, error)
 }
 
@@ -31,8 +43,10 @@ type ListFilter struct {
 	Before    time.Time // zero = no upper bound on CreatedAt
 }
 
-// ListStore defines a generic list storage interface.
+// ListStore defines a generic list storage interface for ordered,
+// filterable collections of items.
 type ListStore[T any] interface {
+	// ReadAll returns every item in the store in insertion order.
 	ReadAll(ctx context.Context) ([]T, error)
 
 	// Query returns items matching the filter, bounded by limit and offset.
@@ -42,17 +56,28 @@ type ListStore[T any] interface {
 	// Count returns the total number of items in the store.
 	Count(ctx context.Context) (int, error)
 
+	// Append adds an item to the end of the store.
 	Append(ctx context.Context, item T) error
+
+	// Update replaces the item at the given zero-based index.
 	Update(ctx context.Context, id int64, item T) error
+
+	// Delete removes the item at the given zero-based index.
 	Delete(ctx context.Context, id int64) error
+
+	// DeleteAll removes every item from the store.
 	DeleteAll(ctx context.Context) error
 }
 
 // Task represents a unit of work in the to-do list.
 type Task struct {
-	ID        int64     `json:"id"`
-	Content   string    `json:"content"`
-	Status    string    `json:"status"` // pending, completed
+	// ID is the unique, monotonically increasing identifier.
+	ID int64 `json:"id"`
+	// Content is the human-readable description of the task.
+	Content string `json:"content"`
+	// Status is the current state: "pending" or "completed".
+	Status string `json:"status"`
+	// CreatedAt records when the task was added.
 	CreatedAt time.Time `json:"created_at"`
 }
 
@@ -78,9 +103,19 @@ type TaskReader interface {
 
 // TaskWriter defines the interface for modifying tasks.
 type TaskWriter interface {
+	// AddTask creates a new task with the given content and "pending" status.
+	// Returns the created task with its assigned ID.
 	AddTask(ctx context.Context, content string) (Task, error)
+
+	// UpdateTask modifies the content and/or status of an existing task.
+	// An empty content string leaves the content unchanged.
 	UpdateTask(ctx context.Context, id int64, content, status string) (Task, error)
+
+	// DeleteTask removes the task with the given ID. Returns an error
+	// if the task does not exist.
 	DeleteTask(ctx context.Context, id int64) error
+
+	// ClearTasks removes all tasks from the store.
 	ClearTasks(ctx context.Context) error
 }
 
@@ -92,19 +127,31 @@ type TaskStore interface {
 
 // Initializer defines an interface for components requiring lifecycle initialization.
 type Initializer interface {
+	// Initialize performs one-time setup (e.g., creating database tables,
+	// running migrations). It must be called before any other methods.
+	// Implementations must be idempotent.
 	Initialize(ctx context.Context) error
 }
 
 // PersistenceProvider provides access to domain-specific persistence services.
 type PersistenceProvider interface {
+	// GetTasks returns the task management store.
 	GetTasks() TaskStore
+
+	// GetSettings returns the key-value store for application settings.
 	GetSettings() KVStore
+
+	// GetHealthChecker returns a health checker for the persistence layer.
 	GetHealthChecker() HealthChecker
 }
 
 // SessionStateProvider manages session-level metadata and state.
 type SessionStateProvider interface {
+	// GetInfo returns a snapshot of the current session metadata.
 	GetInfo() SessionInfo
+
+	// SetInfo replaces the session metadata. The update is immediate
+	// and visible to subsequent GetInfo calls.
 	SetInfo(info SessionInfo)
 }
 

--- a/internal/domain/ports/session.go
+++ b/internal/domain/ports/session.go
@@ -24,9 +24,12 @@ const (
 
 // Session encapsulates the state of a single conversation session.
 type Session struct {
-	ID        string
+	// ID is the unique identifier for this session, typically a UUID.
+	ID string
+	// StartTime records when the session was created.
 	StartTime time.Time
-	History   HistoryManager
+	// History provides access to the conversation's persisted message history.
+	History HistoryManager
 }
 
 // NewSession creates a new Session state.
@@ -40,17 +43,33 @@ func NewSession(id string, h HistoryManager) *Session {
 
 // ChatExecutor defines the interface for executing chat turns and lifecycle management.
 type ChatExecutor interface {
+	// Chat executes a single conversation turn. It blocks until the turn
+	// completes (including all tool calls) or the context is cancelled.
+	// The prompt is the user's input text; the session provides history
+	// and configuration context.
 	Chat(ctx context.Context, s *Session, prompt string) error
+
+	// Shutdown initiates graceful shutdown of the chat executor. It blocks
+	// until all in-flight operations complete or the context is cancelled.
+	// After Shutdown returns, no further Chat calls should be made.
 	Shutdown(ctx context.Context) error
 }
 
 // ChatConfigurator defines the interface for configuring chat parameters.
 type ChatConfigurator interface {
+	// SetLimits configures the maximum number of tool-calling turns,
+	// the history token budget, and the history turn budget.
+	// A value of 0 for any parameter means "no limit" (or the system default).
+	// This method is safe to call between Chat invocations.
 	SetLimits(ctx context.Context, toolTurns, historyTokens, historyTurns int) error
 }
 
 // ChatEventSource defines the interface for subscribing to chat events.
 type ChatEventSource interface {
+	// Subscribe registers a callback that receives all chat events published
+	// by this Chatter. The callback is invoked synchronously on the event
+	// publisher's goroutine. Callers must not block inside the callback.
+	// Multiple subscribers are supported; the order of delivery is undefined.
 	Subscribe(sub func(context.Context, events.Event))
 }
 
@@ -63,11 +82,16 @@ type Chatter interface {
 
 // ChatterConfig encapsulates the primitive configuration for a Chatter instance.
 type ChatterConfig struct {
+	// ProviderName identifies the LLM provider (e.g., "openai", "anthropic", "google").
 	ProviderName string
-	Model        string
-	Mode         string
-	LogPath      string
-	TracePath    string
+	// Model specifies the LLM model name (e.g., "gpt-5", "claude-3-5-sonnet").
+	Model string
+	// Mode selects the agent personality/mode (e.g., "architect", "coder", "reviewer").
+	Mode string
+	// LogPath is the filesystem path for writing structured chat logs.
+	LogPath string
+	// TracePath is the filesystem path for writing detailed execution traces.
+	TracePath string
 }
 
 // ChatterFactory defines the functional signature for creating a Chatter instance.
@@ -75,18 +99,38 @@ type ChatterFactory func(ctx context.Context, deps SessionDependencies, cfg Chat
 
 // SessionConfig defines the configuration interface for a session.
 type SessionConfig interface {
+	// GetPrompt returns the user's input prompt for the current turn.
 	GetPrompt() string
+
+	// GetLastN returns the number of recent history entries to display.
 	GetLastN() int
+
+	// GetBackN returns the number of turns to roll back when processing
+	// a history navigation command.
 	GetBackN() int
+
+	// GetRawOutput returns true if markdown rendering should be disabled
+	// and output should be displayed as plain text.
 	GetRawOutput() bool
+
+	// GetConfig returns the full application configuration.
 	GetConfig() *config.Config
 }
 
 // LLMDependencyProvider provides access to LLM-related services.
 type LLMDependencyProvider interface {
+	// GetGateway returns the LLM gateway used for generating responses.
 	GetGateway() llm.LLMGateway
+
+	// GetPricingOverrides returns user-configured pricing overrides
+	// that supplement or replace the built-in pricing data.
 	GetPricingOverrides() map[string]pricing.ModelPricing
+
+	// GetTracker returns the cost tracker for monitoring cumulative
+	// token usage and estimated spend.
 	GetTracker() pricing.CostTracker
+
+	// GetPricingData returns the built-in pricing data for all known models.
 	GetPricingData() pricing.PricingData
 }
 
@@ -114,43 +158,90 @@ type SessionDependencies interface {
 	InfrastructureDependencyProvider
 }
 
-// ContextMetadata contains diagnostics and auxiliary data from the pipeline.
+// ContextMetadata contains diagnostics and auxiliary data produced by the
+// context preparation pipeline (pruning, summarization, truncation).
+//
+// Consumers receive this via ContextRequest and should treat it as
+// read-only except for Warnings (which may be appended to).
 type ContextMetadata struct {
-	OriginalTokenCount     int
-	FinalTokenCount        int
-	FinalTurnCount         int
-	PrunedTurns            int
-	SummarizedTurns        int
+	// OriginalTokenCount is the token count of the full history before any
+	// pruning or summarization was applied.
+	OriginalTokenCount int
+	// FinalTokenCount is the token count after all transformations.
+	FinalTokenCount int
+	// FinalTurnCount is the number of conversation turns retained after pruning.
+	FinalTurnCount int
+	// PrunedTurns is the number of turns removed by pruning policies.
+	PrunedTurns int
+	// SummarizedTurns is the number of turns replaced by a summary.
+	SummarizedTurns int
+	// SummarizationAttempted is true if the summarizer was invoked,
+	// regardless of whether it succeeded.
 	SummarizationAttempted bool
-	MaintenanceBlocked     bool
-	Warnings               []string
-	TotalTurnsKept         int
-	KeptByPolicy           map[string]int
-	History                []*llm.Content
+	// MaintenanceBlocked is true if context maintenance was skipped
+	// (e.g., because the conversation is too short to benefit).
+	MaintenanceBlocked bool
+	// Warnings collects non-fatal diagnostic messages from the pipeline.
+	// Consumers may append to this slice.
+	Warnings []string
+	// TotalTurnsKept is the total number of turns retained across all
+	// retention policies.
+	TotalTurnsKept int
+	// KeptByPolicy maps each pruning policy name to the number of turns
+	// that policy elected to keep.
+	KeptByPolicy map[string]int
+	// History is the post-transform content slice that will be sent to
+	// the LLM. Callers must Clone before mutating.
+	History []*llm.Content
 }
 
 // ContextRequest represents the input and state of a context preparation pipeline.
 type ContextRequest struct {
-	Turn           int
-	History        []*llm.Content
-	Metadata       ContextMetadata
+	// Turn is the zero-based index of the current conversation turn.
+	Turn int
+	// History is the raw, pre-transform conversation history.
+	// Transformers may replace or truncate this slice.
+	History []*llm.Content
+	// Metadata accumulates diagnostics as the request flows through the
+	// transformer chain. Transformers should update relevant fields.
+	Metadata ContextMetadata
+	// PersistHistory indicates whether the final History should be
+	// persisted after the pipeline completes. Set by the orchestrator.
 	PersistHistory bool
 }
 
 // PruningPolicy defines how to mark turns for pruning.
 type PruningPolicy interface {
+	// MarkTurns evaluates each turn group and sets the corresponding
+	// keep[i] to true if the turn should be retained. It returns the
+	// number of turns marked for retention. A non-nil error aborts the
+	// pruning pipeline.
 	MarkTurns(ctx context.Context, turns [][]*llm.Content, keep []bool) (int, error)
+
+	// Name returns a human-readable identifier for this policy,
+	// used in ContextMetadata.KeptByPolicy and diagnostic logs.
 	Name() string
 }
 
 // ContextTransformer modifies the context before it's sent to the LLM.
+// Transformers are applied in ascending Priority order.
 type ContextTransformer interface {
+	// Transform applies a mutation to the ContextRequest. Common
+	// transformations include summarization, truncation, and pruning.
+	// Implementations must be safe for single-goroutine sequential use;
+	// concurrent invocation is not required.
 	Transform(ctx context.Context, req *ContextRequest) error
+
+	// Priority returns the execution order of this transformer.
+	// Lower values execute first. Values need not be contiguous.
 	Priority() int
 }
 
 // ResultStrategy defines how tool outputs are transformed back into LLM messages.
 type ResultStrategy interface {
+	// Format converts a tool execution result into an LLM-compatible Part.
+	// The call parameter provides the original function invocation context;
+	// the result parameter contains the tool's output.
 	Format(call *llm.FunctionCall, result tools.ToolResult) *llm.Part
 }
 

--- a/internal/domain/tools/doc.go
+++ b/internal/domain/tools/doc.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package tools defines the domain model for the tool execution system.
+//
+// # Core Concepts
+//
+// Tools are functions callable by the LLM during a conversation turn. Each
+// tool has a ToolDeclaration (name, description, JSON Schema parameters,
+// consent requirements) and a handler function (ToolFunc).
+//
+// # Tool Execution Lifecycle
+//
+//  1. The LLM requests a tool call via a FunctionCall in its response.
+//  2. The orchestrator looks up the tool in the Registry and invokes it
+//     via ToolExecutor.Execute.
+//  3. The tool handler (ToolFunc) runs, optionally sending heartbeat
+//     signals on the provided channel to indicate liveness.
+//  4. ZombieTool monitors long-running tools and reports stalled
+//     executions to the ExecutionObserver.
+//  5. The tool's output (ToolResult) is formatted and sent back to the LLM.
+//
+// # Concurrency Model
+//
+// Tools may be executed concurrently unless ToolOptions.Serial is set.
+// Long-running tools (ToolOptions.LongRunning) are exempt from default
+// timeouts. Heartbeat monitoring (ToolOptions.LivenessThreshold) detects
+// hung tools — a ZombieTool declares the execution timed out if no
+// heartbeat is received within the threshold.
+//
+// # Registry Architecture
+//
+// The Registry is the central tool catalog, composed of three role
+// interfaces:
+//   - ToolRegistrar: adds tools to the registry (startup/wiring phase)
+//   - ToolExecutor: invokes tools at runtime
+//   - ToolMetadataProvider: lists available tools for LLM function calling
+//
+// Toolkits allow grouping related tools (e.g., "git", "file", "network")
+// for lazy-loading and scoped declaration requests.
+//
+// # Error Conventions
+//
+// Sentinel errors (ErrNotImplemented, ErrUserDeclined, ErrSecurityPolicy)
+// signal terminal failures that the orchestrator must not retry.
+// ToolFunc implementations return errors in ToolResult.Error for
+// tool-specific failures that may be reported to the LLM.
+package tools

--- a/internal/domain/tools/errors.go
+++ b/internal/domain/tools/errors.go
@@ -5,8 +5,21 @@ package tools
 
 import "errors"
 
+// Sentinel errors for tool execution. These errors signal terminal
+// (non-retryable) failures to the orchestrator.
 var (
+	// ErrNotImplemented is returned when a tool's functionality has not
+	// been implemented yet. The orchestrator treats this as a terminal
+	// failure and does not retry.
 	ErrNotImplemented = errors.New("not implemented")
-	ErrUserDeclined   = errors.New("user explicitly declined the action")
+
+	// ErrUserDeclined is returned when the user explicitly declines a
+	// tool's consent prompt. The orchestrator treats this as a terminal
+	// failure and does not retry.
+	ErrUserDeclined = errors.New("user explicitly declined the action")
+
+	// ErrSecurityPolicy is returned when a tool invocation is blocked
+	// by the security manager. The orchestrator treats this as a terminal
+	// failure and does not retry.
 	ErrSecurityPolicy = errors.New("action blocked by security policy")
 )

--- a/internal/domain/tools/executor.go
+++ b/internal/domain/tools/executor.go
@@ -8,8 +8,19 @@ import (
 )
 
 // CommandExecutor defines the interface for executing system commands.
+// It mirrors os/exec.Cmd but accepts a context for cancellation.
 type CommandExecutor interface {
+	// Output runs the command and returns its standard output.
+	// If the command exits with a non-zero status, the error is of type
+	// *exec.ExitError and includes the stderr output.
 	Output(ctx context.Context, name string, args ...string) ([]byte, error)
+
+	// CombinedOutput runs the command and returns its combined standard
+	// output and standard error.
 	CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error)
+
+	// LookPath searches for an executable named file in the directories
+	// named by the PATH environment variable. It returns the absolute
+	// path if found, or an error if not.
 	LookPath(file string) (string, error)
 }

--- a/internal/domain/tools/types.go
+++ b/internal/domain/tools/types.go
@@ -11,34 +11,61 @@ import (
 
 // ToolDeclaration represents a function that can be called by the model.
 type ToolDeclaration struct {
-	Name            string
-	Description     string
-	Parameters      *Schema
+	// Name is the unique identifier for this tool. It is used by the
+	// LLM when requesting a function call and by the Registry for lookup.
+	Name string
+	// Description is a natural-language explanation of what the tool does.
+	// It is included in the LLM's system prompt to guide function selection.
+	Description string
+	// Parameters defines the JSON Schema for the tool's arguments.
+	// When nil, the tool accepts no arguments.
+	Parameters *Schema
+	// RequiresConsent indicates whether the user must approve the tool
+	// invocation before it executes. Consent prompts are displayed by
+	// the orchestrator before calling the handler.
 	RequiresConsent bool
 }
 
-// Schema represents the parameters of a tool.
+// Schema represents the JSON Schema for a tool's parameters.
+// It follows a subset of JSON Schema Draft 2020-12.
 type Schema struct {
-	Type        string             `json:"type"`
-	Description string             `json:"description,omitempty"`
-	Properties  map[string]*Schema `json:"properties,omitempty"`
-	Required    []string           `json:"required,omitempty"`
-	Enum        []string           `json:"enum,omitempty"`
-	Items       *Schema            `json:"items,omitempty"`
+	// Type is the JSON type: "object", "string", "number", "boolean", "array".
+	Type string `json:"type"`
+	// Description provides a natural-language explanation of this parameter.
+	Description string `json:"description,omitempty"`
+	// Properties defines the fields when Type is "object". Keys are
+	// parameter names; values are nested schemas.
+	Properties map[string]*Schema `json:"properties,omitempty"`
+	// Required lists the parameter names that must be provided.
+	Required []string `json:"required,omitempty"`
+	// Enum restricts values to a fixed set when Type is "string".
+	Enum []string `json:"enum,omitempty"`
+	// Items defines the element schema when Type is "array".
+	Items *Schema `json:"items,omitempty"`
 }
 
 // ToolResult represents the outcome of a tool execution.
 type ToolResult struct {
-	Text       string
+	// Text is the primary human-readable output of the tool.
+	// It is included in the LLM context as the tool's response.
+	Text string
+	// BinaryData contains multi-modal output (e.g., images, files)
+	// produced by the tool.
 	BinaryData []BinaryData
-	Error      error                  // Optional: captures the error that occurred during execution
-	Metadata   map[string]interface{} // Metadata allows passing structured data back to the orchestrator
+	// Error captures a non-terminal error that occurred during execution.
+	// The orchestrator may relay this to the LLM for recovery.
+	Error error
+	// Metadata allows passing structured data back to the orchestrator
+	// for post-processing (e.g., file paths, record IDs).
+	Metadata map[string]interface{}
 }
 
-// BinaryData represents multi-modal content.
+// BinaryData represents multi-modal content produced by a tool.
 type BinaryData struct {
+	// MIMEType is the IANA media type (e.g., "image/png", "application/pdf").
 	MIMEType string
-	Data     []byte
+	// Data is the raw binary content.
+	Data []byte
 }
 
 // UnmarshalArgs helper converts map[string]interface{} to a target struct.
@@ -51,6 +78,17 @@ func UnmarshalArgs(args map[string]interface{}, target interface{}) error {
 }
 
 // ToolFunc is the signature for Go functions that can be called by the model.
+//
+// The hb chan<- struct{} is a heartbeat channel. When ToolOptions.LivenessThreshold
+// is greater than zero, the tool implementation MUST send a heartbeat at intervals
+// not exceeding the threshold. Failure to send heartbeats causes ZombieTool to
+// declare the execution timed out.
+//
+// Sending heartbeats is optional when LivenessThreshold is zero. The implementation
+// MUST NOT close the channel.
+//
+// The returned ToolResult may contain an Error field; the orchestrator inspects
+// this to determine whether to report the failure to the LLM.
 type ToolFunc func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (ToolResult, error)
 
 // ToolOptions defines execution behavior for a tool.
@@ -61,10 +99,24 @@ type ToolOptions struct {
 }
 
 // ToolRegistrar defines the interface for adding tools to the registry.
+// Registration must happen before the first tool execution; concurrent
+// registration and execution is not supported.
 type ToolRegistrar interface {
+	// Register adds a tool with default options. Returns an error if
+	// a tool with the same name is already registered.
 	Register(def *ToolDeclaration, handler ToolFunc) error
+
+	// RegisterWithOptions adds a tool with custom execution options
+	// (e.g., Serial, LongRunning, LivenessThreshold).
 	RegisterWithOptions(def *ToolDeclaration, handler ToolFunc, opts ToolOptions) error
+
+	// RegisterToToolkit adds a tool to a named toolkit. Toolkit
+	// membership is used for lazy-loading and scoped declaration
+	// requests. The toolkit is created if it does not exist.
 	RegisterToToolkit(toolkit string, def *ToolDeclaration, handler ToolFunc) error
+
+	// RegisterToToolkitWithOptions adds a tool to a named toolkit
+	// with custom execution options.
 	RegisterToToolkitWithOptions(toolkit string, def *ToolDeclaration, handler ToolFunc, opts ToolOptions) error
 }
 
@@ -77,10 +129,22 @@ type ToolExecutor interface {
 }
 
 // ToolMetadataProvider defines the interface for listing available tools.
+// The declarations returned are used to construct the LLM's function-calling
+// schema in each request.
 type ToolMetadataProvider interface {
+	// GetDeclarations returns all registered tool declarations.
 	GetDeclarations() []*ToolDeclaration
+
+	// GetCoreDeclarations returns declarations for tools that are
+	// always available, regardless of which toolkits are loaded.
 	GetCoreDeclarations() []*ToolDeclaration
+
+	// GetDeclarationsByToolkits returns declarations for all tools
+	// belonging to any of the specified toolkits. Duplicates are
+	// resolved by name (last wins).
 	GetDeclarationsByToolkits(toolkits []string) []*ToolDeclaration
+
+	// ListAvailableToolkits returns the names of all registered toolkits.
 	ListAvailableToolkits() []string
 }
 

--- a/internal/domain/tools/zombie.go
+++ b/internal/domain/tools/zombie.go
@@ -10,16 +10,26 @@ import (
 )
 
 // ExecutionObserver defines the domain's external monitoring needs.
+// Implementations receive callbacks when tool goroutines exhibit
+// abnormal lifecycle behavior.
 type ExecutionObserver interface {
+	// ExecutionTimedOut is called when a tool fails to complete or
+	// send a heartbeat within the configured LivenessThreshold.
 	ExecutionTimedOut(toolID string)
+
+	// ExecutionCompletedLate is called when a tool finishes execution
+	// after its context has been cancelled, indicating a goroutine
+	// that outlived its intended lifetime.
 	ExecutionCompletedLate(toolID string)
 }
 
 // ToolOutput captures the result and error of a tool execution.
 // It is used to monitor goroutines that may outlive their context.
 type ToolOutput struct {
+	// Result is the tool's output, populated only when Err is nil.
 	Result ToolResult
-	Err    error
+	// Err is the error returned by the tool handler, or nil on success.
+	Err error
 }
 
 // ZombieTool handles the monitoring of potentially leaked tool goroutines.

--- a/internal/infrastructure/llm/doc.go
+++ b/internal/infrastructure/llm/doc.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package llm provides the infrastructure layer for LLM provider integration.
+//
+// # Components
+//
+// Factory (factory.go):
+//
+//	NewClient is the central factory that inspects configuration and
+//	instantiates the appropriate provider client (OpenAI, Anthropic, or
+//	Google Gemini). It handles authentication, timeout resolution,
+//	thinking budget, and wraps the result in a resilient client.
+//
+// Resilience (resilient_client.go):
+//
+//	NewResilientClient wraps any LLMClient with automatic retry on
+//	transient failures, auth token refresh, and connection reset. It
+//	classifies errors using the llmerr package and delegates to the
+//	underlying client for normal operation.
+//
+// Health (provider_health.go):
+//
+//	NewLLMProviderHealthChecker performs connectivity and authentication
+//	checks against the configured LLM provider. It implements
+//	ports.HealthChecker and reports per-component status.
+//
+// Summarization (summarizer.go):
+//
+//	NewSummarizer implements ports.Summarizer using the LLM gateway to
+//	compress conversation history into a structured Markdown summary.
+//	It strips binary data before sending to avoid INVALID_ARGUMENT errors.
+//
+// # Sub-Packages
+//
+//   - anthropic: Anthropic Messages API client
+//   - openai: OpenAI Chat Completions API client (also supports DeepSeek)
+//   - gemini: Google Gemini / Vertex AI client
+//   - llmerr: Unified error classification across all providers
+package llm

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -29,7 +29,27 @@ import (
 // Pinned by TestFactory_MaxTokensAboveSoftCeiling_EmitsWarning.
 const softMaxTokensCeiling = 200_000
 
-// NewClient is the central factory for creating LLM providers.
+// NewClient is the central factory for creating LLM provider clients.
+//
+// It inspects cfg.GetActiveProvider() to determine the provider type
+// ("openai", "deepseek", "anthropic", "google", "gemini"), creates the
+// appropriate authenticator, resolves timeout and thinking budget, and
+// instantiates a provider-specific client. The resulting client is
+// wrapped in a resilientClient for automatic retry on transient failures.
+//
+// Parameters:
+//   - cfg: must have at least one configured provider with a non-empty
+//     Type. The active provider is determined by cfg.SelectedProvider.
+//   - pData: pricing data used to resolve per-model token limits and
+//     thinking budget caps.
+//   - bus: event bus for publishing usage metrics and diagnostics.
+//     May be nil, in which case metrics are not published.
+//   - logger: if nil, a NoOpLogger is used. The logger receives
+//     provider configuration diagnostics and soft warnings.
+//
+// Returns an llm.ExtendedClient ready for concurrent use, or an error
+// if no provider is configured or authentication setup fails. Unknown
+// provider types fall back to Gemini for backward compatibility.
 func NewClient(cfg *config.Config, pData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 	p := cfg.GetActiveProvider()
 
@@ -177,7 +197,20 @@ func resolveTimeout(cfg *config.Config) time.Duration {
 	return timeout
 }
 
-// CreateAuthenticator exposed for toolchain/health checks.
+// CreateAuthenticator creates an authenticator for the given provider
+// configuration. It is the public entry point for authentication setup,
+// used by the toolchain and health check subsystems.
+//
+// The authenticator type is determined by the provider type and
+// available credentials:
+//   - APIKey: BearerAuth (OpenAI/DeepSeek), AnthropicAuth, or
+//     APIKeyAuth (Google/Gemini with explicit key)
+//   - Service Account JSON file: ServiceAccountAuth
+//   - Google/Gemini without API key: VertexAuth (Application Default
+//     Credentials)
+//
+// Returns an error if no credentials are available and the provider
+// does not support credential-less authentication.
 func CreateAuthenticator(p *config.LLMProvider) (auth.Authenticator, error) {
 	return createAuthenticator(p)
 }


### PR DESCRIPTION
Closes #613.

## Summary
Systematic audit of godoc documentation for exported symbols across the three priority targets:

- **internal/domain/ports/** — All 51 exported types/interfaces documented with package-level overview, method contracts, field usage guidance, and concurrency semantics
- **internal/domain/tools/** — All exported symbols documented including critical ToolFunc heartbeat semantics, sentinel errors, and Registry architecture
- **internal/infrastructure/llm/factory.go** — Package-level doc with component overview, expanded NewClient parameter documentation, and CreateAuthenticator credential selection logic

## Changes
| Package | Files | Changes |
|---------|-------|---------|
|  | 9 files (+1 new doc.go) | Package doc, all interfaces, structs, methods, fields |
|  | 5 files (+1 new doc.go) | Package doc, sentinel errors, ToolFunc heartbeat contract, Registry |
|  | 2 files (+1 new doc.go) | Package doc, NewClient, CreateAuthenticator |

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go vet ./... | PASS |
| go test ./... | PASS |
| go doc (ports, tools, llm) | All non-empty package overviews |
| make check-full | Partial: fmt/tidy/build/vet/test pass |