### PR TITLE
fix(di): decouple DI container from infra_llm via ClientFactory interface (#636)

### DIFF
--- a/internal/cli/chat_integration_test.go
+++ b/internal/cli/chat_integration_test.go
@@ -57,9 +57,9 @@ func TestChatCommand_NewSessionIntegration(t *testing.T) {
 	cfg.Version = "1.0.0"
 	cfg.Stdout = &stdout
 	cfg.Stderr = &stderr
-	cfg.ClientFactory = func(c *domain_config.Config, p domain_pricing.PricingData, bus events.EventBus, logger ports.Logger) (domain_llm.ExtendedClient, error) {
+	cfg.ClientFactory = ports.ClientFactoryFunc(func(c *domain_config.Config, p domain_pricing.PricingData, bus events.EventBus, logger ports.Logger) (domain_llm.ExtendedClient, error) {
 		return mClient, nil
-	}
+	})
 	b := di.NewBootstrapper(cfg)
 
 	// Wrap bootstrapper to override AgentFactory

--- a/internal/domain/ports/factory.go
+++ b/internal/domain/ports/factory.go
@@ -7,6 +7,9 @@ import (
 	"context"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 )
 
 // HistoryManagerProvider defines the interface for providing history-related services.
@@ -24,4 +27,30 @@ type HistoryManagerProvider interface {
 type SuggestionProvider interface {
 	// GetSuggestionService initializes and returns the suggestion service.
 	GetSuggestionService(ctx context.Context, recentHistory []string) (SuggestionService, error)
+}
+
+// ClientFactory abstracts LLM client creation for the DI container.
+// The two methods share an identical parameter signature — each receives
+// the full configuration, pricing data, event bus, and logger needed
+// to construct a provider client or failover chain.
+//
+// Concrete implementations live in internal/infrastructure/llm.
+type ClientFactory interface {
+	NewClient(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error)
+	NewFailoverChain(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error)
+}
+
+// ClientFactoryFunc adapts a single-client factory function to the ClientFactory
+// interface. NewFailoverChain returns nil, nil — callers fall back to NewClient.
+//
+// This adapter preserves backward compatibility with all existing tests that
+// assign anonymous functions to BootstrapperConfig.ClientFactory.
+type ClientFactoryFunc func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error)
+
+func (f ClientFactoryFunc) NewClient(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+	return f(cfg, pricingData, bus, logger)
+}
+
+func (f ClientFactoryFunc) NewFailoverChain(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+	return nil, nil
 }

--- a/internal/infrastructure/di/config.go
+++ b/internal/infrastructure/di/config.go
@@ -8,9 +8,6 @@ import (
 	"io"
 	"log/slog"
 
-	"github.com/gosharplite/tell-me-go/internal/domain/config"
-	"github.com/gosharplite/tell-me-go/internal/domain/events"
-	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
@@ -37,7 +34,7 @@ type BootstrapperConfig struct {
 	WorkspacePolicy services.WorkspacePolicy
 
 	// Factory functions
-	ClientFactory    func(*config.Config, pricing.PricingData, events.EventBus, ports.Logger) (llm.ExtendedClient, error)
+	ClientFactory    ports.ClientFactory
 	RegisterAllTools func(infra_tools.ToolRegistrationParams) error
 	RegisterMetrics  func(tools.Registry, security.Manager, string, string, string, string, map[string]pricing.ModelPricing, ports.KVStore) error
 	RotateSession    func(context.Context, infra_persistence.FileSystem, io.Writer, persistence.Paths, int, *slog.Logger) error
@@ -51,7 +48,7 @@ func DefaultBootstrapperConfig() BootstrapperConfig {
 	return BootstrapperConfig{
 		Logger:           slog.Default(),
 		FileSystem:       &infra_persistence.OSFileSystem{},
-		ClientFactory:    infra_llm.NewClient,
+		ClientFactory:    &infra_llm.DefaultClientFactory{},
 		RegisterAllTools: infra_tools.RegisterAll,
 		RegisterMetrics:  telemetry.RegisterMetrics,
 		RotateSession:    infra_persistence.RotateSession,

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -50,7 +50,7 @@ type Bootstrapper struct {
 // NewBootstrapper creates a new Bootstrapper instance.
 func NewBootstrapper(cfg BootstrapperConfig) *Bootstrapper {
 	if cfg.ClientFactory == nil {
-		cfg.ClientFactory = infra_llm.NewClient
+		cfg.ClientFactory = &infra_llm.DefaultClientFactory{}
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
@@ -114,7 +114,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 	logger := telemetry.NewSlogLogger(b.cfg.Logger)
 	lazyClient := newLazyClient(func() (llm.ExtendedClient, error) {
 		if len(cfg.FailoverOrder) > 0 {
-			gw, err := infra_llm.NewFailoverChain(cfg, pricingData, bus, logger)
+			gw, err := b.cfg.ClientFactory.NewFailoverChain(cfg, pricingData, bus, logger)
 			if err != nil {
 				return nil, err
 			}
@@ -122,7 +122,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 				return gw, nil
 			}
 		}
-		return b.cfg.ClientFactory(cfg, pricingData, bus, logger)
+		return b.cfg.ClientFactory.NewClient(cfg, pricingData, bus, logger)
 	})
 
 	deps := &sessionDeps{

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -132,9 +132,9 @@ func TestBuildSessionDependencies(t *testing.T) {
 	cfg.Version = "1.0.0"
 	cfg.Stdout = io.Discard
 	cfg.Stderr = io.Discard
-	cfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	cfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return client, nil
-	}
+	})
 	bootstrapper := NewBootstrapper(cfg)
 
 	testCfg := &config.Config{
@@ -192,7 +192,7 @@ func TestBootstrapper_Initialize_Errors(t *testing.T) {
 	tests := []struct {
 		name          string
 		setup         func(t *testing.T) string // Returns homeDir for this test case
-		clientFactory func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error)
+		clientFactory ports.ClientFactory
 		mockSetup     func(sm *mockConfigurableSecurityManager)
 		wantErr       string
 		targetErr     error
@@ -228,9 +228,9 @@ func TestBootstrapper_Initialize_Errors(t *testing.T) {
 			setup: func(t *testing.T) string {
 				return filepath.Join(tempDir, "factory-err-home")
 			},
-			clientFactory: func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+			clientFactory: ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 				return nil, simulatedErr
-			},
+			}),
 			mockSetup: func(sm *mockConfigurableSecurityManager) {
 				sm.On("RegisterPolicyTools", mock.Anything, mock.Anything).Return(nil).Maybe()
 				sm.On("SetBypassActive", mock.Anything).Return().Maybe()
@@ -278,9 +278,9 @@ func TestBootstrapper_Initialize_Errors(t *testing.T) {
 			}
 			cf := tt.clientFactory
 			if cf == nil {
-				cf = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+				cf = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 					return new(mockLLMClient), nil
-				}
+				})
 			}
 			bcfg := DefaultBootstrapperConfig()
 			bcfg.HomeDir = homeDir
@@ -337,9 +337,9 @@ func TestSucceedsWithWarningOnTriggerNewSession_RecordCostError(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = &stderr
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return new(mockLLMClient), nil
-	}
+	})
 	bootstrapper := NewBootstrapper(bcfg)
 
 	deps, hManager, cleanup, err := bootstrapper.BuildSessionDependencies(ctx, testCfg, "config.yaml", true, nil)
@@ -384,9 +384,9 @@ func TestFinalizeSession(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return client, nil
-	}
+	})
 	b := NewBootstrapper(bcfg)
 
 	sm.On("RegisterPolicyTools", mock.Anything, mock.Anything).Return(nil).Maybe()
@@ -545,9 +545,9 @@ func TestBuildSessionDependencies_NewSession(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return client, nil
-	}
+	})
 	bootstrapper := NewBootstrapper(bcfg)
 
 	testCfg := &config.Config{
@@ -752,9 +752,9 @@ func TestContainer_InitializationErrors(t *testing.T) {
 			bcfg.Version = "1.0.0"
 			bcfg.Stdout = io.Discard
 			bcfg.Stderr = &stderr
-			bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+			bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 				return new(mockLLMClient), nil
-			}
+			})
 
 			if tt.cfgSetup != nil {
 				tt.cfgSetup(&bcfg, sm)
@@ -815,9 +815,9 @@ func TestCrossSessionPersistence(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return new(mockLLMClient), nil
-	}
+	})
 	bootstrapper := NewBootstrapper(bcfg)
 	testCfg := &config.Config{Mode: mode, Model: "test-model"}
 	_, _, cleanup, err := bootstrapper.BuildSessionDependencies(ctx, testCfg, "config.yaml", false, nil)
@@ -945,9 +945,9 @@ func TestBootstrapper_Cleanup_ClosesTurnsLogger(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return new(mockLLMClient), nil
-	}
+	})
 	bootstrapper := NewBootstrapper(bcfg)
 
 	testCfg := &config.Config{
@@ -1043,9 +1043,9 @@ func TestBootstrapper_Cleanup_ChainsErrors(t *testing.T) {
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
 	bcfg.FileSystem = fs
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return new(mockLLMClient), nil
-	}
+	})
 	bcfg.NewSessionState = func(ctx context.Context, modeDir string) (ports.SessionProvider, error) {
 		return mockSP, nil
 	}
@@ -1364,9 +1364,9 @@ func TestGetUnifiedHistoryProvider_SuccessPath(t *testing.T) {
 	bcfg.Version = "1.0.0"
 	bcfg.Stdout = io.Discard
 	bcfg.Stderr = io.Discard
-	bcfg.ClientFactory = func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return client, nil
-	}
+	})
 	b := NewBootstrapper(bcfg)
 	testCfg := &config.Config{Mode: "assistant"}
 

--- a/internal/infrastructure/di/lazy_test.go
+++ b/internal/infrastructure/di/lazy_test.go
@@ -38,10 +38,10 @@ func TestBuildSessionDependencies_LazyInitialization_Proxy(t *testing.T) {
 	callCount := 0
 	simulatedErr := errors.New("llm init failed")
 
-	clientFactory := func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	clientFactory := ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		callCount++
 		return nil, simulatedErr
-	}
+	})
 
 	bcfg := DefaultBootstrapperConfig()
 	bcfg.HomeDir = tempDir

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -306,3 +306,29 @@ func resolveTimeout(cfg *config.Config) time.Duration {
 func CreateAuthenticator(p *config.LLMProvider) (auth.Authenticator, error) {
 	return createAuthenticator(p)
 }
+
+// DefaultClientFactory implements ports.ClientFactory by delegating to
+// the canonical package-level constructor functions (NewClient and
+// NewFailoverChain). It is the production implementation wired by
+// DefaultBootstrapperConfig.
+type DefaultClientFactory struct{}
+
+// NewClient delegates to the package-level NewClient constructor.
+func (f *DefaultClientFactory) NewClient(cfg *config.Config, pData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	return NewClient(cfg, pData, bus, logger)
+}
+
+// NewFailoverChain delegates to the package-level NewFailoverChain constructor.
+// The nil-return convention is preserved: when no failover providers are
+// configured, the underlying NewFailoverChain returns (nil, nil), and this
+// method propagates that through the llm.ExtendedClient interface.
+func (f *DefaultClientFactory) NewFailoverChain(cfg *config.Config, pData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	gw, err := NewFailoverChain(cfg, pData, bus, logger)
+	if err != nil {
+		return nil, err
+	}
+	return gw, nil
+}
+
+// Compile-time verification that DefaultClientFactory satisfies ports.ClientFactory.
+var _ ports.ClientFactory = (*DefaultClientFactory)(nil)

--- a/tests/e2e/golden_path_test.go
+++ b/tests/e2e/golden_path_test.go
@@ -59,9 +59,9 @@ func TestGoldenPath_ConfigToShutdown(t *testing.T) {
 	bsCfg.Stdout = io.Discard
 	bsCfg.Stderr = io.Discard
 	bsCfg.Logger = logger
-	bsCfg.ClientFactory = func(c *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	bsCfg.ClientFactory = ports.ClientFactoryFunc(func(c *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
 		return &goldenPathMockClient{}, nil
-	}
+	})
 	bootstrapper := di.NewBootstrapper(bsCfg)
 
 	// Step 3 — Build session dependencies


### PR DESCRIPTION
Closes #636.

## Summary

Introduced a `ClientFactory` interface in the domain ports layer to decouple the DI container from direct `infra_llm` constructor calls. The key changes:

- **`internal/domain/ports/factory.go`** — New `ClientFactory` interface (2 methods: `NewClient`, `NewFailoverChain`) + `ClientFactoryFunc` adapter for backward compatibility
- **`internal/infrastructure/llm/factory.go`** — `DefaultClientFactory` struct implementing the interface via delegation to existing package-level constructors
- **`internal/infrastructure/di/config.go`** — `BootstrapperConfig.ClientFactory` field changed from function type to `ports.ClientFactory` interface; removed 3 unused imports
- **`internal/infrastructure/di/container.go`** — `BuildSessionDependencies` now calls `b.cfg.ClientFactory.NewFailoverChain()` and `.NewClient()` instead of direct `infra_llm` calls; nil-guard uses `&infra_llm.DefaultClientFactory{}`
- **Test files** — All function literals wrapped with `ports.ClientFactoryFunc()` adapter

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go fmt ./... | PASS |
| go vet ./... | PASS |
| go test ./... | PASS |
| golangci-lint | 0 issues |
