### PR TITLE
fix(workspace): reduce test complexity below threshold 10 (#683)

### DIFF
--- a/internal/tools/workspace/pipeline_test.go
+++ b/internal/tools/workspace/pipeline_test.go
@@ -376,33 +376,49 @@ func TestNewPipelineCmd(t *testing.T) {
 			cmd, err := e.newPipelineCmd(ctx, tt.parts, tt.index, tt.config)
 
 			if tt.wantErr != "" {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				if !strings.Contains(err.Error(), tt.wantErr) {
-					t.Errorf("expected error containing %q, got %q", tt.wantErr, err.Error())
-				}
+				assertPipelineCmdError(t, err, tt.wantErr)
 				return
 			}
 
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if tt.wantCmd && cmd == nil {
-				t.Fatal("expected non-nil *exec.Cmd")
+			if tt.wantCmd {
+				assertCmdNotNil(t, cmd)
 			}
 			if tt.wantEnv != "" {
-				found := false
-				for _, e := range cmd.Env {
-					if e == tt.wantEnv {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected cmd.Env to contain %q", tt.wantEnv)
-				}
+				assertEnvVarPresent(t, cmd.Env, tt.wantEnv)
 			}
 		})
 	}
+}
+
+// assertPipelineCmdError checks that err is non-nil and contains wantSubstr.
+func assertPipelineCmdError(t *testing.T, err error, wantSubstr string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), wantSubstr) {
+		t.Errorf("expected error containing %q, got %q", wantSubstr, err.Error())
+	}
+}
+
+// assertCmdNotNil checks that cmd is non-nil.
+func assertCmdNotNil(t *testing.T, cmd *exec.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		t.Fatal("expected non-nil *exec.Cmd")
+	}
+}
+
+// assertEnvVarPresent checks that the env slice contains the exact "KEY=VALUE" entry.
+func assertEnvVarPresent(t *testing.T, env []string, want string) {
+	t.Helper()
+	for _, e := range env {
+		if e == want {
+			return
+		}
+	}
+	t.Errorf("expected cmd.Env to contain %q", want)
 }

--- a/internal/tools/workspace/process_executor_stream_unix_test.go
+++ b/internal/tools/workspace/process_executor_stream_unix_test.go
@@ -38,20 +38,11 @@ func TestRunCommand_NonExitErrorWaitPath_SIGKILL(t *testing.T) {
 	t.Fatal(lastErr)
 }
 
-// runNonExitErrorWaitPathTest executes a single attempt at triggering
-// the non-ExitError branch. It returns nil on success or an error.
-func runNonExitErrorWaitPathTest(t *testing.T) error {
+// spawnPreReaper starts a goroutine that reads a PID from pidFile,
+// sends SIGKILL, and pre-reaps the zombie via syscall.Wait4 so that
+// cmd.Wait() receives ECHILD instead of observing the process exit.
+func spawnPreReaper(t *testing.T, pidFile string) {
 	t.Helper()
-
-	e := newprocessExecutor()
-	ctx := context.Background() // NOT a cancellable context
-
-	pidFile := filepath.Join(t.TempDir(), "pid")
-
-	// Background goroutine: kill the sleep process and pre-reap it
-	// before cmd.Wait() is called internally by RunCommand. Using
-	// syscall.Wait4 in a tight loop reliably beats Go's SIGCHLD
-	// handler, forcing cmd.Wait() to receive ECHILD.
 	go func() {
 		var pid int
 		for i := 0; i < 50; i++ {
@@ -66,16 +57,9 @@ func runNonExitErrorWaitPathTest(t *testing.T) error {
 			return
 		}
 		_ = syscall.Kill(pid, syscall.SIGKILL)
-		// Immediate blocking reap: after SIGKILL the kernel
-		// makes the process a zombie immediately. A blocking
-		// Wait4 reliably reaps it before Go's internal SIGCHLD
-		// handler or cmd.Wait() does.
 		var wstatus syscall.WaitStatus
 		wpid, werr := syscall.Wait4(pid, &wstatus, 0, nil)
 		if wpid <= 0 && werr == nil {
-			// Fallback: WNOHANG polling loop (should be
-			// rarely reached; only if the kernel hasn't
-			// delivered the zombie yet).
 			for i := 0; i < 1000; i++ {
 				wpid, werr = syscall.Wait4(pid, &wstatus, syscall.WNOHANG, nil)
 				if wpid > 0 || werr != nil {
@@ -85,6 +69,38 @@ func runNonExitErrorWaitPathTest(t *testing.T) error {
 			}
 		}
 	}()
+}
+
+// assertNonExitErrorResult verifies that RunCommand returned a
+// non-context, non-ExitError error with a non-zero exit code.
+func assertNonExitErrorResult(t *testing.T, res executionResult, err error) {
+	t.Helper()
+	if err == nil {
+		t.Error("expected error from non-ExitError path in RunCommand")
+		return
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Errorf("unexpected context error (should have hit non-ExitError branch): %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Error("expected non-zero exit code")
+	}
+	if res.Output == "" {
+		t.Log("no partial output (expected for immediate SIGKILL)")
+	}
+}
+
+// runNonExitErrorWaitPathTest executes a single attempt at triggering
+// the non-ExitError branch. It returns nil on success or an error.
+func runNonExitErrorWaitPathTest(t *testing.T) error {
+	t.Helper()
+
+	e := newprocessExecutor()
+	ctx := context.Background()
+
+	pidFile := filepath.Join(t.TempDir(), "pid")
+
+	spawnPreReaper(t, pidFile)
 
 	res, err := e.RunCommand(ctx, []string{
 		"/bin/sh", "-c",
@@ -95,18 +111,7 @@ func runNonExitErrorWaitPathTest(t *testing.T) error {
 		return fmt.Errorf("expected error from non-ExitError path in RunCommand")
 	}
 
-	// Verify it's not a context error (we used context.Background())
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return fmt.Errorf("unexpected context error (should have hit non-ExitError branch): %v", err)
-	}
-
-	if res.ExitCode == 0 {
-		t.Error("expected non-zero exit code")
-	}
-
-	if res.Output == "" {
-		t.Log("no partial output (expected for immediate SIGKILL)")
-	}
+	assertNonExitErrorResult(t, res, err)
 
 	return nil
 }

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -5,8 +5,10 @@ package workspace
 
 import (
 	"context"
+	"io"
+	"os"
+	"os/exec"
 	"runtime"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -230,68 +232,90 @@ func TestSetupCommand(t *testing.T) {
 	executor := &processExecutor{}
 	ctx := context.Background()
 
-	t.Run("empty parts returns error", func(t *testing.T) {
-		t.Parallel()
+	tests := []struct {
+		name            string
+		parts           []string
+		config          executionConfig
+		wantErr         string
+		expectNilCmd    bool
+		expectNilStdout bool
+		expectNilStderr bool
+		expectNilFile   bool
+		wantEnv         string
+	}{
+		{
+			name:            "empty parts returns error",
+			parts:           []string{},
+			config:          executionConfig{},
+			wantErr:         "empty command",
+			expectNilCmd:    true,
+			expectNilStdout: true,
+			expectNilStderr: true,
+			expectNilFile:   true,
+		},
+		{
+			name:          "valid command returns cmd with pipes",
+			parts:         []string{"echo", "hello"},
+			expectNilFile: true,
+		},
+		{
+			name:          "custom env vars are propagated",
+			parts:         []string{"echo", "hello"},
+			config:        executionConfig{Env: map[string]string{"TELL_ME_TEST_665": "task2_value"}},
+			wantEnv:       "TELL_ME_TEST_665=task2_value",
+			expectNilFile: true,
+		},
+	}
 
-		cmd, stdout, stderr, file, err := executor.setupCommand(ctx, []string{}, executionConfig{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "empty command") {
-			t.Errorf("expected error to contain 'empty command', got: %v", err)
-		}
-		if cmd != nil {
-			t.Error("expected nil cmd")
-		}
-		if stdout != nil {
-			t.Error("expected nil stdout")
-		}
-		if stderr != nil {
-			t.Error("expected nil stderr")
-		}
-		if file != nil {
-			t.Error("expected nil file")
-		}
-	})
+			cmd, stdout, stderr, file, err := executor.setupCommand(ctx, tt.parts, tt.config)
 
-	t.Run("valid command returns cmd with pipes", func(t *testing.T) {
-		t.Parallel()
+			if tt.wantErr != "" {
+				assertPipelineCmdError(t, err, tt.wantErr)
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
-		cmd, stdout, stderr, _, err := executor.setupCommand(ctx, []string{"echo", "hello"}, executionConfig{})
+			assertSetupCommandNils(t, cmd, stdout, stderr, file,
+				tt.expectNilCmd, tt.expectNilStdout, tt.expectNilStderr, tt.expectNilFile)
 
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if cmd == nil {
-			t.Fatal("expected non-nil *exec.Cmd")
-		}
-		if stdout == nil {
-			t.Error("expected non-nil stdout io.ReadCloser")
-		}
-		if stderr == nil {
-			t.Error("expected non-nil stderr io.ReadCloser")
-		}
-	})
-
-	t.Run("custom env vars are propagated", func(t *testing.T) {
-		t.Parallel()
-
-		const envKey = "TELL_ME_TEST_665"
-		const envVal = "task2_value"
-		cmd, _, _, _, err := executor.setupCommand(ctx, []string{"echo", "hello"}, executionConfig{
-			Env: map[string]string{envKey: envVal},
+			if tt.wantEnv != "" {
+				assertEnvVarPresent(t, cmd.Env, tt.wantEnv)
+			}
 		})
+	}
+}
 
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		want := envKey + "=" + envVal
-		if !slices.Contains(cmd.Env, want) {
-			t.Errorf("expected cmd.Env to contain %q", want)
-		}
-	})
+// assertSetupCommandNils checks nil/non-nil expectations for all four return values.
+func assertSetupCommandNils(t *testing.T, cmd *exec.Cmd, stdout, stderr io.ReadCloser, file *os.File, expectNilCmd, expectNilStdout, expectNilStderr, expectNilFile bool) {
+	t.Helper()
+	if expectNilCmd && cmd != nil {
+		t.Error("expected nil cmd")
+	}
+	if !expectNilCmd && cmd == nil {
+		t.Error("expected non-nil *exec.Cmd")
+	}
+	if expectNilStdout && stdout != nil {
+		t.Error("expected nil stdout")
+	}
+	if !expectNilStdout && stdout == nil {
+		t.Error("expected non-nil stdout io.ReadCloser")
+	}
+	if expectNilStderr && stderr != nil {
+		t.Error("expected nil stderr")
+	}
+	if !expectNilStderr && stderr == nil {
+		t.Error("expected non-nil stderr io.ReadCloser")
+	}
+	if expectNilFile && file != nil {
+		t.Error("expected nil file")
+	}
+	if !expectNilFile && file == nil {
+		t.Error("expected non-nil *os.File")
+	}
 }
 
 // TestWithinParent covers withinParent(parent, target string) bool.


### PR DESCRIPTION
Closes #683.

## Summary
Refactored three test functions exceeding cyclomatic complexity threshold 10 in `internal/tools/workspace/`:

| Function | File | Old CC | New CC |
|----------|------|--------|--------|
| `TestNewPipelineCmd` | `pipeline_test.go` | 12 | **6** |
| `TestSetupCommand` | `process_executor_test.go` | 13 | **5** |
| `runNonExitErrorWaitPathTest` | `process_executor_stream_unix_test.go` | 14 | **2** |

### Approach
- **`TestNewPipelineCmd`**: Extracted `assertPipelineCmdError`, `assertCmdNotNil`, `assertEnvVarPresent` helpers
- **`TestSetupCommand`**: Converted three `t.Run` subtests to table-driven, extracted `assertSetupCommandNils` helper, reused shared helpers
- **`runNonExitErrorWaitPathTest`**: Structural decomposition into `spawnPreReaper` + `assertNonExitErrorResult` (not table-driven — only one scenario)

### Verification
| Check | Status |
|-------|--------|
| `go test -race ./internal/tools/workspace/...` | PASS |
| `golangci-lint run ./internal/tools/workspace/...` | 0 issues |
| Coverage (`internal/tools/workspace/...`) | 96.0% |
| All three functions below CC 10 | ✅ |
