### PR TITLE
fix(workspace): add env propagation test through RunPipeline (#661)

### DIFF
--- a/internal/tools/workspace/pipeline_test.go
+++ b/internal/tools/workspace/pipeline_test.go
@@ -239,6 +239,49 @@ func TestPipeline_StartFailureDeadlock(t *testing.T) {
 	}
 }
 
+// TestRunPipeline_EnvPropagation verifies that custom environment variables
+// set via executionConfig.Env are visible to commands executed inside a pipeline.
+func TestRunPipeline_EnvPropagation(t *testing.T) {
+	e := newprocessExecutor()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{
+			name: "custom env var propagates through pipeline",
+			env:  map[string]string{"TELL_ME_TEST_661": "pipeline_value_661"},
+			want: "pipeline_value_661",
+		},
+		{
+			name: "empty env map does not crash",
+			env:  map[string]string{},
+			want: "", // printenv outputs nothing for missing var
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pipedParts := [][]string{
+				{helperPath, "printenv", "TELL_ME_TEST_661"},
+				{helperPath, "cat"},
+			}
+			res, err := e.RunPipeline(ctx, pipedParts, executionConfig{Env: tt.env})
+			if err != nil {
+				t.Fatalf("RunPipeline failed: %v", err)
+			}
+			if tt.want != "" && !strings.Contains(res.Output, tt.want) {
+				t.Errorf("expected output to contain %q, got %q", tt.want, res.Output)
+			}
+			if tt.want == "" && strings.Contains(res.Output, "TELL_ME_TEST_661") {
+				t.Errorf("expected no env var output, got %q", res.Output)
+			}
+		})
+	}
+}
+
 // TestNewPipeline_WirePipesError exercises the error return path in newPipeline
 // when wirePipes fails due to a pre-consumed pipe.
 //

--- a/internal/tools/workspace/process_executor_stream_test.go
+++ b/internal/tools/workspace/process_executor_stream_test.go
@@ -781,5 +781,3 @@ func TestRunCommand_NonExitErrorWaitPath(t *testing.T) {
 		}
 	})
 }
-
-


### PR DESCRIPTION
Closes #661.

## Summary
Added `TestRunPipeline_EnvPropagation` to `internal/tools/workspace/pipeline_test.go` — a table-driven test that verifies custom environment variables set via `executionConfig.Env` propagate correctly through the pipeline.

The analysis revealed that 3 of the 5 original gaps were already covered, 1 is Windows-only (untestable on Linux), and the remaining boundary condition (#5) was the only actionable gap — now closed.

### Changes
- `pipeline_test.go`: Added `TestRunPipeline_EnvPropagation` with 2 subtests (custom env var propagation + empty env map safety)
- `process_executor_stream_test.go`: Trailing whitespace cleanup (from `make check-full`)

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Workspace coverage | 94.2% |
| No regressions | All 22 pipeline tests PASS |