### PR TITLE
fix(llm): add context cancellation check in failover loop (#637)

### DIFF
--- a/internal/infrastructure/llm/failover.go
+++ b/internal/infrastructure/llm/failover.go
@@ -50,6 +50,10 @@ func NewFailoverGateway(clients []NamedClient) *FailoverGateway {
 func (fg *FailoverGateway) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
 	var lastErr error
 	for _, nc := range fg.clients {
+		if err := ctx.Err(); err != nil {
+			return nil, nil, fmt.Errorf("failover: context cancelled before provider %q: %w", nc.Name, err)
+		}
+
 		content, metrics, err := nc.Client.Generate(ctx, input, tools, resolver)
 		if err == nil {
 			if metrics != nil {
@@ -79,6 +83,10 @@ func (fg *FailoverGateway) Generate(ctx context.Context, input []*llm.Content, t
 
 // SendChat delegates to the primary client.
 func (fg *FailoverGateway) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, fmt.Errorf("failover: context cancelled: %w", err)
+	}
+
 	return fg.clients[0].Client.SendChat(ctx, history, tools, resolver)
 }
 

--- a/internal/infrastructure/llm/failover_test.go
+++ b/internal/infrastructure/llm/failover_test.go
@@ -427,3 +427,108 @@ func TestFailoverGateway_Generate_PrimaryUnrecognizedErrorFailsImmediately(t *te
 		t.Errorf("secondary should not have been called, but was called %d times", secondary.generateCalled)
 	}
 }
+
+func TestFailoverGateway_Generate_ContextCancelledBeforeAttempt(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // immediately cancel
+
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			t.Error("primary should not be called when context is cancelled")
+			return nil, nil, nil
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			t.Error("secondary should not be called when context is cancelled")
+			return nil, nil, nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(ctx, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error to wrap context.Canceled, got %v", err)
+	}
+	if primary.generateCalled != 0 {
+		t.Errorf("primary.generateCalled = %d, want 0", primary.generateCalled)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary.generateCalled = %d, want 0", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_ContextCancelledMidFailover(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	primary := &mockExtendedClient{
+		name: "primary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			cancel() // cancel after primary is called, before next iteration
+			return nil, nil, llm.ErrTransient
+		},
+	}
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			t.Error("secondary should not be called after context is cancelled")
+			return nil, nil, nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+		{Name: secondary.name, Client: secondary},
+	})
+
+	_, _, err := fg.Generate(ctx, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error to wrap context.Canceled, got %v", err)
+	}
+	if primary.generateCalled != 1 {
+		t.Errorf("primary.generateCalled = %d, want 1", primary.generateCalled)
+	}
+	if secondary.generateCalled != 0 {
+		t.Errorf("secondary.generateCalled = %d, want 0", secondary.generateCalled)
+	}
+}
+
+func TestFailoverGateway_SendChat_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	primary := &mockExtendedClient{
+		name: "primary",
+		sendChatFn: func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			t.Error("primary should not be called when context is cancelled")
+			return nil, nil, nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: primary.name, Client: primary},
+	})
+
+	_, _, err := fg.SendChat(ctx, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected error to wrap context.Canceled, got %v", err)
+	}
+	if primary.sendChatCalled != 0 {
+		t.Errorf("primary.sendChatCalled = %d, want 0", primary.sendChatCalled)
+	}
+}


### PR DESCRIPTION
Closes #637.

## Summary
Adds explicit `ctx.Err()` pre-condition checks in `FailoverGateway.Generate` (top of failover loop) and `FailoverGateway.SendChat` (before primary delegation) as defense-in-depth against future modifications to transient error classification.

Three new table-driven unit tests validate:
- Cancelled context before any provider attempt
- Cancelled context mid-failover (after transient error)
- Cancelled context in SendChat delegation

## Changes
| File | Change |
|------|--------|
| `internal/infrastructure/llm/failover.go` | +8 lines (ctx.Err() guards) |
| `internal/infrastructure/llm/failover_test.go` | +105 lines (3 new tests) |

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `golangci-lint run ./...` | 0 issues |
| `go test ./...` | ALL PASS |
| `go test -race ./internal/infrastructure/llm/` | PASS (no races) |
| Coverage `internal/infrastructure/llm/` | 91.3% |
