### PR TITLE
fix(complexity): reduce 4 functions from CC 10 to ≤8 through extract-method (#640)

### DIFF
--- a/internal/agent/drift.go
+++ b/internal/agent/drift.go
@@ -50,6 +50,51 @@ type CtxManagerDrift struct {
 	ActualMaxHistoryTurns    int
 }
 
+// diffEngine compares the engine's live configuration against the canonical
+// config. Returns nil when the engine is in sync or nil (uninitialized).
+func (a *agent) diffEngine(cfg *runtimeConfig) *EngineDrift {
+	if a.engine == nil {
+		return nil
+	}
+	engineSnap := a.engine.GetConfig()
+	if cfg.ProviderName != engineSnap.ProviderName ||
+		cfg.Model != engineSnap.Model ||
+		cfg.Mode != engineSnap.Mode {
+		return &EngineDrift{
+			ExpectedProvider: cfg.ProviderName,
+			ActualProvider:   engineSnap.ProviderName,
+			ExpectedModel:    cfg.Model,
+			ActualModel:      engineSnap.Model,
+			ExpectedMode:     cfg.Mode,
+			ActualMode:       engineSnap.Mode,
+		}
+	}
+	return nil
+}
+
+// diffCtxManager compares the context manager's live limits against the
+// canonical config. Returns nil when the context manager is in sync or
+// nil (uninitialized).
+func (a *agent) diffCtxManager(cfg *runtimeConfig) *CtxManagerDrift {
+	if a.ctxManager == nil {
+		return nil
+	}
+	limits := a.ctxManager.GetLimits()
+	if cfg.Limits.MaxHistoryTokens != limits.MaxHistoryTokens ||
+		cfg.Limits.MaxToolTurns != limits.MaxToolTurns ||
+		cfg.Limits.MaxHistoryTurns != limits.MaxHistoryTurns {
+		return &CtxManagerDrift{
+			ExpectedMaxHistoryTokens: cfg.Limits.MaxHistoryTokens,
+			ActualMaxHistoryTokens:   limits.MaxHistoryTokens,
+			ExpectedMaxToolTurns:     cfg.Limits.MaxToolTurns,
+			ActualMaxToolTurns:       limits.MaxToolTurns,
+			ExpectedMaxHistoryTurns:  cfg.Limits.MaxHistoryTurns,
+			ActualMaxHistoryTurns:    limits.MaxHistoryTurns,
+		}
+	}
+	return nil
+}
+
 // DiffConfig compares the canonical intended configuration (a.config)
 // against the live state of the engine and context manager. It returns
 // a DriftReport describing any mismatches.
@@ -74,40 +119,14 @@ func (a *agent) DiffConfig() *DriftReport {
 
 	report := &DriftReport{InSync: true}
 
-	// Compare engine state
-	if a.engine != nil {
-		engineSnap := a.engine.GetConfig()
-		if cfg.ProviderName != engineSnap.ProviderName ||
-			cfg.Model != engineSnap.Model ||
-			cfg.Mode != engineSnap.Mode {
-			report.InSync = false
-			report.EngineDrift = &EngineDrift{
-				ExpectedProvider: cfg.ProviderName,
-				ActualProvider:   engineSnap.ProviderName,
-				ExpectedModel:    cfg.Model,
-				ActualModel:      engineSnap.Model,
-				ExpectedMode:     cfg.Mode,
-				ActualMode:       engineSnap.Mode,
-			}
-		}
+	if ed := a.diffEngine(cfg); ed != nil {
+		report.InSync = false
+		report.EngineDrift = ed
 	}
 
-	// Compare context manager state
-	if a.ctxManager != nil {
-		limits := a.ctxManager.GetLimits()
-		if cfg.Limits.MaxHistoryTokens != limits.MaxHistoryTokens ||
-			cfg.Limits.MaxToolTurns != limits.MaxToolTurns ||
-			cfg.Limits.MaxHistoryTurns != limits.MaxHistoryTurns {
-			report.InSync = false
-			report.CtxManagerDrift = &CtxManagerDrift{
-				ExpectedMaxHistoryTokens: cfg.Limits.MaxHistoryTokens,
-				ActualMaxHistoryTokens:   limits.MaxHistoryTokens,
-				ExpectedMaxToolTurns:     cfg.Limits.MaxToolTurns,
-				ActualMaxToolTurns:       limits.MaxToolTurns,
-				ExpectedMaxHistoryTurns:  cfg.Limits.MaxHistoryTurns,
-				ActualMaxHistoryTurns:    limits.MaxHistoryTurns,
-			}
-		}
+	if cmd := a.diffCtxManager(cfg); cmd != nil {
+		report.InSync = false
+		report.CtxManagerDrift = cmd
 	}
 
 	return report

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -29,6 +29,59 @@ import (
 // Pinned by TestFactory_MaxTokensAboveSoftCeiling_EmitsWarning.
 const softMaxTokensCeiling = 200_000
 
+// buildBaseClient constructs a provider-specific LLM client based on the
+// provider type. Unknown or empty types fall back to Gemini. The caller
+// must provide a pre-created authenticator.
+func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, persona string, useSearch bool, timeout time.Duration, maxBudget int, bus events.EventBus, logger ports.Logger) (llm.LLMClient, error) {
+	var baseClient llm.LLMClient
+	var err error
+
+	switch p.Type {
+	case "openai", "deepseek":
+		baseClient = openai.NewClient(p.URL, p.Model, authenticator,
+			openai.WithHeaders(p.Headers),
+			openai.WithPersona(persona),
+			openai.WithTimeout(timeout),
+			openai.WithThinkingBudget(maxBudget),
+			openai.WithMaxTokens(p.MaxTokens),
+			openai.WithLogger(logger),
+		)
+	case "anthropic":
+		baseClient = anthropic.NewClient(p.URL, p.Model, authenticator,
+			anthropic.WithHeaders(p.Headers),
+			anthropic.WithThinkingBudget(maxBudget),
+			anthropic.WithMaxTokens(p.MaxTokens),
+			anthropic.WithPersona(persona),
+			anthropic.WithTimeout(timeout),
+			anthropic.WithLogger(logger),
+		)
+	case "google", "gemini", "":
+		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
+			gemini.WithHeaders(p.Headers),
+			gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
+			gemini.WithMaxOutputTokens(p.MaxTokens),
+			gemini.WithSystemInstruction(persona),
+			gemini.WithSearch(useSearch),
+			gemini.WithEventBus(bus),
+			gemini.WithTimeout(timeout),
+			gemini.WithLogger(logger),
+		)
+	default:
+		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
+			gemini.WithHeaders(p.Headers),
+			gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
+			gemini.WithMaxOutputTokens(p.MaxTokens),
+			gemini.WithSystemInstruction(persona),
+			gemini.WithSearch(useSearch),
+			gemini.WithEventBus(bus),
+			gemini.WithTimeout(timeout),
+			gemini.WithLogger(logger),
+		)
+	}
+
+	return baseClient, err
+}
+
 // newClient is the central factory for creating LLM provider clients.
 //
 // It inspects cfg.GetActiveProvider() to determine the provider type
@@ -77,52 +130,7 @@ func newClient(cfg *config.Config, pData pricing.PricingData, bus events.EventBu
 	maxBudget := cfg.ResolveThinkingBudget(p.Model, pData)
 	timeout := resolveTimeout(cfg)
 
-	var baseClient llm.LLMClient
-
-	switch p.Type {
-	case "openai", "deepseek":
-		baseClient = openai.NewClient(p.URL, p.Model, authenticator,
-			openai.WithHeaders(p.Headers),
-			openai.WithPersona(cfg.Person),
-			openai.WithTimeout(timeout),
-			openai.WithThinkingBudget(maxBudget),
-			openai.WithMaxTokens(p.MaxTokens),
-			openai.WithLogger(logger),
-		)
-	case "anthropic":
-		baseClient = anthropic.NewClient(p.URL, p.Model, authenticator,
-			anthropic.WithHeaders(p.Headers),
-			anthropic.WithThinkingBudget(maxBudget),
-			anthropic.WithMaxTokens(p.MaxTokens),
-			anthropic.WithPersona(cfg.Person),
-			anthropic.WithTimeout(timeout),
-			anthropic.WithLogger(logger),
-		)
-	case "google", "gemini", "": // Default to Gemini for now
-		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
-			gemini.WithHeaders(p.Headers),
-			gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
-			gemini.WithMaxOutputTokens(p.MaxTokens),
-			gemini.WithSystemInstruction(cfg.Person),
-			gemini.WithSearch(cfg.UseSearch),
-			gemini.WithEventBus(bus),
-			gemini.WithTimeout(timeout),
-			gemini.WithLogger(logger),
-		)
-	default:
-		// Fallback to Gemini if type is unknown for backward compatibility
-		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
-			gemini.WithHeaders(p.Headers),
-			gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
-			gemini.WithMaxOutputTokens(p.MaxTokens),
-			gemini.WithSystemInstruction(cfg.Person),
-			gemini.WithSearch(cfg.UseSearch),
-			gemini.WithEventBus(bus),
-			gemini.WithTimeout(timeout),
-			gemini.WithLogger(logger),
-		)
-	}
-
+	baseClient, err := buildBaseClient(p, authenticator, cfg.Person, cfg.UseSearch, timeout, maxBudget, bus, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -163,52 +171,7 @@ func newFailoverChain(cfg *config.Config, pData pricing.PricingData, bus events.
 
 		maxBudget := cfg.ResolveThinkingBudget(p.Model, pData)
 
-		var baseClient llm.LLMClient
-
-		switch p.Type {
-		case "openai", "deepseek":
-			baseClient = openai.NewClient(p.URL, p.Model, authenticator,
-				openai.WithHeaders(p.Headers),
-				openai.WithPersona(cfg.Person),
-				openai.WithTimeout(timeout),
-				openai.WithThinkingBudget(maxBudget),
-				openai.WithMaxTokens(p.MaxTokens),
-				openai.WithLogger(logger),
-			)
-		case "anthropic":
-			baseClient = anthropic.NewClient(p.URL, p.Model, authenticator,
-				anthropic.WithHeaders(p.Headers),
-				anthropic.WithThinkingBudget(maxBudget),
-				anthropic.WithMaxTokens(p.MaxTokens),
-				anthropic.WithPersona(cfg.Person),
-				anthropic.WithTimeout(timeout),
-				anthropic.WithLogger(logger),
-			)
-		case "google", "gemini", "": // Default to Gemini for now
-			baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
-				gemini.WithHeaders(p.Headers),
-				gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
-				gemini.WithMaxOutputTokens(p.MaxTokens),
-				gemini.WithSystemInstruction(cfg.Person),
-				gemini.WithSearch(cfg.UseSearch),
-				gemini.WithEventBus(bus),
-				gemini.WithTimeout(timeout),
-				gemini.WithLogger(logger),
-			)
-		default:
-			// Fallback to Gemini if type is unknown for backward compatibility
-			baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
-				gemini.WithHeaders(p.Headers),
-				gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
-				gemini.WithMaxOutputTokens(p.MaxTokens),
-				gemini.WithSystemInstruction(cfg.Person),
-				gemini.WithSearch(cfg.UseSearch),
-				gemini.WithEventBus(bus),
-				gemini.WithTimeout(timeout),
-				gemini.WithLogger(logger),
-			)
-		}
-
+		baseClient, err := buildBaseClient(p, authenticator, cfg.Person, cfg.UseSearch, timeout, maxBudget, bus, logger)
 		if err != nil {
 			return nil, fmt.Errorf("failover chain: provider %q: %w", p.Type, err)
 		}

--- a/internal/tools/analysis/sequence.go
+++ b/internal/tools/analysis/sequence.go
@@ -424,9 +424,8 @@ func (a *defaultSequenceAnalyzer) exprToString(expr ast.Expr) string {
 // matches package "github.com/foo/bar"). When multiple packages match, the
 // one with the longest import path wins. Returns the matched package and the
 // remaining portion of the symbol after the package path, or nil if no match.
-// When modName is non-empty, a second pass strips the module prefix
-// from each package path and retries, enabling resolution of
-// module-relative symbols like "internal/tools/analysis.Func".
+// When modName is non-empty and the first pass finds no match,
+// matchByModuleRelative is tried as a fallback.
 func (a *defaultSequenceAnalyzer) findByPrefix(symbol string, allPkgs []*packages.Package, modName string) (*packages.Package, string) {
 	var startPkg *packages.Package
 	var remaining string
@@ -438,21 +437,27 @@ func (a *defaultSequenceAnalyzer) findByPrefix(symbol string, allPkgs []*package
 			}
 		}
 	}
-	// Second pass: try module-relative matching. Strip the module prefix
-	// from each package path (e.g. "github.com/foo/bar/internal/pkg" →
-	// "internal/pkg") and retry the prefix check.
 	if modName != "" {
-		modPrefix := modName + "/"
-		for _, p := range allPkgs {
-			relPath := strings.TrimPrefix(p.PkgPath, modPrefix)
-			if relPath == p.PkgPath {
-				continue // trim had no effect; skip
-			}
-			if strings.HasPrefix(symbol, relPath+".") {
-				if startPkg == nil {
-					startPkg = p
-					remaining = symbol[len(relPath)+1:]
-				}
+		startPkg, remaining = a.matchByModuleRelative(symbol, allPkgs, modName+"/", startPkg, remaining)
+	}
+	return startPkg, remaining
+}
+
+// matchByModuleRelative is the second-pass fallback for findByPrefix.
+// It strips the module prefix from each package path (e.g.
+// "github.com/foo/bar/internal/pkg" → "internal/pkg") and retries the
+// prefix check. Only sets startPkg when the first pass found nothing
+// (startPkg == nil).
+func (a *defaultSequenceAnalyzer) matchByModuleRelative(symbol string, allPkgs []*packages.Package, modPrefix string, startPkg *packages.Package, remaining string) (*packages.Package, string) {
+	for _, p := range allPkgs {
+		relPath := strings.TrimPrefix(p.PkgPath, modPrefix)
+		if relPath == p.PkgPath {
+			continue // trim had no effect; skip
+		}
+		if strings.HasPrefix(symbol, relPath+".") {
+			if startPkg == nil {
+				startPkg = p
+				remaining = symbol[len(relPath)+1:]
 			}
 		}
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -42,8 +42,9 @@ type ToolRegistrationParams struct {
 	HealthManager    ports.HealthCheckManager
 }
 
-// RegisterAll registers all available tools into the registry.
-func RegisterAll(params ToolRegistrationParams) error {
+// validateRegistrationParams checks required fields in ToolRegistrationParams
+// and returns an error if any are nil.
+func validateRegistrationParams(params ToolRegistrationParams) error {
 	if params.Registry == nil {
 		return fmt.Errorf("RegisterAll: Registry is required and must not be nil")
 	}
@@ -52,6 +53,14 @@ func RegisterAll(params ToolRegistrationParams) error {
 	}
 	if params.WorkspacePolicy == nil {
 		return fmt.Errorf("RegisterAll: WorkspacePolicy is required and must not be nil")
+	}
+	return nil
+}
+
+// RegisterAll registers all available tools into the registry.
+func RegisterAll(params ToolRegistrationParams) error {
+	if err := validateRegistrationParams(params); err != nil {
+		return err
 	}
 	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager); err != nil {
 		return err


### PR DESCRIPTION
Closes #640.

## Summary
Pre-emptive cyclomatic complexity reduction for 4 production-code functions at threshold (10). Extracted helper methods to bring all below the 11 alert threshold, with 3 of 4 reduced to ≤6.

## Changes

| # | Function | File | Before | After | Extracted Helper |
|---|----------|------|--------|-------|-----------------|
| 1 | `RegisterAll` | `internal/tools/tools.go` | 10 | **8** | `validateRegistrationParams` (4) |
| 2 | `DiffConfig` | `internal/agent/drift.go` | 10 | **4** | `diffEngine` (5), `diffCtxManager` (5) |
| 3 | `findByPrefix` | `internal/tools/analysis/sequence.go` | 10 | **6** | `matchByModuleRelative` (5) |
| 4 | `newFailoverChain` | `internal/infrastructure/llm/factory.go` | 10 | **6** | `buildBaseClient` (5) |
| — | `newClient` (bonus) | `internal/infrastructure/llm/factory.go` | 9 | **5** | same `buildBaseClient` |

## Verification
| Check | Status |
|-------|--------|
| `go fmt`, `go mod tidy`, `go build` | PASS |
| `golangci-lint run ./...` | 0 issues |
| `go vet ./...` | PASS |
| `go test -race` (agent, tools, llm) | PASS |
| Coverage (agent, tools, llm) | 91-100% |
| `golangci-lint --enable-only=gocyclo` | 0 production functions > 10 |