### PR TITLE
fix(agenttest): convert mocks to hand-rolled spy pattern per ADR-021 (#708)

### DIFF
--- a/internal/agent/agenttest/mock_chatter.go
+++ b/internal/agent/agenttest/mock_chatter.go
@@ -5,34 +5,98 @@ package agenttest
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	"github.com/stretchr/testify/mock"
 )
 
-// MockChatter is a testify-based mock of ports.Chatter. Configure
-// behaviour with mock.On(...) and assert calls with mock.AssertCalled
-// or mock.AssertExpectations.
+// MockChatter is a hand-rolled test double for ports.Chatter.
+// Override function fields (ChatFn, SetLimitsFn, SubscribeFn,
+// ShutdownFn) to script behaviour. All methods record invocation
+// counts and names accessible via Snapshot().
 type MockChatter struct {
-	mock.Mock
+	mu              sync.Mutex
+	calledChat      int
+	calledSetLimits int
+	calledSubscribe int
+	calledShutdown  int
+	calledMethods   []string
+
+	// Function fields — set before test to script behaviour.
+	ChatFn      func(ctx context.Context, s *ports.Session, prompt string) error
+	SetLimitsFn func(ctx context.Context, toolTurns, historyTokens, historyTurns int) error
+	SubscribeFn func(sub func(context.Context, events.Event))
+	ShutdownFn  func(ctx context.Context) error
 }
 
+// Snapshot returns a point-in-time view of invocation counters and
+// method call order. The returned slice is a defensive copy safe for
+// inspection without holding the mutex.
+func (m *MockChatter) Snapshot() (chat, setLimits, subscribe, shutdown int, methods []string) {
+	m.mu.Lock()
+	chat = m.calledChat
+	setLimits = m.calledSetLimits
+	subscribe = m.calledSubscribe
+	shutdown = m.calledShutdown
+	methods = make([]string, len(m.calledMethods))
+	copy(methods, m.calledMethods)
+	m.mu.Unlock()
+	return
+}
+
+// Chat executes a single conversation turn. When ChatFn is nil the
+// default is success (nil error).
 func (m *MockChatter) Chat(ctx context.Context, s *ports.Session, prompt string) error {
-	args := m.Called(ctx, s, prompt)
-	return args.Error(0)
+	m.mu.Lock()
+	m.calledChat++
+	m.calledMethods = append(m.calledMethods, "Chat")
+	m.mu.Unlock()
+
+	if m.ChatFn != nil {
+		return m.ChatFn(ctx, s, prompt)
+	}
+	return nil
 }
 
+// SetLimits configures tool-turn, history-token, and history-turn
+// budgets. When SetLimitsFn is nil the default is success (nil error).
 func (m *MockChatter) SetLimits(ctx context.Context, toolTurns, historyTokens, historyTurns int) error {
-	args := m.Called(ctx, toolTurns, historyTokens, historyTurns)
-	return args.Error(0)
+	m.mu.Lock()
+	m.calledSetLimits++
+	m.calledMethods = append(m.calledMethods, "SetLimits")
+	m.mu.Unlock()
+
+	if m.SetLimitsFn != nil {
+		return m.SetLimitsFn(ctx, toolTurns, historyTokens, historyTurns)
+	}
+	return nil
 }
 
+// Subscribe registers an event subscriber. The subscriber callback is
+// forwarded to SubscribeFn when set; otherwise it is silently discarded.
+// Tests that need to capture the subscriber must set SubscribeFn.
 func (m *MockChatter) Subscribe(sub func(context.Context, events.Event)) {
-	m.Called(sub)
+	m.mu.Lock()
+	m.calledSubscribe++
+	m.calledMethods = append(m.calledMethods, "Subscribe")
+	m.mu.Unlock()
+
+	if m.SubscribeFn != nil {
+		m.SubscribeFn(sub)
+	}
 }
 
+// Shutdown initiates graceful shutdown. When ShutdownFn is nil the
+// default is success (nil error).
 func (m *MockChatter) Shutdown(ctx context.Context) error {
-	args := m.Called(ctx)
-	return args.Error(0)
+	m.mu.Lock()
+	m.calledShutdown++
+	m.calledMethods = append(m.calledMethods, "Shutdown")
+	m.mu.Unlock()
+
+	if m.ShutdownFn != nil {
+		return m.ShutdownFn(ctx)
+	}
+	return nil
 }

--- a/internal/agent/agenttest/mock_chatter_test.go
+++ b/internal/agent/agenttest/mock_chatter_test.go
@@ -5,11 +5,11 @@ package agenttest
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestMockChatter_Chat(t *testing.T) {
@@ -18,14 +18,38 @@ func TestMockChatter_Chat(t *testing.T) {
 	ctx := context.Background()
 	sess := &ports.Session{ID: "s1"}
 
-	m := new(MockChatter)
-	m.On("Chat", ctx, sess, "hello").Return(nil)
+	t.Run("default success when ChatFn is nil", func(t *testing.T) {
+		m := new(MockChatter)
 
-	err := m.Chat(ctx, sess, "hello")
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	m.AssertExpectations(t)
+		err := m.Chat(ctx, sess, "hello")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		chat, _, _, _, methods := m.Snapshot()
+		if chat != 1 {
+			t.Errorf("calledChat = %d; want 1", chat)
+		}
+		if len(methods) != 1 || methods[0] != "Chat" {
+			t.Errorf("methods = %v; want [Chat]", methods)
+		}
+	})
+
+	t.Run("delegates to ChatFn when set", func(t *testing.T) {
+		wantErr := errors.New("chat failed")
+		m := &MockChatter{
+			ChatFn: func(ctx context.Context, s *ports.Session, prompt string) error {
+				if s.ID != "s1" || prompt != "hello" {
+					t.Errorf("ChatFn got s.ID=%q, prompt=%q", s.ID, prompt)
+				}
+				return wantErr
+			},
+		}
+
+		err := m.Chat(ctx, sess, "hello")
+		if err != wantErr {
+			t.Fatalf("got err=%v; want %v", err, wantErr)
+		}
+	})
 }
 
 func TestMockChatter_SetLimits(t *testing.T) {
@@ -33,26 +57,72 @@ func TestMockChatter_SetLimits(t *testing.T) {
 
 	ctx := context.Background()
 
-	m := new(MockChatter)
-	m.On("SetLimits", ctx, 5, 1000, 10).Return(nil)
+	t.Run("default success when SetLimitsFn is nil", func(t *testing.T) {
+		m := new(MockChatter)
 
-	err := m.SetLimits(ctx, 5, 1000, 10)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	m.AssertExpectations(t)
+		err := m.SetLimits(ctx, 5, 1000, 10)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, setLimits, _, _, methods := m.Snapshot()
+		if setLimits != 1 {
+			t.Errorf("calledSetLimits = %d; want 1", setLimits)
+		}
+		if len(methods) != 1 || methods[0] != "SetLimits" {
+			t.Errorf("methods = %v; want [SetLimits]", methods)
+		}
+	})
+
+	t.Run("delegates to SetLimitsFn when set", func(t *testing.T) {
+		wantErr := errors.New("limits error")
+		m := &MockChatter{
+			SetLimitsFn: func(ctx context.Context, tt, ht, ht2 int) error {
+				if tt != 5 || ht != 1000 || ht2 != 10 {
+					t.Errorf("SetLimitsFn got (%d,%d,%d)", tt, ht, ht2)
+				}
+				return wantErr
+			},
+		}
+
+		err := m.SetLimits(ctx, 5, 1000, 10)
+		if err != wantErr {
+			t.Fatalf("got err=%v; want %v", err, wantErr)
+		}
+	})
 }
 
 func TestMockChatter_Subscribe(t *testing.T) {
 	t.Parallel()
 
-	sub := func(ctx context.Context, ev events.Event) {}
+	t.Run("no-op when SubscribeFn is nil", func(t *testing.T) {
+		m := new(MockChatter)
+		sub := func(ctx context.Context, ev events.Event) {}
 
-	m := new(MockChatter)
-	m.On("Subscribe", mock.Anything).Return()
+		m.Subscribe(sub)
+		_, _, subscribe, _, methods := m.Snapshot()
+		if subscribe != 1 {
+			t.Errorf("calledSubscribe = %d; want 1", subscribe)
+		}
+		if len(methods) != 1 || methods[0] != "Subscribe" {
+			t.Errorf("methods = %v; want [Subscribe]", methods)
+		}
+	})
 
-	m.Subscribe(sub)
-	m.AssertCalled(t, "Subscribe", mock.Anything)
+	t.Run("delegates to SubscribeFn with captured subscriber", func(t *testing.T) {
+		var captured func(context.Context, events.Event)
+		m := &MockChatter{
+			SubscribeFn: func(sub func(context.Context, events.Event)) {
+				captured = sub
+			},
+		}
+
+		mySub := func(ctx context.Context, ev events.Event) {}
+		m.Subscribe(mySub)
+
+		if captured == nil {
+			t.Fatal("captured subscriber is nil; SubscribeFn was not called")
+		}
+	})
 }
 
 func TestMockChatter_Shutdown(t *testing.T) {
@@ -60,12 +130,70 @@ func TestMockChatter_Shutdown(t *testing.T) {
 
 	ctx := context.Background()
 
-	m := new(MockChatter)
-	m.On("Shutdown", ctx).Return(nil)
+	t.Run("default success when ShutdownFn is nil", func(t *testing.T) {
+		m := new(MockChatter)
 
-	err := m.Shutdown(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
+		err := m.Shutdown(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		_, _, _, shutdown, methods := m.Snapshot()
+		if shutdown != 1 {
+			t.Errorf("calledShutdown = %d; want 1", shutdown)
+		}
+		if len(methods) != 1 || methods[0] != "Shutdown" {
+			t.Errorf("methods = %v; want [Shutdown]", methods)
+		}
+	})
+
+	t.Run("delegates to ShutdownFn when set", func(t *testing.T) {
+		wantErr := errors.New("shutdown failed")
+		m := &MockChatter{
+			ShutdownFn: func(ctx context.Context) error {
+				return wantErr
+			},
+		}
+
+		err := m.Shutdown(ctx)
+		if err != wantErr {
+			t.Fatalf("got err=%v; want %v", err, wantErr)
+		}
+	})
+}
+
+func TestMockChatter_Snapshot(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	sess := &ports.Session{ID: "s1"}
+
+	m := new(MockChatter)
+
+	// Perform various calls out of order.
+	m.Shutdown(ctx)
+	m.Chat(ctx, sess, "hi")
+	m.SetLimits(ctx, 1, 2, 3)
+	m.Subscribe(func(ctx context.Context, ev events.Event) {})
+
+	chat, setLimits, subscribe, shutdown, methods := m.Snapshot()
+	if chat != 1 || setLimits != 1 || subscribe != 1 || shutdown != 1 {
+		t.Errorf("counters = (%d,%d,%d,%d); want (1,1,1,1)",
+			chat, setLimits, subscribe, shutdown)
 	}
-	m.AssertExpectations(t)
+	want := []string{"Shutdown", "Chat", "SetLimits", "Subscribe"}
+	if len(methods) != len(want) {
+		t.Fatalf("methods len = %d; want %d (methods=%v)", len(methods), len(want), methods)
+	}
+	for i, m := range methods {
+		if m != want[i] {
+			t.Errorf("methods[%d] = %q; want %q", i, m, want[i])
+		}
+	}
+
+	// Verify defensive copy: mutating the returned slice does not affect mock.
+	methods[0] = "INJECTED"
+	_, _, _, _, methods2 := m.Snapshot()
+	if methods2[0] != "Shutdown" {
+		t.Errorf("defensive copy failed: methods2[0] = %q; want Shutdown", methods2[0])
+	}
 }

--- a/internal/agent/agenttest/mock_llm_client.go
+++ b/internal/agent/agenttest/mock_llm_client.go
@@ -6,40 +6,83 @@ package agenttest
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/stretchr/testify/mock"
 )
 
-// MockLLMClient is a flexible test double for llm.LLMClient. Override
-// SendChatFn to script chat responses and RefreshAuthFn to script
-// auth-refresh behaviour. The default SendChat returns an error
-// (unconfigured); callers must script behaviour explicitly.
+// MockLLMClient is a hand-rolled test double for llm.LLMClient.
+// Override SendChatFn to script chat responses and RefreshAuthFn to
+// script auth-refresh behaviour. When SendChatFn is nil, SendChat
+// returns an error ("SendChatFn not implemented"); callers must
+// script behaviour explicitly.
 type MockLLMClient struct {
-	mock.Mock
+	mu                   sync.Mutex
+	calledSendChat       int
+	calledGenerateImages int
+	calledRefreshAuth    int
+	calledGenerate       int
+	calledMethods        []string
+
+	// Function fields — set before test to script behaviour.
 	SendChatFn    func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error)
 	RefreshAuthFn func() error
 }
 
+// Snapshot returns a race-safe copy of observable call state.
+func (m *MockLLMClient) Snapshot() (sendChat, generateImages, refreshAuth, generate int, methods []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.calledMethods))
+	copy(out, m.calledMethods)
+	return m.calledSendChat, m.calledGenerateImages, m.calledRefreshAuth, m.calledGenerate, out
+}
+
+// SendChat scripts chat responses via SendChatFn. When SendChatFn is nil,
+// it returns an error instructing the caller to configure the mock.
 func (m *MockLLMClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	m.mu.Lock()
+	m.calledSendChat++
+	m.calledMethods = append(m.calledMethods, "SendChat")
+	m.mu.Unlock()
+
 	if m.SendChatFn != nil {
 		return m.SendChatFn(ctx, history, tools, resolver)
 	}
 	return nil, nil, fmt.Errorf("SendChatFn not implemented")
 }
 
+// GenerateImages is a stub that returns nil, nil.
 func (m *MockLLMClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	m.mu.Lock()
+	m.calledGenerateImages++
+	m.calledMethods = append(m.calledMethods, "GenerateImages")
+	m.mu.Unlock()
+
 	return nil, nil
 }
 
+// RefreshAuth scripts auth-refresh behaviour via RefreshAuthFn.
+// When RefreshAuthFn is nil, it returns nil.
 func (m *MockLLMClient) RefreshAuth() error {
+	m.mu.Lock()
+	m.calledRefreshAuth++
+	m.calledMethods = append(m.calledMethods, "RefreshAuth")
+	m.mu.Unlock()
+
 	if m.RefreshAuthFn != nil {
 		return m.RefreshAuthFn()
 	}
 	return nil
 }
 
+// Generate delegates to SendChat with the same arguments.
 func (m *MockLLMClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	m.mu.Lock()
+	m.calledGenerate++
+	m.calledMethods = append(m.calledMethods, "Generate")
+	m.mu.Unlock()
+
 	return m.SendChat(ctx, input, tools, resolver)
 }

--- a/internal/agent/agenttest/mock_llm_client_test.go
+++ b/internal/agent/agenttest/mock_llm_client_test.go
@@ -7,7 +7,9 @@ import (
 	"context"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
@@ -18,6 +20,7 @@ func TestMockLLMClient_SendChat_Default(t *testing.T) {
 
 	m := &MockLLMClient{}
 	content, metrics, err := m.SendChat(context.Background(), nil, nil, nil)
+
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -30,6 +33,23 @@ func TestMockLLMClient_SendChat_Default(t *testing.T) {
 	if metrics != nil {
 		t.Errorf("got metrics %+v; want nil", metrics)
 	}
+
+	sendChat, genImg, refreshAuth, generate, methods := m.Snapshot()
+	if sendChat != 1 {
+		t.Errorf("sendChat = %d; want 1", sendChat)
+	}
+	if genImg != 0 {
+		t.Errorf("generateImages = %d; want 0", genImg)
+	}
+	if refreshAuth != 0 {
+		t.Errorf("refreshAuth = %d; want 0", refreshAuth)
+	}
+	if generate != 0 {
+		t.Errorf("generate = %d; want 0", generate)
+	}
+	if len(methods) != 1 || methods[0] != "SendChat" {
+		t.Errorf("methods = %v; want [SendChat]", methods)
+	}
 }
 
 func TestMockLLMClient_SendChat_Override(t *testing.T) {
@@ -37,23 +57,72 @@ func TestMockLLMClient_SendChat_Override(t *testing.T) {
 
 	wantContent := &llm.Content{Role: "assistant"}
 	wantMetrics := &llm.Metrics{PromptTokens: 10}
-	wantErr := errors.New("custom error")
 
 	m := &MockLLMClient{
 		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
-			return wantContent, wantMetrics, wantErr
+			return wantContent, wantMetrics, nil
+		},
+	}
+
+	// Call twice.
+	for range 2 {
+		content, metrics, err := m.SendChat(context.Background(), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if content != wantContent {
+			t.Fatalf("got content %+v; want %+v", content, wantContent)
+		}
+		if metrics != wantMetrics {
+			t.Fatalf("got metrics %+v; want %+v", metrics, wantMetrics)
+		}
+	}
+
+	sendChat, genImg, refreshAuth, generate, methods := m.Snapshot()
+	if sendChat != 2 {
+		t.Errorf("sendChat = %d; want 2", sendChat)
+	}
+	if genImg != 0 {
+		t.Errorf("generateImages = %d; want 0", genImg)
+	}
+	if refreshAuth != 0 {
+		t.Errorf("refreshAuth = %d; want 0", refreshAuth)
+	}
+	if generate != 0 {
+		t.Errorf("generate = %d; want 0", generate)
+	}
+	if len(methods) != 2 {
+		t.Fatalf("len(methods) = %d; want 2", len(methods))
+	}
+	if methods[0] != "SendChat" || methods[1] != "SendChat" {
+		t.Errorf("methods = %v; want [SendChat SendChat]", methods)
+	}
+}
+
+func TestMockLLMClient_SendChat_Override_Error(t *testing.T) {
+	t.Parallel()
+
+	errSentinel := errors.New("boom")
+	m := &MockLLMClient{
+		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return nil, nil, errSentinel
 		},
 	}
 
 	content, metrics, err := m.SendChat(context.Background(), nil, nil, nil)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("got error %v; want %v", err, wantErr)
+	if !errors.Is(err, errSentinel) {
+		t.Fatalf("got error %v; want %v", err, errSentinel)
 	}
-	if content != wantContent {
-		t.Fatalf("got content %+v; want %+v", content, wantContent)
+	if content != nil {
+		t.Errorf("got content %+v; want nil", content)
 	}
-	if metrics != wantMetrics {
-		t.Fatalf("got metrics %+v; want %+v", metrics, wantMetrics)
+	if metrics != nil {
+		t.Errorf("got metrics %+v; want nil", metrics)
+	}
+
+	sendChat, _, _, _, _ := m.Snapshot()
+	if sendChat != 1 {
+		t.Errorf("sendChat = %d; want 1", sendChat)
 	}
 }
 
@@ -68,6 +137,23 @@ func TestMockLLMClient_GenerateImages(t *testing.T) {
 	if data != nil {
 		t.Fatalf("got data %v; want nil", data)
 	}
+
+	sendChat, genImg, refreshAuth, generate, methods := m.Snapshot()
+	if sendChat != 0 {
+		t.Errorf("sendChat = %d; want 0", sendChat)
+	}
+	if genImg != 1 {
+		t.Errorf("generateImages = %d; want 1", genImg)
+	}
+	if refreshAuth != 0 {
+		t.Errorf("refreshAuth = %d; want 0", refreshAuth)
+	}
+	if generate != 0 {
+		t.Errorf("generate = %d; want 0", generate)
+	}
+	if len(methods) != 1 || methods[0] != "GenerateImages" {
+		t.Errorf("methods = %v; want [GenerateImages]", methods)
+	}
 }
 
 func TestMockLLMClient_RefreshAuth_Default(t *testing.T) {
@@ -77,6 +163,20 @@ func TestMockLLMClient_RefreshAuth_Default(t *testing.T) {
 	err := m.RefreshAuth()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+
+	sendChat, genImg, refreshAuth, generate, _ := m.Snapshot()
+	if sendChat != 0 {
+		t.Errorf("sendChat = %d; want 0", sendChat)
+	}
+	if genImg != 0 {
+		t.Errorf("generateImages = %d; want 0", genImg)
+	}
+	if refreshAuth != 1 {
+		t.Errorf("refreshAuth = %d; want 1", refreshAuth)
+	}
+	if generate != 0 {
+		t.Errorf("generate = %d; want 0", generate)
 	}
 }
 
@@ -91,30 +191,96 @@ func TestMockLLMClient_RefreshAuth_Override(t *testing.T) {
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("got error %v; want %v", err, wantErr)
 	}
+
+	sendChat, genImg, refreshAuth, generate, _ := m.Snapshot()
+	if sendChat != 0 {
+		t.Errorf("sendChat = %d; want 0", sendChat)
+	}
+	if genImg != 0 {
+		t.Errorf("generateImages = %d; want 0", genImg)
+	}
+	if refreshAuth != 1 {
+		t.Errorf("refreshAuth = %d; want 1", refreshAuth)
+	}
+	if generate != 0 {
+		t.Errorf("generate = %d; want 0", generate)
+	}
 }
 
 func TestMockLLMClient_Generate_DelegatesToSendChat(t *testing.T) {
 	t.Parallel()
 
-	// Default SendChat returns error.
-	m := &MockLLMClient{}
-	_, _, err := m.Generate(context.Background(), nil, nil, nil)
-	if err == nil {
-		t.Fatal("expected error from default SendChat, got nil")
-	}
-
-	// Override SendChatFn; Generate should delegate.
-	wantContent := &llm.Content{Role: "assistant"}
-	m2 := &MockLLMClient{
+	wantContent := &llm.Content{Role: "model"}
+	m := &MockLLMClient{
 		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
 			return wantContent, nil, nil
 		},
 	}
-	content, _, err := m2.Generate(context.Background(), nil, nil, nil)
+
+	content, _, err := m.Generate(context.Background(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if content != wantContent {
 		t.Fatalf("got content %+v; want %+v", content, wantContent)
+	}
+
+	sendChat, genImg, refreshAuth, generate, methods := m.Snapshot()
+	if sendChat != 1 {
+		t.Errorf("sendChat = %d; want 1", sendChat)
+	}
+	if genImg != 0 {
+		t.Errorf("generateImages = %d; want 0", genImg)
+	}
+	if refreshAuth != 0 {
+		t.Errorf("refreshAuth = %d; want 0", refreshAuth)
+	}
+	if generate != 1 {
+		t.Errorf("generate = %d; want 1", generate)
+	}
+	if len(methods) != 2 {
+		t.Fatalf("len(methods) = %d; want 2", len(methods))
+	}
+	if methods[0] != "Generate" {
+		t.Errorf("methods[0] = %q; want Generate", methods[0])
+	}
+	if methods[1] != "SendChat" {
+		t.Errorf("methods[1] = %q; want SendChat", methods[1])
+	}
+}
+
+// Run: go test -race -run TestMockLLMClient_Concurrency
+func TestMockLLMClient_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	m := &MockLLMClient{
+		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			time.Sleep(10 * time.Millisecond)
+			return &llm.Content{Role: "assistant"}, nil, nil
+		},
+	}
+
+	const goroutines = 10
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_, _, err := m.SendChat(context.Background(), nil, nil, nil)
+			if err != nil {
+				// Use panic to ensure the test fails — t.Errorf from a goroutine
+				// is not safe (race detector will flag it). Instead we collect
+				// the error via the call returning it; the mock returns nil here.
+				panic(err)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	sendChat, _, _, _, _ := m.Snapshot()
+	if sendChat != goroutines {
+		t.Errorf("sendChat = %d; want %d", sendChat, goroutines)
 	}
 }

--- a/internal/agent/agenttest/mock_ui_renderer.go
+++ b/internal/agent/agenttest/mock_ui_renderer.go
@@ -5,85 +5,239 @@ package agenttest
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/stretchr/testify/mock"
 )
 
-// MockUIRenderer is a testify-based test double for ports.UIRenderer.
-// All methods record their invocation through mock.Mock; the spinner
-// methods additionally return a stop-function (defaulting to a no-op
-// when no function is scripted). For tests that need a no-op stub
-// rather than a recording mock, see stubUIRenderer in helpers.go.
+// MockUIRenderer is a hand-rolled test double for ports.UIRenderer.
+// Override function fields to script behaviour. All methods record
+// invocation counts and names accessible via Snapshot(). The spinner
+// methods return a no-op func() when their function field is nil.
 type MockUIRenderer struct {
-	mock.Mock
+	mu                            sync.Mutex
+	calledStartSpinner            int
+	calledStartSpinnerWithStatus  int
+	calledStartSpinnerWithMetrics int
+	calledRenderResponse          int
+	calledLogTurnStatus           int
+	calledLogUsage                int
+	calledLogToolCall             int
+	calledLogToolResult           int
+	calledLogSystemMessage        int
+	calledRenderHealthReport      int
+	calledSetUseColor             int
+	calledSetForceSpinner         int
+	calledIsTerminalContext       int
+	calledMethods                 []string
+
+	// Function fields — set before test to script behaviour.
+	StartSpinnerFn            func(ctx context.Context) func()
+	StartSpinnerWithStatusFn  func(ctx context.Context, status string) func()
+	StartSpinnerWithMetricsFn func(ctx context.Context, status string) func()
+	RenderResponseFn          func(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool)
+	LogTurnStatusFn           func(ctx context.Context, status events.TurnStatus)
+	LogUsageFn                func(ctx context.Context, m *llm.Metrics, logFile string, startTime time.Time)
+	LogToolCallFn             func(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool)
+	LogToolResultFn           func(ctx context.Context, name string, result tools.ToolResult, showTools bool)
+	LogSystemMessageFn        func(ctx context.Context, msg string, level string)
+	RenderHealthReportFn      func(ctx context.Context, report *ports.HealthReport)
+	SetUseColorFn             func(use bool)
+	SetForceSpinnerFn         func(force bool)
+	IsTerminalContextFn       func() bool
 }
 
+// UIRendererSnapshot holds a race-safe copy of mock call counts and method names.
+type UIRendererSnapshot struct {
+	StartSpinner, StartSpinnerWithStatus, StartSpinnerWithMetrics int
+	RenderResponse, LogTurnStatus, LogUsage                       int
+	LogToolCall, LogToolResult, LogSystemMessage                  int
+	RenderHealthReport, SetUseColor, SetForceSpinner              int
+	IsTerminalContext                                             int
+	Methods                                                       []string
+}
+
+// Snapshot returns a race-safe copy of invocation counts and ordered method names.
+func (m *MockUIRenderer) Snapshot() UIRendererSnapshot {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	methods := make([]string, len(m.calledMethods))
+	copy(methods, m.calledMethods)
+	return UIRendererSnapshot{
+		StartSpinner:            m.calledStartSpinner,
+		StartSpinnerWithStatus:  m.calledStartSpinnerWithStatus,
+		StartSpinnerWithMetrics: m.calledStartSpinnerWithMetrics,
+		RenderResponse:          m.calledRenderResponse,
+		LogTurnStatus:           m.calledLogTurnStatus,
+		LogUsage:                m.calledLogUsage,
+		LogToolCall:             m.calledLogToolCall,
+		LogToolResult:           m.calledLogToolResult,
+		LogSystemMessage:        m.calledLogSystemMessage,
+		RenderHealthReport:      m.calledRenderHealthReport,
+		SetUseColor:             m.calledSetUseColor,
+		SetForceSpinner:         m.calledSetForceSpinner,
+		IsTerminalContext:       m.calledIsTerminalContext,
+		Methods:                 methods,
+	}
+}
+
+// ---- ResponseRenderer methods ----
+
 func (m *MockUIRenderer) StartSpinner(ctx context.Context) func() {
-	args := m.Called(ctx)
-	if fn, ok := args.Get(0).(func()); ok {
-		return fn
+	m.mu.Lock()
+	m.calledStartSpinner++
+	m.calledMethods = append(m.calledMethods, "StartSpinner")
+	m.mu.Unlock()
+
+	if m.StartSpinnerFn != nil {
+		return m.StartSpinnerFn(ctx)
 	}
 	return func() {}
 }
 
 func (m *MockUIRenderer) StartSpinnerWithStatus(ctx context.Context, status string) func() {
-	args := m.Called(ctx, status)
-	if fn, ok := args.Get(0).(func()); ok {
-		return fn
+	m.mu.Lock()
+	m.calledStartSpinnerWithStatus++
+	m.calledMethods = append(m.calledMethods, "StartSpinnerWithStatus")
+	m.mu.Unlock()
+
+	if m.StartSpinnerWithStatusFn != nil {
+		return m.StartSpinnerWithStatusFn(ctx, status)
 	}
 	return func() {}
 }
 
 func (m *MockUIRenderer) StartSpinnerWithMetrics(ctx context.Context, status string) func() {
-	args := m.Called(ctx, status)
-	if fn, ok := args.Get(0).(func()); ok {
-		return fn
+	m.mu.Lock()
+	m.calledStartSpinnerWithMetrics++
+	m.calledMethods = append(m.calledMethods, "StartSpinnerWithMetrics")
+	m.mu.Unlock()
+
+	if m.StartSpinnerWithMetricsFn != nil {
+		return m.StartSpinnerWithMetricsFn(ctx, status)
 	}
 	return func() {}
 }
 
 func (m *MockUIRenderer) RenderResponse(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool) {
-	m.Called(ctx, content, showThoughts, rawOutput)
+	m.mu.Lock()
+	m.calledRenderResponse++
+	m.calledMethods = append(m.calledMethods, "RenderResponse")
+	m.mu.Unlock()
+
+	if m.RenderResponseFn != nil {
+		m.RenderResponseFn(ctx, content, showThoughts, rawOutput)
+	}
 }
+
+// ---- StatusLogger methods ----
 
 func (m *MockUIRenderer) LogTurnStatus(ctx context.Context, status events.TurnStatus) {
-	m.Called(ctx, status)
-}
+	m.mu.Lock()
+	m.calledLogTurnStatus++
+	m.calledMethods = append(m.calledMethods, "LogTurnStatus")
+	m.mu.Unlock()
 
-func (m *MockUIRenderer) LogUsage(ctx context.Context, metrics *llm.Metrics, logFile string, startTime time.Time) {
-	m.Called(ctx, metrics, logFile, startTime)
-}
-
-func (m *MockUIRenderer) LogToolCall(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool) {
-	m.Called(ctx, calls, turn, maxTurns, showTools)
-}
-
-func (m *MockUIRenderer) LogToolResult(ctx context.Context, name string, result tools.ToolResult, showTools bool) {
-	m.Called(ctx, name, result, showTools)
+	if m.LogTurnStatusFn != nil {
+		m.LogTurnStatusFn(ctx, status)
+	}
 }
 
 func (m *MockUIRenderer) LogSystemMessage(ctx context.Context, msg string, level string) {
-	m.Called(ctx, msg, level)
+	m.mu.Lock()
+	m.calledLogSystemMessage++
+	m.calledMethods = append(m.calledMethods, "LogSystemMessage")
+	m.mu.Unlock()
+
+	if m.LogSystemMessageFn != nil {
+		m.LogSystemMessageFn(ctx, msg, level)
+	}
 }
 
 func (m *MockUIRenderer) RenderHealthReport(ctx context.Context, report *ports.HealthReport) {
-	m.Called(ctx, report)
+	m.mu.Lock()
+	m.calledRenderHealthReport++
+	m.calledMethods = append(m.calledMethods, "RenderHealthReport")
+	m.mu.Unlock()
+
+	if m.RenderHealthReportFn != nil {
+		m.RenderHealthReportFn(ctx, report)
+	}
 }
 
+// ---- UsageLogger methods ----
+
+func (m *MockUIRenderer) LogUsage(ctx context.Context, metrics *llm.Metrics, logFile string, startTime time.Time) {
+	m.mu.Lock()
+	m.calledLogUsage++
+	m.calledMethods = append(m.calledMethods, "LogUsage")
+	m.mu.Unlock()
+
+	if m.LogUsageFn != nil {
+		m.LogUsageFn(ctx, metrics, logFile, startTime)
+	}
+}
+
+// ---- ToolLogger methods ----
+
+func (m *MockUIRenderer) LogToolCall(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool) {
+	m.mu.Lock()
+	m.calledLogToolCall++
+	m.calledMethods = append(m.calledMethods, "LogToolCall")
+	m.mu.Unlock()
+
+	if m.LogToolCallFn != nil {
+		m.LogToolCallFn(ctx, calls, turn, maxTurns, showTools)
+	}
+}
+
+func (m *MockUIRenderer) LogToolResult(ctx context.Context, name string, result tools.ToolResult, showTools bool) {
+	m.mu.Lock()
+	m.calledLogToolResult++
+	m.calledMethods = append(m.calledMethods, "LogToolResult")
+	m.mu.Unlock()
+
+	if m.LogToolResultFn != nil {
+		m.LogToolResultFn(ctx, name, result, showTools)
+	}
+}
+
+// ---- RendererConfigurator methods ----
+
 func (m *MockUIRenderer) SetUseColor(use bool) {
-	m.Called(use)
+	m.mu.Lock()
+	m.calledSetUseColor++
+	m.calledMethods = append(m.calledMethods, "SetUseColor")
+	m.mu.Unlock()
+
+	if m.SetUseColorFn != nil {
+		m.SetUseColorFn(use)
+	}
 }
 
 func (m *MockUIRenderer) SetForceSpinner(force bool) {
-	m.Called(force)
+	m.mu.Lock()
+	m.calledSetForceSpinner++
+	m.calledMethods = append(m.calledMethods, "SetForceSpinner")
+	m.mu.Unlock()
+
+	if m.SetForceSpinnerFn != nil {
+		m.SetForceSpinnerFn(force)
+	}
 }
 
 func (m *MockUIRenderer) IsTerminalContext() bool {
-	args := m.Called()
-	return args.Bool(0)
+	m.mu.Lock()
+	m.calledIsTerminalContext++
+	m.calledMethods = append(m.calledMethods, "IsTerminalContext")
+	m.mu.Unlock()
+
+	if m.IsTerminalContextFn != nil {
+		return m.IsTerminalContextFn()
+	}
+	return false
 }

--- a/internal/agent/agenttest/mock_ui_renderer_test.go
+++ b/internal/agent/agenttest/mock_ui_renderer_test.go
@@ -5,6 +5,7 @@ package agenttest
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -12,263 +13,752 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/stretchr/testify/mock"
 )
 
-func TestMockUIRenderer_StartSpinner_NilStopFunc(t *testing.T) {
+// ---------------------------------------------------------------------------
+// ResponseRenderer tests
+// ---------------------------------------------------------------------------
+
+func TestMockUIRenderer_StartSpinner(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	m := new(MockUIRenderer)
-	// Return nil → should return a no-op func() (not nil).
-	m.On("StartSpinner", ctx).Return(nil)
+	t.Run("nil fn returns no-op stop func", func(t *testing.T) {
+		t.Parallel()
 
-	stop := m.StartSpinner(ctx)
-	if stop == nil {
-		t.Fatal("got nil stop func; want non-nil no-op")
-	}
-	// Must not panic.
-	stop()
-	m.AssertExpectations(t)
-}
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-func TestMockUIRenderer_StartSpinner_CustomStopFunc(t *testing.T) {
-	t.Parallel()
+		stop := m.StartSpinner(ctx)
+		if stop == nil {
+			t.Fatal("got nil stop func; want non-nil no-op")
+		}
+		// Must not panic.
+		stop()
 
-	ctx := context.Background()
-	called := false
-	customStop := func() { called = true }
+		snap := m.Snapshot()
+		if snap.StartSpinner != 1 {
+			t.Errorf("StartSpinner count = %d; want 1", snap.StartSpinner)
+		}
+	})
 
-	m := new(MockUIRenderer)
-	m.On("StartSpinner", ctx).Return(customStop)
+	t.Run("custom fn returns fn result", func(t *testing.T) {
+		t.Parallel()
 
-	stop := m.StartSpinner(ctx)
-	stop()
-	if !called {
-		t.Error("custom stop func was not called")
-	}
-	m.AssertExpectations(t)
+		ctx := context.Background()
+		called := false
+		m := &MockUIRenderer{
+			StartSpinnerFn: func(_ context.Context) func() {
+				return func() { called = true }
+			},
+		}
+
+		stop := m.StartSpinner(ctx)
+		if stop == nil {
+			t.Fatal("got nil stop func; want non-nil")
+		}
+		stop()
+		if !called {
+			t.Error("custom stop func was not called")
+		}
+
+		snap := m.Snapshot()
+		if snap.StartSpinner != 1 {
+			t.Errorf("StartSpinner count = %d; want 1", snap.StartSpinner)
+		}
+	})
+
+	t.Run("snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		m := &MockUIRenderer{}
+
+		m.StartSpinner(ctx)
+		snap := m.Snapshot()
+
+		if snap.StartSpinner != 1 {
+			t.Errorf("StartSpinner = %d; want 1", snap.StartSpinner)
+		}
+		if len(snap.Methods) < 1 || snap.Methods[0] != "StartSpinner" {
+			t.Errorf("Methods[0] = %q; want %q", snap.Methods[0], "StartSpinner")
+		}
+	})
 }
 
 func TestMockUIRenderer_StartSpinnerWithStatus(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	status := "loading"
-	called := false
-	customStop := func() { called = true }
+	t.Run("nil fn returns no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("StartSpinnerWithStatus", ctx, status).Return(customStop)
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-	stop := m.StartSpinnerWithStatus(ctx, status)
-	stop()
-	if !called {
-		t.Error("custom stop func was not called")
-	}
-	m.AssertExpectations(t)
-}
+		stop := m.StartSpinnerWithStatus(ctx, "loading")
+		if stop == nil {
+			t.Fatal("got nil stop func; want non-nil no-op")
+		}
+		stop()
 
-func TestMockUIRenderer_StartSpinnerWithStatus_NilStopFunc(t *testing.T) {
-	t.Parallel()
+		snap := m.Snapshot()
+		if snap.StartSpinnerWithStatus != 1 {
+			t.Errorf("StartSpinnerWithStatus count = %d; want 1", snap.StartSpinnerWithStatus)
+		}
+	})
 
-	ctx := context.Background()
-	status := "loading"
+	t.Run("custom fn receives status", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	// Return nil → should return a no-op func() (not nil).
-	m.On("StartSpinnerWithStatus", ctx, status).Return(nil)
+		ctx := context.Background()
+		var gotStatus string
+		called := false
+		m := &MockUIRenderer{
+			StartSpinnerWithStatusFn: func(_ context.Context, status string) func() {
+				gotStatus = status
+				return func() { called = true }
+			},
+		}
 
-	stop := m.StartSpinnerWithStatus(ctx, status)
-	if stop == nil {
-		t.Fatal("got nil stop func; want non-nil no-op")
-	}
-	// Must not panic.
-	stop()
-	m.AssertExpectations(t)
-}
+		stop := m.StartSpinnerWithStatus(ctx, "loading")
+		if gotStatus != "loading" {
+			t.Errorf("status = %q; want %q", gotStatus, "loading")
+		}
+		stop()
+		if !called {
+			t.Error("custom stop func was not called")
+		}
 
-func TestMockUIRenderer_StartSpinnerWithMetrics_NilStopFunc(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	status := "processing"
-
-	m := new(MockUIRenderer)
-	// Return nil → should return a no-op func() (not nil).
-	m.On("StartSpinnerWithMetrics", ctx, status).Return(nil)
-
-	stop := m.StartSpinnerWithMetrics(ctx, status)
-	if stop == nil {
-		t.Fatal("got nil stop func; want non-nil no-op")
-	}
-	// Must not panic.
-	stop()
-	m.AssertExpectations(t)
+		snap := m.Snapshot()
+		if snap.StartSpinnerWithStatus != 1 {
+			t.Errorf("StartSpinnerWithStatus count = %d; want 1", snap.StartSpinnerWithStatus)
+		}
+	})
 }
 
 func TestMockUIRenderer_StartSpinnerWithMetrics(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	status := "processing"
-	called := false
-	customStop := func() { called = true }
+	t.Run("nil fn returns no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("StartSpinnerWithMetrics", ctx, status).Return(customStop)
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-	stop := m.StartSpinnerWithMetrics(ctx, status)
-	stop()
-	if !called {
-		t.Error("custom stop func was not called")
-	}
-	m.AssertExpectations(t)
+		stop := m.StartSpinnerWithMetrics(ctx, "processing")
+		if stop == nil {
+			t.Fatal("got nil stop func; want non-nil no-op")
+		}
+		stop()
+
+		snap := m.Snapshot()
+		if snap.StartSpinnerWithMetrics != 1 {
+			t.Errorf("StartSpinnerWithMetrics count = %d; want 1", snap.StartSpinnerWithMetrics)
+		}
+	})
+
+	t.Run("custom fn receives status", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		var gotStatus string
+		called := false
+		m := &MockUIRenderer{
+			StartSpinnerWithMetricsFn: func(_ context.Context, status string) func() {
+				gotStatus = status
+				return func() { called = true }
+			},
+		}
+
+		stop := m.StartSpinnerWithMetrics(ctx, "processing")
+		if gotStatus != "processing" {
+			t.Errorf("status = %q; want %q", gotStatus, "processing")
+		}
+		stop()
+		if !called {
+			t.Error("custom stop func was not called")
+		}
+
+		snap := m.Snapshot()
+		if snap.StartSpinnerWithMetrics != 1 {
+			t.Errorf("StartSpinnerWithMetrics count = %d; want 1", snap.StartSpinnerWithMetrics)
+		}
+	})
 }
 
 func TestMockUIRenderer_RenderResponse(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	content := &llm.Content{Role: "assistant"}
-	showThoughts := true
-	rawOutput := false
+	t.Run("nil fn is no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("RenderResponse", ctx, content, showThoughts, rawOutput).Return()
+		ctx := context.Background()
+		content := &llm.Content{Role: "assistant"}
+		m := &MockUIRenderer{}
 
-	m.RenderResponse(ctx, content, showThoughts, rawOutput)
-	m.AssertCalled(t, "RenderResponse", ctx, content, showThoughts, rawOutput)
+		// Must not panic.
+		m.RenderResponse(ctx, content, true, false)
+
+		snap := m.Snapshot()
+		if snap.RenderResponse != 1 {
+			t.Errorf("RenderResponse count = %d; want 1", snap.RenderResponse)
+		}
+	})
+
+	t.Run("custom fn receives args", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		content := &llm.Content{Role: "assistant"}
+		var gotRole string
+		var gotShowThoughts, gotRawOutput bool
+		m := &MockUIRenderer{
+			RenderResponseFn: func(_ context.Context, c *llm.Content, showThoughts, rawOutput bool) {
+				gotRole = c.Role
+				gotShowThoughts = showThoughts
+				gotRawOutput = rawOutput
+			},
+		}
+
+		m.RenderResponse(ctx, content, true, false)
+
+		if gotRole != "assistant" {
+			t.Errorf("role = %q; want %q", gotRole, "assistant")
+		}
+		if !gotShowThoughts {
+			t.Error("showThoughts = false; want true")
+		}
+		if gotRawOutput {
+			t.Error("rawOutput = true; want false")
+		}
+
+		snap := m.Snapshot()
+		if snap.RenderResponse != 1 {
+			t.Errorf("RenderResponse count = %d; want 1", snap.RenderResponse)
+		}
+	})
 }
+
+// ---------------------------------------------------------------------------
+// StatusLogger tests
+// ---------------------------------------------------------------------------
 
 func TestMockUIRenderer_LogTurnStatus(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	status := events.TurnStatus{CurrentTurns: 1}
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("LogTurnStatus", ctx, status).Return()
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-	m.LogTurnStatus(ctx, status)
-	m.AssertCalled(t, "LogTurnStatus", ctx, status)
-}
+		// Must not panic.
+		m.LogTurnStatus(ctx, events.TurnStatus{SessionTurns: 1})
 
-func TestMockUIRenderer_LogUsage(t *testing.T) {
-	t.Parallel()
+		snap := m.Snapshot()
+		if snap.LogTurnStatus != 1 {
+			t.Errorf("LogTurnStatus count = %d; want 1", snap.LogTurnStatus)
+		}
+	})
 
-	ctx := context.Background()
-	metrics := &llm.Metrics{PromptTokens: 100}
-	logFile := "/tmp/log"
-	startTime := time.Now()
+	t.Run("custom fn receives status", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("LogUsage", ctx, metrics, logFile, mock.Anything).Return()
+		ctx := context.Background()
+		var gotStatus events.TurnStatus
+		m := &MockUIRenderer{
+			LogTurnStatusFn: func(_ context.Context, status events.TurnStatus) {
+				gotStatus = status
+			},
+		}
 
-	m.LogUsage(ctx, metrics, logFile, startTime)
-	m.AssertCalled(t, "LogUsage", ctx, metrics, logFile, mock.Anything)
-}
+		m.LogTurnStatus(ctx, events.TurnStatus{SessionTurns: 1})
 
-func TestMockUIRenderer_LogToolCall(t *testing.T) {
-	t.Parallel()
+		if gotStatus.SessionTurns != 1 {
+			t.Errorf("SessionTurns = %d; want 1", gotStatus.SessionTurns)
+		}
 
-	ctx := context.Background()
-	calls := []*llm.FunctionCall{{Name: "test"}}
-	turn := 1
-	maxTurns := 10
-	showTools := true
-
-	m := new(MockUIRenderer)
-	m.On("LogToolCall", ctx, calls, turn, maxTurns, showTools).Return()
-
-	m.LogToolCall(ctx, calls, turn, maxTurns, showTools)
-	m.AssertCalled(t, "LogToolCall", ctx, calls, turn, maxTurns, showTools)
-}
-
-func TestMockUIRenderer_LogToolResult(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-	name := "test-tool"
-	result := tools.ToolResult{Text: "done"}
-	showTools := false
-
-	m := new(MockUIRenderer)
-	m.On("LogToolResult", ctx, name, result, showTools).Return()
-
-	m.LogToolResult(ctx, name, result, showTools)
-	m.AssertCalled(t, "LogToolResult", ctx, name, result, showTools)
+		snap := m.Snapshot()
+		if snap.LogTurnStatus != 1 {
+			t.Errorf("LogTurnStatus count = %d; want 1", snap.LogTurnStatus)
+		}
+	})
 }
 
 func TestMockUIRenderer_LogSystemMessage(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	msg := "system message"
-	level := "info"
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("LogSystemMessage", ctx, msg, level).Return()
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-	m.LogSystemMessage(ctx, msg, level)
-	m.AssertCalled(t, "LogSystemMessage", ctx, msg, level)
+		// Must not panic.
+		m.LogSystemMessage(ctx, "test", "info")
+
+		snap := m.Snapshot()
+		if snap.LogSystemMessage != 1 {
+			t.Errorf("LogSystemMessage count = %d; want 1", snap.LogSystemMessage)
+		}
+	})
+
+	t.Run("custom fn receives msg and level", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		var gotMsg, gotLevel string
+		m := &MockUIRenderer{
+			LogSystemMessageFn: func(_ context.Context, msg string, level string) {
+				gotMsg = msg
+				gotLevel = level
+			},
+		}
+
+		m.LogSystemMessage(ctx, "test", "info")
+
+		if gotMsg != "test" {
+			t.Errorf("msg = %q; want %q", gotMsg, "test")
+		}
+		if gotLevel != "info" {
+			t.Errorf("level = %q; want %q", gotLevel, "info")
+		}
+
+		snap := m.Snapshot()
+		if snap.LogSystemMessage != 1 {
+			t.Errorf("LogSystemMessage count = %d; want 1", snap.LogSystemMessage)
+		}
+	})
 }
 
 func TestMockUIRenderer_RenderHealthReport(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	report := &ports.HealthReport{OverallStatus: ports.StatusHealthy}
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("RenderHealthReport", ctx, report).Return()
+		ctx := context.Background()
+		m := &MockUIRenderer{}
 
-	m.RenderHealthReport(ctx, report)
-	m.AssertCalled(t, "RenderHealthReport", ctx, report)
+		// Must not panic.
+		m.RenderHealthReport(ctx, &ports.HealthReport{OverallStatus: ports.StatusHealthy})
+
+		snap := m.Snapshot()
+		if snap.RenderHealthReport != 1 {
+			t.Errorf("RenderHealthReport count = %d; want 1", snap.RenderHealthReport)
+		}
+	})
+
+	t.Run("custom fn receives report", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		var gotOverall ports.HealthStatus
+		m := &MockUIRenderer{
+			RenderHealthReportFn: func(_ context.Context, report *ports.HealthReport) {
+				gotOverall = report.OverallStatus
+			},
+		}
+
+		m.RenderHealthReport(ctx, &ports.HealthReport{OverallStatus: ports.StatusHealthy})
+
+		if gotOverall != ports.StatusHealthy {
+			t.Errorf("OverallStatus = %q; want %q", gotOverall, ports.StatusHealthy)
+		}
+
+		snap := m.Snapshot()
+		if snap.RenderHealthReport != 1 {
+			t.Errorf("RenderHealthReport count = %d; want 1", snap.RenderHealthReport)
+		}
+	})
 }
+
+// ---------------------------------------------------------------------------
+// UsageLogger test
+// ---------------------------------------------------------------------------
+
+func TestMockUIRenderer_LogUsage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		m := &MockUIRenderer{}
+
+		// Must not panic.
+		m.LogUsage(ctx, &llm.Metrics{PromptTokens: 10}, "/tmp/log", time.Now())
+
+		snap := m.Snapshot()
+		if snap.LogUsage != 1 {
+			t.Errorf("LogUsage count = %d; want 1", snap.LogUsage)
+		}
+	})
+
+	t.Run("custom fn receives args", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		var gotTokens int32
+		var gotLogFile string
+		m := &MockUIRenderer{
+			LogUsageFn: func(_ context.Context, metrics *llm.Metrics, logFile string, _ time.Time) {
+				gotTokens = metrics.PromptTokens
+				gotLogFile = logFile
+			},
+		}
+
+		m.LogUsage(ctx, &llm.Metrics{PromptTokens: 10}, "/tmp/log", time.Now())
+
+		if gotTokens != 10 {
+			t.Errorf("PromptTokens = %d; want 10", gotTokens)
+		}
+		if gotLogFile != "/tmp/log" {
+			t.Errorf("logFile = %q; want %q", gotLogFile, "/tmp/log")
+		}
+
+		snap := m.Snapshot()
+		if snap.LogUsage != 1 {
+			t.Errorf("LogUsage count = %d; want 1", snap.LogUsage)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// ToolLogger tests
+// ---------------------------------------------------------------------------
+
+func TestMockUIRenderer_LogToolCall(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		calls := []*llm.FunctionCall{{Name: "test"}}
+		m := &MockUIRenderer{}
+
+		// Must not panic.
+		m.LogToolCall(ctx, calls, 1, 5, true)
+
+		snap := m.Snapshot()
+		if snap.LogToolCall != 1 {
+			t.Errorf("LogToolCall count = %d; want 1", snap.LogToolCall)
+		}
+	})
+
+	t.Run("custom fn receives args", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		calls := []*llm.FunctionCall{{Name: "test"}}
+		var gotName string
+		var gotTurn, gotMaxTurns int
+		var gotShowTools bool
+		m := &MockUIRenderer{
+			LogToolCallFn: func(_ context.Context, c []*llm.FunctionCall, turn, maxTurns int, showTools bool) {
+				if len(c) > 0 {
+					gotName = c[0].Name
+				}
+				gotTurn = turn
+				gotMaxTurns = maxTurns
+				gotShowTools = showTools
+			},
+		}
+
+		m.LogToolCall(ctx, calls, 1, 5, true)
+
+		if gotName != "test" {
+			t.Errorf("name = %q; want %q", gotName, "test")
+		}
+		if gotTurn != 1 {
+			t.Errorf("turn = %d; want 1", gotTurn)
+		}
+		if gotMaxTurns != 5 {
+			t.Errorf("maxTurns = %d; want 5", gotMaxTurns)
+		}
+		if !gotShowTools {
+			t.Error("showTools = false; want true")
+		}
+
+		snap := m.Snapshot()
+		if snap.LogToolCall != 1 {
+			t.Errorf("LogToolCall count = %d; want 1", snap.LogToolCall)
+		}
+	})
+}
+
+func TestMockUIRenderer_LogToolResult(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		m := &MockUIRenderer{}
+
+		// Must not panic.
+		m.LogToolResult(ctx, "test-tool", tools.ToolResult{Text: "done"}, false)
+
+		snap := m.Snapshot()
+		if snap.LogToolResult != 1 {
+			t.Errorf("LogToolResult count = %d; want 1", snap.LogToolResult)
+		}
+	})
+
+	t.Run("custom fn receives args", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		var gotName, gotText string
+		var gotShowTools bool
+		m := &MockUIRenderer{
+			LogToolResultFn: func(_ context.Context, name string, result tools.ToolResult, showTools bool) {
+				gotName = name
+				gotText = result.Text
+				gotShowTools = showTools
+			},
+		}
+
+		m.LogToolResult(ctx, "test-tool", tools.ToolResult{Text: "done"}, false)
+
+		if gotName != "test-tool" {
+			t.Errorf("name = %q; want %q", gotName, "test-tool")
+		}
+		if gotText != "done" {
+			t.Errorf("text = %q; want %q", gotText, "done")
+		}
+		if gotShowTools {
+			t.Error("showTools = true; want false")
+		}
+
+		snap := m.Snapshot()
+		if snap.LogToolResult != 1 {
+			t.Errorf("LogToolResult count = %d; want 1", snap.LogToolResult)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// RendererConfigurator tests
+// ---------------------------------------------------------------------------
 
 func TestMockUIRenderer_SetUseColor(t *testing.T) {
 	t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("SetUseColor", true).Return()
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m.SetUseColor(true)
-	m.AssertCalled(t, "SetUseColor", true)
+		m := &MockUIRenderer{}
+
+		// Must not panic.
+		m.SetUseColor(true)
+
+		snap := m.Snapshot()
+		if snap.SetUseColor != 1 {
+			t.Errorf("SetUseColor count = %d; want 1", snap.SetUseColor)
+		}
+	})
+
+	t.Run("custom fn receives use", func(t *testing.T) {
+		t.Parallel()
+
+		var gotUse bool
+		m := &MockUIRenderer{
+			SetUseColorFn: func(use bool) {
+				gotUse = use
+			},
+		}
+
+		m.SetUseColor(true)
+
+		if !gotUse {
+			t.Error("use = false; want true")
+		}
+
+		snap := m.Snapshot()
+		if snap.SetUseColor != 1 {
+			t.Errorf("SetUseColor count = %d; want 1", snap.SetUseColor)
+		}
+	})
 }
 
 func TestMockUIRenderer_SetForceSpinner(t *testing.T) {
 	t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("SetForceSpinner", false).Return()
+	t.Run("nil fn no-op", func(t *testing.T) {
+		t.Parallel()
 
-	m.SetForceSpinner(false)
-	m.AssertCalled(t, "SetForceSpinner", false)
+		m := &MockUIRenderer{}
+
+		// Must not panic.
+		m.SetForceSpinner(false)
+
+		snap := m.Snapshot()
+		if snap.SetForceSpinner != 1 {
+			t.Errorf("SetForceSpinner count = %d; want 1", snap.SetForceSpinner)
+		}
+	})
+
+	t.Run("custom fn receives force", func(t *testing.T) {
+		t.Parallel()
+
+		var gotForce bool
+		m := &MockUIRenderer{
+			SetForceSpinnerFn: func(force bool) {
+				gotForce = force
+			},
+		}
+
+		m.SetForceSpinner(false)
+
+		if gotForce {
+			t.Error("force = true; want false")
+		}
+
+		snap := m.Snapshot()
+		if snap.SetForceSpinner != 1 {
+			t.Errorf("SetForceSpinner count = %d; want 1", snap.SetForceSpinner)
+		}
+	})
 }
 
-func TestMockUIRenderer_IsTerminalContext_True(t *testing.T) {
+func TestMockUIRenderer_IsTerminalContext(t *testing.T) {
 	t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("IsTerminalContext").Return(true)
+	t.Run("nil fn returns false", func(t *testing.T) {
+		t.Parallel()
 
-	got := m.IsTerminalContext()
-	if !got {
-		t.Error("got false; want true")
-	}
-	m.AssertExpectations(t)
+		m := &MockUIRenderer{}
+
+		got := m.IsTerminalContext()
+		if got {
+			t.Error("got true; want false (nil fn default)")
+		}
+
+		snap := m.Snapshot()
+		if snap.IsTerminalContext != 1 {
+			t.Errorf("IsTerminalContext count = %d; want 1", snap.IsTerminalContext)
+		}
+	})
+
+	t.Run("custom fn returns true", func(t *testing.T) {
+		t.Parallel()
+
+		m := &MockUIRenderer{
+			IsTerminalContextFn: func() bool {
+				return true
+			},
+		}
+
+		got := m.IsTerminalContext()
+		if !got {
+			t.Error("got false; want true")
+		}
+
+		snap := m.Snapshot()
+		if snap.IsTerminalContext != 1 {
+			t.Errorf("IsTerminalContext count = %d; want 1", snap.IsTerminalContext)
+		}
+	})
 }
 
-func TestMockUIRenderer_IsTerminalContext_False(t *testing.T) {
+// ---------------------------------------------------------------------------
+// Snapshot integration test
+// ---------------------------------------------------------------------------
+
+func TestMockUIRenderer_Snapshot_AllMethods(t *testing.T) {
 	t.Parallel()
 
-	m := new(MockUIRenderer)
-	m.On("IsTerminalContext").Return(false)
+	ctx := context.Background()
+	m := &MockUIRenderer{}
 
-	got := m.IsTerminalContext()
-	if got {
-		t.Error("got true; want false")
+	// Call one method from each sub-interface.
+	m.SetUseColor(true)                                     // RendererConfigurator
+	m.StartSpinner(ctx)                                     // ResponseRenderer
+	m.LogTurnStatus(ctx, events.TurnStatus{})               // StatusLogger
+	m.LogUsage(ctx, &llm.Metrics{}, "/tmp/log", time.Now()) // UsageLogger
+	m.LogToolCall(ctx, nil, 0, 0, false)                    // ToolLogger
+
+	snap := m.Snapshot()
+
+	// Called counters must be 1.
+	if snap.SetUseColor != 1 {
+		t.Errorf("SetUseColor = %d; want 1", snap.SetUseColor)
 	}
-	m.AssertExpectations(t)
+	if snap.StartSpinner != 1 {
+		t.Errorf("StartSpinner = %d; want 1", snap.StartSpinner)
+	}
+	if snap.LogTurnStatus != 1 {
+		t.Errorf("LogTurnStatus = %d; want 1", snap.LogTurnStatus)
+	}
+	if snap.LogUsage != 1 {
+		t.Errorf("LogUsage = %d; want 1", snap.LogUsage)
+	}
+	if snap.LogToolCall != 1 {
+		t.Errorf("LogToolCall = %d; want 1", snap.LogToolCall)
+	}
+
+	// Uncalled counters must be 0.
+	if snap.StartSpinnerWithStatus != 0 {
+		t.Errorf("StartSpinnerWithStatus = %d; want 0", snap.StartSpinnerWithStatus)
+	}
+	if snap.StartSpinnerWithMetrics != 0 {
+		t.Errorf("StartSpinnerWithMetrics = %d; want 0", snap.StartSpinnerWithMetrics)
+	}
+	if snap.RenderResponse != 0 {
+		t.Errorf("RenderResponse = %d; want 0", snap.RenderResponse)
+	}
+	if snap.LogSystemMessage != 0 {
+		t.Errorf("LogSystemMessage = %d; want 0", snap.LogSystemMessage)
+	}
+	if snap.RenderHealthReport != 0 {
+		t.Errorf("RenderHealthReport = %d; want 0", snap.RenderHealthReport)
+	}
+	if snap.LogToolResult != 0 {
+		t.Errorf("LogToolResult = %d; want 0", snap.LogToolResult)
+	}
+	if snap.SetForceSpinner != 0 {
+		t.Errorf("SetForceSpinner = %d; want 0", snap.SetForceSpinner)
+	}
+	if snap.IsTerminalContext != 0 {
+		t.Errorf("IsTerminalContext = %d; want 0", snap.IsTerminalContext)
+	}
+
+	// Methods slice must have correct order and length.
+	wantMethods := []string{"SetUseColor", "StartSpinner", "LogTurnStatus", "LogUsage", "LogToolCall"}
+	if len(snap.Methods) != len(wantMethods) {
+		t.Fatalf("len(Methods) = %d; want %d", len(snap.Methods), len(wantMethods))
+	}
+	for i, want := range wantMethods {
+		if snap.Methods[i] != want {
+			t.Errorf("Methods[%d] = %q; want %q", i, snap.Methods[i], want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrency test
+// ---------------------------------------------------------------------------
+
+// Run: go test -race -run TestMockUIRenderer_Concurrency
+func TestMockUIRenderer_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	m := &MockUIRenderer{}
+	var wg sync.WaitGroup
+	n := 10
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			m.LogTurnStatus(context.Background(), events.TurnStatus{})
+		}()
+	}
+	wg.Wait()
+
+	snap := m.Snapshot()
+	if snap.LogTurnStatus != n {
+		t.Errorf("LogTurnStatus = %d; want %d", snap.LogTurnStatus, n)
+	}
 }

--- a/internal/agent/session/ui/backpressure_test.go
+++ b/internal/agent/session/ui/backpressure_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -54,11 +53,18 @@ func TestUIBridge_LoadShedding_NonBlocking(t *testing.T) {
 func TestUIBridge_Shutdown_GracefulDrain(t *testing.T) {
 	t.Parallel()
 	f := newUIBridgeFixture(t)
-	f.BlockLoop(t)
-
 	// We expect all events to be processed during graceful drain
-	f.renderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Once()
-	f.renderer.On("LogSystemMessage", mock.Anything, "processed", "warn").Return().Once()
+	var renderCalled, sysMsgCalled bool
+	f.renderer.RenderResponseFn = func(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool) {
+		renderCalled = true
+	}
+	f.renderer.LogSystemMessageFn = func(ctx context.Context, msg string, level string) {
+		if msg == "processed" && level == "warn" {
+			sysMsgCalled = true
+		}
+	}
+
+	f.BlockLoop(t)
 
 	// Send events that MUST be drained
 	_ = f.bridge.HandleEvent(context.Background(), events.ResponseEvent{Content: &llm.Content{}})
@@ -83,7 +89,8 @@ func TestUIBridge_Shutdown_GracefulDrain(t *testing.T) {
 		t.Fatal("Cleanup did not finish even after unblocking; pipeline is deadlocked")
 	}
 
-	f.renderer.AssertExpectations(t)
+	assert.True(t, renderCalled, "expected RenderResponse to be called during graceful drain")
+	assert.True(t, sysMsgCalled, "expected LogSystemMessage(processed, warn) to be called")
 }
 
 func TestUIBridge_QoSRouting(t *testing.T) {
@@ -143,12 +150,6 @@ func TestUIBridge_QoSRouting(t *testing.T) {
 			}
 
 			f := newUIBridgeFixture(t)
-			f.renderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
-			f.renderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-			f.renderer.On("LogSystemMessage", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-			f.renderer.On("LogToolCall", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-			f.renderer.On("LogToolResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-			f.renderer.On("LogUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
 			f.BlockLoop(t)
 			f.FillQueue(events.TurnStatusEvent{})
@@ -177,9 +178,6 @@ func TestUIBridge_ContextCancellationMidFlight(t *testing.T) {
 	}
 
 	f := newUIBridgeFixture(t)
-	f.renderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
-	f.renderer.On("LogSystemMessage", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-	f.renderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
 
 	f.BlockLoop(t)
 	f.FillQueue(events.ResponseEvent{})

--- a/internal/agent/session/ui/fixture_test.go
+++ b/internal/agent/session/ui/fixture_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/stretchr/testify/mock"
 )
 
 // controllableUIRenderer provides synchronization hooks for testing bridge backpressure.
@@ -156,7 +155,6 @@ func newUIBridgeFixture(t *testing.T, opts ...bridgeOption) *uiBridgeFixture {
 // BlockLoop sends a TurnStatusEvent and waits for the renderer to be entered and blocked.
 func (f *uiBridgeFixture) BlockLoop(t *testing.T) {
 	t.Helper()
-	f.renderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
 
 	if err := f.bridge.HandleEvent(context.Background(), events.TurnStatusEvent{}); err != nil {
 		t.Fatalf("failed to send blocking event: %v", err)


### PR DESCRIPTION
Closes #708.

## Summary

Convert 5 mock-definition files in `internal/agent/agenttest/` from `testify/mock` to the hand-rolled function-field + `sync.Mutex`-guarded spy pattern per ADR-021.

### Files Changed (8 total)
| File | Change |
|------|--------|
| `mock_llm_client.go` | Removed `mock.Mock` embedding, added mutex-guarded spy state, preserved `SendChatFn`/`RefreshAuthFn` |
| `mock_llm_client_test.go` | 8 new self-tests using Snapshot() and function-field scripting |
| `mock_chatter.go` | Removed `mock.Mock` embedding, added 4 function fields + `SubscribeFn` for subscriber capture |
| `mock_chatter_test.go` | 10 new subtests using spy verification |
| `mock_ui_renderer.go` | Removed `mock.Mock` embedding, added 13 function fields + `UIRendererSnapshot` struct |
| `mock_ui_renderer_test.go` | 15 new tests, 100% coverage on mock methods |
| `fixture_test.go` | Compatibility shim: removed testify/mock import + dead .On() call |
| `backpressure_test.go` | Compatibility shim: replaced .On() calls with function fields |

### Pattern
All mocks follow `mock_clock.go` canonical: lock only around counter/methods slice mutations, release before calling function fields.

## Verification
| Check | Status |
|-------|--------|
| `go build ./internal/agent/agenttest/...` | ✅ PASS |
| `go vet ./internal/agent/agenttest/...` | ✅ PASS |
| `go test -race ./internal/agent/agenttest/...` | ✅ PASS (1.060s) |
| Mock self-test coverage | ✅ 100% on mock_ui_renderer.go |
| Zero testify/mock in 6 migrated files | ✅ grep confirms |

### Known: Consumer test breakage (Phase 2 scope)
Consumer tests in `session/`, `session/ui/bridge_test.go`, and `tests/integration/` will have build failures until Phase 2 lands. Phase 1 deliverable is the mock definitions and self-tests only.