### PR TITLE
fix(llm): simplify FailoverGateway error routing to single !IsTransient gate (#643)

### DIFF
--- a/internal/infrastructure/llm/failover.go
+++ b/internal/infrastructure/llm/failover.go
@@ -21,6 +21,18 @@ type NamedClient struct {
 // list of provider clients on Generate, falling through on transient errors.
 // Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to the
 // primary (first) client.
+//
+// Separation of concerns:
+//
+//	ResilientClient (wraps each provider) — single-provider retry, auth refresh,
+//	connection resetting, and raw error → domain sentinel classification via
+//	llmerr.Classify. Every client in the failover chain MUST be wrapped in
+//	ResilientClient (this is enforced by newFailoverChain in factory.go).
+//
+//	FailoverGateway (this type) — provider iteration and routing decisions based
+//	solely on the domain sentinels returned by ResilientClient. It does NOT
+//	repeat error classification; it only checks IsTransient() to decide whether
+//	to try the next provider or abort the chain.
 type FailoverGateway struct {
 	clients []NamedClient // clients[0] is primary
 }
@@ -41,11 +53,14 @@ func NewFailoverGateway(clients []NamedClient) *FailoverGateway {
 
 // Generate implements the core failover logic.
 //
-// It iterates through fg.clients in order:
+// Each client in the chain is expected to return domain-classified errors
+// (via ResilientClient / llmerr.Classify). FailoverGateway only routes
+// based on the error category:
 //   - On success: sets metrics.Provider to the client's name and returns.
-//   - On auth or terminal error: wraps and returns immediately (no fallback).
-//   - On transient error (including rate limits): records the error and tries
-//     the next provider.
+//   - On transient (including rate limits): records the error and tries the
+//     next provider in the chain.
+//   - On any non-transient error (auth, terminal, unrecognized): aborts
+//     immediately — no further providers are tried.
 //   - If all providers are exhausted: returns the last error wrapped as terminal.
 func (fg *FailoverGateway) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
 	var lastErr error
@@ -62,18 +77,17 @@ func (fg *FailoverGateway) Generate(ctx context.Context, input []*llm.Content, t
 			return content, metrics, nil
 		}
 
-		if llm.IsAuth(err) || llm.IsTerminal(err) {
+		// ResilientClient already classified this error as a domain sentinel
+		// (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal) via llmerr.Classify.
+		// FailoverGateway only decides whether to retry the next provider.
+		if !llm.IsTransient(err) {
+			// Auth, terminal, context-limit, and any unclassified errors abort the chain.
 			return nil, nil, fmt.Errorf("failover: provider %q: %w", nc.Name, err)
 		}
 
-		// IsTransient covers both ErrTransient and ErrRateLimit
-		if llm.IsTransient(err) {
-			lastErr = err
-			continue
-		}
-
-		// Any unrecognised error is treated as terminal
-		return nil, nil, fmt.Errorf("failover: provider %q: %w", nc.Name, err)
+		// IsTransient covers both ErrTransient and ErrRateLimit — try next provider.
+		lastErr = err
+		continue
 	}
 
 	// All providers exhausted — wrap last error as terminal

--- a/internal/infrastructure/llm/failover_test.go
+++ b/internal/infrastructure/llm/failover_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/llm/llmerr"
 )
 
 // mockExtendedClient implements llm.ExtendedClient with configurable behaviour.
@@ -530,5 +531,134 @@ func TestFailoverGateway_SendChat_ContextCancelled(t *testing.T) {
 	}
 	if primary.sendChatCalled != 0 {
 		t.Errorf("primary.sendChatCalled = %d, want 0", primary.sendChatCalled)
+	}
+}
+
+func TestFailoverGateway_Generate_Routing(t *testing.T) {
+	unrecognizedErr := errors.New("unknown protocol error")
+
+	tests := []struct {
+		name       string
+		primaryErr error
+		wantErr    error // expected sentinel in the returned error (nil = success)
+	}{
+		{
+			name:       "success passes through",
+			primaryErr: nil,
+			wantErr:    nil,
+		},
+		{
+			name:       "transient falls through to secondary",
+			primaryErr: llm.ErrTransient,
+			wantErr:    nil, // secondary succeeds (default mock behavior)
+		},
+		{
+			name:       "rate limit falls through to secondary",
+			primaryErr: llm.ErrRateLimit,
+			wantErr:    nil, // secondary succeeds
+		},
+		{
+			name:       "auth aborts immediately",
+			primaryErr: llm.ErrAuth,
+			wantErr:    llm.ErrAuth,
+		},
+		{
+			name:       "terminal aborts immediately",
+			primaryErr: llm.ErrTerminal,
+			wantErr:    llm.ErrTerminal,
+		},
+		{
+			name:       "unrecognized error aborts immediately",
+			primaryErr: unrecognizedErr,
+			wantErr:    unrecognizedErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			primary := &mockExtendedClient{
+				name: "primary",
+				generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+					if tt.primaryErr != nil {
+						return nil, nil, tt.primaryErr
+					}
+					return successContent(), successMetrics(), nil
+				},
+			}
+			secondary := &mockExtendedClient{
+				name: "secondary",
+				generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+					return successContent(), successMetrics(), nil
+				},
+			}
+
+			fg := NewFailoverGateway([]NamedClient{
+				{Name: primary.name, Client: primary},
+				{Name: secondary.name, Client: secondary},
+			})
+
+			_, _, err := fg.Generate(context.Background(), nil, nil, nil)
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected error wrapping %v, got %v", tt.wantErr, err)
+			}
+
+			// For non-transient errors, secondary must NOT be called
+			if !llm.IsTransient(tt.primaryErr) && secondary.generateCalled != 0 {
+				t.Errorf("secondary should not be called for non-transient error, called %d times", secondary.generateCalled)
+			}
+
+			// For transient errors, secondary MUST be called
+			if llm.IsTransient(tt.primaryErr) && secondary.generateCalled != 1 {
+				t.Errorf("secondary should be called for transient error, called %d times", secondary.generateCalled)
+			}
+		})
+	}
+}
+
+func TestFailoverGateway_WithResilientClient_ClassifiesAndRoutes(t *testing.T) {
+	// Primary returns a raw HTTP 429 that ResilientClient classifies as ErrRateLimit.
+	// FailoverGateway should see IsTransient=true and fall through to secondary.
+	primaryRaw := &mockLLMClient{
+		sendChatFn: func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, &llmerr.APIError{Status: 429, Body: "Too Many Requests"}
+		},
+	}
+	primaryResilient := NewResilientClient(primaryRaw)
+
+	secondary := &mockExtendedClient{
+		name: "secondary",
+		generateFn: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return successContent(), successMetrics(), nil
+		},
+	}
+
+	fg := NewFailoverGateway([]NamedClient{
+		{Name: "primary", Client: primaryResilient},
+		{Name: "secondary", Client: secondary},
+	})
+
+	content, metrics, err := fg.Generate(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content.Parts[0].Text != "success" {
+		t.Errorf("got %q, want %q", content.Parts[0].Text, "success")
+	}
+	if metrics.Provider != "secondary" {
+		t.Errorf("got provider %q, want %q", metrics.Provider, "secondary")
+	}
+	if secondary.generateCalled != 1 {
+		t.Errorf("secondary.generateCalled = %d, want 1", secondary.generateCalled)
 	}
 }


### PR DESCRIPTION
Closes #643.

## Summary

Collapse the 3-branch error classification in `FailoverGateway.Generate` 
(`IsAuth||IsTerminal`, `IsTransient`, unrecognized→terminal) into a 
single `!IsTransient` check. `ResilientClient` (applied in factory wiring) 
already classifies all raw errors via `llmerr.Classify`, so 
`FailoverGateway` only needs to route on transient vs non-transient.

## Changes

| File | Change |
|------|--------|
| `failover.go` | Simplify `Generate` error routing (CC 8→6); add struct-level separation-of-concerns docs |
| `failover_test.go` | Add table-driven routing test (6 subtests) + integration test (FailoverGateway over ResilientClient with HTTP 429) |

No changes to `resilient_client.go` or `factory.go` — the factory was already 
correctly wrapping each provider in `ResilientClient`.

## Verification

| Check | Status |
|-------|--------|
| `go test ./...` | PASS (all packages) |
| `make check-full` | PASS (lint 0 issues, vulncheck clean, dead-code clean; one pre-existing race timeout in unrelated `tools/analysis` package) |
| FailoverGateway tests | 16 tests PASS |
