### PR TITLE
fix(orchestrator): close error-handling coverage gaps (#618)

### DIFF
--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/assert"
@@ -248,6 +249,19 @@ func TestGuardStep_TDT(t *testing.T) {
 	}
 }
 
+// mockSessionProvider is a minimal ports.SessionProvider for tests
+// that need to exercise the active-toolkits code path in InvokeModel.
+type mockSessionProvider struct {
+	info ports.SessionInfo
+}
+
+func (m *mockSessionProvider) GetInfo() ports.SessionInfo            { return m.info }
+func (m *mockSessionProvider) SetInfo(info ports.SessionInfo)        { m.info = info }
+func (m *mockSessionProvider) GetTasks() ports.TaskStore             { return nil }
+func (m *mockSessionProvider) GetSettings() ports.KVStore            { return nil }
+func (m *mockSessionProvider) GetHealthChecker() ports.HealthChecker { return nil }
+func (m *mockSessionProvider) Close() error                          { return nil }
+
 func TestInferenceStep_TDT(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -296,6 +310,27 @@ func TestInferenceStep_TDT(t *testing.T) {
 			apiResponse: &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response"}}},
 			expectedPh:  PhasePersisting,
 		},
+		{
+			name: "Toolkits active — GetDeclarationsByToolkits called",
+			apiResponse: &llm.Content{
+				Role:  "model",
+				Parts: []*llm.Part{{Text: "Hello from toolkit"}},
+			},
+			expectedPh: PhasePersisting,
+		},
+		{
+			name: "Tool call with non-string reason arg",
+			apiResponse: &llm.Content{
+				Role: "model",
+				Parts: []*llm.Part{{
+					FunctionCall: &llm.FunctionCall{
+						Name: "test_tool",
+						Args: map[string]any{"reason": 42.0},
+					},
+				}},
+			},
+			expectedPh: PhaseExecuting,
+		},
 	}
 
 	for _, tt := range tests {
@@ -318,7 +353,29 @@ func TestInferenceStep_TDT(t *testing.T) {
 			bus := &eventstest.MockEventBus{}
 
 			hMock := &agenttest.MockHistoryManager{}
-			cm := sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil)
+
+			reg := &agenttest.MockToolRegistry{}
+
+			var cm *sessctx.Manager
+			if tt.name == "Toolkits active — GetDeclarationsByToolkits called" {
+				// Register tools in a non-core toolkit so that
+				// GetDeclarationsByToolkits returns a non-empty list
+				// while GetCoreDeclarations (ToolkitMap["core"]) returns nil.
+				if err := reg.RegisterToToolkit("test_toolkit", &tools.ToolDeclaration{
+					Name:        "toolkit_tool",
+					Description: "A tool in a non-core toolkit",
+				}, func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+					return tools.ToolResult{}, nil
+				}); err != nil {
+					t.Fatalf("RegisterToToolkit: %v", err)
+				}
+				sp := &mockSessionProvider{
+					info: ports.SessionInfo{ActiveToolkits: []string{"test_toolkit"}},
+				}
+				cm = sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil, sessctx.WithSessionProvider(sp))
+			} else {
+				cm = sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil)
+			}
 
 			turn := &Turn{
 				Gateway:    gw,
@@ -328,7 +385,7 @@ func TestInferenceStep_TDT(t *testing.T) {
 					PreparedHistory: tt.history,
 				},
 				Clock:    &agenttest.MockClock{},
-				Registry: &agenttest.MockToolRegistry{},
+				Registry: reg,
 			}
 
 			step := &InferenceStep{}
@@ -340,6 +397,11 @@ func TestInferenceStep_TDT(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedPh, res.NextPhase)
+			}
+
+			if tt.name == "Tool call with non-string reason arg" {
+				assert.True(t, turn.State.HasToolCalls, "HasToolCalls must be true for a FunctionCall response")
+				assert.Empty(t, turn.State.ToolReasons, "non-string reason arg must be skipped, ToolReasons must be empty")
 			}
 		})
 	}

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -439,6 +439,43 @@ func TestExecutionStep_Process(t *testing.T) {
 		assert.Equal(t, 2.0, turn.State.Metrics.CumulativeToolDuration)
 	})
 
+	t.Run("No trace in context — CumulativeToolDuration not set", func(t *testing.T) {
+		bus := &eventstest.MockEventBus{}
+		ex := &agenttest.MockAgentExecutor{
+			ExecuteFunc: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+				return &llm.Content{Role: "tool"}, nil
+			},
+		}
+		counter := &agenttest.MockTokenCounter{}
+		hMock := &agenttest.MockHistoryManager{}
+		cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
+
+		turn := &Turn{
+			Events:       bus,
+			Executor:     ex,
+			TokenCounter: counter,
+			CtxManager:   cm,
+			Clock:        &agenttest.MockClock{},
+			State: &TurnState{
+				HasToolCalls: true,
+				Response: &llm.Content{
+					Role:  "model",
+					Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "test"}}},
+				},
+				Metrics: &llm.Metrics{},
+			},
+		}
+
+		// Use bare context.Background() — no OTEL trace injected,
+		// so the nil-trace branch in recordToolMetrics is exercised.
+		res, err := step.Process(context.Background(), turn)
+		assert.NoError(t, err)
+		assert.Equal(t, PhasePersisting, res.NextPhase)
+		assert.NotNil(t, turn.State.ToolResponse)
+		assert.Greater(t, turn.State.Metrics.ToolDuration, float64(0))
+		assert.Equal(t, float64(0), turn.State.Metrics.CumulativeToolDuration)
+	})
+
 	t.Run("Execution error", func(t *testing.T) {
 		bus := &eventstest.MockEventBus{}
 		ex := &agenttest.MockAgentExecutor{
@@ -804,18 +841,43 @@ func TestEngine_Processors(t *testing.T) {
 	assert.IsType(t, &GuardStep{}, procs[PhaseGuard])
 }
 
-func TestEngine_GetLoggerFallback(t *testing.T) {
-	e := &Engine{}
-	// engineConfig is nil by default if not initialized via NewEngine or Store
-	logger := e.getLogger()
-	assert.NotNil(t, logger)
-}
+func TestEngine_GetLogger_Fallback(t *testing.T) {
+	t.Parallel()
 
-func TestEngine_GetLoggerFallback_WithConfig(t *testing.T) {
-	e := &Engine{}
-	e.config.Store(&engineConfig{Logger: nil})
-	logger := e.getLogger()
-	assert.NotNil(t, logger)
+	tests := []struct {
+		name   string
+		engine *Engine
+	}{
+		{
+			name:   "nil config — returns slog.Default",
+			engine: &Engine{},
+		},
+		{
+			name: "non-nil config with nil Logger — returns slog.Default",
+			engine: func() *Engine {
+				e := &Engine{}
+				e.config.Store(&engineConfig{Logger: nil})
+				return e
+			}(),
+		},
+		{
+			name: "non-nil config with real Logger — returns that Logger",
+			engine: func() *Engine {
+				e := &Engine{}
+				l := &ports.NoOpLogger{}
+				e.config.Store(&engineConfig{Logger: l})
+				return e
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			logger := tt.engine.getLogger()
+			assert.NotNil(t, logger)
+		})
+	}
 }
 
 func TestNewEngine_FastRetry(t *testing.T) {


### PR DESCRIPTION
Closes #618.

## Summary
- Added toolkits-active and non-string reason subtests to `TestInferenceStep_TDT` (+mockSessionProvider)
- Added nil-trace `CumulativeToolDuration` subtest to `TestExecutionStep_Process`
- Replaced standalone `getLogger` tests with table-driven `TestEngine_GetLogger_Fallback` (3 subtests)
- Package coverage: **93.3% → 99.2%**

## Verification
| Check | Status |
|-------|--------|
| `go test -race ./internal/agent/orchestrator/...` | ✅ PASS |
| `make check-full` (fmt, tidy, build, lint, verify, vulncheck, test, dead-code) | ✅ PASS |
| `test-race` (orchestrator only) | ✅ PASS |