### PR TITLE
fix(agent): migrate session/ui test consumers to hand-rolled mocks (#713)

### DIFF
--- a/internal/agent/agenttest/mock_ui_renderer.go
+++ b/internal/agent/agenttest/mock_ui_renderer.go
@@ -18,6 +18,9 @@ import (
 // Override function fields to script behaviour. All methods record
 // invocation counts and names accessible via Snapshot(). The spinner
 // methods return a no-op func() when their function field is nil.
+//
+// All methods are safe for concurrent use. Function fields are captured
+// under the mutex and invoked outside it to avoid deadlocks.
 type MockUIRenderer struct {
 	mu                            sync.Mutex
 	calledStartSpinner            int
@@ -91,10 +94,11 @@ func (m *MockUIRenderer) StartSpinner(ctx context.Context) func() {
 	m.mu.Lock()
 	m.calledStartSpinner++
 	m.calledMethods = append(m.calledMethods, "StartSpinner")
+	fn := m.StartSpinnerFn
 	m.mu.Unlock()
 
-	if m.StartSpinnerFn != nil {
-		return m.StartSpinnerFn(ctx)
+	if fn != nil {
+		return fn(ctx)
 	}
 	return func() {}
 }
@@ -103,10 +107,11 @@ func (m *MockUIRenderer) StartSpinnerWithStatus(ctx context.Context, status stri
 	m.mu.Lock()
 	m.calledStartSpinnerWithStatus++
 	m.calledMethods = append(m.calledMethods, "StartSpinnerWithStatus")
+	fn := m.StartSpinnerWithStatusFn
 	m.mu.Unlock()
 
-	if m.StartSpinnerWithStatusFn != nil {
-		return m.StartSpinnerWithStatusFn(ctx, status)
+	if fn != nil {
+		return fn(ctx, status)
 	}
 	return func() {}
 }
@@ -115,10 +120,11 @@ func (m *MockUIRenderer) StartSpinnerWithMetrics(ctx context.Context, status str
 	m.mu.Lock()
 	m.calledStartSpinnerWithMetrics++
 	m.calledMethods = append(m.calledMethods, "StartSpinnerWithMetrics")
+	fn := m.StartSpinnerWithMetricsFn
 	m.mu.Unlock()
 
-	if m.StartSpinnerWithMetricsFn != nil {
-		return m.StartSpinnerWithMetricsFn(ctx, status)
+	if fn != nil {
+		return fn(ctx, status)
 	}
 	return func() {}
 }
@@ -127,10 +133,11 @@ func (m *MockUIRenderer) RenderResponse(ctx context.Context, content *llm.Conten
 	m.mu.Lock()
 	m.calledRenderResponse++
 	m.calledMethods = append(m.calledMethods, "RenderResponse")
+	fn := m.RenderResponseFn
 	m.mu.Unlock()
 
-	if m.RenderResponseFn != nil {
-		m.RenderResponseFn(ctx, content, showThoughts, rawOutput)
+	if fn != nil {
+		fn(ctx, content, showThoughts, rawOutput)
 	}
 }
 
@@ -140,10 +147,11 @@ func (m *MockUIRenderer) LogTurnStatus(ctx context.Context, status events.TurnSt
 	m.mu.Lock()
 	m.calledLogTurnStatus++
 	m.calledMethods = append(m.calledMethods, "LogTurnStatus")
+	fn := m.LogTurnStatusFn
 	m.mu.Unlock()
 
-	if m.LogTurnStatusFn != nil {
-		m.LogTurnStatusFn(ctx, status)
+	if fn != nil {
+		fn(ctx, status)
 	}
 }
 
@@ -151,10 +159,11 @@ func (m *MockUIRenderer) LogSystemMessage(ctx context.Context, msg string, level
 	m.mu.Lock()
 	m.calledLogSystemMessage++
 	m.calledMethods = append(m.calledMethods, "LogSystemMessage")
+	fn := m.LogSystemMessageFn
 	m.mu.Unlock()
 
-	if m.LogSystemMessageFn != nil {
-		m.LogSystemMessageFn(ctx, msg, level)
+	if fn != nil {
+		fn(ctx, msg, level)
 	}
 }
 
@@ -162,10 +171,11 @@ func (m *MockUIRenderer) RenderHealthReport(ctx context.Context, report *ports.H
 	m.mu.Lock()
 	m.calledRenderHealthReport++
 	m.calledMethods = append(m.calledMethods, "RenderHealthReport")
+	fn := m.RenderHealthReportFn
 	m.mu.Unlock()
 
-	if m.RenderHealthReportFn != nil {
-		m.RenderHealthReportFn(ctx, report)
+	if fn != nil {
+		fn(ctx, report)
 	}
 }
 
@@ -175,10 +185,11 @@ func (m *MockUIRenderer) LogUsage(ctx context.Context, metrics *llm.Metrics, log
 	m.mu.Lock()
 	m.calledLogUsage++
 	m.calledMethods = append(m.calledMethods, "LogUsage")
+	fn := m.LogUsageFn
 	m.mu.Unlock()
 
-	if m.LogUsageFn != nil {
-		m.LogUsageFn(ctx, metrics, logFile, startTime)
+	if fn != nil {
+		fn(ctx, metrics, logFile, startTime)
 	}
 }
 
@@ -188,10 +199,11 @@ func (m *MockUIRenderer) LogToolCall(ctx context.Context, calls []*llm.FunctionC
 	m.mu.Lock()
 	m.calledLogToolCall++
 	m.calledMethods = append(m.calledMethods, "LogToolCall")
+	fn := m.LogToolCallFn
 	m.mu.Unlock()
 
-	if m.LogToolCallFn != nil {
-		m.LogToolCallFn(ctx, calls, turn, maxTurns, showTools)
+	if fn != nil {
+		fn(ctx, calls, turn, maxTurns, showTools)
 	}
 }
 
@@ -199,23 +211,35 @@ func (m *MockUIRenderer) LogToolResult(ctx context.Context, name string, result 
 	m.mu.Lock()
 	m.calledLogToolResult++
 	m.calledMethods = append(m.calledMethods, "LogToolResult")
+	fn := m.LogToolResultFn
 	m.mu.Unlock()
 
-	if m.LogToolResultFn != nil {
-		m.LogToolResultFn(ctx, name, result, showTools)
+	if fn != nil {
+		fn(ctx, name, result, showTools)
 	}
 }
 
 // ---- RendererConfigurator methods ----
 
+// SwapLogSystemMessageFn atomically replaces LogSystemMessageFn and returns
+// the previous value. Safe for concurrent use with method calls.
+func (m *MockUIRenderer) SwapLogSystemMessageFn(fn func(ctx context.Context, msg string, level string)) func(ctx context.Context, msg string, level string) {
+	m.mu.Lock()
+	prev := m.LogSystemMessageFn
+	m.LogSystemMessageFn = fn
+	m.mu.Unlock()
+	return prev
+}
+
 func (m *MockUIRenderer) SetUseColor(use bool) {
 	m.mu.Lock()
 	m.calledSetUseColor++
 	m.calledMethods = append(m.calledMethods, "SetUseColor")
+	fn := m.SetUseColorFn
 	m.mu.Unlock()
 
-	if m.SetUseColorFn != nil {
-		m.SetUseColorFn(use)
+	if fn != nil {
+		fn(use)
 	}
 }
 
@@ -223,10 +247,11 @@ func (m *MockUIRenderer) SetForceSpinner(force bool) {
 	m.mu.Lock()
 	m.calledSetForceSpinner++
 	m.calledMethods = append(m.calledMethods, "SetForceSpinner")
+	fn := m.SetForceSpinnerFn
 	m.mu.Unlock()
 
-	if m.SetForceSpinnerFn != nil {
-		m.SetForceSpinnerFn(force)
+	if fn != nil {
+		fn(force)
 	}
 }
 
@@ -234,10 +259,11 @@ func (m *MockUIRenderer) IsTerminalContext() bool {
 	m.mu.Lock()
 	m.calledIsTerminalContext++
 	m.calledMethods = append(m.calledMethods, "IsTerminalContext")
+	fn := m.IsTerminalContextFn
 	m.mu.Unlock()
 
-	if m.IsTerminalContextFn != nil {
-		return m.IsTerminalContextFn()
+	if fn != nil {
+		return fn()
 	}
 	return false
 }

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // newStartedTestBridge creates a Bridge with default test options,
@@ -67,9 +66,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogTurnStatus", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+				m.LogTurnStatusFn = func(ctx context.Context, status events.TurnStatus) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -82,9 +81,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogUsage", mock.Anything, mock.Anything, "log.txt", mock.Anything).Run(func(_ mock.Arguments) {
+				m.LogUsageFn = func(ctx context.Context, metrics *llm.Metrics, logFile string, startTime time.Time) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -97,9 +96,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogToolCall", mock.Anything, mock.Anything, 0, 5, true).Run(func(_ mock.Arguments) {
+				m.LogToolCallFn = func(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -111,9 +110,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogToolResult", mock.Anything, "test", mock.Anything, true).Run(func(_ mock.Arguments) {
+				m.LogToolResultFn = func(ctx context.Context, name string, result tools.ToolResult, showTools bool) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -125,9 +124,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogSystemMessage", mock.Anything, "msg", "info").Run(func(_ mock.Arguments) {
+				m.LogSystemMessageFn = func(ctx context.Context, msg string, level string) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -139,9 +138,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("LogSystemMessage", mock.Anything, "updating", "info").Run(func(_ mock.Arguments) {
+				m.LogSystemMessageFn = func(ctx context.Context, msg string, level string) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -152,9 +151,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithStatus", mock.Anything, " Thinking [gpt-4o]...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -163,9 +163,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			event: events.InferenceStartedEvent{},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithStatus", mock.Anything, " Thinking...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -174,9 +175,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			event: events.SummarizationStartedEvent{},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithStatus", mock.Anything, " Compressing context...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -187,9 +189,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithMetrics", mock.Anything, " Executing [search_files]...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithMetricsFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -200,9 +203,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithMetrics", mock.Anything, " Executing tools [list_files, read_files]...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithMetricsFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -211,9 +215,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			event: events.ToolExecutionStartedEvent{},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithMetrics", mock.Anything, " Executing tools...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithMetricsFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -224,9 +229,10 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithStatus", mock.Anything, " Retrying in 5s...").Run(func(_ mock.Arguments) {
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 					close(done)
-				}).Return(func() {})
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -235,9 +241,11 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			event: events.ConsentStartedEvent{},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
-					close(done)
-				}).Return(func() {})
+				var once sync.Once
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+					once.Do(func() { close(done) })
+					return func() {}
+				}
 				return done
 			},
 			preSetup: func(b *Bridge, m *agenttest.MockUIRenderer) {
@@ -261,11 +269,14 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
 				var count int32
-				m.On("StartSpinnerWithStatus", mock.Anything, " Thinking [gpt-4o]...").Run(func(_ mock.Arguments) {
-					if atomic.AddInt32(&count, 1) == 2 {
-						close(done)
+				m.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+					if status == " Thinking [gpt-4o]..." {
+						if atomic.AddInt32(&count, 1) == 2 {
+							close(done)
+						}
 					}
-				}).Return(func() {}).Twice()
+					return func() {}
+				}
 				return done
 			},
 		},
@@ -276,9 +287,9 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 			},
 			setup: func(m *agenttest.MockUIRenderer) <-chan struct{} {
 				done := make(chan struct{})
-				m.On("RenderResponse", mock.Anything, mock.Anything, true, false).Run(func(_ mock.Arguments) {
+				m.RenderResponseFn = func(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool) {
 					close(done)
-				}).Return()
+				}
 				return done
 			},
 		},
@@ -355,16 +366,6 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
-	// Setup mocks with Maybe() to handle concurrent calls safely
-	mRenderer.On("StartSpinner", mock.Anything).Return(func() {}).Maybe()
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {}).Maybe()
-	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogSystemMessage", mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogUsage", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogToolCall", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogToolResult", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
-
 	var wg sync.WaitGroup
 	const iterations = 1000
 	start := make(chan struct{})
@@ -430,10 +431,6 @@ func TestUIBridge_LogicalRace(t *testing.T) {
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
-	// StartSpinnerWithStatus should NOT be called because ResponseEvent is already rendering
-	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {}).Maybe()
-
 	// 1. Mark as rendering via ResponseEvent
 	_ = bridge.HandleEvent(ctx, events.ResponseEvent{
 		Content: &llm.Content{},
@@ -444,9 +441,9 @@ func TestUIBridge_LogicalRace(t *testing.T) {
 
 	// 3. Send a sentinel to ensure #2 was processed
 	done := make(chan struct{})
-	mRenderer.On("LogTurnStatus", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+	mRenderer.LogTurnStatusFn = func(ctx context.Context, status events.TurnStatus) {
 		close(done)
-	}).Return().Once()
+	}
 	_ = bridge.HandleEvent(ctx, events.TurnStatusEvent{})
 
 	select {
@@ -455,8 +452,9 @@ func TestUIBridge_LogicalRace(t *testing.T) {
 		t.Fatal("timeout waiting for LogicalRace sentinel")
 	}
 
-	// Verification
-	mRenderer.AssertNotCalled(t, "StartSpinnerWithStatus", mock.Anything, mock.Anything)
+	// Verification: StartSpinnerWithStatus must NOT be called when already rendering
+	snap := mRenderer.Snapshot()
+	assert.Equal(t, 0, snap.StartSpinnerWithStatus, "StartSpinnerWithStatus must NOT be called when already rendering")
 }
 
 func TestUIBridge_AbortedTurn_SpinnerCleanup(t *testing.T) {
@@ -468,7 +466,12 @@ func TestUIBridge_AbortedTurn_SpinnerCleanup(t *testing.T) {
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
 	spinnerStopped := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Thinking...").Return(func() { close(spinnerStopped) })
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		if status == " Thinking..." {
+			return func() { close(spinnerStopped) }
+		}
+		return func() {}
+	}
 
 	// Start Inference
 	_ = bridge.HandleEvent(context.Background(), events.InferenceStartedEvent{})
@@ -493,9 +496,12 @@ func TestUIBridge_Retry_Spinner(t *testing.T) {
 
 	// First attempt
 	done1 := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Thinking...").Run(func(_ mock.Arguments) {
-		close(done1)
-	}).Return(func() {}).Once()
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		if status == " Thinking..." {
+			close(done1)
+		}
+		return func() {}
+	}
 	_ = bridge.HandleEvent(context.Background(), events.InferenceStartedEvent{})
 	select {
 	case <-done1:
@@ -505,9 +511,9 @@ func TestUIBridge_Retry_Spinner(t *testing.T) {
 
 	// Response (e.g. error)
 	done2 := make(chan struct{})
-	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+	mRenderer.RenderResponseFn = func(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool) {
 		close(done2)
-	}).Return().Once()
+	}
 	_ = bridge.HandleEvent(context.Background(), events.ResponseEvent{
 		Content: &llm.Content{},
 	})
@@ -520,17 +526,18 @@ func TestUIBridge_Retry_Spinner(t *testing.T) {
 	// Second attempt (Retry)
 	// Now this SHOULD be called because RetryWaitingEvent resets isRendering.
 	done3 := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Retrying in 5s...").Run(func(_ mock.Arguments) {
-		close(done3)
-	}).Return(func() {}).Once()
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		if status == " Retrying in 5s..." {
+			close(done3)
+		}
+		return func() {}
+	}
 	_ = bridge.HandleEvent(context.Background(), events.RetryWaitingEvent{Duration: 5 * time.Second})
 	select {
 	case <-done3:
 	case <-time.After(2 * time.Second):
 		t.Fatal("timeout waiting for retry spinner")
 	}
-
-	mRenderer.AssertExpectations(t)
 }
 
 func TestUIBridge_CleanupOnUnexpectedExit(t *testing.T) {
@@ -542,9 +549,13 @@ func TestUIBridge_CleanupOnUnexpectedExit(t *testing.T) {
 
 	spinnerStarted := make(chan struct{})
 	spinnerStopped := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Thinking...").Run(func(args mock.Arguments) {
-		close(spinnerStarted)
-	}).Return(func() { close(spinnerStopped) })
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		if status == " Thinking..." {
+			close(spinnerStarted)
+			return func() { close(spinnerStopped) }
+		}
+		return func() {}
+	}
 
 	// Start Inference
 	_ = bridge.HandleEvent(context.Background(), events.InferenceStartedEvent{})
@@ -575,24 +586,25 @@ func TestUIBridge_SpinnerTransitions(t *testing.T) {
 	// 1. Summarization starts
 	stopSummarizationCalled := make(chan struct{})
 	doneSummarization := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Compressing context...").Run(func(_ mock.Arguments) {
-		close(doneSummarization)
-	}).Return(func() {
-		close(stopSummarizationCalled)
-	}).Once()
+	stopInferenceCalled := make(chan struct{})
+	doneInference := make(chan struct{})
+
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		switch status {
+		case " Compressing context...":
+			close(doneSummarization)
+			return func() { close(stopSummarizationCalled) }
+		case " Thinking...":
+			close(doneInference)
+			return func() { close(stopInferenceCalled) }
+		}
+		return func() {}
+	}
 
 	_ = bridge.HandleEvent(context.Background(), events.SummarizationStartedEvent{})
 	waitOrFatal(t, doneSummarization, "timeout waiting for summarization spinner")
 
 	// 2. Inference starts (should stop summarization spinner first)
-	stopInferenceCalled := make(chan struct{})
-	doneInference := make(chan struct{})
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, " Thinking...").Run(func(_ mock.Arguments) {
-		close(doneInference)
-	}).Return(func() {
-		close(stopInferenceCalled)
-	}).Once()
-
 	_ = bridge.HandleEvent(context.Background(), events.InferenceStartedEvent{})
 	waitOrFatal(t, doneInference, "timeout waiting for inference spinner")
 
@@ -603,8 +615,6 @@ func TestUIBridge_SpinnerTransitions(t *testing.T) {
 	bridge.CloseInput()
 	bridge.Cleanup()
 	waitOrFatal(t, stopInferenceCalled, "Expected inference spinner to be stopped during cleanup")
-
-	mRenderer.AssertExpectations(t)
 }
 
 func TestUIBridge_SpinnerConcurrency(t *testing.T) {
@@ -617,11 +627,10 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 	var activeSpinners int32
 
 	// Thread-safe mock setup
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 		atomic.AddInt32(&activeSpinners, 1)
-	}).Return(func() {
-		atomic.AddInt32(&activeSpinners, -1)
-	})
+		return func() { atomic.AddInt32(&activeSpinners, -1) }
+	}
 
 	var wg sync.WaitGroup
 	for i := 0; i < 50; i++ {

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestUIBridge_StressConcurrency(t *testing.T) {
@@ -27,14 +26,13 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	var activeSpinners int32
 
 	// Thread-safe mock setup with atomic tracking
-	mRenderer.On("StartSpinnerWithMetrics", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mRenderer.StartSpinnerWithMetricsFn = func(ctx context.Context, status string) func() {
 		current := atomic.AddInt32(&activeSpinners, 1)
 		assert.LessOrEqual(t, current, int32(1), "Actor model violation: Concurrent spinners detected")
-	}).Return(func() {
-		atomic.AddInt32(&activeSpinners, -1) // Return the expected func() type for cleanup
-	})
-
-	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Maybe()
+		return func() {
+			atomic.AddInt32(&activeSpinners, -1)
+		}
+	}
 
 	const numGoroutines = 100
 	var wg sync.WaitGroup
@@ -81,10 +79,16 @@ func TestUIBridge_LogicalStateVerification(t *testing.T) {
 
 	// 1. Expect the spinner to start first
 	// Note: startSpinnerForPhase(ToolExecutionStartedEvent) calls StartSpinnerWithMetrics
-	mRenderer.On("StartSpinnerWithMetrics", mock.Anything, " Executing tools...").Return(func() {}).Once()
+	var metricsCalled, renderCalled int32
+	mRenderer.StartSpinnerWithMetricsFn = func(ctx context.Context, status string) func() {
+		atomic.AddInt32(&metricsCalled, 1)
+		return func() {}
+	}
 
 	// 2. Expect the response to be rendered sequentially after
-	mRenderer.On("RenderResponse", mock.Anything, mock.Anything, true, false).Return().Once()
+	mRenderer.RenderResponseFn = func(ctx context.Context, content *llm.Content, showThoughts, rawOutput bool) {
+		atomic.AddInt32(&renderCalled, 1)
+	}
 
 	// 3. Queue the events sequentially
 	_ = bridge.HandleEvent(testCtx, events.ToolExecutionStartedEvent{})
@@ -94,5 +98,6 @@ func TestUIBridge_LogicalStateVerification(t *testing.T) {
 	syncBridge(t, bridge, mRenderer)
 
 	// 5. Verify the sequential execution happened as expected
-	mRenderer.AssertExpectations(t)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&metricsCalled), "StartSpinnerWithMetrics should be called exactly once")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&renderCalled), "RenderResponse should be called exactly once")
 }

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -7,12 +7,12 @@ import (
 	"context"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -22,16 +22,13 @@ func TestUIBridge_ConsentSpinnerLeak(t *testing.T) {
 	block := make(chan struct{})
 
 	// Setup a block to freeze the actor loop
-	mRenderer.On("LogSystemMessage", mock.Anything, "BLOCK", mock.Anything).Run(func(_ mock.Arguments) {
-		<-block
-	}).Return().Once()
-
-	// Handle other expected calls with .Maybe() to prevent panic masking.
-	// We use a specific matcher to avoid overlap with SYNC_SENTINEL used by syncBridge.
-	mRenderer.On("LogSystemMessage", mock.Anything, mock.MatchedBy(func(s string) bool {
-		return s != "BLOCK" && s != "SYNC_SENTINEL"
-	}), mock.Anything).Return().Maybe()
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {}).Maybe()
+	mRenderer.LogSystemMessageFn = func(ctx context.Context, msg string, level string) {
+		if msg == "BLOCK" {
+			<-block
+		}
+		// Other messages (including SYNC_SENTINEL handled by syncBridge chaining) are no-ops
+	}
+	// StartSpinnerWithStatusFn: nil → no-op (replaces .Maybe())
 
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
 	_, _, _ = startListen(t, bridge)
@@ -51,9 +48,9 @@ func TestUIBridge_ConsentSpinnerLeak(t *testing.T) {
 	close(block)
 	syncBridge(t, bridge, mRenderer)
 
-	// 3. Assert it was eventually resumed. .Maybe() recorded it, so AssertCalled will find it.
-	mRenderer.AssertCalled(t, "StartSpinnerWithStatus", mock.Anything, " Compressing context...")
-	mRenderer.AssertExpectations(t)
+	// 3. Assert it was eventually resumed.
+	snap := mRenderer.Snapshot()
+	assert.GreaterOrEqual(t, snap.StartSpinnerWithStatus, 1, "expected StartSpinnerWithStatus to be called at least once for summarization")
 }
 
 func TestUIBridge_SystemMessageDuringConsent(t *testing.T) {
@@ -72,15 +69,21 @@ func TestUIBridge_SystemMessageDuringConsent(t *testing.T) {
 	syncBridge(t, bridge, mRenderer)
 
 	// 2. System message arrives during consent
-	mRenderer.On("LogSystemMessage", mock.Anything, "Hello", "info").Return().Once()
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {}).Maybe()
+	var msgCount int32
+	mRenderer.LogSystemMessageFn = func(ctx context.Context, msg string, level string) {
+		if msg == "Hello" && level == "info" {
+			atomic.AddInt32(&msgCount, 1)
+		}
+	}
+	// StartSpinnerWithStatusFn: nil → no-op (replaces .Maybe())
 	_ = bridge.HandleEvent(context.Background(), events.SystemMessageEvent{Message: "Hello", Level: "info"})
 	syncBridge(t, bridge, mRenderer)
 
-	// Should NOT start a spinner because isWaitingForConsent is true
-	mRenderer.AssertNotCalled(t, "StartSpinnerWithStatus", mock.Anything, mock.Anything)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&msgCount), "LogSystemMessage(Hello, info) should be called exactly once")
 
-	mRenderer.AssertExpectations(t)
+	// Should NOT start a spinner because isWaitingForConsent is true
+	snap := mRenderer.Snapshot()
+	assert.Equal(t, 0, snap.StartSpinnerWithStatus, "StartSpinnerWithStatus must NOT be called during consent")
 }
 
 func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
@@ -103,13 +106,12 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 		}
 	}
 
-	mRenderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
-	mRenderer.On("LogSystemMessage", mock.Anything, mock.MatchedBy(func(s string) bool {
-		return s != "SYNC_SENTINEL"
-	}), mock.Anything).Return().Maybe()
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(startSpinner).Maybe()
-
-	mRenderer.Test(t)
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		return startSpinner()
+	}
+	// LogTurnStatusFn: nil → no-op (replaces .Maybe())
+	// LogSystemMessageFn: nil → no-op (replaces .Maybe() with MatchedBy)
+	// REMOVED: mRenderer.Test(t) — not needed for hand-rolled mock
 
 	testCtx := context.Background()
 

--- a/internal/agent/session/ui/event_queue_test.go
+++ b/internal/agent/session/ui/event_queue_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // TestEventQueue_EnqueueNonCritical_CtxDone covers the ctx.Done() branch
@@ -22,10 +21,6 @@ import (
 func TestEventQueue_EnqueueNonCritical_CtxDone(t *testing.T) {
 	t.Parallel()
 	f := newUIBridgeFixture(t, withBridgeQueueCapacity(1))
-
-	// TurnStatusEvent sent via sendDirect will be consumed by Listen;
-	// the mock must be set up before it arrives.
-	f.renderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
 
 	// Fill the single-slot channel so the send case would block
 	f.bridge.queue.(*eventQueue).sendDirect(events.TurnStatusEvent{})
@@ -44,10 +39,6 @@ func TestEventQueue_EnqueueNonCritical_CtxDone(t *testing.T) {
 func TestEventQueue_EnqueueNonCritical_ActorDead(t *testing.T) {
 	t.Parallel()
 	f := newUIBridgeFixture(t, withBridgeQueueCapacity(1))
-
-	// TurnStatusEvent sent via sendDirect will be consumed by Listen;
-	// the mock must be set up before it arrives.
-	f.renderer.On("LogTurnStatus", mock.Anything, mock.Anything).Return().Maybe()
 
 	// Fill the single-slot channel so the send case would block
 	f.bridge.queue.(*eventQueue).sendDirect(events.TurnStatusEvent{})

--- a/internal/agent/session/ui/export_test.go
+++ b/internal/agent/session/ui/export_test.go
@@ -8,13 +8,11 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/stretchr/testify/mock"
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 )
 
 // SyncBridge is exported for use by external test packages (package ui_test).
-func SyncBridge(t *testing.T, b *Bridge, m interface {
-	On(methodName string, arguments ...interface{}) *mock.Call
-}) {
+func SyncBridge(t *testing.T, b *Bridge, m *agenttest.MockUIRenderer) {
 	syncBridge(t, b, m)
 }
 

--- a/internal/agent/session/ui/helpers_test.go
+++ b/internal/agent/session/ui/helpers_test.go
@@ -11,18 +11,30 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
-	"github.com/stretchr/testify/mock"
 )
 
-func syncBridge(t *testing.T, b *Bridge, m interface {
-	On(methodName string, arguments ...interface{}) *mock.Call
-}) {
+func syncBridge(t *testing.T, b *Bridge, m *agenttest.MockUIRenderer) {
 	t.Helper()
 	done := make(chan struct{})
-	m.On("LogSystemMessage", mock.Anything, "SYNC_SENTINEL", "info").Run(func(_ mock.Arguments) {
-		close(done)
-	}).Return().Once()
+	var once sync.Once
+	var mu sync.Mutex
+	var prev func(ctx context.Context, msg string, level string)
+
+	mu.Lock()
+	prev = m.SwapLogSystemMessageFn(func(ctx context.Context, msg string, level string) {
+		if msg == "SYNC_SENTINEL" && level == "info" {
+			once.Do(func() { close(done) })
+		}
+		mu.Lock()
+		p := prev
+		mu.Unlock()
+		if p != nil {
+			p(ctx, msg, level)
+		}
+	})
+	mu.Unlock()
 
 	if err := b.HandleEvent(context.Background(), events.SystemMessageEvent{Message: "SYNC_SENTINEL", Level: "info"}); err != nil {
 		t.Fatalf("Failed to queue sync sentinel: %v", err)

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type panicMockRenderer struct {
@@ -113,9 +112,9 @@ func TestUIBridge_PanicRecoveryLogging(t *testing.T) {
 
 	mockRenderer := new(agenttest.MockUIRenderer)
 	// This mock will panic when StartSpinnerWithStatus is called
-	mockRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mockRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
 		panic("intentional test panic")
-	}).Return(func() {})
+	}
 
 	bridge := ui.NewBridge(mockRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, _, done := ui.StartListen(t, bridge)
@@ -148,10 +147,12 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 
 	mRenderer := new(agenttest.MockUIRenderer)
 	// Mock the renderer to return a closure that panics when called.
-	// We use .Maybe() because SyncBridge might trigger resumeActiveSpinner which calls this again.
-	mRenderer.On("StartSpinnerWithStatus", mock.Anything, mock.Anything).Return(func() {
-		panic("renderer panic in stop closure")
-	}).Maybe()
+	// SyncBridge might trigger resumeActiveSpinner which calls this again.
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		return func() {
+			panic("renderer panic in stop closure")
+		}
+	}
 
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
@@ -172,9 +173,9 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 	// 3. Trigger a primary panic.
 	// This will trigger the recovery block, which calls b.stopActiveSpinner().
 	// That call will trigger the double-panic.
-	mRenderer.On("LogTurnStatus", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mRenderer.LogTurnStatusFn = func(ctx context.Context, status events.TurnStatus) {
 		panic("primary panic")
-	}).Once()
+	}
 
 	_ = bridge.HandleEvent(ctx, events.TurnStatusEvent{Status: events.TurnStatus{Mode: "test"}})
 
@@ -185,8 +186,6 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timeout waiting for bridge to shutdown after double-panic")
 	}
-
-	mRenderer.AssertExpectations(t)
 }
 
 func TestUIBridge_PoisonPill(t *testing.T) {
@@ -197,9 +196,9 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 
 	mRenderer := new(agenttest.MockUIRenderer)
 	// First event panics
-	mRenderer.On("LogTurnStatus", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+	mRenderer.LogTurnStatusFn = func(ctx context.Context, status events.TurnStatus) {
 		panic("first panic")
-	}).Once()
+	}
 
 	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
 	ctx, _, _ := ui.StartListen(t, bridge)
@@ -219,7 +218,8 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 	assert.Contains(t, output, "first panic")
 
 	// Verify that RenderResponse was NOT called (it was the second event in the queue)
-	mRenderer.AssertNotCalled(t, "RenderResponse", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	snap := mRenderer.Snapshot()
+	assert.Equal(t, 0, snap.RenderResponse, "RenderResponse must NOT be called after panic")
 }
 
 func TestUIBridge_SendToClosedChannel(t *testing.T) {


### PR DESCRIPTION
Closes #713.

## Summary
Migrate 7 consumer test files in `internal/agent/session/ui/` from testify/mock to hand-rolled `MockUIRenderer` function fields. Part of the Epic to eliminate testify/mock (Phase 2 — Consumer Migration).

### Files changed (8)
- `helpers_test.go` — `syncBridge` uses `SwapLogSystemMessageFn` with prev chaining
- `export_test.go` — `SyncBridge` signature: `mock.Call` → `*agenttest.MockUIRenderer`
- `event_queue_test.go` — `.Maybe()` guards removed (nil Fn = default no-op)
- `concurrency_test.go` — `.Once()` + `AssertExpectations` → atomic counters
- `consent_test.go` — `.MatchedBy()` → inline conditions, `.Test(t)` removed
- `panic_test.go` — `AssertNotCalled` → `Snapshot().RenderResponse` count
- `bridge_test.go` — 30+ testify chains, `.Twice()` → atomic counter, sequential Fn overwrites → switch
- `mock_ui_renderer.go` — thread-safety fix (Fn reads under mutex), `SwapLogSystemMessageFn`

## Verification
| Check | Status |
|-------|--------|
| `go test -race ./internal/agent/session/ui/...` | PASS |
| `go test -race ./internal/agent/agenttest/...` | PASS |
| `go vet` | PASS |
| Coverage (`session/ui`) | 98.9% |
| Zero `testify/mock` imports | PASS |
| Zero `.On()/.Return()/.AssertExpectations()` | PASS |
