### PR TITLE
fix(session): close error-handling coverage gaps (#693)

### DIFF
--- a/internal/agent/session/context/context_manager_test.go
+++ b/internal/agent/session/context/context_manager_test.go
@@ -844,3 +844,33 @@ func TestManager_Prepare_ExecutePipeline_Coverage(t *testing.T) {
 		})
 	}
 }
+
+func TestNewManager_WithFactorySummarizer(t *testing.T) {
+	tc := &agenttest.MockTokenCounter{}
+	strategy := sessctx.NewStrategy(tc)
+	mockSum := &agenttest.MockSummarizer{}
+	factory := &sessctx.Factory{
+		Estimator:  strategy,
+		Summarizer: mockSum,
+	}
+	history := &agenttest.MockHistoryManager{}
+	cm := sessctx.NewManager(strategy, history, nil, factory)
+
+	require.NotNil(t, cm.Summarizer)
+	assert.Same(t, mockSum, cm.Summarizer, "Summarizer should be the same pointer as factory.Summarizer")
+	assert.NotNil(t, factory.Logger, "factory.Logger should be set to the manager's logger")
+}
+
+// stubSessionProvider is a minimal implementation of ports.SessionProvider
+// whose methods panic if called. It exists solely to satisfy the type system
+// for testing WithSessionProvider.
+type stubSessionProvider struct {
+	ports.SessionProvider
+}
+
+func TestWithSessionProvider(t *testing.T) {
+	cm := sessctx.NewManager(nil, nil, nil, nil,
+		sessctx.WithSessionProvider(&stubSessionProvider{}),
+	)
+	assert.NotNil(t, cm.SessionProvider)
+}

--- a/internal/agent/session/context/error_coverage_test.go
+++ b/internal/agent/session/context/error_coverage_test.go
@@ -475,3 +475,23 @@ func TestTokenGatekeeper_PublishSystemEvent_ErrBusNotInitialized(t *testing.T) {
 
 	require.Empty(t, logger.GetErrors(), "ErrBusNotInitialized should be silently swallowed, not logged")
 }
+
+func TestCheckWindowSize_EndIdxZero(t *testing.T) {
+	hm := &agenttest.MockHistoryManager{
+		Contents: []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "u1"}}},
+			{Role: "model", Parts: []*llm.Part{{Text: "m1"}}},
+		},
+	}
+
+	strategy := NewStrategy(&agenttest.MockTokenCounter{})
+	cm := NewManager(strategy, hm, nil, nil)
+
+	ctx := context.Background()
+	found, subset, endIdx, err := cm.checkWindowSize(ctx, 2, 5, 2)
+
+	require.True(t, found)
+	require.Nil(t, subset)
+	require.Equal(t, 0, endIdx)
+	require.NoError(t, err)
+}

--- a/internal/agent/session/context/group_turns_error_test.go
+++ b/internal/agent/session/context/group_turns_error_test.go
@@ -204,3 +204,17 @@ func (m *mockTokenCounterWithFn) Count(contents []*llm.Content) int {
 	}
 	return 0
 }
+
+func TestGroupTurns_NilHistory(t *testing.T) {
+	_, err := groupTurns(context.Background(), nil)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrInvalidPayload)
+	require.Contains(t, err.Error(), "groupTurns")
+}
+
+func TestGroupTurns_EmptyHistory(t *testing.T) {
+	turns, err := groupTurns(context.Background(), []*llm.Content{})
+	require.NoError(t, err)
+	require.Nil(t, turns)
+	require.Len(t, turns, 0)
+}

--- a/internal/agent/session/context/pruner_test.go
+++ b/internal/agent/session/context/pruner_test.go
@@ -6,12 +6,15 @@ package context
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"sync"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -161,4 +164,25 @@ func TestCompositePruningPolicy_MarkTurns_ErrorPropagation(t *testing.T) {
 
 	_, err := composite.MarkTurns(context.Background(), turns, keep)
 	require.ErrorIs(t, err, mockErr)
+}
+
+func TestHistoryPruner_GetLogger_NonNil(t *testing.T) {
+	customLogger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	pruner := &HistoryPruner{
+		Logger: customLogger,
+	}
+	result := pruner.getLogger()
+	assert.Same(t, customLogger, result)
+}
+
+func TestHistoryPruner_Transform_EmptyHistory(t *testing.T) {
+	pruner := &HistoryPruner{
+		Policy: &SlidingWindowPolicy{MaxTurns: 1},
+	}
+	req := &ports.ContextRequest{
+		History: nil,
+	}
+	err := pruner.Transform(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, 0, req.Metadata.PrunedTurns)
 }

--- a/internal/agent/session/context/token_counter_test.go
+++ b/internal/agent/session/context/token_counter_test.go
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Count tests
+// ---------------------------------------------------------------------------
+
+func TestCount_TransientParts(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	// Content with one text Part and one TransientPart
+	contentWithTransients := &llm.Content{
+		Role: "user",
+		Parts: []*llm.Part{
+			{Text: "hello"},
+		},
+		TransientParts: []*llm.Part{
+			{Text: "world"},
+		},
+	}
+
+	// Same Parts but no TransientParts
+	contentNoTransients := &llm.Content{
+		Role: "user",
+		Parts: []*llm.Part{
+			{Text: "hello"},
+		},
+	}
+
+	resultWithTransients := counter.Count([]*llm.Content{contentWithTransients})
+	resultNoTransients := counter.Count([]*llm.Content{contentNoTransients})
+
+	// TransientParts characters were counted: result should be higher
+	require.Greater(t, resultWithTransients, resultNoTransients,
+		"TransientParts should contribute to token count")
+
+	// TokenCount is NOT cached when TransientParts are present
+	require.Equal(t, 0, contentWithTransients.TokenCount,
+		"TokenCount must not be cached when TransientParts are present")
+}
+
+func TestCount_NoTransientParts_CachesTokenCount(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	content := &llm.Content{
+		Role: "user",
+		Parts: []*llm.Part{
+			{Text: "hello world this is a test"},
+		},
+		// TransientParts is nil / zero-length
+	}
+
+	_ = counter.Count([]*llm.Content{content})
+
+	// TokenCount must be cached (positive) when TransientParts are absent
+	require.Greater(t, content.TokenCount, 0,
+		"TokenCount must be cached when TransientParts are empty")
+}
+
+func TestCount_RegistryTools(t *testing.T) {
+	counterNoReg := NewHeuristicTokenCounter(nil)
+
+	// Create a stub registry with tool declarations that contribute tokens
+	reg := &stubRegistry{
+		decls: []*tools.ToolDeclaration{
+			{
+				Name:        "read_file",
+				Description: "Reads the content of a file at the given path.",
+				Parameters: &tools.Schema{
+					Type: "object",
+					Properties: map[string]*tools.Schema{
+						"path": {Type: "string", Description: "The file path to read."},
+					},
+				},
+			},
+		},
+	}
+	counterWithReg := NewHeuristicTokenCounter(reg)
+
+	contents := []*llm.Content{
+		{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+	}
+
+	resultNoReg := counterNoReg.Count(contents)
+	resultWithReg := counterWithReg.Count(contents)
+
+	// Tool declarations must contribute to the total
+	require.Greater(t, resultWithReg, resultNoReg,
+		"Registry with tool declarations must increase token count")
+}
+
+// ---------------------------------------------------------------------------
+// estimatePartChars tests
+// ---------------------------------------------------------------------------
+
+func TestEstimatePartChars_NilPart(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	chars := counter.estimatePartChars(nil)
+
+	require.Equal(t, 0, chars, "nil Part must return 0 chars")
+}
+
+func TestEstimatePartChars_FunctionResponse(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	resp := map[string]interface{}{
+		"status":  "ok",
+		"count":   float64(42),
+		"enabled": true,
+		"tags":    []interface{}{"a", "bb"},
+	}
+
+	part := &llm.Part{
+		FunctionResponse: &llm.FunctionResponse{
+			Name:     "search_files",
+			Response: resp,
+		},
+	}
+
+	chars := counter.estimatePartChars(part)
+
+	// Expected: len("search_files") = 12
+	// + estimateMapSizeInternal(resp)
+	//   "status"(6) + "ok"(2) = 8
+	//   "count"(5) + float64→10 = 15
+	//   "enabled"(7) + bool→5 = 12
+	//   "tags"(4) + []interface{}(1 + "a"(1) + "bb"(2)) = 8
+	//   total map = 43
+	// = 12 + 43 = 55
+	expected := 55
+
+	require.Equal(t, expected, chars,
+		"FunctionResponse chars must include Name length + response map size")
+}
+
+func TestEstimatePartChars_InlineData(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	part := &llm.Part{
+		InlineData: &llm.Blob{
+			MIMEType: "image/png",
+			Data:     []byte("mock-data"),
+		},
+	}
+
+	chars := counter.estimatePartChars(part)
+
+	require.Equal(t, 160, chars,
+		"InlineData must contribute exactly 160 character-equivalents")
+}
+
+// ---------------------------------------------------------------------------
+// estimateMapSizeInternal tests
+// ---------------------------------------------------------------------------
+
+func TestEstimateMapSizeInternal_NilMap(t *testing.T) {
+	size := estimateMapSizeInternal(nil)
+
+	require.Equal(t, 0, size, "nil map must return 0")
+}
+
+// ---------------------------------------------------------------------------
+// estimateValueSizeInternal tests (table-driven)
+// ---------------------------------------------------------------------------
+
+func TestEstimateValueSizeInternal_AllTypes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected int
+	}{
+		{"nil", nil, 4},
+		{"string", "hello", 5},
+		{"float64", float64(3.14), 10},
+		{"int", int(42), 10},
+		{"int64", int64(99), 10},
+		{"bool true", true, 5},
+		{"bool false", false, 5},
+		{
+			name:     "map string to string",
+			input:    map[string]interface{}{"k": "v"},
+			expected: len("k") + len("v"), // 1 + 1 = 2
+		},
+		{
+			name:     "slice of strings",
+			input:    []interface{}{"ab", "cd"},
+			expected: 1 + len("ab") + len("cd"), // 1 + 2 + 2 = 5
+		},
+		{
+			name:     "unknown type (struct)",
+			input:    struct{}{},
+			expected: 20,
+		},
+		{
+			name: "nested map",
+			input: map[string]interface{}{
+				"outer": map[string]interface{}{
+					"inner": "val",
+				},
+			},
+			// "outer"(5) + ("inner"(5) + "val"(3)) = 13
+			expected: len("outer") + len("inner") + len("val"),
+		},
+		{
+			name:     "slice with mixed types",
+			input:    []interface{}{"x", float64(0), true},
+			expected: 1 + len("x") + 10 + 5, // 1 + 1 + 10 + 5 = 17
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := estimateValueSizeInternal(tt.input)
+			require.Equal(t, tt.expected, got,
+				"estimateValueSizeInternal(%v)", tt.input)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// estimatePartChars integration tests (table-driven)
+// ---------------------------------------------------------------------------
+
+func TestEstimatePartChars_AllPartTypes(t *testing.T) {
+	counter := NewHeuristicTokenCounter(nil)
+
+	tests := []struct {
+		name     string
+		part     *llm.Part
+		expected int
+	}{
+		{
+			name:     "empty part",
+			part:     &llm.Part{},
+			expected: 0,
+		},
+		{
+			name:     "text only",
+			part:     &llm.Part{Text: "hello world"},
+			expected: len("hello world"), // 11
+		},
+		{
+			name: "function call with args",
+			part: &llm.Part{
+				FunctionCall: &llm.FunctionCall{
+					Name: "do_stuff",
+					Args: map[string]interface{}{
+						"param": "value",
+						"num":   float64(1),
+					},
+				},
+			},
+			// len("do_stuff")=8 + ("param"(5)+"value"(5)) + ("num"(3)+float64→10) = 31
+			expected: len("do_stuff") + len("param") + len("value") + len("num") + 10,
+		},
+		{
+			name: "function response",
+			part: &llm.Part{
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "fn",
+					Response: map[string]interface{}{
+						"ok": true,
+					},
+				},
+			},
+			// len("fn")=2 + ("ok"(2)+bool→5) = 9
+			expected: len("fn") + len("ok") + 5,
+		},
+		{
+			name: "inline data only",
+			part: &llm.Part{
+				InlineData: &llm.Blob{MIMEType: "image/png"},
+			},
+			expected: 160,
+		},
+		{
+			name: "mix of all types",
+			part: &llm.Part{
+				Text: "abc",
+				FunctionCall: &llm.FunctionCall{
+					Name: "f",
+					Args: map[string]interface{}{
+						"x": "y",
+					},
+				},
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "g",
+					Response: map[string]interface{}{
+						"z": float64(0),
+					},
+				},
+				InlineData: &llm.Blob{MIMEType: "image/png"},
+			},
+			// Text(3) + fc(len("f")=1 + "x"(1)+"y"(1)) + fr(len("g")=1 + "z"(1)+10) + inline(160)
+			// = 3 + 3 + 12 + 160 = 178
+			expected: len("abc") + len("f") + len("x") + len("y") +
+				len("g") + len("z") + 10 + 160,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := counter.estimatePartChars(tt.part)
+			require.Equal(t, tt.expected, got,
+				"estimatePartChars returned unexpected value for %s", tt.name)
+		})
+	}
+}

--- a/internal/agent/session/context/warning_injector_fix_test.go
+++ b/internal/agent/session/context/warning_injector_fix_test.go
@@ -125,3 +125,155 @@ func TestWarningInjector_Idempotency(t *testing.T) {
 		}
 	}
 }
+
+// TestWarningInjector_GatherWarnings_Empty verifies that gatherWarnings returns
+// ("", nil) when getWarnings() produces an empty slice (no limits are reached).
+func TestWarningInjector_GatherWarnings_Empty(t *testing.T) {
+	strategy := NewStrategy(NewHeuristicTokenCounter(&agenttest.MockToolRegistry{}))
+	// Huge limits so no warnings trigger — token ratio 10/100000 = 0.0001, turn ratio 1/100 = 0.01
+	strategy.SetLimits(100000, 100, 100)
+
+	injector := &WarningInjector{Strategy: strategy}
+
+	req := &request{
+		Turn: 1,
+		History: []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+		},
+	}
+	req.Metadata.FinalTokenCount = 10
+
+	combined, list := injector.gatherWarnings(req, 10, 1)
+
+	if combined != "" {
+		t.Errorf("expected empty combined, got %q", combined)
+	}
+	if list != nil {
+		t.Errorf("expected nil list, got %v", list)
+	}
+}
+
+// TestWarningInjector_InjectWarning_EmptyHistory verifies that injectWarning is
+// a no-op (no panic) when req.History is empty.
+func TestWarningInjector_InjectWarning_EmptyHistory(t *testing.T) {
+	strategy := NewStrategy(NewHeuristicTokenCounter(&agenttest.MockToolRegistry{}))
+	injector := &WarningInjector{Strategy: strategy}
+
+	req := &request{
+		History: []*llm.Content{},
+	}
+
+	// Must not panic; must not modify history
+	injector.injectWarning(req, "some warning text")
+
+	if len(req.History) != 0 {
+		t.Errorf("expected history to remain empty, got %d messages", len(req.History))
+	}
+}
+
+// TestWarningInjector_InjectWarning_TransientPartsDedup verifies the
+// TransientParts idempotency check: if the last message already has the warning
+// text in its TransientParts, no new message is appended.
+func TestWarningInjector_InjectWarning_TransientPartsDedup(t *testing.T) {
+	strategy := NewStrategy(NewHeuristicTokenCounter(&agenttest.MockToolRegistry{}))
+	injector := &WarningInjector{Strategy: strategy}
+
+	warningText := "WARNING: some warning"
+
+	req := &request{
+		History: []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "first message"}}},
+			{
+				Role:  "model",
+				Parts: []*llm.Part{{Text: "second message"}},
+				TransientParts: []*llm.Part{
+					{Text: "\n\n" + warningText},
+				},
+			},
+		},
+	}
+
+	originalLen := len(req.History)
+	originalTransientCount := len(req.History[1].TransientParts)
+
+	injector.injectWarning(req, warningText)
+
+	if len(req.History) != originalLen {
+		t.Errorf("expected history length %d, got %d", originalLen, len(req.History))
+	}
+
+	if len(req.History[1].TransientParts) != originalTransientCount {
+		t.Errorf("expected TransientParts count %d, got %d",
+			originalTransientCount, len(req.History[1].TransientParts))
+	}
+}
+
+// TestWarningInjector_GatherWarnings_Multiple verifies that gatherWarnings
+// concatenates multiple warnings with "\n" when two or more warning types
+// trigger simultaneously. This covers the multi-warning concatenation path
+// at warning_injector.go:68-70 (combined += "\n").
+func TestWarningInjector_GatherWarnings_Multiple(t *testing.T) {
+	strategy := NewStrategy(NewHeuristicTokenCounter(&agenttest.MockToolRegistry{}))
+	// maxHistoryTokens=1000, maxToolTurns=3, maxHistoryTurns=100
+	strategy.SetLimits(1000, 3, 100)
+
+	injector := &WarningInjector{Strategy: strategy}
+
+	req := &request{
+		Turn: 0, // remaining = 3-0 = 3 → triggers turn warning "3 turns remaining"
+		History: []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+		},
+	}
+	req.Metadata.FinalTokenCount = 910 // ratio = 910/1000 = 0.91 > 0.90 → triggers token warning
+
+	// Call gatherWarnings directly with tokens=910, turns=0
+	combined, list := injector.gatherWarnings(req, 910, 0)
+
+	// Verify both warnings are present and separated by newline
+	if !strings.Contains(combined, "\n") {
+		t.Errorf("expected combined to contain newline separator between two warnings, got %q", combined)
+	}
+	if len(list) != 2 {
+		t.Fatalf("expected 2 warnings in list, got %d: %v", len(list), list)
+	}
+
+	// Verify the two specific warning substrings
+	if !strings.Contains(list[0], "3 turns remaining") {
+		t.Errorf("expected turn warning in list[0], got %q", list[0])
+	}
+	if !strings.Contains(list[1], "90% capacity") {
+		t.Errorf("expected token warning in list[1], got %q", list[1])
+	}
+}
+
+// TestWarningInjector_GatherWarnings_Clogged verifies that gatherWarnings returns
+// the clogged warning when SummarizationAttempted is true and tokens exceed 85% of max.
+// This covers the uncovered branch at warning_injector.go:55-57.
+func TestWarningInjector_GatherWarnings_Clogged(t *testing.T) {
+	strategy := NewStrategy(NewHeuristicTokenCounter(&agenttest.MockToolRegistry{}))
+	strategy.SetLimits(1000, 10, 20) // maxTokens=1000, threshold=850
+
+	injector := &WarningInjector{Strategy: strategy}
+
+	req := &request{
+		Turn: 1,
+		History: []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+		},
+	}
+	req.Metadata.SummarizationAttempted = true
+	req.Metadata.FinalTokenCount = 860 // > 850 threshold
+
+	combined, list := injector.gatherWarnings(req, 860, 1)
+
+	if combined == "" {
+		t.Error("expected non-empty combined warning, got empty")
+	}
+	if len(list) != 1 {
+		t.Fatalf("expected 1 warning in list, got %d: %v", len(list), list)
+	}
+	if !strings.Contains(list[0], "summarization failed to significantly reduce") {
+		t.Errorf("expected clogged warning, got %q", list[0])
+	}
+}

--- a/internal/agent/session/internal_tools_test.go
+++ b/internal/agent/session/internal_tools_test.go
@@ -532,3 +532,15 @@ func TestEmitHeartbeats_TickerPaths(t *testing.T) {
 		testEmitHeartbeatsPath(t, make(chan struct{}, 1), true)
 	})
 }
+
+func TestProdHeartbeatHooks_OnTick(t *testing.T) {
+	// Verify the production no-op doesn't panic.
+	prodHeartbeatHooks{}.onTick()
+}
+
+func TestNewInternalTools_NilLogger(t *testing.T) {
+	it := NewInternalTools(&sessctx.Manager{History: &failingHMBase{}}, nil)
+	require.NotNil(t, it.logger, "nil logger should fall back to NoOpLogger")
+	_, ok := it.logger.(*ports.NoOpLogger)
+	require.True(t, ok, "nil logger should fall back to *ports.NoOpLogger")
+}

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -849,3 +850,15 @@ func (p *panicFakeEnqueuer) isInputClosed() bool                                
 func (p *panicFakeEnqueuer) closeInput()                                              {}
 func (p *panicFakeEnqueuer) recv() <-chan events.Event                                { return nil }
 func (p *panicFakeEnqueuer) drainRemainingEvents(func(context.Context, events.Event)) {}
+
+func TestWithBridgeClock(t *testing.T) {
+	t.Parallel()
+	mRenderer := new(agenttest.MockUIRenderer)
+	bridge := NewBridge(mRenderer,
+		WithBridgeClock(clock.RealClock{}),
+	)
+	bridge.AbortStart()
+	defer bridge.Cleanup()
+
+	assert.NotNil(t, bridge.clock, "bridge.clock should not be nil after WithBridgeClock")
+}

--- a/internal/agent/session/ui/dispatcher_test.go
+++ b/internal/agent/session/ui/dispatcher_test.go
@@ -20,8 +20,10 @@ import (
 
 // spyRenderer records calls for assertion without depending on testify/mock.
 type spyRenderer struct {
-	logToolCallCalls   []logToolCallArgs
-	logToolResultCalls []logToolResultArgs
+	logToolCallCalls             []logToolCallArgs
+	logToolResultCalls           []logToolResultArgs
+	startSpinnerWithMetricsCalls int
+	startSpinnerWithStatusCalls  int
 }
 
 type logToolCallArgs struct {
@@ -46,9 +48,15 @@ func (s *spyRenderer) LogToolResult(_ context.Context, name string, result tools
 }
 
 // Remaining ports.UIRenderer methods — no-op stubs
-func (s *spyRenderer) StartSpinner(_ context.Context) func()                       { return func() {} }
-func (s *spyRenderer) StartSpinnerWithStatus(_ context.Context, _ string) func()   { return func() {} }
-func (s *spyRenderer) StartSpinnerWithMetrics(_ context.Context, _ string) func()  { return func() {} }
+func (s *spyRenderer) StartSpinner(_ context.Context) func() { return func() {} }
+func (s *spyRenderer) StartSpinnerWithStatus(_ context.Context, _ string) func() {
+	s.startSpinnerWithStatusCalls++
+	return func() {}
+}
+func (s *spyRenderer) StartSpinnerWithMetrics(_ context.Context, _ string) func() {
+	s.startSpinnerWithMetricsCalls++
+	return func() {}
+}
 func (s *spyRenderer) RenderResponse(_ context.Context, _ *llm.Content, _, _ bool) {}
 func (s *spyRenderer) LogTurnStatus(_ context.Context, _ events.TurnStatus)        {}
 func (s *spyRenderer) LogUsage(_ context.Context, _ *llm.Metrics, _ string, _ time.Time) {
@@ -222,4 +230,141 @@ func TestEnsureContext(t *testing.T) {
 			t.Error("expected context.TODO() to pass through unchanged")
 		}
 	})
+}
+
+func TestStartSpinnerForPhase_WithMetrics(t *testing.T) {
+	t.Parallel()
+
+	renderer := &spyRenderer{}
+	logger := &testfixtures.SpyLogger{}
+	sc := newSpinnerCoord(renderer, logger)
+
+	// ToolExecutionStartedEvent has withMetrics: true in getSpinnerInfo.
+	e := events.ToolExecutionStartedEvent{ToolNames: []string{"test"}}
+
+	started := sc.startSpinnerForPhase(context.Background(), e, stateIdle, nil)
+
+	assert.True(t, started, "expected spinner to be started")
+	assert.Equal(t, 1, renderer.startSpinnerWithMetricsCalls, "StartSpinnerWithMetrics should be called once")
+	assert.Equal(t, 0, renderer.startSpinnerWithStatusCalls, "StartSpinnerWithStatus should not be called")
+}
+
+func TestStartSpinnerForPhase_ResetRendering(t *testing.T) {
+	t.Parallel()
+
+	renderer := &spyRenderer{}
+	logger := &testfixtures.SpyLogger{}
+	sc := newSpinnerCoord(renderer, logger)
+
+	// SummarizationStartedEvent has resetRendering: true, withMetrics: false.
+	e := events.SummarizationStartedEvent{}
+
+	var callbackCalled bool
+	resetFn := func() uiState {
+		callbackCalled = true
+		return stateIdle
+	}
+
+	started := sc.startSpinnerForPhase(context.Background(), e, stateRendering, resetFn)
+
+	assert.True(t, started, "expected spinner to be started after rendering reset")
+	assert.True(t, callbackCalled, "expected resetRendering callback to be invoked")
+	assert.Equal(t, 1, renderer.startSpinnerWithStatusCalls, "StartSpinnerWithStatus should be called once")
+	assert.Equal(t, 0, renderer.startSpinnerWithMetricsCalls, "StartSpinnerWithMetrics should not be called")
+}
+
+func TestHandleUsageMetrics_ResumesSpinner(t *testing.T) {
+	t.Parallel()
+
+	d, _, _ := newTestDispatcher(t)
+
+	// Set an active phase so resumeActiveSpinner returns true.
+	d.spinner.activePhase = events.InferenceStartedEvent{Model: "gpt-4"}
+
+	d.dispatch(context.Background(), events.UsageMetricsEvent{
+		Metrics:   &llm.Metrics{PromptTokens: 10},
+		StartTime: time.Now(),
+		Context:   context.Background(),
+	})
+
+	assert.Equal(t, stateThinking, d.stateMachine.current())
+}
+
+func TestHandleToolEvents_ToolResult_ResumesSpinner(t *testing.T) {
+	t.Parallel()
+
+	d, _, _ := newTestDispatcher(t)
+
+	// Set an active phase so resumeActiveSpinner returns true.
+	d.spinner.activePhase = events.InferenceStartedEvent{}
+
+	d.dispatch(context.Background(), events.ToolResultEvent{
+		Name:   "search",
+		Result: tools.ToolResult{Text: "ok"},
+	})
+
+	assert.Equal(t, stateThinking, d.stateMachine.current())
+}
+
+func TestHandleSystemMessage_StatusUpdate_ResumesSpinner(t *testing.T) {
+	t.Parallel()
+
+	d, _, _ := newTestDispatcher(t)
+
+	// Set an active phase so resumeActiveSpinner returns true.
+	d.spinner.activePhase = events.InferenceStartedEvent{}
+
+	d.dispatch(context.Background(), events.StatusUpdate{
+		Message: "msg",
+		Level:   "info",
+	})
+
+	assert.Equal(t, stateThinking, d.stateMachine.current())
+}
+
+func TestHandleSystemMessage_SystemMessageEvent_ResumesSpinner(t *testing.T) {
+	t.Parallel()
+
+	d, _, _ := newTestDispatcher(t)
+
+	// Set an active phase so resumeActiveSpinner returns true.
+	d.spinner.activePhase = events.InferenceStartedEvent{}
+
+	d.dispatch(context.Background(), events.SystemMessageEvent{
+		Message: "msg",
+		Level:   "info",
+	})
+
+	assert.Equal(t, stateThinking, d.stateMachine.current())
+}
+
+func TestHandleSystemMessage_DefaultCase(t *testing.T) {
+	t.Parallel()
+
+	d, renderer, _ := newTestDispatcher(t)
+
+	// TurnStarted is neither SystemMessageEvent nor StatusUpdate,
+	// so handleSystemMessage hits the default: return at dispatcher.go:173-174.
+	d.handleSystemMessage(context.Background(), events.TurnStarted{})
+
+	// Verify no renderer methods were called — the default case returns silently.
+	assert.Empty(t, renderer.logToolCallCalls)
+	assert.Empty(t, renderer.logToolResultCalls)
+	assert.Equal(t, 0, renderer.startSpinnerWithMetricsCalls)
+	assert.Equal(t, 0, renderer.startSpinnerWithStatusCalls)
+}
+
+func TestStartSpinnerForPhase_UnknownEvent(t *testing.T) {
+	t.Parallel()
+
+	renderer := &spyRenderer{}
+	logger := &testfixtures.SpyLogger{}
+	sc := newSpinnerCoord(renderer, logger)
+
+	// TurnStarted is not a spinner event → getSpinnerInfo returns spinnerInfo{}, false.
+	started := sc.startSpinnerForPhase(context.Background(), events.TurnStarted{}, stateIdle, nil)
+
+	assert.False(t, started, "expected spinner not to be started for unknown event")
+	assert.Equal(t, 0, renderer.startSpinnerWithMetricsCalls)
+	assert.Equal(t, 0, renderer.startSpinnerWithStatusCalls)
 }

--- a/internal/agent/session/ui/state_machine_test.go
+++ b/internal/agent/session/ui/state_machine_test.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- helpers ---
+
+// sentinelStopFn returns a func that toggles *called and a helper to read it.
+// Use this to detect whether stopActiveSpinner invokes the stored stopFn.
+func sentinelStopFn() (stopFn func(), wasCalled func() bool) {
+	called := false
+	return func() { called = true }, func() bool { return called }
+}
+
+func newTestStateMachine(t *testing.T) (*uiStateMachine, *spinnerCoord) {
+	t.Helper()
+	renderer := &spyRenderer{}
+	logger := &testfixtures.SpyLogger{}
+	sc := newSpinnerCoord(renderer, logger)
+	sm := newUIStateMachine(sc)
+	return sm, sc
+}
+
+// --- tests ---
+
+func TestTransition_SelfTransition_NoOp(t *testing.T) {
+	t.Parallel()
+
+	sm, sc := newTestStateMachine(t)
+
+	// Set up: state is thinking, spinner is active with a sentinel stopFn.
+	sm.state = stateThinking
+	stopFn, wasCalled := sentinelStopFn()
+	sc.stopFn = stopFn
+
+	// Act: transition to the same state.
+	sm.transition(stateThinking)
+
+	// Assert: state unchanged, spinner NOT stopped.
+	assert.Equal(t, stateThinking, sm.current(), "state must remain stateThinking after self-transition")
+	assert.False(t, wasCalled(), "stopFn must not be called during self-transition (guard at line 39-41)")
+	assert.NotNil(t, sc.stopFn, "stopFn must not be cleared during self-transition")
+}
+
+func TestTransition_ToThinking_StopsSpinner(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		fromState uiState
+	}{
+		{"IdleToThinking", stateIdle},
+		{"RenderingToThinking", stateRendering},
+		{"AwaitingConsentToThinking", stateAwaitingConsent},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sm, sc := newTestStateMachine(t)
+
+			// Set up: state is the fromState, spinner is active with a sentinel.
+			sm.state = tt.fromState
+			stopFn, wasCalled := sentinelStopFn()
+			sc.stopFn = stopFn
+
+			// Act: transition to stateThinking.
+			sm.transition(stateThinking)
+
+			// Assert: state changed, spinner was stopped.
+			assert.Equal(t, stateThinking, sm.current(),
+				"state must transition to stateThinking from %v", tt.fromState)
+			assert.True(t, wasCalled(),
+				"stopFn must be called when entering stateThinking from %v (line 53)", tt.fromState)
+			assert.Nil(t, sc.stopFn,
+				"stopFn must be cleared after stopActiveSpinner (line 53)")
+		})
+	}
+}


### PR DESCRIPTION
Closes #693.

## Summary
Adds comprehensive test coverage for untested error paths in agent session management, context, and UI bridge layer.

### Coverage Results
| Package | Before | After |
|---------|--------|-------|
| context | 97.8% | **100.0%** |
| session | 99.3% | **100.0%** |
| ui | 95.8% | **98.9%** |
| **Overall** | — | **99.8%** |

### Changes
- 10 test files (8 modified, 2 new)
- 821 lines added
- No production code changes — test-only

### Verification
| Check | Status |
|-------|--------|
| go fmt | PASS |
| go vet | PASS |
| go build | PASS |
| go test (all) | PASS |
| go test -race | PASS |
| Coverage ≥95.8% | PASS (99.8%) |
