### PR TITLE
fix(di): add tests for untested failover DI paths (#645)

### DIFF
--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -64,6 +64,27 @@ func (m *mockLLMClient) Generate(ctx context.Context, input []*llm.Content, tool
 	return args.Get(0).(*llm.Content), args.Get(1).(*llm.Metrics), args.Error(2)
 }
 
+// mockClientFactory implements ports.ClientFactory for testing failover paths.
+type mockClientFactory struct {
+	mock.Mock
+}
+
+func (m *mockClientFactory) NewClient(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	args := m.Called(cfg, pricingData, bus, logger)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(llm.ExtendedClient), args.Error(1)
+}
+
+func (m *mockClientFactory) NewFailoverChain(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+	args := m.Called(cfg, pricingData, bus, logger)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(llm.ExtendedClient), args.Error(1)
+}
+
 type mockConfigurableSecurityManager struct {
 	mock.Mock
 }
@@ -1409,4 +1430,113 @@ func TestNewBootstrapper_DefaultFallbacks(t *testing.T) {
 	assert.NotNil(t, b.GetHistoryBrowser())
 	assert.NotNil(t, b.GetUIRenderer())
 	assert.NotNil(t, b.GetHistoryRenderer())
+}
+
+func TestBuildSessionDependencies_FailoverChain(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	simulatedErr := errors.New("failover init failed")
+
+	testCfg := &config.Config{
+		Mode:          "assistant",
+		Model:         "test-model",
+		FailoverOrder: []string{"provider-a", "provider-b"},
+	}
+
+	tests := []struct {
+		name            string
+		mockSetup       func(factory *mockClientFactory, gwClient *mockExtendedClient)
+		expectNewClient bool
+		expectGwUsed    bool
+		wantGenerateErr error
+	}{
+		{
+			name: "NewFailoverChain_ReturnsError",
+			mockSetup: func(factory *mockClientFactory, gwClient *mockExtendedClient) {
+				factory.On("NewFailoverChain", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, simulatedErr)
+			},
+			expectNewClient: false,
+			expectGwUsed:    false,
+			wantGenerateErr: simulatedErr,
+		},
+		{
+			name: "NewFailoverChain_ReturnsNilNil_FallsBackToNewClient",
+			mockSetup: func(factory *mockClientFactory, gwClient *mockExtendedClient) {
+				factory.On("NewFailoverChain", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(nil, nil)
+				factory.On("NewClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(gwClient, nil)
+				gwClient.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(&llm.Content{}, &llm.Metrics{}, nil)
+			},
+			expectNewClient: true,
+			expectGwUsed:    true,
+			wantGenerateErr: nil,
+		},
+		{
+			name: "NewFailoverChain_ReturnsGateway_UsesGateway",
+			mockSetup: func(factory *mockClientFactory, gwClient *mockExtendedClient) {
+				factory.On("NewFailoverChain", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(gwClient, nil)
+				gwClient.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return(&llm.Content{}, &llm.Metrics{}, nil)
+			},
+			expectNewClient: false,
+			expectGwUsed:    true,
+			wantGenerateErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := new(mockConfigurableSecurityManager)
+			setupDefaultSMExpectations(sm)
+			sm.On("RegisterPolicyTools", mock.Anything, mock.Anything).Return(nil).Maybe()
+			sm.On("SetBypassActive", mock.Anything).Return().Maybe()
+
+			gwClient := new(mockExtendedClient)
+			factory := new(mockClientFactory)
+			if tt.mockSetup != nil {
+				tt.mockSetup(factory, gwClient)
+			}
+
+			bcfg := DefaultBootstrapperConfig()
+			bcfg.HomeDir = tempDir
+			bcfg.SM = sm
+			bcfg.Version = "1.0.0"
+			bcfg.Stdout = io.Discard
+			bcfg.Stderr = io.Discard
+			bcfg.ClientFactory = factory
+			b := NewBootstrapper(bcfg)
+
+			deps, _, cleanup, err := b.BuildSessionDependencies(ctx, testCfg, "config.yaml", false, nil)
+			require.NoError(t, err)
+			require.NotNil(t, deps)
+			defer func() { _ = cleanup(ctx) }()
+
+			// Trigger lazy client initialization
+			gw := deps.GetGateway()
+			_, _, genErr := gw.Generate(ctx, nil, nil, nil)
+
+			if tt.wantGenerateErr != nil {
+				require.Error(t, genErr)
+				assert.ErrorIs(t, genErr, tt.wantGenerateErr,
+					"Generate should propagate the failover chain error")
+				assert.Contains(t, genErr.Error(), "LLM provider initialization failed")
+			} else {
+				require.NoError(t, genErr)
+			}
+
+			if tt.expectNewClient {
+				factory.AssertCalled(t, "NewClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			} else {
+				factory.AssertNotCalled(t, "NewClient", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+			}
+
+			if tt.expectGwUsed {
+				gwClient.AssertExpectations(t)
+			}
+		})
+	}
 }

--- a/internal/infrastructure/di/factory_error_test.go
+++ b/internal/infrastructure/di/factory_error_test.go
@@ -26,6 +26,7 @@ import (
 	infra_tools "github.com/gosharplite/tell-me-go/internal/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 type mockFailingFS struct {
@@ -233,6 +234,7 @@ func TestBuildSession_FailurePaths(t *testing.T) {
 		{
 			name: "EnsureDirectoriesFailure",
 			setup: func(f *defaultSessionFactory) {
+				f.setupSecurityFunc = f.setupSecurity
 				f.FileSystem = &mockFailingFS{mkdirErr: simulatedErr}
 			},
 			wantErr: errInfraInit,
@@ -240,9 +242,20 @@ func TestBuildSession_FailurePaths(t *testing.T) {
 		{
 			name: "SessionStateInitializationFailure",
 			setup: func(f *defaultSessionFactory) {
+				f.setupSecurityFunc = f.setupSecurity
 				f.FileSystem = &infra_persistence.OSFileSystem{}
 				f.NewSessionState = func(ctx context.Context, modeDir string) (ports.SessionProvider, error) {
 					return nil, simulatedErr
+				}
+			},
+			wantErr: errInfraInit,
+		},
+		{
+			name: "SetupSecurityFailure",
+			setup: func(f *defaultSessionFactory) {
+				f.FileSystem = &infra_persistence.OSFileSystem{}
+				f.setupSecurityFunc = func(paths *persistence.Paths, configPath string) error {
+					return simulatedErr
 				}
 			},
 			wantErr: errInfraInit,
@@ -412,6 +425,19 @@ type failingProgramRunner struct{ err error }
 
 func (r *failingProgramRunner) Run() (tea.Model, error) { return nil, r.err }
 
+// quitModel is a minimal bubbletea Model that immediately quits.
+type quitModel struct{}
+
+func (m quitModel) Init() tea.Cmd { return tea.Quit }
+func (m quitModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg.(type) {
+	case tea.QuitMsg:
+		return m, tea.Quit
+	}
+	return m, nil
+}
+func (m quitModel) View() string { return "" }
+
 func TestTUIHistoryBrowser_Browse_LoggerCloseError(t *testing.T) {
 	ctx := context.Background()
 	simulatedErr := errors.New("disk full")
@@ -485,4 +511,37 @@ func TestTUIHistoryBrowser_Browse_ProgramRunError(t *testing.T) {
 	// The warning log should NOT contain any close error since we skipped the logger
 	logOutput := logBuf.String()
 	assert.NotContains(t, logOutput, "failed to close tui logger")
+}
+
+func TestTeaProgramRunner_Run(t *testing.T) {
+	p := tea.NewProgram(quitModel{}, tea.WithoutRenderer(), tea.WithInput(nil))
+	runner := &teaProgramRunner{p: p}
+
+	model, err := runner.Run()
+
+	require.NoError(t, err, "teaProgramRunner.Run should not error with a simple model")
+	require.NotNil(t, model)
+	_, ok := model.(quitModel)
+	assert.True(t, ok, "Run should return the model passed to NewProgram")
+}
+
+func TestDefaultUIFactory_HistoryBrowser_Constructor(t *testing.T) {
+	sm := new(mockConfigurableSecurityManager)
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	factory := newUIFactory(sm, io.Discard, io.Discard, logger)
+
+	browser := factory.HistoryBrowser()
+	require.NotNil(t, browser)
+
+	tuiBrowser, ok := browser.(*tuiHistoryBrowser)
+	require.True(t, ok, "HistoryBrowser should return *tuiHistoryBrowser")
+
+	assert.Equal(t, logger, tuiBrowser.logger)
+	assert.NotNil(t, tuiBrowser.initLogger, "initLogger should be the real tui.InitLogger")
+	assert.NotNil(t, tuiBrowser.newProgram, "newProgram should be the real closure")
+
+	runner := tuiBrowser.newProgram(quitModel{})
+	require.NotNil(t, runner)
+	_, ok = runner.(*teaProgramRunner)
+	assert.True(t, ok, "newProgram should return a *teaProgramRunner")
 }

--- a/internal/infrastructure/di/session_factory.go
+++ b/internal/infrastructure/di/session_factory.go
@@ -24,18 +24,19 @@ type sessionFactory interface {
 }
 
 type defaultSessionFactory struct {
-	HomeDir         string
-	FileSystem      infra_persistence.FileSystem
-	SM              ConfigurableSecurityManager
-	Stderr          io.Writer
-	Stdout          io.Writer
-	Logger          *slog.Logger
-	RotateSession   func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error
-	NewSessionState func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error)
+	HomeDir           string
+	FileSystem        infra_persistence.FileSystem
+	SM                ConfigurableSecurityManager
+	Stderr            io.Writer
+	Stdout            io.Writer
+	Logger            *slog.Logger
+	RotateSession     func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error
+	NewSessionState   func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error)
+	setupSecurityFunc func(paths *persistence.Paths, configPath string) error
 }
 
 func newSessionFactory(homeDir string, fs infra_persistence.FileSystem, sm ConfigurableSecurityManager, stdout, stderr io.Writer, logger *slog.Logger, rotate func(ctx stdctx.Context, fs infra_persistence.FileSystem, stdout io.Writer, paths persistence.Paths, retentionDays int, logger *slog.Logger) error, newState func(ctx stdctx.Context, modeDir string) (ports.SessionProvider, error)) sessionFactory {
-	return &defaultSessionFactory{
+	f := &defaultSessionFactory{
 		HomeDir:         homeDir,
 		FileSystem:      fs,
 		SM:              sm,
@@ -45,6 +46,8 @@ func newSessionFactory(homeDir string, fs infra_persistence.FileSystem, sm Confi
 		RotateSession:   rotate,
 		NewSessionState: newState,
 	}
+	f.setupSecurityFunc = f.setupSecurity
+	return f
 }
 
 func (f *defaultSessionFactory) buildSessionProvider(ctx stdctx.Context, paths *persistence.Paths, cfg *config.Config) (ports.SessionProvider, func(stdctx.Context) error, error) {
@@ -142,7 +145,7 @@ func (f *defaultSessionFactory) BuildSession(ctx stdctx.Context, cfg *config.Con
 		return nil, nil, nil, fmt.Errorf("%w: failed to ensure directories for %s: %w", errInfraInit, cfg.Mode, err)
 	}
 
-	if err := f.setupSecurity(paths, configPath); err != nil {
+	if err := f.setupSecurityFunc(paths, configPath); err != nil {
 		return nil, nil, nil, fmt.Errorf("%w: security setup: %w", errInfraInit, err)
 	}
 


### PR DESCRIPTION
Closes #645.

## Summary
Added targeted unit tests for 7 previously untested code paths in `internal/infrastructure/di`:

### Changes
- **`container_test.go`**: Added `mockClientFactory` type and `TestBuildSessionDependencies_FailoverChain` — 3 table-driven subtests covering failover chain error propagation, nil-nil fallback to NewClient, and gateway utilization (gaps 1-4)
- **`session_factory.go`**: Added `setupSecurityFunc` function field (following existing pattern of `RotateSession`/`NewSessionState`) to make `setupSecurity` error path testable (gap 5)
- **`factory_error_test.go`**: Added `SetupSecurityFailure` test case, `TestTeaProgramRunner_Run`, and `TestDefaultUIFactory_HistoryBrowser_Constructor` (gaps 5-7)

### Coverage
| Function | Before | After |
|----------|--------|-------|
| `BuildSessionDependencies` | 82.1% | **100.0%** |
| `BuildSession` | 93.3% | **100.0%** |
| `teaProgramRunner.Run` | 0.0% | **100.0%** |
| `HistoryBrowser` | 50.0% | **100.0%** |
| **Package total** | **96.9%** | **100.0%** |

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go build ./...` | PASS |
| `golangci-lint run ./...` | PASS (0 issues) |
| `go test -race ./internal/infrastructure/di/...` | PASS |
| `go test -cover ./internal/infrastructure/di/...` | PASS (100.0%) |