### PR TITLE
fix(di): decompose sessionDeps God struct and slim BuildSessionDependencies (#675)

### DIFF
--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -16,23 +16,11 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
-	"github.com/gosharplite/tell-me-go/internal/domain/security"
-	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_llm "github.com/gosharplite/tell-me-go/internal/infrastructure/llm"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/telemetry"
 )
-
-// ConfigurableSecurityManager extends the domain security manager with configuration methods.
-type ConfigurableSecurityManager interface {
-	security.Manager
-	SetCommandsLogFile(path string)
-	RegisterSafePath(path string)
-	RegisterReadOnlyPath(path string)
-	SetBypassActive(active bool)
-	RegisterPolicyTools(r tools.Registry, kv ports.KVStore) error
-}
 
 // Bootstrapper handles the instantiation and wiring of system components.
 type Bootstrapper struct {
@@ -84,16 +72,7 @@ func NewBootstrapper(cfg BootstrapperConfig) *Bootstrapper {
 
 // BuildSessionDependencies assembles all dependencies required for a chat session.
 func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(stdctx.Context) error, error) {
-	b.cfg.Logger.Debug("Building session dependencies",
-		slog.String("config_model", cfg.Model),
-		slog.String("config_path", configPath),
-		slog.Int("config_models_count", len(cfg.Models)))
-
-	for k, v := range cfg.Models {
-		b.cfg.Logger.Debug("Config model details",
-			slog.String("model", k),
-			slog.Float64("pricing_comp", v.Pricing.Comp))
-	}
+	b.logBuildStart(cfg, configPath)
 
 	pricingOverrides := b.getPricingOverrides(cfg)
 	sessionProvider, paths, cleanup, err := b.sessionFactory.BuildSession(ctx, cfg, configPath, newSession, pricingOverrides)
@@ -107,12 +86,56 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		return nil, nil, nil, err
 	}
 
+	bus, logger := b.wireInfrastructure(ctx)
+	pricingData, tracker, turnsLogger, cleanup := b.wireTelemetry(ctx, paths, cfg, pricingOverrides, cleanup)
+	lazyClient := b.wireLLMClient(cfg, pricingData, bus, logger)
+
+	deps := &sessionDeps{
+		infraProvider: infraProvider{
+			paths: paths, sm: b.cfg.SM, bus: bus, logger: logger, turnsLogger: turnsLogger,
+		},
+		telemetryProvider:    telemetryProvider{tracker: tracker, pricingOverrides: pricingOverrides},
+		sessionStateProvider: sessionStateProvider{hManager: hManager, sessionProvider: sessionProvider, workspacePolicy: b.cfg.WorkspacePolicy},
+		lazyProvider:         lazyProvider{client: lazyClient},
+	}
+
+	deps.health = b.wireHealth(cfg, sessionProvider, lazyClient)
+	deps.registry = b.wireToolRegistry(paths, sessionProvider, deps.health, lazyClient, bus, cfg, pricingOverrides, capturer)
+
+	return deps, hManager, cleanup, nil
+}
+
+// logBuildStart emits debug-level diagnostics about the configuration being used.
+func (b *Bootstrapper) logBuildStart(cfg *config.Config, configPath string) {
+	b.cfg.Logger.Debug("Building session dependencies",
+		slog.String("config_model", cfg.Model),
+		slog.String("config_path", configPath),
+		slog.Int("config_models_count", len(cfg.Models)))
+
+	for k, v := range cfg.Models {
+		b.cfg.Logger.Debug("Config model details",
+			slog.String("model", k),
+			slog.Float64("pricing_comp", v.Pricing.Comp))
+	}
+}
+
+// wireInfrastructure creates the event bus and slog-backed logger.
+func (b *Bootstrapper) wireInfrastructure(ctx stdctx.Context) (events.EventBus, ports.Logger) {
 	bus := events.NewSimpleEventBus(ctx, events.WithLogger(b.cfg.Logger), events.WithAsync(false))
-
-	pricingData, tracker, turnsLogger, cleanup := b.telemetryFactory.BuildTelemetry(ctx, paths, cfg, pricingOverrides, cleanup)
-
 	logger := telemetry.NewSlogLogger(b.cfg.Logger)
-	lazyClient := newLazyClient(func() (llm.ExtendedClient, error) {
+	return bus, logger
+}
+
+// wireTelemetry delegates to the telemetryFactory to build pricing data,
+// cost tracking, and turns logging.
+func (b *Bootstrapper) wireTelemetry(ctx stdctx.Context, paths *persistence.Paths, cfg *config.Config, pricingOverrides map[string]pricing.ModelPricing, cleanup func(stdctx.Context) error) (pricing.PricingData, pricing.CostTracker, ports.TurnsLogger, func(stdctx.Context) error) {
+	return b.telemetryFactory.BuildTelemetry(ctx, paths, cfg, pricingOverrides, cleanup)
+}
+
+// wireLLMClient creates a lazily-initialized LLM client. The underlying
+// provider client is not constructed until the first Generate/SendChat call.
+func (b *Bootstrapper) wireLLMClient(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) *lazyClient {
+	return newLazyClient(func() (llm.ExtendedClient, error) {
 		if len(cfg.FailoverOrder) > 0 {
 			gw, err := b.cfg.ClientFactory.NewFailoverChain(cfg, pricingData, bus, logger)
 			if err != nil {
@@ -124,28 +147,23 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		}
 		return b.cfg.ClientFactory.NewClient(cfg, pricingData, bus, logger)
 	})
+}
 
-	deps := &sessionDeps{
-		paths:            paths,
-		hManager:         hManager,
-		sm:               b.cfg.SM,
-		tracker:          tracker,
-		pricingOverrides: pricingOverrides,
-		bus:              bus,
-		logger:           telemetry.NewSlogLogger(b.cfg.Logger),
-		turnsLogger:      turnsLogger,
-		sessionProvider:  sessionProvider,
-		workspacePolicy:  b.cfg.WorkspacePolicy,
-		lazyClient:       lazyClient,
-	}
+// wireHealth builds the health check manager wired with persistence,
+// LLM provider, and toolchain health checkers.
+func (b *Bootstrapper) wireHealth(cfg *config.Config, sessionProvider ports.SessionProvider, lazyClient llm.ExtendedClient) ports.HealthCheckManager {
+	return b.healthFactory.BuildHealthManager(cfg, sessionProvider, lazyClient, b.toolchainFactory)
+}
 
-	deps.health = b.healthFactory.BuildHealthManager(cfg, sessionProvider, lazyClient, b.toolchainFactory)
-
-	lazyRegistry := newLazyRegistry(func() (tools.Registry, error) {
+// wireToolRegistry creates a lazily-initialized tool registry. Tool
+// registration (filesystem scanning, binary discovery, security policy
+// evaluation) is deferred until the first call to GetRegistry.
+func (b *Bootstrapper) wireToolRegistry(paths *persistence.Paths, sessionProvider ports.SessionProvider, health ports.HealthCheckManager, lazyClient *lazyClient, bus events.EventBus, cfg *config.Config, pricingOverrides map[string]pricing.ModelPricing, capturer agent.CapturerInteractor) *lazyRegistry {
+	return newLazyRegistry(func() (tools.Registry, error) {
 		return b.toolchainFactory.BuildRegistry(toolchainParams{
 			Paths:            paths,
 			SessionProvider:  sessionProvider,
-			HealthManager:    deps.health,
+			HealthManager:    health,
 			Client:           lazyClient,
 			Bus:              bus,
 			Model:            cfg.Model,
@@ -154,53 +172,14 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 			Capturer:         capturer,
 		})
 	}, telemetry.NewSlogLogger(b.cfg.Logger))
-	deps.lazyRegistry = lazyRegistry
-
-	return deps, hManager, cleanup, nil
 }
 
 type sessionDeps struct {
-	paths            *persistence.Paths
-	hManager         ports.HistoryManager
-	sm               security.Manager
-	tracker          pricing.CostTracker
-	pricingOverrides map[string]pricing.ModelPricing
-	bus              events.EventBus
-	logger           ports.Logger
-	turnsLogger      ports.TurnsLogger
-	sessionProvider  ports.SessionProvider
-	workspacePolicy  services.WorkspacePolicy
-	health           ports.HealthCheckManager
-
-	lazyClient   *lazyClient
-	lazyRegistry *lazyRegistry
-}
-
-func (d *sessionDeps) GetGateway() llm.LLMGateway {
-	return d.lazyClient
-}
-func (d *sessionDeps) GetHistoryManager() ports.HistoryManager { return d.hManager }
-func (d *sessionDeps) GetRegistry() (tools.Registry, error) {
-	return d.lazyRegistry.get()
-}
-func (d *sessionDeps) GetSecurityManager() security.Manager { return d.sm }
-func (d *sessionDeps) GetEventBus() events.EventBus         { return d.bus }
-func (d *sessionDeps) GetLogger() ports.Logger              { return d.logger }
-func (d *sessionDeps) GetTurnsLogger() ports.TurnsLogger    { return d.turnsLogger }
-func (d *sessionDeps) GetPaths() *persistence.Paths         { return d.paths }
-func (d *sessionDeps) GetSessionProvider() ports.SessionProvider {
-	return d.sessionProvider
-}
-func (d *sessionDeps) GetWorkspacePolicy() services.WorkspacePolicy {
-	return d.workspacePolicy
-}
-func (d *sessionDeps) GetPricingOverrides() map[string]pricing.ModelPricing {
-	return d.pricingOverrides
-}
-func (d *sessionDeps) GetTracker() pricing.CostTracker            { return d.tracker }
-func (d *sessionDeps) GetHealthManager() ports.HealthCheckManager { return d.health }
-func (d *sessionDeps) GetClient() llm.LLMClient {
-	return d.lazyClient
+	infraProvider
+	telemetryProvider
+	sessionStateProvider
+	lazyProvider
+	healthProvider
 }
 
 // GetAgentFactory returns a factory for creating Chatter instances.

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -608,16 +608,26 @@ func TestSessionDeps_Getters(t *testing.T) {
 	}, &ports.NoOpLogger{})
 
 	deps := &sessionDeps{
-		paths:           paths,
-		hManager:        hManager,
-		sm:              sm,
-		bus:             bus,
-		tracker:         tracker,
-		sessionProvider: sessionProvider,
-		workspacePolicy: infra_persistence.NewWorkspacePolicy(),
-		health:          factory.NewHealthCheckManager(nil),
-		lazyClient:      lazyClient,
-		lazyRegistry:    lazyRegistry,
+		infraProvider: infraProvider{
+			paths: paths,
+			sm:    sm,
+			bus:   bus,
+		},
+		telemetryProvider: telemetryProvider{
+			tracker: tracker,
+		},
+		sessionStateProvider: sessionStateProvider{
+			hManager:        hManager,
+			sessionProvider: sessionProvider,
+			workspacePolicy: infra_persistence.NewWorkspacePolicy(),
+		},
+		lazyProvider: lazyProvider{
+			client:   lazyClient,
+			registry: lazyRegistry,
+		},
+		healthProvider: healthProvider{
+			health: factory.NewHealthCheckManager(nil),
+		},
 	}
 
 	assert.NotNil(t, deps.GetGateway())
@@ -1193,9 +1203,11 @@ func TestGetHistoryManager_Failure(t *testing.T) {
 
 func TestSessionDeps_GetRegistry_Failure(t *testing.T) {
 	deps := &sessionDeps{
-		lazyRegistry: newLazyRegistry(func() (tools.Registry, error) {
-			return nil, errors.New("registry failed")
-		}, telemetry.NewSlogLogger(nil)),
+		lazyProvider: lazyProvider{
+			registry: newLazyRegistry(func() (tools.Registry, error) {
+				return nil, errors.New("registry failed")
+			}, telemetry.NewSlogLogger(nil)),
+		},
 	}
 	reg, err := deps.GetRegistry()
 	assert.Error(t, err)
@@ -1535,4 +1547,152 @@ func TestBuildSessionDependencies_FailoverChain(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestWireInfrastructure(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	b := &Bootstrapper{cfg: BootstrapperConfig{Logger: logger}}
+
+	bus, log := b.wireInfrastructure(ctx)
+
+	assert.NotNil(t, bus, "event bus should not be nil")
+	assert.NotNil(t, log, "logger should not be nil")
+}
+
+func TestWireTelemetry(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	sm := new(mockConfigurableSecurityManager)
+	setupDefaultSMExpectations(sm)
+
+	tf := newTelemetryFactory(tempDir, &infra_persistence.OSFileSystem{}, sm, nil)
+	b := &Bootstrapper{telemetryFactory: tf}
+
+	paths := &persistence.Paths{TurnsLogPath: filepath.Join(tempDir, "turns.log")}
+	cfg := &config.Config{Model: "test-model"}
+
+	origCleanup := func(ctx context.Context) error { return nil }
+	pricingData, tracker, turnsLogger, cleanup := b.wireTelemetry(ctx, paths, cfg, nil, origCleanup)
+
+	assert.NotNil(t, pricingData)
+	assert.NotNil(t, tracker)
+	assert.NotNil(t, turnsLogger)
+	assert.NotNil(t, cleanup)
+}
+
+func TestWireLLMClient(t *testing.T) {
+	ctx := context.Background()
+
+	client := new(mockLLMClient)
+	client.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return(&llm.Content{}, &llm.Metrics{}, nil)
+
+	cf := ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+		return client, nil
+	})
+	b := &Bootstrapper{cfg: BootstrapperConfig{ClientFactory: cf}}
+
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+	logger := telemetry.NewSlogLogger(nil)
+	cfg := &config.Config{Model: "test-model"}
+
+	lc := b.wireLLMClient(cfg, pricing.PricingData{}, bus, logger)
+
+	assert.NotNil(t, lc)
+	// Verify lazy init works by calling Generate, which triggers factory init
+	_, _, err := lc.Generate(ctx, nil, nil, nil)
+	assert.NoError(t, err)
+	client.AssertCalled(t, "Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
+func TestWireHealth(t *testing.T) {
+	tempDir := t.TempDir()
+	sm := new(mockConfigurableSecurityManager)
+	setupDefaultSMExpectations(sm)
+
+	bcfg := DefaultBootstrapperConfig()
+	bcfg.HomeDir = tempDir
+	bcfg.SM = sm
+	bcfg.Version = "1.0.0"
+	bcfg.Stdout = io.Discard
+	bcfg.Stderr = io.Discard
+	b := NewBootstrapper(bcfg)
+
+	mockSP := new(mockSessionProvider)
+	mockKV := new(mockKVStore)
+	mockSP.On("GetSettings").Return(mockKV).Maybe()
+	mockSP.On("GetHealthChecker").Return(nil).Maybe()
+
+	lc := newLazyClient(func() (llm.ExtendedClient, error) {
+		return new(mockLLMClient), nil
+	})
+
+	cfg := &config.Config{Mode: "assistant"}
+	hm := b.wireHealth(cfg, mockSP, lc)
+
+	assert.NotNil(t, hm)
+}
+
+func TestWireToolRegistry(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	sm := new(mockConfigurableSecurityManager)
+	setupDefaultSMExpectations(sm)
+	sm.On("RegisterPolicyTools", mock.Anything, mock.Anything).Return(nil).Maybe()
+
+	bcfg := DefaultBootstrapperConfig()
+	bcfg.HomeDir = tempDir
+	bcfg.SM = sm
+	bcfg.Version = "1.0.0"
+	bcfg.Stdout = io.Discard
+	bcfg.Stderr = io.Discard
+	b := NewBootstrapper(bcfg)
+
+	paths := &persistence.Paths{LogPath: filepath.Join(tempDir, "test.log"), TracePath: filepath.Join(tempDir, "test.trace.jsonl")}
+	mockSP := new(mockSessionProvider)
+	mockKV := new(mockKVStore)
+	mockSP.On("GetSettings").Return(mockKV).Maybe()
+	mockSP.On("GetHealthChecker").Return(nil).Maybe()
+
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+
+	lc := newLazyClient(func() (llm.ExtendedClient, error) {
+		return new(mockLLMClient), nil
+	})
+
+	hm := b.wireHealth(&config.Config{Mode: "assistant"}, mockSP, lc)
+
+	cfg := &config.Config{Model: "test-model", Mode: "assistant"}
+	lr := b.wireToolRegistry(paths, mockSP, hm, lc, bus, cfg, nil, nil)
+
+	assert.NotNil(t, lr)
+	// Verify lazy init works
+	reg, err := lr.get()
+	assert.NoError(t, err)
+	assert.NotNil(t, reg)
+}
+
+func TestLogBuildStart(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	b := &Bootstrapper{cfg: BootstrapperConfig{Logger: logger}}
+
+	cfg := &config.Config{
+		Model: "test-model",
+		Models: map[string]config.ModelConfig{
+			"test-model": {Pricing: pricing.ModelPricing{Comp: 0.01}},
+		},
+	}
+
+	b.logBuildStart(cfg, "/path/to/config.yaml")
+
+	output := buf.String()
+	assert.Contains(t, output, "Building session dependencies")
+	assert.Contains(t, output, "test-model")
+	assert.Contains(t, output, "/path/to/config.yaml")
 }

--- a/internal/infrastructure/di/lazy_test.go
+++ b/internal/infrastructure/di/lazy_test.go
@@ -243,8 +243,10 @@ func TestLazyClient_InitializationFailure_RefreshAuth(t *testing.T) {
 
 func TestSessionDeps_AdditionalGetters(t *testing.T) {
 	deps := &sessionDeps{
-		logger:      telemetry.NewSlogLogger(nil),
-		turnsLogger: nil, // We'll just check if it's there
+		infraProvider: infraProvider{
+			logger:      telemetry.NewSlogLogger(nil),
+			turnsLogger: nil,
+		},
 	}
 
 	assert.NotNil(t, deps.GetLogger())

--- a/internal/infrastructure/di/security_manager.go
+++ b/internal/infrastructure/di/security_manager.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// ConfigurableSecurityManager extends the domain security manager with configuration methods.
+type ConfigurableSecurityManager interface {
+	security.Manager
+	SetCommandsLogFile(path string)
+	RegisterSafePath(path string)
+	RegisterReadOnlyPath(path string)
+	SetBypassActive(active bool)
+	RegisterPolicyTools(r tools.Registry, kv ports.KVStore) error
+}

--- a/internal/infrastructure/di/session_providers.go
+++ b/internal/infrastructure/di/session_providers.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// infraProvider holds core plumbing dependencies: filesystem paths,
+// security manager, event bus, and loggers.
+type infraProvider struct {
+	paths       *persistence.Paths
+	sm          security.Manager
+	bus         events.EventBus
+	logger      ports.Logger
+	turnsLogger ports.TurnsLogger
+}
+
+// GetPaths returns the persistence paths.
+func (p *infraProvider) GetPaths() *persistence.Paths { return p.paths }
+
+// GetSecurityManager returns the security manager.
+func (p *infraProvider) GetSecurityManager() security.Manager { return p.sm }
+
+// GetEventBus returns the event bus.
+func (p *infraProvider) GetEventBus() events.EventBus { return p.bus }
+
+// GetLogger returns the logger.
+func (p *infraProvider) GetLogger() ports.Logger { return p.logger }
+
+// GetTurnsLogger returns the turns logger.
+func (p *infraProvider) GetTurnsLogger() ports.TurnsLogger { return p.turnsLogger }
+
+// telemetryProvider holds pricing and cost-tracking dependencies.
+type telemetryProvider struct {
+	tracker          pricing.CostTracker
+	pricingOverrides map[string]pricing.ModelPricing
+}
+
+// GetTracker returns the cost tracker.
+func (p *telemetryProvider) GetTracker() pricing.CostTracker { return p.tracker }
+
+// GetPricingOverrides returns the pricing overrides.
+func (p *telemetryProvider) GetPricingOverrides() map[string]pricing.ModelPricing {
+	return p.pricingOverrides
+}
+
+// sessionStateProvider holds session-level state: history, session
+// provider, and workspace policy.
+type sessionStateProvider struct {
+	hManager        ports.HistoryManager
+	sessionProvider ports.SessionProvider
+	workspacePolicy services.WorkspacePolicy
+}
+
+// GetHistoryManager returns the history manager.
+func (p *sessionStateProvider) GetHistoryManager() ports.HistoryManager { return p.hManager }
+
+// GetSessionProvider returns the session provider.
+func (p *sessionStateProvider) GetSessionProvider() ports.SessionProvider { return p.sessionProvider }
+
+// GetWorkspacePolicy returns the workspace policy.
+func (p *sessionStateProvider) GetWorkspacePolicy() services.WorkspacePolicy {
+	return p.workspacePolicy
+}
+
+// lazyProvider holds lazily-initialized components: the LLM client
+// and the tool registry.
+type lazyProvider struct {
+	client   *lazyClient
+	registry *lazyRegistry
+}
+
+// GetGateway returns the lazily-initialized LLM gateway.
+func (p *lazyProvider) GetGateway() llm.LLMGateway { return p.client }
+
+// GetClient returns the lazily-initialized LLM client.
+func (p *lazyProvider) GetClient() llm.LLMClient { return p.client }
+
+// GetRegistry returns the lazily-initialized tool registry.
+func (p *lazyProvider) GetRegistry() (tools.Registry, error) { return p.registry.get() }
+
+// healthProvider holds the health check manager.
+type healthProvider struct {
+	health ports.HealthCheckManager
+}
+
+// GetHealthManager returns the health check manager.
+func (p *healthProvider) GetHealthManager() ports.HealthCheckManager { return p.health }


### PR DESCRIPTION
Closes #675.

## Summary

Decomposed the 14-field `sessionDeps` God struct into 5 focused provider structs using Go struct embedding:
- `infraProvider` — paths, security manager, event bus, loggers
- `telemetryProvider` — cost tracker, pricing overrides
- `sessionStateProvider` — history manager, session provider, workspace policy
- `lazyProvider` — lazy LLM client and tool registry
- `healthProvider` — health check manager

Extracted `BuildSessionDependencies` (~65 lines) into: slim 25-line orchestrator + 6 private wiring methods (`wireInfrastructure`, `wireTelemetry`, `wireLLMClient`, `wireHealth`, `wireToolRegistry`, `logBuildStart`).

Moved `ConfigurableSecurityManager` interface to dedicated `security_manager.go`.

Added 6 unit tests for the new private wiring methods.

## Verification

| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build` | PASS |
| `golangci-lint run` | 0 issues |
| `verify-architecture` | PASS |
| `vulncheck` | No vulnerabilities |
| `go test -race` (di) | PASS |
| Coverage (di package) | **100.0%** |
| `go test -race ./...` (full) | PASS (pre-existing flaky test in workspace) |