### PR TITLE
fix(analysis): add excluded_packages parameter to get_detailed_coverage (#679)

### DIFF
--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -414,11 +414,40 @@ func (m *healthManager) getDetailedCoverage(ctx context.Context, packagePath str
 	return blocks, nil
 }
 
+// filterExcludedBlocks removes blocks whose File path contains any of the
+// excluded package patterns. This matches the Makefile's grep -v exclusion
+// for *test packages (mocks, stubs, test doubles) whose error-return paths
+// are exercised via m.Called() — opaque to static coverage analysis.
+// When excluded is empty or nil, the original slice is returned unchanged.
+func filterExcludedBlocks(blocks []uncoveredBlock, excluded []string) []uncoveredBlock {
+	if len(excluded) == 0 {
+		return blocks
+	}
+	filtered := make([]uncoveredBlock, 0, len(blocks))
+	for _, b := range blocks {
+		skip := false
+		for _, pattern := range excluded {
+			if strings.Contains(b.File, pattern) {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			filtered = append(filtered, b)
+		}
+	}
+	return filtered
+}
+
 // getDetailedCoverageReport generates a formatted report optimized for LLM consumption.
-func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePath string, hb chan<- struct{}) (string, error) {
+func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePath string, excludedPackages []string, hb chan<- struct{}) (string, error) {
 	blocks, err := m.getDetailedCoverage(ctx, packagePath, hb)
 	if err != nil && len(blocks) == 0 {
 		return "", err
+	}
+
+	if len(excludedPackages) > 0 {
+		blocks = filterExcludedBlocks(blocks, excludedPackages)
 	}
 
 	report := formatDetailedCoverageReport(packagePath, blocks)

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -92,6 +92,82 @@ func TestUncoveredBlock_Classify(t *testing.T) {
 	}
 }
 
+func TestFilterExcludedBlocks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name      string
+		blocks    []uncoveredBlock
+		excluded  []string
+		wantLen   int
+		wantFiles []string // expected File values in result, in order
+	}{
+		{
+			name:      "nil excluded returns all",
+			blocks:    []uncoveredBlock{{File: "pkg/a.go"}, {File: "pkg/b.go"}},
+			excluded:  nil,
+			wantLen:   2,
+			wantFiles: []string{"pkg/a.go", "pkg/b.go"},
+		},
+		{
+			name:      "empty excluded returns all",
+			blocks:    []uncoveredBlock{{File: "pkg/a.go"}},
+			excluded:  []string{},
+			wantLen:   1,
+			wantFiles: []string{"pkg/a.go"},
+		},
+		{
+			name: "single pattern match excludes block",
+			blocks: []uncoveredBlock{
+				{File: "internal/agent/agenttest/mock.go"},
+				{File: "pkg/real.go"},
+			},
+			excluded:  []string{"agenttest"},
+			wantLen:   1,
+			wantFiles: []string{"pkg/real.go"},
+		},
+		{
+			name: "multiple patterns partial match",
+			blocks: []uncoveredBlock{
+				{File: "internal/agent/agenttest/a.go"},
+				{File: "internal/infrastructure/testing/b.go"},
+				{File: "internal/domain/logic.go"},
+			},
+			excluded:  []string{"agenttest", "testing"},
+			wantLen:   1,
+			wantFiles: []string{"internal/domain/logic.go"},
+		},
+		{
+			name:      "no match retains all",
+			blocks:    []uncoveredBlock{{File: "pkg/a.go"}, {File: "pkg/b.go"}},
+			excluded:  []string{"nomatch"},
+			wantLen:   2,
+			wantFiles: []string{"pkg/a.go", "pkg/b.go"},
+		},
+		{
+			name:      "empty blocks returns empty",
+			blocks:    nil,
+			excluded:  []string{"test"},
+			wantLen:   0,
+			wantFiles: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := filterExcludedBlocks(tt.blocks, tt.excluded)
+			if len(got) != tt.wantLen {
+				t.Errorf("filterExcludedBlocks() len = %d, want %d", len(got), tt.wantLen)
+			}
+			for i, f := range tt.wantFiles {
+				if i >= len(got) || got[i].File != f {
+					t.Errorf("filterExcludedBlocks()[%d].File = %q, want %q", i, got[i].File, f)
+				}
+			}
+		})
+	}
+}
+
 func TestParseCoverageLine(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -460,7 +536,7 @@ func TestGetDetailedCoverageReport(t *testing.T) {
 	}
 	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
-	_, err := hea.getDetailedCoverageReport(ctx, "./non-existent", nil)
+	_, err := hea.getDetailedCoverageReport(ctx, "./non-existent", nil, nil)
 	if err == nil {
 		t.Error("expected error for non-existent package, got nil")
 	}
@@ -741,7 +817,7 @@ func TestGetDetailedCoverageReport_Success(t *testing.T) {
 	}
 	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
-	report, err := hea.getDetailedCoverageReport(ctx, ".", nil)
+	report, err := hea.getDetailedCoverageReport(ctx, ".", nil, nil)
 	if err != nil {
 		t.Fatalf("getDetailedCoverageReport failed: %v", err)
 	}
@@ -1058,7 +1134,7 @@ func TestGetDetailedCoverageReport_ErrorWithData(t *testing.T) {
 	}
 	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
-	report, err := hea.getDetailedCoverageReport(ctx, ".", nil)
+	report, err := hea.getDetailedCoverageReport(ctx, ".", nil, nil)
 	// Should return BOTH report content AND nil error (error is embedded in report)
 	if err != nil {
 		t.Errorf("expected nil error (warning in report), got: %v", err)

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -347,7 +347,18 @@ func (m *healthManager) GetDetailedCoverage(ctx context.Context, args map[string
 		path = "./..."
 	}
 
-	report, err := m.getDetailedCoverageReport(ctx, path, hb)
+	var excludedPackages []string
+	if raw, ok := args["excluded_packages"]; ok {
+		if arr, ok := raw.([]interface{}); ok {
+			for _, item := range arr {
+				if s, ok := item.(string); ok {
+					excludedPackages = append(excludedPackages, s)
+				}
+			}
+		}
+	}
+
+	report, err := m.getDetailedCoverageReport(ctx, path, excludedPackages, hb)
 	if err != nil {
 		return tools.ToolResult{Text: "Error: " + err.Error()}, nil
 	}

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -466,6 +466,53 @@ func TestGetDetailedCoverage_DefaultPath(t *testing.T) {
 	}
 }
 
+func TestGetDetailedCoverage_ExcludedPackages(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := &mockExecutor{
+		OutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("github.com/user/repo"), nil
+		},
+		CombinedOutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-coverprofile=") {
+					path := strings.TrimPrefix(arg, "-coverprofile=")
+					// Profile with blocks in both excluded and non-excluded paths
+					coverageContent := "mode: set\n" +
+						"github.com/user/repo/internal/agent/agenttest/mock_agent.go:10.0,12.0 3 0\n" +
+						"github.com/user/repo/internal/domain/logic.go:5.0,7.0 2 0\n"
+					if err := os.WriteFile(path, []byte(coverageContent), 0644); err != nil {
+						t.Errorf("failed to write mock coverage file: %v", err)
+					}
+				}
+			}
+			return []byte("ok"), nil
+		},
+	}
+	m := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
+
+	args := map[string]interface{}{
+		"path":              ".",
+		"excluded_packages": []interface{}{"agenttest"},
+	}
+	result, err := m.GetDetailedCoverage(ctx, args, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// agenttest block should be excluded, logic.go should remain
+	if strings.Contains(result.Text, "mock_agent.go") {
+		t.Error("expected mock_agent.go to be excluded from report")
+	}
+	if !strings.Contains(result.Text, "logic.go") {
+		t.Error("expected logic.go to appear in report")
+	}
+	if !strings.Contains(result.Text, "Total Gaps: 1") {
+		t.Errorf("expected 1 total gap after exclusion, got: %s", result.Text)
+	}
+}
+
 func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -50,6 +50,11 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 					Type: "OBJECT",
 					Properties: map[string]*tools.Schema{
 						"path": {Type: "STRING", Description: "The package path to analyze (e.g., './internal/service/...')"},
+						"excluded_packages": {
+							Type:        "ARRAY",
+							Items:       &tools.Schema{Type: "STRING"},
+							Description: "Patterns of packages to ignore (e.g., 'agenttest', 'testing'). Matches substrings in file paths.",
+						},
 					},
 					Required: []string{"path"},
 				},


### PR DESCRIPTION
Closes #679.

## Summary
Added `excluded_packages` parameter to `get_detailed_coverage` tool, matching the existing API of `dead_code_graph` which already supports `excluded_packages []string`. This eliminates 66 false-positive high-priority gaps every session caused by test-double packages (testify mocks, stubs) whose error-return paths are opaque to static analysis.

The exclusion uses substring matching on file paths, consistent with the Makefile's `grep -v` exclusion in the `test-coverage` target.

### Changes
| File | Change |
|------|--------|
| `registration.go` | Added `excluded_packages` ARRAY parameter to `get_detailed_coverage` schema |
| `health.go` | Extract and thread `excluded_packages` through handler |
| `coverage_parser.go` | Added `filterExcludedBlocks` helper + filtering in report pipeline |
| `coverage_parser_test.go` | Table-driven tests for `filterExcludedBlocks` (6 cases) |
| `health_test.go` | Integration test verifying excluded packages produce zero gaps |

## Verification
| Check | Status |
|-------|--------|
| make fmt | PASS |
| make tidy | PASS |
| make build | PASS |
| make lint | PASS (0 issues) |
| make verify-architecture | PASS |
| make vulncheck | PASS (no vulnerabilities) |
| make test | PASS (all packages) |
| make dead-code | PASS (no dead code) |
| make test-coverage | PASS |
