### PR TITLE
fix(workspace): refactor resolveAndValidateOutputPath to reduce cyclomatic complexity (#658)

### DIFF
--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -279,42 +279,43 @@ func (e *processExecutor) formatPipelineResult(stdoutStr, stderrStr string, trun
 	}, nil
 }
 
-// resolveAndValidateOutputPath converts a cleaned path to an absolute path,
-// validating that it does not escape the current working directory or the
-// system temporary directory. originalPath is used only for the error message.
-func resolveAndValidateOutputPath(cleanedPath, originalPath string) (string, error) {
-	// withinParent checks whether target is inside the given parent directory.
-	withinParent := func(parent, target string) bool {
-		rel, err := filepath.Rel(parent, target)
-		if err != nil {
-			return false
-		}
-		if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-			return false
-		}
-		return true
+// withinParent reports whether target resides inside the parent directory.
+func withinParent(parent, target string) bool {
+	rel, err := filepath.Rel(parent, target)
+	if err != nil {
+		return false
+	}
+	if strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return false
+	}
+	return true
+}
+
+// validateAbsPath checks an absolute cleanedPath against CWD and TempDir boundaries.
+// originalPath is used only for error messages.
+func validateAbsPath(cleanedPath, originalPath string) (string, error) {
+	// 1. Check CWD boundary.
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current directory: %w", err)
+	}
+	if withinParent(cwd, cleanedPath) {
+		return cleanedPath, nil
 	}
 
-	if filepath.IsAbs(cleanedPath) {
-		// 1. Check CWD boundary.
-		cwd, err := os.Getwd()
-		if err != nil {
-			return "", fmt.Errorf("failed to get current directory: %w", err)
-		}
-		if withinParent(cwd, cleanedPath) {
+	// 2. Check os.TempDir() boundary (skip if empty).
+	if tmpDir := os.TempDir(); tmpDir != "" {
+		if withinParent(tmpDir, cleanedPath) {
 			return cleanedPath, nil
 		}
-
-		// 2. Check os.TempDir() boundary (skip if empty).
-		if tmpDir := os.TempDir(); tmpDir != "" {
-			if withinParent(tmpDir, cleanedPath) {
-				return cleanedPath, nil
-			}
-		}
-
-		return "", fmt.Errorf("output file path cannot escape current directory: %q", originalPath)
 	}
 
+	return "", fmt.Errorf("output file path cannot escape current directory: %q", originalPath)
+}
+
+// validateAndResolveRelPath resolves a relative cleanedPath against CWD
+// and checks that it does not escape. originalPath is used only for error messages.
+func validateAndResolveRelPath(cleanedPath, originalPath string) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("failed to get current directory: %w", err)
@@ -322,11 +323,21 @@ func resolveAndValidateOutputPath(cleanedPath, originalPath string) (string, err
 
 	absPath := filepath.Join(cwd, cleanedPath)
 
-	rel, err := filepath.Rel(cwd, absPath)
-	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+	if !withinParent(cwd, absPath) {
 		return "", fmt.Errorf("output file path cannot escape current directory: %q", originalPath)
 	}
 	return absPath, nil
+}
+
+// resolveAndValidateOutputPath converts a cleaned path to an absolute path,
+// validating that it does not escape the current working directory or the
+// system temporary directory. originalPath is used only for the error message.
+func resolveAndValidateOutputPath(cleanedPath, originalPath string) (string, error) {
+	if filepath.IsAbs(cleanedPath) {
+		return validateAbsPath(cleanedPath, originalPath)
+	}
+
+	return validateAndResolveRelPath(cleanedPath, originalPath)
 }
 
 func (e *processExecutor) openOutputFile(config executionConfig) (*os.File, error) {


### PR DESCRIPTION
Closes #658.

## Summary
Refactored `resolveAndValidateOutputPath` in `internal/tools/workspace/process_executor.go` to reduce cyclomatic complexity from **13 → 2** (threshold: 10).

### Changes
- **`withinParent`** — promoted from closure to package-level unexported function (zero captured variables, purely mechanical)
- **`validateAbsPath`** — extracted CWD/TempDir boundary checks for absolute paths (complexity 5)
- **`validateAndResolveRelPath`** — extracted relative-path resolution with deduplication, now uses `withinParent` instead of duplicated inline escape-check logic (complexity 3)
- **`resolveAndValidateOutputPath`** — reduced to a 2-branch dispatcher delegating to the two extracted functions (complexity 2)

### Side benefit
Eliminated pre-existing technical debt of duplicated escape-check logic in the relative-path branch.

## Verification
| Check | Status |
|-------|--------|
| make check | PASS |
| lint | 0 issues |
| vulncheck | No vulnerabilities |
| dead-code | No dead code |
| test (all packages) | PASS |
| test-race (workspace) | PASS |
| Complexity (target ≤4) | 2 ✅ |