### PR TITLE
fix(agenttest): add nil stop-func tests for spinner mocks (#694)

### DIFF
--- a/internal/agent/agenttest/mock_ui_renderer_test.go
+++ b/internal/agent/agenttest/mock_ui_renderer_test.go
@@ -69,6 +69,44 @@ func TestMockUIRenderer_StartSpinnerWithStatus(t *testing.T) {
 	m.AssertExpectations(t)
 }
 
+func TestMockUIRenderer_StartSpinnerWithStatus_NilStopFunc(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	status := "loading"
+
+	m := new(MockUIRenderer)
+	// Return nil → should return a no-op func() (not nil).
+	m.On("StartSpinnerWithStatus", ctx, status).Return(nil)
+
+	stop := m.StartSpinnerWithStatus(ctx, status)
+	if stop == nil {
+		t.Fatal("got nil stop func; want non-nil no-op")
+	}
+	// Must not panic.
+	stop()
+	m.AssertExpectations(t)
+}
+
+func TestMockUIRenderer_StartSpinnerWithMetrics_NilStopFunc(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	status := "processing"
+
+	m := new(MockUIRenderer)
+	// Return nil → should return a no-op func() (not nil).
+	m.On("StartSpinnerWithMetrics", ctx, status).Return(nil)
+
+	stop := m.StartSpinnerWithMetrics(ctx, status)
+	if stop == nil {
+		t.Fatal("got nil stop func; want non-nil no-op")
+	}
+	// Must not panic.
+	stop()
+	m.AssertExpectations(t)
+}
+
 func TestMockUIRenderer_StartSpinnerWithMetrics(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #694.

## Summary
Added two test functions to  that exercise the nil-return else-branches in  and . These were the only two real coverage gaps among the 21 methods listed in the issue — the remaining 15 methods have zero-statement bodies (0% is a Go tooling artifact) and 2 were already fully covered.

## Changes
- `TestMockUIRenderer_StartSpinnerWithStatus_NilStopFunc` — tests the nil-return branch at mock_ui_renderer.go:39
- `TestMockUIRenderer_StartSpinnerWithMetrics_NilStopFunc` — tests the nil-return branch at mock_ui_renderer.go:47
- Both tests follow the existing `TestMockUIRenderer_StartSpinner_NilStopFunc` pattern
- Test-only — no production code changes

## Verification
| Check | Status |
|-------|--------|
| go fmt ./... | PASS |
| go mod tidy | PASS |
| go build ./... | PASS |
| go test ./... | PASS |
| go test -race (agenttest) | PASS |
| golangci-lint | 0 issues |
| Coverage (agenttest) | 99.7% (≥95.8% target) |
