### PR TITLE
fix(workspace): fix pipeline deadlock on start failure (#650)

### DIFF
--- a/internal/infrastructure/testing/bin/helper/main.go
+++ b/internal/infrastructure/testing/bin/helper/main.go
@@ -21,6 +21,7 @@ var commands = map[string]func([]string){
 	"grep":          handleGrep,
 	"deadlock-test": handleDeadlockTest,
 	"multi-line":    handleMultiLine,
+	"pipe-fill":     handlePipeFill,
 	"printf":        handlePrintf,
 	"stress-output": handleStressOutput,
 	"diff":          handleDiff,
@@ -150,6 +151,14 @@ func handleMultiLine(args []string) {
 		_, _ = fmt.Fprintf(os.Stdout, "STDOUT_LINE_%d\n", i)
 		_, _ = fmt.Fprintf(os.Stderr, "STDERR_LINE_%d\n", i)
 	}
+}
+
+func handlePipeFill(_ []string) {
+	data := make([]byte, 200*1024)
+	for i := range data {
+		data[i] = 'x'
+	}
+	_, _ = os.Stdout.Write(data)
 }
 
 func handlePrintf(args []string) {

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -236,6 +236,7 @@ func (e *processExecutor) RunPipeline(ctx context.Context, pipedParts [][]string
 	}
 
 	if err = p.start(); err != nil {
+		p.closePipes()  // Close pipes to unblock running commands
 		_, _ = p.wait() // Ensure started processes are cleaned up
 		return executionResult{ExitCode: 1}, fmt.Errorf("pipeline failed to start: %w", err)
 	}

--- a/internal/tools/workspace/process_executor_stream_test.go
+++ b/internal/tools/workspace/process_executor_stream_test.go
@@ -805,6 +805,50 @@ func TestPipeline_StartFailure(t *testing.T) {
 	})
 }
 
+// TestPipeline_StartFailureDeadlock verifies that when p.start() fails after
+// a previous command has started and is producing output, the error path
+// does not deadlock. It uses a pipe-filling command that writes 200KB to
+// stdout (exceeding the OS pipe buffer) paired with a nonexistent second
+// command whose Start() fails. Without the p.closePipes() fix in the error
+// path, the first command blocks on the pipe write and p.wait() hangs forever.
+func TestPipeline_StartFailureDeadlock(t *testing.T) {
+	e := newprocessExecutor()
+
+	pipedParts := [][]string{
+		{helperPath, "pipe-fill"},                 // writes 200KB to stdout, blocks when pipe buffer full
+		{"/nonexistent/binary_xyz_31415", "arg1"}, // Start() fails, but cmd[0] is already running
+	}
+
+	done := make(chan struct{})
+	var res executionResult
+	var runErr error
+
+	go func() {
+		res, runErr = e.RunPipeline(context.Background(), pipedParts, executionConfig{})
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Success: RunPipeline returned without deadlocking
+	case <-time.After(2 * time.Second):
+		t.Fatal("deadlock: RunPipeline did not return within 2 seconds — p.wait() is blocked on a pipe-saturated command")
+	}
+
+	if runErr == nil {
+		t.Fatal("expected error from pipeline start failure")
+	}
+	if !strings.Contains(runErr.Error(), "pipeline failed to start") {
+		t.Errorf("expected 'pipeline failed to start' in error, got: %v", runErr)
+	}
+	if !strings.Contains(runErr.Error(), "command 1 failed to start") {
+		t.Errorf("expected 'command 1 failed to start' in error, got: %v", runErr)
+	}
+	if res.ExitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", res.ExitCode)
+	}
+}
+
 // TestRunCommand_NonExitErrorWaitPath directly exercises the non-*exec.ExitError
 // wait path in RunCommand by testing formatPipelineResult with a signal-style
 // error that is not an ExitError. This is the code path at lines 82-84.


### PR DESCRIPTION
Closes #650.

## Summary
Fixes a deterministic deadlock in `RunPipeline`'s start-failure error path. When `p.start()` fails after some pipeline commands have started, those commands could be blocked writing to full pipe buffers. The deferred `p.closePipes()` never executed because `p.wait()` blocked first — a classic deadlock.

**Fix**: Explicitly call `p.closePipes()` before `p.wait()` in the error block. This closes pipe read ends, unblocking any writers before we wait for them to exit.

**Additions**:
- `pipe-fill` test helper (200KB unbuffered stdout write) to reliably saturate pipe buffers
- `TestPipeline_StartFailureDeadlock` regression test using goroutine + select + timeout pattern

## Verification

| Check | Status |
|-------|--------|
| `make check-full` | PASS (fmt, tidy, build, lint, verify-architecture, vulncheck, test, dead-code) |
| `test-race` (workspace) | PASS |
| `test-race` (helper) | PASS |
| Coverage (workspace) | 94.1% |

## Files Changed

| File | Change |
|------|--------|
| `internal/tools/workspace/process_executor.go` | +1 line — `p.closePipes()` before `p.wait()` |
| `internal/tools/workspace/process_executor_stream_test.go` | +44 lines — `TestPipeline_StartFailureDeadlock` |
| `internal/infrastructure/testing/bin/helper/main.go` | +9 lines — `pipe-fill` subcommand |