### PR TITLE
fix(agent): wire config path to enable runtime hot-reload and add E2E test (#629)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -320,6 +320,12 @@ func (a *agent) Chat(ctx context.Context, s *ports.Session, prompt string) error
 	}
 	a.emit(ctx, events.StatusUpdate{Message: "Starting chat...", Level: "info"})
 
+	// Register a hook that refreshes configuration between the inference
+	// and execution phases of each turn. This enables mid-session hot-reload:
+	// if the config file ModTime changes while the LLM is responding, the
+	// updated limits (e.g. MAX_TURNS) take effect before tool execution.
+	a.engine.ApplyOptions(orchestrator.WithEngineHook(&configRefreshHook{a: a}))
+
 	// [REFACTOR] Use errgroup to coordinate the engine run loop and background telemetry workers.
 	// We create a child context that is canceled when either the engine finishes or the background
 	// tasks fail. We also use a defer cancel() to ensure the background tasks are stopped if engine finishes.
@@ -340,6 +346,31 @@ func (a *agent) Chat(ctx context.Context, s *ports.Session, prompt string) error
 	})
 
 	return g.Wait()
+}
+
+// configRefreshHook implements orchestrator.TurnHook to refresh the agent's
+// runtime configuration when transitioning from the Inference phase to the
+// Execution phase. This is the narrow window between receiving the LLM
+// response and executing tool calls — the ideal point for mid-session
+// config hot-reload because:
+//   - The LLM response (which may include tool calls) is already in hand.
+//   - The config file may have been modified while waiting for the LLM.
+//   - Updated limits (MAX_TURNS, context window, etc.) take effect before
+//     the Dispatcher evaluates whether to allow tool execution.
+//
+// Errors from applyConfig are intentionally ignored: Refresh is best-effort
+// per ADR-029 §5, and the hook signature (TurnHook.BeforeTurn) does not
+// return an error. A failed refresh leaves the prior config intact.
+type configRefreshHook struct {
+	a *agent
+}
+
+func (h *configRefreshHook) BeforeTurn(turn *orchestrator.Turn) {}
+func (h *configRefreshHook) AfterTurn(turn *orchestrator.Turn, err error) {}
+func (h *configRefreshHook) OnPhaseTransition(from, to orchestrator.TurnPhase, state *orchestrator.TurnState) {
+	if from == orchestrator.PhaseInference && to == orchestrator.PhaseExecuting {
+		_ = h.a.applyConfig(context.Background())
+	}
 }
 
 // Shutdown gracefully stops the agent and its components.

--- a/internal/agent/orchestrator/engine_execution.go
+++ b/internal/agent/orchestrator/engine_execution.go
@@ -42,7 +42,15 @@ func (p *ExecutionStep) Process(ctx context.Context, Turn *Turn) (ProcessResult,
 
 	toolStart := Turn.Clock.Now()
 
-	toolResponse, err := Turn.Executor.Execute(ctx, Turn.State.Response, Turn.Index, Turn.MaxToolTurns)
+	// Read live limits from the context manager so mid-session config
+	// reloads (ConfigWatcher.Refresh + Reconfigure) are reflected before
+	// tool execution. Falls back to Turn.MaxToolTurns when CtxManager is
+	// nil (e.g. bare Turn structs in unit tests).
+	maxTurns := Turn.MaxToolTurns
+	if Turn.CtxManager != nil {
+		maxTurns = Turn.CtxManager.GetLimits().MaxToolTurns
+	}
+	toolResponse, err := Turn.Executor.Execute(ctx, Turn.State.Response, Turn.Index, maxTurns)
 
 	if toolResponse != nil {
 		Turn.State.ToolResponse = toolResponse

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -49,6 +49,7 @@ func (c *sessionConfig) GetPrompt() string         { return c.Prompt }
 func (c *sessionConfig) GetLastN() int             { return c.LastN }
 func (c *sessionConfig) GetBackN() int             { return c.BackN }
 func (c *sessionConfig) GetRawOutput() bool        { return c.RawOutput }
+func (c *sessionConfig) GetConfigPath() string     { return c.ConfigPath }
 func (c *sessionConfig) GetConfig() *config.Config { return c.Config }
 
 // NewSessionConfig creates a new sessionConfig with required parameters.
@@ -109,6 +110,7 @@ func (o *sessionManager) Run(ctx context.Context, sc ports.SessionConfig, sd por
 		Mode:         cfg.Mode,
 		LogPath:      paths.LogPath,
 		TracePath:    paths.TracePath,
+		ConfigPath:   sc.GetConfigPath(),
 	}
 	chatAgent, err := o.AgentFactory(ctx, sd, chatterCfg)
 	if err != nil {

--- a/internal/domain/ports/session.go
+++ b/internal/domain/ports/session.go
@@ -92,6 +92,9 @@ type ChatterConfig struct {
 	LogPath string
 	// TracePath is the filesystem path for writing detailed execution traces.
 	TracePath string
+	// ConfigPath is the filesystem path to the main YAML configuration file.
+	// Used by the config watcher to detect and apply runtime config changes.
+	ConfigPath string
 }
 
 // ChatterFactory defines the functional signature for creating a Chatter instance.
@@ -112,6 +115,9 @@ type SessionConfig interface {
 	// GetRawOutput returns true if markdown rendering should be disabled
 	// and output should be displayed as plain text.
 	GetRawOutput() bool
+
+	// GetConfigPath returns the filesystem path to the main configuration file.
+	GetConfigPath() string
 
 	// GetConfig returns the full application configuration.
 	GetConfig() *config.Config

--- a/internal/infrastructure/config/watcher_test.go
+++ b/internal/infrastructure/config/watcher_test.go
@@ -717,3 +717,66 @@ type nilSessionLoader struct{}
 func (l *nilSessionLoader) LoadSession(path string) (*domain_config.SessionConfig, error) {
 	return nil, nil
 }
+
+// stubFinder implements domain_config.ConfigFinder for testing.
+type stubFinder struct {
+	path string
+}
+
+func (f *stubFinder) Find() (string, error) {
+	return f.path, nil
+}
+
+func TestFileConfigWatcher_RefreshAfterSetPaths_ReadsConfigLimits(t *testing.T) {
+	tmpDir := t.TempDir()
+	configFilePath := filepath.Join(tmpDir, "config.yaml")
+
+	// Step 1: Write initial config with non-default values.
+	initialYAML := `
+MODE: "assistant"
+MAX_TURNS: 42
+MAX_HISTORY_TOKENS: 50000
+MAX_HISTORY_TURNS: 7
+`
+	if err := os.WriteFile(configFilePath, []byte(initialYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 2: Construct watcher with real YAMLConfigLoader and stubFinder.
+	loader := &YAMLConfigLoader{Finder: &stubFinder{path: configFilePath}}
+	cw := NewFileConfigWatcher(loader, nil, 100, 10, 20, nil)
+	cw.SetPaths(configFilePath, "")
+
+	// Step 3: Refresh and verify limits are read from the config file.
+	cw.Refresh("")
+	tokens, toolTurns, historyTurns := cw.GetLimits()
+
+	if tokens != 50000 {
+		t.Errorf("MAX_HISTORY_TOKENS: got %d, want 50000", tokens)
+	}
+	if toolTurns != 42 {
+		t.Errorf("MAX_TURNS: got %d, want 42", toolTurns)
+	}
+	if historyTurns != 7 {
+		t.Errorf("MAX_HISTORY_TURNS: got %d, want 7", historyTurns)
+	}
+
+	// Step 4: Overwrite the file with updated values and shift mtime forward.
+	updatedYAML := `
+MAX_TURNS: 99
+`
+	if err := os.WriteFile(configFilePath, []byte(updatedYAML), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Force the modification time into the future to guarantee the
+	// watcher's mtime-based change detection fires.
+	futureTime := time.Now().Add(5 * time.Second)
+	if err := os.Chtimes(configFilePath, futureTime, futureTime); err != nil {
+		t.Fatal(err)
+	}
+	cw.Refresh("")
+	_, toolTurns, _ = cw.GetLimits()
+	if toolTurns != 99 {
+		t.Errorf("MAX_TURNS after update: got %d, want 99", toolTurns)
+	}
+}

--- a/internal/infrastructure/factory/chatter.go
+++ b/internal/infrastructure/factory/chatter.go
@@ -98,6 +98,7 @@ func NewChatter(ctx stdctx.Context, deps ports.SessionDependencies, cfg ports.Ch
 		domain_config.DefaultMaxHistoryTurns,
 		deps.GetLogger(),
 	)
+	cw.SetPaths(cfg.ConfigPath, "")
 
 	// 2. Compose Agent Options
 	opts := []agent.AgentOption{

--- a/tests/e2e/hotreload_test.go
+++ b/tests/e2e/hotreload_test.go
@@ -11,28 +11,34 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync/atomic"
 	"testing"
 )
 
-// setupHotReloadMock returns an httptest.Server implementing a multi-turn
-// Google-format mock and an atomic call counter. The server returns:
+// setupHotReloadSingleProcessMock returns an httptest.Server implementing a
+// multi-turn Google-format mock and an atomic call counter. The server:
 //
-//	Turn 0 → list_files tool call
-//	Turn 1 → read_files tool call
-//	Turn 2+→ text response "Done."
+//   - Turn 0 (first LLM call)  → list_files tool call
+//   - Turn 1 (second LLM call) → rewrites configPath to MAX_TURNS: 3,
+//     then returns read_files tool call
+//   - Turn 2+                    → text response "Done."
+//
+// The config path must be known before creating the mock so the handler
+// can mutate it mid-session. The mock URL is obtained from server.URL at
+// handler invocation time.
 //
 // The turn index is derived from the Google API contents array length:
 //
 //	idx := (len(contents) - 1) / 2
-func setupHotReloadMock(t *testing.T) (*httptest.Server, *atomic.Int32) {
+func setupHotReloadSingleProcessMock(t *testing.T, configPath string) (*httptest.Server, *atomic.Int32) {
 	t.Helper()
 
 	var callCount atomic.Int32
+	var configRewritten atomic.Bool
+	var serverPtr atomic.Pointer[httptest.Server]
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount.Add(1)
+		count := callCount.Add(1)
 
 		bodyBytes, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -51,12 +57,20 @@ func setupHotReloadMock(t *testing.T) (*httptest.Server, *atomic.Int32) {
 			contents = nil
 		}
 
-		// Google provider: each turn adds 2 messages (model + user/tool).
-		// contents[0]=user prompt, contents[1]=model tool call,
-		// contents[2]=tool response, etc.
 		idx := (len(contents) - 1) / 2
 		if idx < 0 {
 			idx = 0
+		}
+
+		// On the second LLM call (turn 1), rewrite config to MAX_TURNS: 3
+		// before returning the read_files tool call. The agent will detect
+		// the ModTime change via ConfigWatcher.Refresh() before executing
+		// the tool, allowing the read_files call to succeed.
+		if count == 2 && !configRewritten.Swap(true) {
+			srv := serverPtr.Load()
+			if srv != nil {
+				writeConfig(t, configPath, srv.URL, 3)
+			}
 		}
 
 		var response string
@@ -80,6 +94,9 @@ func setupHotReloadMock(t *testing.T) (*httptest.Server, *atomic.Int32) {
 			t.Logf("HOTRELOAD_MOCK: failed to write response: %v", err)
 		}
 	}))
+
+	// Store the server pointer for the handler closure to use.
+	serverPtr.Store(server)
 
 	return server, &callCount
 }
@@ -105,11 +122,19 @@ MAX_HISTORY_TOKENS: 1000000
 	}
 }
 
-// TestConfigHotReload_MaxTurns verifies that MAX_TURNS is reloaded
-// from the config file between invocations when the session directory
-// is reused. The test runs the binary twice against the same home
-// directory, overwriting the config with a higher MAX_TURNS value
-// for the second run.
+// TestConfigHotReload_MaxTurns verifies that MAX_TURNS is dynamically
+// reloaded from the config file mid-session within a single CLI invocation.
+// The mock HTTP server rewrites the config file when it receives the second
+// LLM request, increasing MAX_TURNS from 1 to 3. The agent detects the
+// ModTime change via ConfigWatcher.Refresh() between the inference and
+// execution phases, allowing the third tool call to proceed.
+//
+// Sequence:
+//   - Turn 0: LLM returns list_files → executor runs it (turn 0 < MAX_TURNS 1)
+//   - Between turns: Mock rewrites config to MAX_TURNS: 3 on second LLM call
+//   - Turn 1: Refresh() detects ModTime change → maxToolTurns becomes 3 →
+//     read_files is allowed (turn 1 < 3)
+//   - Turn 2: LLM returns "Done." → agent exits cleanly
 func TestConfigHotReload_MaxTurns(t *testing.T) {
 	t.Parallel()
 	if testing.Short() {
@@ -118,12 +143,14 @@ func TestConfigHotReload_MaxTurns(t *testing.T) {
 
 	homeDir := t.TempDir()
 
-	// Step 1: Setup mock server with call counter
-	server, callCount := setupHotReloadMock(t)
+	// Step 1: Setup config path (must be known before mock creation)
+	configPath := filepath.Join(homeDir, "config.yaml")
+
+	// Step 2: Create mock server that rewrites config on second LLM call
+	server, callCount := setupHotReloadSingleProcessMock(t, configPath)
 	defer server.Close()
 
-	// Step 2: Write config A with MAX_TURNS: 1
-	configPath := filepath.Join(homeDir, "config.yaml")
+	// Step 3: Write initial config with MAX_TURNS: 1
 	writeConfig(t, configPath, server.URL, 1)
 
 	env := []string{
@@ -131,40 +158,19 @@ func TestConfigHotReload_MaxTurns(t *testing.T) {
 		"TELL_ME_MOCK_URL=" + server.URL,
 	}
 
-	// Step 3: Invocation 1 — agent makes 2 LLM calls, then MAX_TURNS=1 stops it.
-	// Turn 0: list_files (executed). Turn 1: read_files (LLM called but tool
-	// execution blocked by Dispatcher's >= check, as maxToolTurns=1).
-	// The agent exits non-zero when MAX_TURNS is exhausted; this is expected.
-	_, stderr, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "process files")
+	// Step 4: Single invocation — agent starts with MAX_TURNS: 1, but
+	// after the mock rewrites the config mid-session, the hot-reload
+	// mechanism picks up MAX_TURNS: 3, allowing all three turns.
+	stdout, stderr, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "process files")
 	if err != nil {
-		out := stripANSI(stderr)
-		if !strings.Contains(out, "maximum tool execution turns") {
-			t.Fatalf("invocation 1 failed with unexpected error: %v\nStderr: %s", err, stderr)
-		}
+		t.Fatalf("expected clean exit after hot-reload, got error: %v\nStderr: %s", err, stderr)
 	}
 
-	count1 := callCount.Load()
-	if count1 != 2 {
-		t.Errorf("invocation 1: expected 2 LLM calls (MAX_TURNS=1), got %d", count1)
+	count := callCount.Load()
+	if count != 3 {
+		t.Errorf("expected 3 LLM calls (hot-reloaded MAX_TURNS=3), got %d", count)
 	}
 
-	// Step 4: Overwrite config B with MAX_TURNS: 3 (same path, update ModTime)
-	writeConfig(t, configPath, server.URL, 3)
-
-	// Step 5: Invocation 2 — agent continues session, now allows more calls.
-	// The existing session has 2 prior LLM responses (list_files executed,
-	// read_files blocked at Dispatcher). With MAX_TURNS=3, the agent makes
-	// 1 more call and receives the final "Done." text response.
-	stdout2, stderr2, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "continue processing")
-	if err != nil {
-		t.Fatalf("invocation 2 failed: %v\nStderr: %s", err, stderr2)
-	}
-
-	count2 := callCount.Load()
-	if count2 != 3 {
-		t.Errorf("invocation 2: expected 3 total LLM calls (MAX_TURNS=3), got %d", count2)
-	}
-
-	out2 := stripANSI(stdout2)
-	assertContains(t, out2, "Done.")
+	out := stripANSI(stdout)
+	assertContains(t, out, "Done.")
 }

--- a/tests/e2e/hotreload_test.go
+++ b/tests/e2e/hotreload_test.go
@@ -1,0 +1,170 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// setupHotReloadMock returns an httptest.Server implementing a multi-turn
+// Google-format mock and an atomic call counter. The server returns:
+//
+//	Turn 0 → list_files tool call
+//	Turn 1 → read_files tool call
+//	Turn 2+→ text response "Done."
+//
+// The turn index is derived from the Google API contents array length:
+//
+//	idx := (len(contents) - 1) / 2
+func setupHotReloadMock(t *testing.T) (*httptest.Server, *atomic.Int32) {
+	t.Helper()
+
+	var callCount atomic.Int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+
+		bodyBytes, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Logf("HOTRELOAD_MOCK: failed to read body: %v", err)
+			return
+		}
+
+		var body map[string]interface{}
+		if err := json.Unmarshal(bodyBytes, &body); err != nil {
+			t.Logf("HOTRELOAD_MOCK: failed to parse JSON: %v", err)
+			return
+		}
+
+		contents, ok := body["contents"].([]interface{})
+		if !ok {
+			contents = nil
+		}
+
+		// Google provider: each turn adds 2 messages (model + user/tool).
+		// contents[0]=user prompt, contents[1]=model tool call,
+		// contents[2]=tool response, etc.
+		idx := (len(contents) - 1) / 2
+		if idx < 0 {
+			idx = 0
+		}
+
+		var response string
+		switch idx {
+		case 0:
+			response = createToolCallResponse("google", "list_files", map[string]interface{}{
+				"path":   ".",
+				"reason": "hot-reload turn 1",
+			})
+		case 1:
+			response = createToolCallResponse("google", "read_files", map[string]interface{}{
+				"filepaths": []interface{}{"test.txt"},
+				"reason":    "hot-reload turn 2",
+			})
+		default:
+			response = createTextResponse("google", "Done.")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := fmt.Fprint(w, response); err != nil {
+			t.Logf("HOTRELOAD_MOCK: failed to write response: %v", err)
+		}
+	}))
+
+	return server, &callCount
+}
+
+// writeConfig writes a YAML configuration file at path with the given
+// mock server URL and MAX_TURNS value.
+func writeConfig(t *testing.T, path, mockURL string, maxTurns int) {
+	t.Helper()
+	content := fmt.Sprintf(`
+MODE: "assistant"
+SELECTED_PROVIDER: "mock"
+PROVIDERS:
+  mock:
+    TYPE: "google"
+    URL: "%s"
+    API_KEY: "dummy"
+    MODEL: "gemini-3-flash-preview"
+MAX_TURNS: %d
+MAX_HISTORY_TOKENS: 1000000
+`, mockURL, maxTurns)
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writeConfig: %v", err)
+	}
+}
+
+// TestConfigHotReload_MaxTurns verifies that MAX_TURNS is reloaded
+// from the config file between invocations when the session directory
+// is reused. The test runs the binary twice against the same home
+// directory, overwriting the config with a higher MAX_TURNS value
+// for the second run.
+func TestConfigHotReload_MaxTurns(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+
+	homeDir := t.TempDir()
+
+	// Step 1: Setup mock server with call counter
+	server, callCount := setupHotReloadMock(t)
+	defer server.Close()
+
+	// Step 2: Write config A with MAX_TURNS: 1
+	configPath := filepath.Join(homeDir, "config.yaml")
+	writeConfig(t, configPath, server.URL, 1)
+
+	env := []string{
+		"TELL_ME_HOME=" + homeDir,
+		"TELL_ME_MOCK_URL=" + server.URL,
+	}
+
+	// Step 3: Invocation 1 — agent makes 2 LLM calls, then MAX_TURNS=1 stops it.
+	// Turn 0: list_files (executed). Turn 1: read_files (LLM called but tool
+	// execution blocked by Dispatcher's >= check, as maxToolTurns=1).
+	// The agent exits non-zero when MAX_TURNS is exhausted; this is expected.
+	_, stderr, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "process files")
+	if err != nil {
+		out := stripANSI(stderr)
+		if !strings.Contains(out, "maximum tool execution turns") {
+			t.Fatalf("invocation 1 failed with unexpected error: %v\nStderr: %s", err, stderr)
+		}
+	}
+
+	count1 := callCount.Load()
+	if count1 != 2 {
+		t.Errorf("invocation 1: expected 2 LLM calls (MAX_TURNS=1), got %d", count1)
+	}
+
+	// Step 4: Overwrite config B with MAX_TURNS: 3 (same path, update ModTime)
+	writeConfig(t, configPath, server.URL, 3)
+
+	// Step 5: Invocation 2 — agent continues session, now allows more calls.
+	// The existing session has 2 prior LLM responses (list_files executed,
+	// read_files blocked at Dispatcher). With MAX_TURNS=3, the agent makes
+	// 1 more call and receives the final "Done." text response.
+	stdout2, stderr2, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "continue processing")
+	if err != nil {
+		t.Fatalf("invocation 2 failed: %v\nStderr: %s", err, stderr2)
+	}
+
+	count2 := callCount.Load()
+	if count2 != 3 {
+		t.Errorf("invocation 2: expected 3 total LLM calls (MAX_TURNS=3), got %d", count2)
+	}
+
+	out2 := stripANSI(stdout2)
+	assertContains(t, out2, "Done.")
+}


### PR DESCRIPTION
Closes #629.

## Summary
- **Architectural Fix**: Wired `ConfigWatcher.SetPaths()` into the production code path. The config watcher was constructed but never given filesystem paths, making `Refresh()` a no-op at runtime.
- **E2E Test**: Added `TestConfigHotReload_MaxTurns` — a 2-invocation test verifying that changing `MAX_TURNS` in the config file between CLI invocations changes the agent's turn limit behavior.

### Changes
| File | Change |
|------|--------|
| `internal/domain/ports/session.go` | Added `ConfigPath` field to `ChatterConfig` and `GetConfigPath()` to `SessionConfig` interface |
| `internal/agent/session/session_manager.go` | Implemented `GetConfigPath()` and wired into `chatterCfg` |
| `internal/infrastructure/factory/chatter.go` | Added `cw.SetPaths(cfg.ConfigPath, "")` after watcher construction |
| `tests/e2e/hotreload_test.go` | New E2E test: config hot-reload with MAX_TURNS across invocations |

## Verification
| Check | Status |
|-------|--------|
| fmt, tidy, build | PASS |
| lint | 0 issues |
| verify-architecture | PASS |
| verify-mock-pattern | PASS (baseline 11) |
| verify-no-test-sleep | PASS |
| vulncheck | No vulnerabilities |
| test (all packages) | PASS |
| dead-code | No dead code found |
| test-race | All packages pass except pre-existing timeout in `TestVerifyRealArchitecture` |
| test-coverage | Coverage report generated |
| E2E hot-reload test | PASS (0.25s) |