### PR TITLE
fix(test): close 6 error-handling coverage gaps (#691)

### DIFF
--- a/internal/agent/agenttest/mock_history_manager_test.go
+++ b/internal/agent/agenttest/mock_history_manager_test.go
@@ -69,6 +69,56 @@ func TestMockHistoryManager_AddContent_Appends(t *testing.T) {
 	}
 }
 
+func TestMockHistoryManager_AddContent_FuncOverride(t *testing.T) {
+	t.Parallel()
+
+	t.Run("AddContentFunc returns error", func(t *testing.T) {
+		injectedErr := errors.New("injected AddContent error")
+		m := &MockHistoryManager{
+			AddContentFunc: func(ctx context.Context, content *llm.Content) error {
+				return injectedErr
+			},
+		}
+
+		err := m.AddContent(context.Background(), &llm.Content{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: "should not be stored"}},
+		})
+
+		if err != injectedErr {
+			t.Errorf("expected injectedErr, got %v", err)
+		}
+		if m.GetTotalEntries() != 0 {
+			t.Errorf("expected 0 entries after error, got %d", m.GetTotalEntries())
+		}
+	})
+
+	t.Run("AddContentFunc returns nil", func(t *testing.T) {
+		m := &MockHistoryManager{}
+		m.AddContentFunc = func(ctx context.Context, content *llm.Content) error {
+			// Custom behavior: store only if role is "user"
+			if content.Role == "user" {
+				m.Mu.Lock()
+				m.Contents = append(m.Contents, llm.CloneContent(content))
+				m.Mu.Unlock()
+			}
+			return nil
+		}
+
+		err := m.AddContent(context.Background(), &llm.Content{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: "hello"}},
+		})
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if m.GetTotalEntries() != 1 {
+			t.Errorf("expected 1 entry, got %d", m.GetTotalEntries())
+		}
+	})
+}
+
 // ---------------------------------------------------------------------------
 // GetWindow
 // ---------------------------------------------------------------------------

--- a/internal/domain/config/configtest/mock_config_loader_test.go
+++ b/internal/domain/config/configtest/mock_config_loader_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package configtest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+)
+
+func TestMockConfigLoader_Load(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		path    string
+		setup   func(m *MockConfigLoader)
+		wantNil bool
+		wantErr bool
+	}{
+		{
+			name: "success path: non-nil args.Get(0) returns config and nil error",
+			path: "/test/config.yaml",
+			setup: func(m *MockConfigLoader) {
+				m.On("Load", "/test/config.yaml").Return(&config.Config{}, nil)
+			},
+			wantNil: false,
+			wantErr: false,
+		},
+		{
+			name: "error path with typed nil: args.Get(0) != nil, returns typed nil config and error",
+			path: "/test/typed-nil.yaml",
+			setup: func(m *MockConfigLoader) {
+				m.On("Load", "/test/typed-nil.yaml").Return((*config.Config)(nil), errors.New("load failed"))
+			},
+			wantNil: true,
+			wantErr: true,
+		},
+		{
+			name: "defensive nil path: args.Get(0) == nil returns hardcoded nil config and error",
+			path: "/test/defensive.yaml",
+			setup: func(m *MockConfigLoader) {
+				// Passing nil through an explicit interface{} variable
+				// preserves the untyped nil so args.Get(0) == nil is true,
+				// triggering the defensive nil-guard branch.
+				var nilCfg interface{}
+				m.On("Load", "/test/defensive.yaml").Return(nilCfg, errors.New("defensive load failed"))
+			},
+			wantNil: true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := new(MockConfigLoader)
+			tt.setup(m)
+
+			cfg, err := m.Load(tt.path)
+
+			if tt.wantNil && cfg != nil {
+				t.Errorf("expected nil config, got %+v", cfg)
+			}
+			if !tt.wantNil && cfg == nil {
+				t.Error("expected non-nil config, got nil")
+			}
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			m.AssertExpectations(t)
+		})
+	}
+}

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -964,6 +964,87 @@ func TestSimpleEventBus_FlushCancellations(t *testing.T) {
 	})
 }
 
+// TestSimpleEventBus_Flush_BusContextCancellation exercises the <-b.ctx.Done()
+// path in Flush's dual select (line 109-110 of event_bus_lifecycle.go).
+//
+// The existing BusClosedDuringFlush test publishes only 1 event, so
+// decPending() fires before the subscriber blocks — pendingCount drops
+// to 0, flushWaiter closes done immediately, and the select picks <-done
+// instead of <-b.ctx.Done(). This test publishes 2 events to keep
+// pendingCount > 0 while a worker is blocked, ensuring the Flush select
+// is forced into the <-b.ctx.Done() branch when Shutdown cancels the bus.
+func TestSimpleEventBus_Flush_BusContextCancellation(t *testing.T) {
+	ctx := context.Background()
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(true), events.WithQueueSize(2))
+
+	// Start the listener so workers pick up events.
+	listenCtx, listenCancel := context.WithCancel(ctx)
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		if err := bus.Listen(listenCtx); err != nil && !errors.Is(err, context.Canceled) {
+			t.Logf("Listen returned: %v", err)
+		}
+	}()
+	bus.WaitStarted()
+
+	// Create a slow subscriber that signals when the worker is blocked.
+	block := make(chan struct{})
+	started := make(chan struct{}, 2)
+	bus.SubscribeGlobal(&uncooperativeSubscriber{
+		block:             block,
+		startedProcessing: started,
+	})
+
+	// Publish 2 events. The worker dequeues event #1, calls decPending()
+	// (pendingCount goes from 2 to 1), then blocks in Handle. Event #2
+	// stays in the queue, so pendingCount remains at 1.
+	if err := bus.Publish(ctx, testEvent{typeName: "slow-1"}); err != nil {
+		close(block)
+		listenCancel()
+		t.Fatalf("Publish event 1 failed: %v", err)
+	}
+	if err := bus.Publish(ctx, testEvent{typeName: "slow-2"}); err != nil {
+		close(block)
+		listenCancel()
+		t.Fatalf("Publish event 2 failed: %v", err)
+	}
+
+	// Wait for the worker to pick up event #1 and block in Handle.
+	select {
+	case <-started:
+	case <-time.After(1 * time.Second):
+		t.Fatal("worker did not start processing")
+	}
+
+	// Flush in a goroutine. With pendingCount > 0, flushWaiter enters
+	// the cond.Wait() loop instead of closing done immediately.
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- bus.Flush(ctx)
+	}()
+
+	// Shutdown cancels the bus context (b.ctx), which triggers
+	// <-b.ctx.Done() in Flush's select.
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		_ = bus.Shutdown(ctx)
+	}()
+
+	err := <-errChan
+	if !errors.Is(err, events.ErrBusClosed) {
+		t.Errorf("expected ErrBusClosed from <-b.ctx.Done() path, got %v", err)
+	}
+
+	// Cleanup: unblock the subscriber so the worker drains, allowing
+	// Shutdown and Listen to return cleanly without goroutine leaks.
+	close(block)
+	listenCancel()
+	<-listenDone
+	<-shutdownDone
+}
+
 func TestSimpleEventBus_ListenDefensive_NilBus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/domain/ports/factory_test.go
+++ b/internal/domain/ports/factory_test.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ports
+
+import (
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
+)
+
+func TestClientFactoryFunc_NewClient(t *testing.T) {
+	t.Parallel()
+
+	// nilDeps provides zero-value arguments for the factory call.
+	// ClientFactoryFunc implementations ignore these in test.
+	var (
+		cfg    *config.Config
+		pd     pricing.PricingData
+		bus    events.EventBus
+		logger Logger
+	)
+
+	tests := []struct {
+		name      string
+		factory   ClientFactoryFunc
+		wantNil   bool
+		wantErr   bool
+		errTarget error
+	}{
+		{
+			name: "success: returns client and nil error",
+			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+				return nil, nil
+			},
+			wantNil: true,
+			wantErr: false,
+		},
+		{
+			name: "error: returns nil client and error",
+			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+				return nil, ErrHistoryNotFound
+			},
+			wantNil:   true,
+			wantErr:   true,
+			errTarget: ErrHistoryNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := tt.factory.NewClient(cfg, pd, bus, logger)
+
+			if tt.wantNil && client != nil {
+				t.Errorf("expected nil client, got %+v", client)
+			}
+			if !tt.wantNil && client == nil {
+				t.Error("expected non-nil client, got nil")
+			}
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if tt.errTarget != nil && err != tt.errTarget {
+				t.Errorf("expected error %v, got %v", tt.errTarget, err)
+			}
+		})
+	}
+}
+
+func TestClientFactoryFunc_NewFailoverChain(t *testing.T) {
+	t.Parallel()
+
+	var (
+		cfg    *config.Config
+		pd     pricing.PricingData
+		bus    events.EventBus
+		logger Logger
+	)
+
+	tests := []struct {
+		name    string
+		factory ClientFactoryFunc
+	}{
+		{
+			name: "returns nil, nil regardless of factory success",
+			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+				return nil, nil // would-be success
+			},
+		},
+		{
+			name: "returns nil, nil regardless of factory error",
+			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+				return nil, ErrHistoryNotFound // would-be error
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := tt.factory.NewFailoverChain(cfg, pd, bus, logger)
+
+			if client != nil {
+				t.Errorf("NewFailoverChain must return nil client, got %+v", client)
+			}
+			if err != nil {
+				t.Errorf("NewFailoverChain must return nil error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #691.

## Summary
Closes all 6 architectural error-handling gaps identified in #689 Phase 1:

| # | Gap | Before | After |
|---|-----|--------|-------|
| 1 | `AddContentFunc` error path | uncovered | 100% |
| 2 | `ClientFactoryFunc.NewClient` error | 0% | 100% |
| 3 | `NewFailoverChain` nil,nil sentinel | 0% | 100% |
| 4 | Flush `<-b.ctx.Done()` dual-select | uncovered | 100% |
| 5 | `MockConfigLoader.Load` error path | 0% | 100% |
| 6 | `MockConfigLoader.Load` success path | 0% | 100% |

**Aggregate coverage**: 99.3% (threshold: 95.8%)
**Production code changes**: Zero — test-only

## Verification
| Check | Status |
|-------|--------|
| go fmt ./... | PASS |
| go mod tidy | PASS |
| go build ./... | PASS |
| go vet ./... | PASS |
| golangci-lint run | PASS (0 issues) |
| go test -race (affected pkgs) | PASS |
| Full test suite | PASS (71/71 pkgs) |
| Coverage ≥95.8% | PASS (99.3%) |