### PR TITLE
fix(llm): add multi-provider failover gateway with E2E tests (#628)

### DIFF
--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -99,6 +99,7 @@ type Config struct {
 	Models             map[string]ModelConfig `yaml:"MODELS"` // Model-specific overrides
 	SelectedProvider   string                 `yaml:"SELECTED_PROVIDER"`
 	Providers          map[string]LLMProvider `yaml:"PROVIDERS"`
+	FailoverOrder      []string               `yaml:"FAILOVER_ORDER"`
 }
 
 // GetActiveProvider returns the configuration for the selected provider.
@@ -143,6 +144,26 @@ type ModelConfig struct {
 	MaxThinkingBudget int                  `yaml:"MAX_THINKING_BUDGET"`
 	ContextWindow     int                  `yaml:"CONTEXT_WINDOW"`
 	Pricing           pricing.ModelPricing `yaml:"PRICING"`
+}
+
+// GetFailoverProviders returns the LLMProvider values from c.Providers in the
+// order specified by c.FailoverOrder. Providers named in FailoverOrder that
+// are not present in the Providers map are silently skipped. Returns nil when
+// FailoverOrder is empty or nil.
+func (c *Config) GetFailoverProviders() []LLMProvider {
+	if len(c.FailoverOrder) == 0 {
+		return nil
+	}
+	result := make([]LLMProvider, 0, len(c.FailoverOrder))
+	for _, name := range c.FailoverOrder {
+		if p, ok := c.Providers[name]; ok {
+			result = append(result, p)
+		}
+	}
+	if len(result) == 0 {
+		return nil
+	}
+	return result
 }
 
 // ResolveThinkingBudget returns the best matching thinking budget for the model.

--- a/internal/domain/config/config_test.go
+++ b/internal/domain/config/config_test.go
@@ -238,6 +238,78 @@ func TestGetActiveProvider(t *testing.T) {
 	}
 }
 
+func TestConfig_GetFailoverProviders(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		failoverOrder []string
+		providers     map[string]LLMProvider
+		expectedLen   int
+		expectedTypes []string // nil means nil slice expected
+	}{
+		{
+			name:          "empty order",
+			failoverOrder: []string{},
+			providers:     map[string]LLMProvider{"p1": {Type: "openai"}},
+			expectedLen:   0,
+			expectedTypes: nil,
+		},
+		{
+			name:          "all found",
+			failoverOrder: []string{"p1", "p2"},
+			providers: map[string]LLMProvider{
+				"p1": {Type: "openai"},
+				"p2": {Type: "anthropic"},
+			},
+			expectedLen:   2,
+			expectedTypes: []string{"openai", "anthropic"},
+		},
+		{
+			name:          "some missing",
+			failoverOrder: []string{"p1", "missing", "p2"},
+			providers: map[string]LLMProvider{
+				"p1": {Type: "openai"},
+				"p2": {Type: "gemini"},
+			},
+			expectedLen:   2,
+			expectedTypes: []string{"openai", "gemini"},
+		},
+		{
+			name:          "all missing",
+			failoverOrder: []string{"x", "y"},
+			providers:     map[string]LLMProvider{"p1": {Type: "openai"}},
+			expectedLen:   0,
+			expectedTypes: nil,
+		},
+		{
+			name:          "nil order",
+			failoverOrder: nil,
+			providers:     map[string]LLMProvider{"p1": {Type: "openai"}},
+			expectedLen:   0,
+			expectedTypes: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := &Config{
+				FailoverOrder: tt.failoverOrder,
+				Providers:     tt.providers,
+			}
+			got := cfg.GetFailoverProviders()
+			assert.Len(t, got, tt.expectedLen)
+			if tt.expectedTypes == nil {
+				assert.Nil(t, got)
+			} else {
+				for i, expectedType := range tt.expectedTypes {
+					assert.Equal(t, expectedType, got[i].Type)
+				}
+			}
+		})
+	}
+}
+
 func TestDeepSeekPricingMatch(t *testing.T) {
 	t.Parallel()
 	pData := DefaultPricing()

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -111,8 +111,18 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 
 	pricingData, tracker, turnsLogger, cleanup := b.telemetryFactory.BuildTelemetry(ctx, paths, cfg, pricingOverrides, cleanup)
 
+	logger := telemetry.NewSlogLogger(b.cfg.Logger)
 	lazyClient := newLazyClient(func() (llm.ExtendedClient, error) {
-		return b.cfg.ClientFactory(cfg, pricingData, bus, telemetry.NewSlogLogger(b.cfg.Logger))
+		if len(cfg.FailoverOrder) > 0 {
+			gw, err := infra_llm.NewFailoverChain(cfg, pricingData, bus, logger)
+			if err != nil {
+				return nil, err
+			}
+			if gw != nil {
+				return gw, nil
+			}
+		}
+		return b.cfg.ClientFactory(cfg, pricingData, bus, logger)
 	})
 
 	deps := &sessionDeps{

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -130,6 +130,98 @@ func NewClient(cfg *config.Config, pData pricing.PricingData, bus events.EventBu
 	return NewResilientClient(baseClient), nil
 }
 
+// NewFailoverChain creates a FailoverGateway from the configured failover
+// provider order. It constructs a resilientClient for each provider in the
+// chain and wraps them in a FailoverGateway for transparent failover.
+//
+// When cfg.FailoverOrder is empty, this returns nil, nil — callers should
+// fall back to NewClient for single-provider operation.
+//
+// Each client in the chain is independently constructed via the same
+// per-provider logic as NewClient (authenticator, timeout, thinking budget,
+// headers), but wrapped in a resilientClient instead of returned directly.
+func NewFailoverChain(cfg *config.Config, pData pricing.PricingData, bus events.EventBus, logger ports.Logger) (*FailoverGateway, error) {
+	providers := cfg.GetFailoverProviders()
+	if len(providers) == 0 {
+		return nil, nil
+	}
+
+	if logger == nil {
+		logger = &ports.NoOpLogger{}
+	}
+
+	timeout := resolveTimeout(cfg)
+	clients := make([]NamedClient, 0, len(providers))
+
+	for _, provider := range providers {
+		p := provider // capture range variable
+
+		authenticator, err := createAuthenticator(&p)
+		if err != nil {
+			return nil, fmt.Errorf("failover chain: provider %q: %w", p.Type, err)
+		}
+
+		maxBudget := cfg.ResolveThinkingBudget(p.Model, pData)
+
+		var baseClient llm.LLMClient
+
+		switch p.Type {
+		case "openai", "deepseek":
+			baseClient = openai.NewClient(p.URL, p.Model, authenticator,
+				openai.WithHeaders(p.Headers),
+				openai.WithPersona(cfg.Person),
+				openai.WithTimeout(timeout),
+				openai.WithThinkingBudget(maxBudget),
+				openai.WithMaxTokens(p.MaxTokens),
+				openai.WithLogger(logger),
+			)
+		case "anthropic":
+			baseClient = anthropic.NewClient(p.URL, p.Model, authenticator,
+				anthropic.WithHeaders(p.Headers),
+				anthropic.WithThinkingBudget(maxBudget),
+				anthropic.WithMaxTokens(p.MaxTokens),
+				anthropic.WithPersona(cfg.Person),
+				anthropic.WithTimeout(timeout),
+				anthropic.WithLogger(logger),
+			)
+		case "google", "gemini", "": // Default to Gemini for now
+			baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
+				gemini.WithHeaders(p.Headers),
+				gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
+				gemini.WithMaxOutputTokens(p.MaxTokens),
+				gemini.WithSystemInstruction(cfg.Person),
+				gemini.WithSearch(cfg.UseSearch),
+				gemini.WithEventBus(bus),
+				gemini.WithTimeout(timeout),
+				gemini.WithLogger(logger),
+			)
+		default:
+			// Fallback to Gemini if type is unknown for backward compatibility
+			baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
+				gemini.WithHeaders(p.Headers),
+				gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
+				gemini.WithMaxOutputTokens(p.MaxTokens),
+				gemini.WithSystemInstruction(cfg.Person),
+				gemini.WithSearch(cfg.UseSearch),
+				gemini.WithEventBus(bus),
+				gemini.WithTimeout(timeout),
+				gemini.WithLogger(logger),
+			)
+		}
+
+		if err != nil {
+			return nil, fmt.Errorf("failover chain: provider %q: %w", p.Type, err)
+		}
+
+		clients = append(clients, NamedClient{
+			Name:   p.Type,
+			Client: NewResilientClient(baseClient),
+		})
+	}
+
+	return NewFailoverGateway(clients), nil
+}
+
 func createAuthenticator(p *config.LLMProvider) (auth.Authenticator, error) {
 	// Preserve the existing logic for Service Account JSON
 	if p.APIKey != "" && strings.HasSuffix(strings.ToLower(p.APIKey), ".json") {

--- a/internal/infrastructure/llm/failover.go
+++ b/internal/infrastructure/llm/failover.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package llm
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// NamedClient pairs an ExtendedClient with a human-readable name for observability.
+type NamedClient struct {
+	Name   string
+	Client llm.ExtendedClient
+}
+
+// FailoverGateway implements llm.ExtendedClient by iterating through an ordered
+// list of provider clients on Generate, falling through on transient errors.
+// Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to the
+// primary (first) client.
+type FailoverGateway struct {
+	clients []NamedClient // clients[0] is primary
+}
+
+// compile-time interface compliance check
+var _ llm.ExtendedClient = (*FailoverGateway)(nil)
+
+// NewFailoverGateway creates a FailoverGateway backed by the given clients.
+// Panics if clients is empty — this is a programmer error that must be caught at startup.
+func NewFailoverGateway(clients []NamedClient) *FailoverGateway {
+	if len(clients) == 0 {
+		panic("FailoverGateway: clients must not be empty")
+	}
+	return &FailoverGateway{
+		clients: clients,
+	}
+}
+
+// Generate implements the core failover logic.
+//
+// It iterates through fg.clients in order:
+//   - On success: sets metrics.Provider to the client's name and returns.
+//   - On auth or terminal error: wraps and returns immediately (no fallback).
+//   - On transient error (including rate limits): records the error and tries
+//     the next provider.
+//   - If all providers are exhausted: returns the last error wrapped as terminal.
+func (fg *FailoverGateway) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	var lastErr error
+	for _, nc := range fg.clients {
+		content, metrics, err := nc.Client.Generate(ctx, input, tools, resolver)
+		if err == nil {
+			if metrics != nil {
+				metrics.Provider = nc.Name
+			}
+			return content, metrics, nil
+		}
+
+		if llm.IsAuth(err) || llm.IsTerminal(err) {
+			return nil, nil, fmt.Errorf("failover: provider %q: %w", nc.Name, err)
+		}
+
+		// IsTransient covers both ErrTransient and ErrRateLimit
+		if llm.IsTransient(err) {
+			lastErr = err
+			continue
+		}
+
+		// Any unrecognised error is treated as terminal
+		return nil, nil, fmt.Errorf("failover: provider %q: %w", nc.Name, err)
+	}
+
+	// All providers exhausted — wrap last error as terminal
+	return nil, nil, fmt.Errorf("failover: all %d providers exhausted: %w: %w",
+		len(fg.clients), lastErr, llm.ErrTerminal)
+}
+
+// SendChat delegates to the primary client.
+func (fg *FailoverGateway) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return fg.clients[0].Client.SendChat(ctx, history, tools, resolver)
+}
+
+// GenerateImages delegates to the primary client.
+func (fg *FailoverGateway) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	return fg.clients[0].Client.GenerateImages(ctx, model, prompt, mimeType)
+}
+
+// RefreshAuth delegates to the primary client.
+func (fg *FailoverGateway) RefreshAuth() error {
+	return fg.clients[0].Client.RefreshAuth()
+}

--- a/internal/infrastructure/llm/failover_test.go
+++ b/internal/infrastructure/llm/failover_test.go
@@ -1,0 +1,429 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// mockExtendedClient implements llm.ExtendedClient with configurable behaviour.
+type mockExtendedClient struct {
+	name             string
+	generateFn       func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error)
+	sendChatFn       func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error)
+	generateImagesFn func(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error)
+	refreshAuthFn    func() error
+
+	// call counters for verifying delegation
+	generateCalled       int
+	sendChatCalled       int
+	generateImagesCalled int
+	refreshAuthCalled    int
+}
+
+func (m *mockExtendedClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	m.generateCalled++
+	if m.generateFn != nil {
+		return m.generateFn(ctx, input, tools, resolver)
+	}
+	return &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}}, &llm.Metrics{}, nil
+}
+
+func (m *mockExtendedClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	m.sendChatCalled++
+	if m.sendChatFn != nil {
+		return m.sendChatFn(ctx, history, tools, resolver)
+	}
+	return nil, nil, nil
+}
+
+func (m *mockExtendedClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	m.generateImagesCalled++
+	if m.generateImagesFn != nil {
+		return m.generateImagesFn(ctx, model, prompt, mimeType)
+	}
+	return nil, nil
+}
+
+func (m *mockExtendedClient) RefreshAuth() error {
+	m.refreshAuthCalled++
+	if m.refreshAuthFn != nil {
+		return m.refreshAuthFn()
+	}
+	return nil
+}
+
+// assertPanic asserts that fn panics with a message containing wantMsg.
+func assertPanic(t *testing.T, fn func(), wantMsg string) {
+	t.Helper()
+	didPanic := true
+	defer func() {
+		if !didPanic {
+			t.Errorf("expected panic containing %q, but did not panic", wantMsg)
+		}
+	}()
+	defer func() {
+		if r := recover(); r != nil {
+			s, ok := r.(string)
+			if !ok {
+				return // panic with non-string; still a panic
+			}
+			if !strings.Contains(s, wantMsg) {
+				t.Errorf("expected panic containing %q, got %q", wantMsg, s)
+			}
+		} else {
+			didPanic = false
+		}
+	}()
+	fn()
+}
+
+func successContent() *llm.Content {
+	return &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "success"}}}
+}
+
+func successMetrics() *llm.Metrics {
+	return &llm.Metrics{Model: "test-model"}
+}
+
+func TestFailoverGateway_Generate_PrimarySucceeds(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return successContent(), successMetrics(), nil
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	content, metrics, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content.Parts[0].Text != "success" {
+		t.Errorf("got %q, want %q", content.Parts[0].Text, "success")
+	}
+	if metrics.Provider != "primary" {
+		t.Errorf("got provider %q, want %q", metrics.Provider, "primary")
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary.generateCalled = %d, want 0", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_PrimaryTransientSecondarySucceeds(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, llm.ErrTransient
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return successContent(), successMetrics(), nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	content, metrics, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content.Parts[0].Text != "success" {
+		t.Errorf("got %q, want %q", content.Parts[0].Text, "success")
+	}
+	if metrics.Provider != "secondary" {
+		t.Errorf("got provider %q, want %q", metrics.Provider, "secondary")
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 1 {
+		t.Errorf("secondary.generateCalled = %d, want 1", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_PrimaryAuthFailsImmediately(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, llm.ErrAuth
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, llm.ErrAuth) {
+		t.Errorf("expected ErrAuth, got %v", err)
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary should not have been called, but was called %d times", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_PrimaryTerminalFailsImmediately(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, llm.ErrTerminal
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, llm.ErrTerminal) {
+		t.Errorf("expected ErrTerminal, got %v", err)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary should not have been called, but was called %d times", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_AllTransientReturnsLastAsTerminal(t *testing.T) {
+	customTransient := errors.New("custom transient")
+
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, llm.ErrTransient
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, fmt.Errorf("%w: %w", customTransient, llm.ErrTransient)
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, llm.ErrTerminal) {
+		t.Errorf("expected ErrTerminal, got %v", err)
+	}
+	// The last error (from secondary) should also be present in the chain
+	if !errors.Is(err, customTransient) {
+		t.Errorf("expected customTransient in error chain, got %v", err)
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 1 {
+		t.Errorf("secondary.generateCalled = %d, want 1", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_NewFailoverGateway_PanicsOnEmpty(t *testing.T) {
+	assertPanic(t, func() {
+		NewFailoverGateway(nil)
+	}, "must not be empty")
+}
+
+func TestFailoverGateway_Generate_PrimaryRateLimitSecondarySucceeds(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, llm.ErrRateLimit
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return successContent(), successMetrics(), nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	content, metrics, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if metrics.Provider != "secondary" {
+		t.Errorf("got provider %q, want %q", metrics.Provider, "secondary")
+	}
+	if content.Parts[0].Text != "success" {
+		t.Errorf("got %q, want %q", content.Parts[0].Text, "success")
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 1 {
+		t.Errorf("secondary.generateCalled = %d, want 1", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_SendChat_DelegatesToPrimary(t *testing.T) {
+	primary := &mockExtendedClient{
+		name: "primary",
+		sendChatFn: func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return successContent(), successMetrics(), nil
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	content, metrics, err := fg.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content.Parts[0].Text != "success" {
+		t.Errorf("got %q, want %q", content.Parts[0].Text, "success")
+	}
+	_ = metrics
+	if primary.sendChatCalled != 1 {
+		t.Errorf("primary.sendChatCalled = %d, want 1", primary.sendChatCalled)
+	}
+	if secondary.sendChatCalled != 0 {
+		t.Errorf("secondary.sendChatCalled = %d, want 0", secondary.sendChatCalled)
+	}
+}
+
+func TestFailoverGateway_GenerateImages_DelegatesToPrimary(t *testing.T) {
+	expectedData := [][]byte{{0x01, 0x02}}
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateImagesFn: func(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+			return expectedData, nil
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	data, err := fg.GenerateImages(context.Background(), "model", "prompt", "image/png")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) != 1 || data[0][0] != 0x01 {
+		t.Errorf("unexpected data: %v", data)
+	}
+	if primary.generateImagesCalled != 1 {
+		t.Errorf("primary.generateImagesCalled = %d, want 1", primary.generateImagesCalled)
+	}
+	if secondary.generateImagesCalled != 0 {
+		t.Errorf("secondary.generateImagesCalled = %d, want 0", secondary.generateImagesCalled)
+	}
+}
+
+func TestFailoverGateway_RefreshAuth_DelegatesToPrimary(t *testing.T) {
+	primary := &mockExtendedClient{
+		name:          "primary",
+		refreshAuthFn: func() error { return nil },
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	err := fg.RefreshAuth()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if primary.refreshAuthCalled != 1 {
+		t.Errorf("primary.refreshAuthCalled = %d, want 1", primary.refreshAuthCalled)
+	}
+	if secondary.refreshAuthCalled != 0 {
+		t.Errorf("secondary.refreshAuthCalled = %d, want 0", secondary.refreshAuthCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_PrimaryUnrecognizedErrorFailsImmediately(t *testing.T) {
+	unrecognized := errors.New("unknown protocol error")
+
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, unrecognized
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// The unrecognized error should be in the chain
+	if !errors.Is(err, unrecognized) {
+		t.Errorf("expected unrecognized error in chain, got %v", err)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary should not have been called, but was called %d times", secondary.generateCalled)
+	}
+}

--- a/tests/e2e/failover_test.go
+++ b/tests/e2e/failover_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_llm "github.com/gosharplite/tell-me-go/internal/infrastructure/llm"
+)
+
+// primaryMockClient returns a transient error to trigger failover.
+type primaryMockClient struct{ callCount *int32 }
+
+func (m *primaryMockClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	atomic.AddInt32(m.callCount, 1)
+	return nil, nil, fmt.Errorf("%w: HTTP 503 Service Unavailable", llm.ErrTransient)
+}
+
+func (m *primaryMockClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return nil, nil, nil
+}
+
+func (m *primaryMockClient) GenerateImages(ctx context.Context, model, prompt, mimeType string) ([][]byte, error) {
+	return nil, nil
+}
+
+func (m *primaryMockClient) RefreshAuth() error { return nil }
+
+// secondaryMockClient returns a success response.
+type secondaryMockClient struct{ callCount *int32 }
+
+func (m *secondaryMockClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	atomic.AddInt32(m.callCount, 1)
+	return &llm.Content{
+		Role:  "model",
+		Parts: []*llm.Part{{Text: "Failover successful — response from secondary!"}},
+	}, &llm.Metrics{PromptTokens: 5, ResponseTokens: 8, Provider: "secondary"}, nil
+}
+
+func (m *secondaryMockClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return nil, nil, nil
+}
+
+func (m *secondaryMockClient) GenerateImages(ctx context.Context, model, prompt, mimeType string) ([][]byte, error) {
+	return nil, nil
+}
+
+func (m *secondaryMockClient) RefreshAuth() error { return nil }
+
+// TestFailover_PrimaryTransient_SecondarySucceeds verifies that when the
+// primary client returns a transient error, the FailoverGateway falls
+// through to the secondary client and returns its successful response.
+func TestFailover_PrimaryTransient_SecondarySucceeds(t *testing.T) {
+	// Step 1 — Setup: create mock clients with atomic call counters
+	var primaryCalls, secondaryCalls int32
+
+	primary := &primaryMockClient{callCount: &primaryCalls}
+	secondary := &secondaryMockClient{callCount: &secondaryCalls}
+
+	// Step 2 — Create FailoverGateway with ordered client list
+	fg := infra_llm.NewFailoverGateway([]infra_llm.NamedClient{
+		{Name: "primary", Client: primary},
+		{Name: "secondary", Client: secondary},
+	})
+
+	// Step 3 — Execute Generate (triggers failover)
+	ctx := context.Background()
+	content, metrics, err := fg.Generate(ctx, nil, nil, nil)
+
+	// Step 4 — Assert no error
+	if err != nil {
+		t.Fatalf("Generate failed: %v", err)
+	}
+
+	// Step 5 — Assert model response contains "Failover successful"
+	if content == nil || len(content.Parts) == 0 {
+		t.Fatal("expected non-empty content")
+	}
+	if content.Parts[0].Text != "Failover successful — response from secondary!" {
+		t.Errorf("got response %q, want %q", content.Parts[0].Text, "Failover successful — response from secondary!")
+	}
+
+	// Step 6 — Assert metrics reflect secondary provider
+	if metrics != nil && metrics.Provider != "secondary" {
+		t.Errorf("got provider %q, want %q", metrics.Provider, "secondary")
+	}
+
+	// Step 7 — Assert call counts: primary tried once, secondary succeeded
+	if got := atomic.LoadInt32(&primaryCalls); got != 1 {
+		t.Errorf("primaryCalls = %d, want 1", got)
+	}
+	if got := atomic.LoadInt32(&secondaryCalls); got != 1 {
+		t.Errorf("secondaryCalls = %d, want 1", got)
+	}
+}
+
+// TestFailover_Anthropic503_OpenAISucceeds is a full CLI E2E test that
+// exercises provider failover through the compiled binary. Two httptest
+// servers simulate a primary that always returns 503 and a secondary that
+// returns a successful text response. The test verifies that the CLI tries
+// the primary, falls through on the transient error, and returns the
+// secondary's response.
+//
+// Both providers use TYPE "google" so per-request format is identical.
+// VertexAI-style URLs (containing aiplatform.googleapis.com as a path
+// segment) are used to trigger parseVertexAI in determineBackend, which
+// extracts a per-provider baseURL from the config URL itself — avoiding
+// the single-process-wide TELL_ME_MOCK_URL constraint.
+func TestFailover_Anthropic503_OpenAISucceeds(t *testing.T) {
+	t.Parallel()
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+
+	// 1. Primary mock server — always returns 503
+	var primaryCalls int32
+	primaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&primaryCalls, 1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"error": {"code": 503, "message": "Service Unavailable"}}`)
+	}))
+	defer primaryServer.Close()
+
+	// 2. Secondary mock server — returns success
+	var secondaryCalls int32
+	secondaryServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&secondaryCalls, 1)
+		w.Header().Set("Content-Type", "application/json")
+		resp := createTextResponse("google", "Failover successful — secondary responded!")
+		_, _ = fmt.Fprint(w, resp)
+	}))
+	defer secondaryServer.Close()
+
+	// 3. Create temp config with two providers and FAILOVER_ORDER.
+	// Use VertexAI-style URLs so determineBackend triggers parseVertexAI
+	// which extracts per-provider baseURL from the URL itself.
+	primaryURL := primaryServer.URL + "/aiplatform.googleapis.com/v1/projects/mock/locations/mock"
+	secondaryURL := secondaryServer.URL + "/aiplatform.googleapis.com/v1/projects/mock/locations/mock"
+
+	configContent := fmt.Sprintf(`
+MODE: "assistant"
+SELECTED_PROVIDER: "mock_primary"
+PROVIDERS:
+  mock_primary:
+    TYPE: "google"
+    URL: "%s"
+    API_KEY: "dummy"
+    MODEL: "gpt-4"
+  mock_secondary:
+    TYPE: "google"
+    URL: "%s"
+    API_KEY: "dummy"
+    MODEL: "gpt-4"
+FAILOVER_ORDER:
+  - mock_primary
+  - mock_secondary
+`, primaryURL, secondaryURL)
+
+	configPath := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 4. Run the CLI — TELL_ME_FAST_RETRY=1 is injected by runCommandWithEnvInDir
+	homeDir := t.TempDir()
+	env := []string{"TELL_ME_HOME=" + homeDir}
+
+	stdout, stderr, err := runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "failover test")
+	if err != nil {
+		t.Fatalf("CLI failed: %v\nStderr: %s", err, stderr)
+	}
+
+	// 5. Assertions
+	if !strings.Contains(stdout, "Failover successful — secondary responded!") {
+		t.Errorf("expected stdout to contain success message, got: %q", stdout)
+	}
+	if got := atomic.LoadInt32(&primaryCalls); got < 1 {
+		t.Errorf("primaryCalls = %d, want >= 1", got)
+	}
+	if got := atomic.LoadInt32(&secondaryCalls); got < 1 {
+		t.Errorf("secondaryCalls = %d, want >= 1", got)
+	}
+}


### PR DESCRIPTION
Closes #628.

## Summary
Implemented multi-provider failover for LLM interactions. When the primary provider returns a transient error (503, rate limit, timeout), the agent transparently falls through to the next provider in the configured FAILOVER_ORDER chain.

## Architecture
```
Engine → Gateway → FailoverGateway → [resilientClient(primary), resilientClient(secondary), ...]
                                         ↑ falls through on transient/rate-limit
                                         ↑ fails fast on auth/terminal
```

## Files Changed

| File | Change |
|------|--------|
| `internal/domain/config/config.go` | Added `FailoverOrder []string` field + `GetFailoverProviders()` |
| `internal/domain/config/config_test.go` | 5 test cases for `GetFailoverProviders()` |
| `internal/infrastructure/llm/failover.go` | **New** — `FailoverGateway` implementing `llm.ExtendedClient` |
| `internal/infrastructure/llm/failover_test.go` | **New** — 11 unit tests (100% coverage) |
| `internal/infrastructure/llm/factory.go` | Added `NewFailoverChain()` — per-provider client factory |
| `internal/infrastructure/di/container.go` | Wired failover into `BuildSessionDependencies` |
| `tests/e2e/failover_test.go` | **New** — in-process + CLI E2E failover tests |

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build ./...` | PASS |
| `golangci-lint run` | 0 issues |
| `go vet ./...` | PASS |
| `go test -short ./...` | PASS |
| `verify-architecture` | PASS |
| failover unit tests (11) | 100% coverage |
| E2E in-process test | PASS |
| E2E CLI test | PASS |