### PR TITLE
fix(workspace): add marshalIndent test seam for GetSessionInfo coverage (#664)

### DIFF
--- a/internal/tools/workspace/persistence_tools.go
+++ b/internal/tools/workspace/persistence_tools.go
@@ -16,27 +16,33 @@ import (
 
 // persistenceTools provides tool wrappers for persistence services.
 type persistenceTools struct {
-	tasks ports.TaskStore
-	state ports.SessionProvider
-	reg   tools.ToolMetadataProvider
+	tasks         ports.TaskStore
+	state         ports.SessionProvider
+	reg           tools.ToolMetadataProvider
+	marshalIndent func(v any, prefix, indent string) ([]byte, error)
 }
 
 // newpersistenceTools creates a new persistenceTools instance.
 func newpersistenceTools(state ports.SessionProvider, reg tools.ToolMetadataProvider) *persistenceTools {
 	if state == nil {
-		return &persistenceTools{}
+		return &persistenceTools{
+			marshalIndent: json.MarshalIndent,
+		}
 	}
 
 	// Handle interface-nil-pointer trap
 	v := reflect.ValueOf(state)
 	if v.Kind() == reflect.Pointer && v.IsNil() {
-		return &persistenceTools{}
+		return &persistenceTools{
+			marshalIndent: json.MarshalIndent,
+		}
 	}
 
 	return &persistenceTools{
-		tasks: state.GetTasks(),
-		state: state,
-		reg:   reg,
+		tasks:         state.GetTasks(),
+		state:         state,
+		reg:           reg,
+		marshalIndent: json.MarshalIndent,
 	}
 }
 
@@ -44,7 +50,7 @@ func newpersistenceTools(state ports.SessionProvider, reg tools.ToolMetadataProv
 func (t *persistenceTools) GetSessionInfo(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	info := t.state.GetInfo()
 
-	data, err := json.MarshalIndent(info, "", "  ")
+	data, err := t.marshalIndent(info, "", "  ")
 	if err != nil {
 		return tools.ToolResult{}, err
 	}

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -6,6 +6,7 @@ package workspace
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -162,21 +163,65 @@ func setupPersistenceTools() (*persistenceTools, *mockSessionProvider) {
 }
 
 func TestPersistenceTools_GetSessionInfo(t *testing.T) {
-	pt, provider := setupPersistenceTools()
-	provider.info.Model = "test-model"
-
-	res, err := pt.GetSessionInfo(context.Background(), nil, nil)
-	if err != nil {
-		t.Fatalf("GetSessionInfo failed: %v", err)
+	tests := []struct {
+		name        string
+		setup       func(*persistenceTools, *mockSessionProvider)
+		wantModel   string
+		wantErr     bool
+		wantErrText string
+	}{
+		{
+			name: "success",
+			setup: func(pt *persistenceTools, p *mockSessionProvider) {
+				p.info.Model = "test-model"
+			},
+			wantModel: "test-model",
+		},
+		{
+			name: "marshal error",
+			setup: func(pt *persistenceTools, p *mockSessionProvider) {
+				pt.marshalIndent = func(v any, prefix, indent string) ([]byte, error) {
+					return nil, errors.New("marshal exploded")
+				}
+			},
+			wantErr:     true,
+			wantErrText: "marshal exploded",
+		},
 	}
 
-	var info ports.SessionInfo
-	if err := json.Unmarshal([]byte(res.Text), &info); err != nil {
-		t.Fatalf("Failed to unmarshal result: %v", err)
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pt, provider := setupPersistenceTools()
+			tt.setup(pt, provider)
 
-	if info.Model != "test-model" {
-		t.Errorf("Expected model test-model, got %s", info.Model)
+			res, err := pt.GetSessionInfo(context.Background(), nil, nil)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if !strings.Contains(err.Error(), tt.wantErrText) {
+					t.Errorf("error = %q; want containing %q", err.Error(), tt.wantErrText)
+				}
+				// Verify ToolResult is zero-valued on error
+				if res.Text != "" {
+					t.Errorf("expected empty result on error, got Text=%q", res.Text)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			var info ports.SessionInfo
+			if err := json.Unmarshal([]byte(res.Text), &info); err != nil {
+				t.Fatalf("failed to unmarshal result: %v", err)
+			}
+			if info.Model != tt.wantModel {
+				t.Errorf("Model = %q; want %q", info.Model, tt.wantModel)
+			}
+		})
 	}
 }
 

--- a/internal/tools/workspace/process_executor_stream_test.go
+++ b/internal/tools/workspace/process_executor_stream_test.go
@@ -781,5 +781,3 @@ func TestRunCommand_NonExitErrorWaitPath(t *testing.T) {
 		}
 	})
 }
-
-


### PR DESCRIPTION
Closes #664.

## Summary
Added a `marshalIndent` function field to `persistenceTools` as a dependency-injection test seam, enabling coverage of the previously unreachable `json.MarshalIndent` error path in `GetSessionInfo`. Refactored the existing single-case test into a table-driven test with two subtests: `success` and `marshal error`.

### Changes
- **`persistence_tools.go`**: Added unexported `marshalIndent` field, initialized to `json.MarshalIndent` in all 3 constructor paths, updated call site
- **`persistence_tools_test.go`**: Table-driven refactor with `marshal error` case injecting a failing marshal function

## Verification
| Check | Status |
|-------|--------|
| `GetSessionInfo` coverage | 80.0% → **100.0%** |
| Package coverage | 94.2% → **94.3%** |
| `go test ./internal/tools/workspace/` | ✅ PASS |
| `go test -race ./internal/tools/workspace/` | ✅ PASS |
| `make check` (fmt/tidy/build/lint/test/vet) | ✅ PASS |
| `make check-full` | ✅ All steps pass (pre-existing test-race failure in `internal/tools/analysis` is unrelated) |