### PR TITLE
fix(workspace): enforce sandbox isolation for absolute output paths (#651)

### DIFF
--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -278,12 +278,40 @@ func (e *processExecutor) formatPipelineResult(stdoutStr, stderrStr string, trun
 	}, nil
 }
 
-// resolveAndValidateOutputPath converts a cleaned relative path to an absolute path,
-// validating that it does not escape the current working directory.
-// originalPath is used only for the error message.
+// resolveAndValidateOutputPath converts a cleaned path to an absolute path,
+// validating that it does not escape the current working directory or the
+// system temporary directory. originalPath is used only for the error message.
 func resolveAndValidateOutputPath(cleanedPath, originalPath string) (string, error) {
+	// withinParent checks whether target is inside the given parent directory.
+	withinParent := func(parent, target string) bool {
+		rel, err := filepath.Rel(parent, target)
+		if err != nil {
+			return false
+		}
+		if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+			return false
+		}
+		return true
+	}
+
 	if filepath.IsAbs(cleanedPath) {
-		return cleanedPath, nil
+		// 1. Check CWD boundary.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("failed to get current directory: %w", err)
+		}
+		if withinParent(cwd, cleanedPath) {
+			return cleanedPath, nil
+		}
+
+		// 2. Check os.TempDir() boundary (skip if empty).
+		if tmpDir := os.TempDir(); tmpDir != "" {
+			if withinParent(tmpDir, cleanedPath) {
+				return cleanedPath, nil
+			}
+		}
+
+		return "", fmt.Errorf("output file path cannot escape current directory: %q", originalPath)
 	}
 
 	cwd, err := os.Getwd()

--- a/internal/tools/workspace/process_executor_security_test.go
+++ b/internal/tools/workspace/process_executor_security_test.go
@@ -80,9 +80,21 @@ func TestOpenOutputFile_Security(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "absolute path",
+			name:    "absolute path within workspace",
 			path:    filepath.Join(tmpDir, "absolute.txt"),
 			wantErr: false,
+		},
+		{
+			name:       "absolute path to etc passwd",
+			path:       "/etc/passwd",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
+		},
+		{
+			name:       "absolute path to etc outside both boundaries",
+			path:       "/etc/cron.d/evil",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
 		},
 		{
 			name:       "nested relative up",
@@ -179,9 +191,21 @@ func TestResolveAndValidateOutputPath_Escape(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:    "absolute path",
-			path:    "/tmp/foo",
+			name:       "absolute path outside both cwd and temp",
+			path:       "/etc/shadow",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
+		},
+		{
+			name:    "absolute path within cwd",
+			path:    func() string { wd, _ := os.Getwd(); return filepath.Join(wd, "safe_output.txt") }(),
 			wantErr: false,
+		},
+		{
+			name:       "absolute path to etc passwd",
+			path:       "/etc/passwd",
+			wantErr:    true,
+			errContain: "cannot escape current directory",
 		},
 	}
 


### PR DESCRIPTION
Closes #651.

## Summary

Fixed `resolveAndValidateOutputPath` in `internal/tools/workspace/process_executor.go` to reject absolute paths that fall outside both the current working directory and `os.TempDir()`. Previously, absolute paths were returned immediately without any workspace boundary validation, creating a defense-in-depth gap.

### Changes
- **`process_executor.go`**: Replaced the blind `return cleanedPath, nil` for absolute paths with inline validation against CWD and `os.TempDir()` boundaries, matching the security layer's `pathPolicy.checkDefaultBoundaries`
- **`process_executor_security_test.go`**: Added test cases for `/etc/passwd`, `/etc/shadow`, `/etc/cron.d/evil` traversal attempts; added absolute-path-within-CWD success case; renamed existing cases for clarity

## Verification
| Check | Status |
|-------|--------|
| go fmt | PASS |
| go mod tidy | PASS |
| go build | PASS |
| golangci-lint | 0 issues |
| go test ./... | PASS (all packages) |
| go test -race ./internal/tools/workspace/ | PASS |
| govulncheck | No vulnerabilities |
| Coverage | 94.0% |
