### PR TITLE
fix(agent): migrate consumer tests to hand-rolled mock APIs (#711)

### DIFF
--- a/internal/agent/agentinternal/accessor.go
+++ b/internal/agent/agentinternal/accessor.go
@@ -25,6 +25,7 @@ package agentinternal
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/agent"
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
@@ -32,7 +33,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
-	"github.com/stretchr/testify/mock"
 )
 
 // AgentInternal wraps an agent.InternalAccessor with typed, read-only
@@ -189,30 +189,52 @@ func (a *AgentInternal) SetRuntimeConfigForTest(snap RuntimeSnapshot) {
 // Mocks
 // ---------------------------------------------------------------------
 
-// mockSessionLifecycleManager is a mock of agent.SessionLifecycleManager.
+// mockSessionLifecycleManager is a hand-rolled mock of agent.SessionLifecycleManager.
 // It must live in this package (rather than in agenttest) because its
 // BuildSessionDependencies signature references agent.CapturerInteractor,
 // which is a distinct interface declared in internal/agent.
 type mockSessionLifecycleManager struct {
-	mock.Mock
+	mu sync.Mutex
+
+	// Func fields — set by test author.
+	BuildSessionDepsFunc func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error)
+	FinalizeSessionFunc  func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error
+
+	// Call counters.
+	calledBuild    int
+	calledFinalize int
+}
+
+// Snapshot returns a race-safe copy of call counts.
+func (m *mockSessionLifecycleManager) Snapshot() map[string]int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return map[string]int{
+		"BuildSessionDependencies": m.calledBuild,
+		"FinalizeSession":          m.calledFinalize,
+	}
 }
 
 func (m *mockSessionLifecycleManager) BuildSessionDependencies(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
-	args := m.Called(ctx, cfg, configPath, newSession, capturer)
-	var deps ports.ChatterComposer
-	if raw := args.Get(0); raw != nil {
-		deps = raw.(ports.ChatterComposer)
+	m.mu.Lock()
+	m.calledBuild++
+	fn := m.BuildSessionDepsFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, cfg, configPath, newSession, capturer)
 	}
-	var hManager ports.HistoryManager
-	if args.Get(1) != nil {
-		hManager = args.Get(1).(ports.HistoryManager)
-	}
-	return deps, hManager, args.Get(2).(func(context.Context) error), args.Error(3)
+	return nil, nil, nil, nil
 }
 
 func (m *mockSessionLifecycleManager) FinalizeSession(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
-	args := m.Called(ctx, hManager, deps, cfg)
-	return args.Error(0)
+	m.mu.Lock()
+	m.calledFinalize++
+	fn := m.FinalizeSessionFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(ctx, hManager, deps, cfg)
+	}
+	return nil
 }
 
 // MockSessionLifecycleManager is a mock of agent.SessionLifecycleManager.

--- a/internal/agent/agentinternal/accessor_test.go
+++ b/internal/agent/agentinternal/accessor_test.go
@@ -5,12 +5,12 @@ package agentinternal
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"reflect"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/agent"
-	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
 	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
@@ -552,105 +552,90 @@ func TestAgentInternal_Actions(t *testing.T) {
 // exercises the nil-guarded type assertions in BuildSessionDependencies
 // to ensure they don't panic when testify returns nil values.
 func TestMockSessionLifecycleManager(t *testing.T) {
-	t.Run("BuildSessionDependencies/all non-nil", func(t *testing.T) {
+	t.Run("BuildSessionDependencies", func(t *testing.T) {
 		m := new(MockSessionLifecycleManager)
-
-		deps := &agenttest.StubChatterComposer{}
-		hm := &agenttest.MockHistoryManager{}
-		cleanup := func(ctx context.Context) error { return nil }
-
-		m.On("BuildSessionDependencies",
-			mock.Anything,
-			mock.AnythingOfType("*config.Config"),
-			mock.AnythingOfType("string"),
-			mock.AnythingOfType("bool"),
-			mock.Anything,
-		).Return(deps, hm, cleanup, nil)
-
-		gotDeps, gotHM, gotCleanup, err := m.BuildSessionDependencies(
-			context.Background(),
-			&domain_config.Config{},
-			"/some/path",
-			true,
-			nil, // CapturerInteractor — nil is fine with mock.Anything
-		)
-
-		assert.NoError(t, err)
-		assert.Same(t, deps, gotDeps, "ChatterComposer should be the same pointer")
-		assert.Same(t, hm, gotHM, "HistoryManager should be the same pointer")
-		assert.NotNil(t, gotCleanup, "cleanup function should be non-nil")
-		m.AssertExpectations(t)
+		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+			return nil, nil, nil, nil
+		}
+		_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		snap := m.Snapshot()
+		if snap["BuildSessionDependencies"] != 1 {
+			t.Errorf("BuildSessionDependencies calls: got %d, want 1", snap["BuildSessionDependencies"])
+		}
+		if snap["FinalizeSession"] != 0 {
+			t.Errorf("FinalizeSession calls: got %d, want 0", snap["FinalizeSession"])
+		}
 	})
 
-	t.Run("BuildSessionDependencies/nil deps and hm", func(t *testing.T) {
+	t.Run("BuildSessionDependencies returns values", func(t *testing.T) {
 		m := new(MockSessionLifecycleManager)
-
-		cleanup := func(ctx context.Context) error { return nil }
-
-		m.On("BuildSessionDependencies",
-			mock.Anything,
-			mock.AnythingOfType("*config.Config"),
-			mock.AnythingOfType("string"),
-			mock.AnythingOfType("bool"),
-			mock.Anything,
-		).Return(nil, nil, cleanup, nil)
-
-		gotDeps, gotHM, gotCleanup, err := m.BuildSessionDependencies(
-			context.Background(),
-			&domain_config.Config{},
-			"/some/path",
-			false,
-			nil,
-		)
-
-		// The nil guards in BuildSessionDependencies must prevent panics
-		// and leave the returned interface values as nil.
-		assert.NoError(t, err)
-		assert.Nil(t, gotDeps, "nil guard: deps should be nil")
-		assert.Nil(t, gotHM, "nil guard: hm should be nil")
-		assert.NotNil(t, gotCleanup, "cleanup function should be non-nil")
-		m.AssertExpectations(t)
+		wantCleanup := func(context.Context) error { return nil }
+		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+			return nil, nil, wantCleanup, nil
+		}
+		_, _, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cleanup == nil {
+			t.Fatal("cleanup should not be nil")
+		}
 	})
 
-	t.Run("FinalizeSession/success", func(t *testing.T) {
+	t.Run("BuildSessionDependencies returns error", func(t *testing.T) {
 		m := new(MockSessionLifecycleManager)
-
-		m.On("FinalizeSession",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-		).Return(nil)
-
-		err := m.FinalizeSession(
-			context.Background(),
-			&agenttest.MockHistoryManager{},
-			&agenttest.StubSessionFinalizer{},
-			&domain_config.Config{},
-		)
-
-		assert.NoError(t, err)
-		m.AssertExpectations(t)
+		wantErr := errors.New("build failed")
+		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+			return nil, nil, nil, wantErr
+		}
+		_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+		if err != wantErr {
+			t.Errorf("got %v; want %v", err, wantErr)
+		}
 	})
 
-	t.Run("FinalizeSession/error", func(t *testing.T) {
+	t.Run("FinalizeSession", func(t *testing.T) {
 		m := new(MockSessionLifecycleManager)
+		m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
+			return nil
+		}
+		err := m.FinalizeSession(context.Background(), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		snap := m.Snapshot()
+		if snap["FinalizeSession"] != 1 {
+			t.Errorf("FinalizeSession calls: got %d, want 1", snap["FinalizeSession"])
+		}
+	})
 
-		m.On("FinalizeSession",
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-			mock.Anything,
-		).Return(assert.AnError)
+	t.Run("FinalizeSession returns error", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+		wantErr := errors.New("finalize failed")
+		m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
+			return wantErr
+		}
+		err := m.FinalizeSession(context.Background(), nil, nil, nil)
+		if err != wantErr {
+			t.Errorf("got %v; want %v", err, wantErr)
+		}
+	})
 
-		err := m.FinalizeSession(
-			context.Background(),
-			&agenttest.MockHistoryManager{},
-			&agenttest.StubSessionFinalizer{},
-			&domain_config.Config{},
-		)
-
-		assert.Error(t, err)
-		m.AssertExpectations(t)
+	t.Run("default behavior when Fn is nil", func(t *testing.T) {
+		m := new(MockSessionLifecycleManager)
+		deps, hm, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if deps != nil || hm != nil || cleanup != nil {
+			t.Error("expected nil returns when Fn is nil")
+		}
+		err = m.FinalizeSession(context.Background(), nil, nil, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 	})
 }

--- a/internal/agent/internal_bridge_test.go
+++ b/internal/agent/internal_bridge_test.go
@@ -9,46 +9,11 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
-	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
-	"github.com/stretchr/testify/mock"
 )
-
-// mockCostTracker is a minimal mock of domain_pricing.CostTracker used
-// by bridge tests that only need a concrete value to inject/extract
-// — no method expectations are set.
-type mockCostTracker struct {
-	mock.Mock
-}
-
-func (m *mockCostTracker) GetTotalCost(ctx context.Context) float64 {
-	return m.Called(ctx).Get(0).(float64)
-}
-
-func (m *mockCostTracker) GetDailyCost(ctx context.Context) float64 {
-	return m.Called(ctx).Get(0).(float64)
-}
-
-func (m *mockCostTracker) GetStats(ctx context.Context) (domain_pricing.UsageStats, float64) {
-	args := m.Called(ctx)
-	return args.Get(0).(domain_pricing.UsageStats), args.Get(1).(float64)
-}
-
-func (m *mockCostTracker) Accumulate(mt llm.Metrics) {
-	m.Called(mt)
-}
-
-func (m *mockCostTracker) AccumulateAndReturn(mt llm.Metrics) float64 {
-	return m.Called(mt).Get(0).(float64)
-}
-
-func (m *mockCostTracker) Warmup() {
-	m.Called()
-}
-
-var _ domain_pricing.CostTracker = (*mockCostTracker)(nil)
 
 // TestInternalBridge_GettersAndSetters verifies that the five orphan
 // bridge methods on *agent — GetTrackerForInternalUse,
@@ -63,7 +28,7 @@ var _ domain_pricing.CostTracker = (*mockCostTracker)(nil)
 func TestInternalBridge_GettersAndSetters(t *testing.T) {
 	t.Run("Getter/GetTrackerForInternalUse", func(t *testing.T) {
 		a := &agent{}
-		tracker := &mockCostTracker{}
+		tracker := &agenttest.MockCostTracker{}
 		a.tracker = tracker
 
 		got := a.GetTrackerForInternalUse()
@@ -107,7 +72,7 @@ func TestInternalBridge_GettersAndSetters(t *testing.T) {
 
 	t.Run("Setter/SetTrackerForInternalUse", func(t *testing.T) {
 		a := &agent{}
-		tracker := &mockCostTracker{}
+		tracker := &agenttest.MockCostTracker{}
 
 		a.SetTrackerForInternalUse(tracker)
 		if a.tracker != tracker {

--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -20,20 +20,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-type mockToolExecutor struct {
-	mock.Mock
-}
-
-func (m *mockToolExecutor) Execute(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
-	args := m.Called(ctx, respContent, turn, maxToolTurns)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
-	}
-	return args.Get(0).(*llm.Content), args.Error(1)
-}
 
 func TestExecuteTurn_TraceEvent(t *testing.T) {
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
@@ -69,7 +56,7 @@ func TestExecuteTurn_TraceEvent(t *testing.T) {
 func TestRunPhaseLoop_EmergencySave(t *testing.T) {
 	// Mock components needed for Engine
 	gw := &agenttest.MockGateway{}
-	ex := &mockToolExecutor{}
+	ex := &agenttest.MockAgentExecutor{}
 	reg := &agenttest.MockToolRegistry{}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
@@ -535,7 +522,7 @@ func TestEngineHooks_Coverage(t *testing.T) {
 			return &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Hello"}}}, &llm.Metrics{}, nil
 		},
 	}
-	ex := &mockToolExecutor{}
+	ex := &agenttest.MockAgentExecutor{}
 	reg := &agenttest.MockToolRegistry{}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
@@ -721,7 +708,7 @@ func TestRecoveryStep_AttemptRetry_SelectContextCancelled(t *testing.T) {
 
 func TestEngineRun_Error(t *testing.T) {
 	gw := &agenttest.MockGateway{}
-	ex := &mockToolExecutor{}
+	ex := &agenttest.MockAgentExecutor{}
 	reg := &agenttest.MockToolRegistry{}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/telemetry"
 	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -792,21 +791,18 @@ func TestTruncateSafe(t *testing.T) {
 	}
 }
 
+// mockTurnHook is a simple mock implementation of TurnHook using counters,
+// matching the same pattern as orchestratortest.MockHook (which cannot be
+// imported here due to import cycle with the same-package test).
 type mockTurnHook struct {
-	mock.Mock
+	BeforeCalled int
+	AfterCalled  int
+	TransCalled  int
 }
 
-func (m *mockTurnHook) BeforeTurn(turn *Turn) {
-	m.Called(turn)
-}
-
-func (m *mockTurnHook) AfterTurn(turn *Turn, err error) {
-	m.Called(turn, err)
-}
-
-func (m *mockTurnHook) OnPhaseTransition(from, to TurnPhase, state *TurnState) {
-	m.Called(from, to, state)
-}
+func (m *mockTurnHook) BeforeTurn(turn *Turn)                                  { m.BeforeCalled++ }
+func (m *mockTurnHook) AfterTurn(turn *Turn, err error)                        { m.AfterCalled++ }
+func (m *mockTurnHook) OnPhaseTransition(from, to TurnPhase, state *TurnState) { m.TransCalled++ }
 
 func TestExecuteTurn_TraceEventBusError(t *testing.T) {
 	bus := &eventstest.MockEventBus{}

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // newProcessMessageFixtures creates the 7 mocks, chatterFactory, and ChatService
@@ -75,8 +74,9 @@ func baseSetup(
 	cleanup func(context.Context) error,
 	cfg *config.Config,
 ) {
-	sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, cap).
-		Return(deps, hm, cleanup, nil)
+	sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return deps, hm, cleanup, nil
+	}
 
 	agentMock.SetLimitsFunc = func(ctx context.Context, maxTurns, contextWindow, historyTurns int) error {
 		return nil
@@ -112,7 +112,9 @@ func TestProcessMessage_Success(t *testing.T) {
 	}
 
 	mockHM := &mockHistoryManagerForRetry{}
-	sf.On("FinalizeSession", mock.Anything, mock.Anything, mock.Anything, cfg).Return(nil)
+	sf.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, c *config.Config) error {
+		return nil
+	}
 
 	deps.EventBus = bus
 	deps.Paths = &persistence.Paths{TurnsLogPath: "turns.log"}
@@ -131,7 +133,9 @@ func TestProcessMessage_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, cleanupCalled, "cleanup should have been called")
 
-	sf.AssertExpectations(t)
+	snap := sf.Snapshot()
+	assert.Equal(t, 1, snap["BuildSessionDependencies"])
+	assert.Equal(t, 1, snap["FinalizeSession"])
 }
 
 // TestProcessMessage_BuildError verifies that a BuildSessionDependencies
@@ -141,8 +145,9 @@ func TestProcessMessage_BuildError(t *testing.T) {
 	sf, _, capturer, _, _, _, _, service := newProcessMessageFixtures(t, io.Discard)
 
 	cfg := &config.Config{Mode: "assistant"}
-	sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, capturer).
-		Return(nil, nil, func(context.Context) error { return nil }, errBuild)
+	sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return nil, nil, func(context.Context) error { return nil }, errBuild
+	}
 
 	cmd := agent.ChatCommand{ConfigPath: "config.yaml"}
 	err := service.ProcessMessage(context.Background(), cfg, cmd, capturer)
@@ -151,7 +156,8 @@ func TestProcessMessage_BuildError(t *testing.T) {
 	assert.Contains(t, err.Error(), "build error")
 	assert.ErrorIs(t, err, errBuild)
 
-	sf.AssertExpectations(t)
+	snap := sf.Snapshot()
+	assert.Equal(t, 1, snap["BuildSessionDependencies"])
 }
 
 // TestProcessMessage_CleanupErrors verifies that cleanup and event-bus
@@ -195,7 +201,9 @@ func TestProcessMessage_CleanupErrors(t *testing.T) {
 			}
 
 			mockHM := &mockHistoryManagerForRetry{}
-			sf.On("FinalizeSession", mock.Anything, mock.Anything, mock.Anything, sharedCfg).Return(nil)
+			sf.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, c *config.Config) error {
+				return nil
+			}
 
 			deps.EventBus = bus
 			deps.Paths = &persistence.Paths{TurnsLogPath: "turns.log"}
@@ -214,7 +222,9 @@ func TestProcessMessage_CleanupErrors(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Contains(t, stderr.String(), tt.stderrContains)
 
-			sf.AssertExpectations(t)
+			snap := sf.Snapshot()
+			assert.Equal(t, 1, snap["BuildSessionDependencies"])
+			assert.Equal(t, 1, snap["FinalizeSession"])
 		})
 	}
 }
@@ -239,9 +249,12 @@ func TestProcessMessage_RetrySuccess(t *testing.T) {
 	}
 
 	mockHM := &mockHistoryManagerForRetry{msg: "retry this", turns: 2}
-	sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, capturer).
-		Return(deps, mockHM, cleanup, nil)
-	sf.On("FinalizeSession", mock.Anything, mock.Anything, mock.Anything, cfg).Return(nil)
+	sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return deps, mockHM, cleanup, nil
+	}
+	sf.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, c *config.Config) error {
+		return nil
+	}
 
 	deps.EventBus = bus
 	deps.Paths = &persistence.Paths{TurnsLogPath: "turns.log"}
@@ -272,7 +285,9 @@ func TestProcessMessage_RetrySuccess(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, cleanupCalled, "cleanup should have been called")
 
-	sf.AssertExpectations(t)
+	snap := sf.Snapshot()
+	assert.Equal(t, 1, snap["BuildSessionDependencies"])
+	assert.Equal(t, 1, snap["FinalizeSession"])
 }
 
 // TestProcessMessage_RetryAborted verifies that when the user declines
@@ -291,8 +306,9 @@ func TestProcessMessage_RetryAborted(t *testing.T) {
 
 	cleanup := func(context.Context) error { return nil }
 	mockHM := &mockHistoryManagerForRetry{msg: "retry this", turns: 2}
-	sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, capturer).
-		Return(deps, mockHM, cleanup, nil)
+	sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return deps, mockHM, cleanup, nil
+	}
 
 	deps.EventBus = bus
 
@@ -303,7 +319,8 @@ func TestProcessMessage_RetryAborted(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	sf.AssertExpectations(t)
+	snap := sf.Snapshot()
+	assert.Equal(t, 1, snap["BuildSessionDependencies"])
 }
 
 // TestProcessMessage_RetryErrors verifies error paths during retry
@@ -351,8 +368,9 @@ func TestProcessMessage_RetryErrors(t *testing.T) {
 				err:   tt.hmErr,
 			}
 
-			sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, capturer).
-				Return(deps, mockHM, cleanup, nil)
+			sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+				return deps, mockHM, cleanup, nil
+			}
 
 			deps.EventBus = bus
 
@@ -409,9 +427,12 @@ func TestProcessMessage_FinalizeErrors(t *testing.T) {
 			cleanup := func(context.Context) error { return nil }
 			mockHM := &mockHistoryManagerForRetry{}
 
-			sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, capturer).
-				Return(deps, mockHM, cleanup, nil)
-			sf.On("FinalizeSession", mock.Anything, mock.Anything, mock.Anything, cfg).Return(errFinalize)
+			sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+				return deps, mockHM, cleanup, nil
+			}
+			sf.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, c *config.Config) error {
+				return errFinalize
+			}
 
 			deps.EventBus = bus
 			deps.Paths = &persistence.Paths{TurnsLogPath: "turns.log"}
@@ -444,7 +465,9 @@ func TestProcessMessage_FinalizeErrors(t *testing.T) {
 				assert.ErrorIs(t, err, tt.extraExpectedErr)
 			}
 
-			sf.AssertExpectations(t)
+			snap := sf.Snapshot()
+			assert.Equal(t, 1, snap["BuildSessionDependencies"])
+			assert.Equal(t, 1, snap["FinalizeSession"])
 		})
 	}
 }
@@ -505,15 +528,14 @@ func (m *mockHistoryManagerForRetry) GetFilePath() string { return "" }
 
 type mockFileSystemStream struct {
 	persistence.FileSystem
-	mock.Mock
+	OpenFunc func(ctx context.Context, name string) (persistence.File, error)
 }
 
 func (m *mockFileSystemStream) Open(ctx context.Context, name string) (persistence.File, error) {
-	args := m.Called(ctx, name)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	if m.OpenFunc != nil {
+		return m.OpenFunc(ctx, name)
 	}
-	return args.Get(0).(persistence.File), args.Error(1)
+	return nil, nil
 }
 
 type minimalFile struct {
@@ -550,8 +572,9 @@ func TestStreamTurnsLog(t *testing.T) {
 			name: "Success",
 			mode: "assistant",
 			setupMock: func(mFS *mockFileSystemStream) {
-				logPath := persistence.ResolvePaths(homeDir, "assistant").TurnsLogPath
-				mFS.On("Open", mock.Anything, logPath).Return(&minimalFile{Reader: strings.NewReader("turn 1: hello")}, nil)
+				mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+					return &minimalFile{Reader: strings.NewReader("turn 1: hello")}, nil
+				}
 			},
 			expectedOut: "turn 1: hello",
 			wantErr:     false,
@@ -560,8 +583,9 @@ func TestStreamTurnsLog(t *testing.T) {
 			name: "LogFileMissing",
 			mode: "developer",
 			setupMock: func(mFS *mockFileSystemStream) {
-				logPath := persistence.ResolvePaths(homeDir, "developer").TurnsLogPath
-				mFS.On("Open", mock.Anything, logPath).Return(nil, os.ErrNotExist)
+				mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+					return nil, os.ErrNotExist
+				}
 			},
 			expectedOut: "No turns log found for this session yet.\n",
 			wantErr:     false,
@@ -570,8 +594,9 @@ func TestStreamTurnsLog(t *testing.T) {
 			name: "PermissionDenied",
 			mode: "assistant",
 			setupMock: func(mFS *mockFileSystemStream) {
-				logPath := persistence.ResolvePaths(homeDir, "assistant").TurnsLogPath
-				mFS.On("Open", mock.Anything, logPath).Return(nil, os.ErrPermission)
+				mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+					return nil, os.ErrPermission
+				}
 			},
 			wantErr: true,
 			errMsg:  "failed to open turns log",
@@ -580,8 +605,9 @@ func TestStreamTurnsLog(t *testing.T) {
 			name: "ReadError",
 			mode: "assistant",
 			setupMock: func(mFS *mockFileSystemStream) {
-				logPath := persistence.ResolvePaths(homeDir, "assistant").TurnsLogPath
-				mFS.On("Open", mock.Anything, logPath).Return(&minimalFile{Reader: &errorReader{}}, nil)
+				mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+					return &minimalFile{Reader: &errorReader{}}, nil
+				}
 			},
 			wantErr: true,
 			errMsg:  "failed to stream log",
@@ -590,11 +616,12 @@ func TestStreamTurnsLog(t *testing.T) {
 			name: "CloseError",
 			mode: "assistant",
 			setupMock: func(mFS *mockFileSystemStream) {
-				logPath := persistence.ResolvePaths(homeDir, "assistant").TurnsLogPath
-				mFS.On("Open", mock.Anything, logPath).Return(&minimalFile{
-					Reader:   strings.NewReader("log content"),
-					closeErr: errors.New("close failure"),
-				}, nil)
+				mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+					return &minimalFile{
+						Reader:   strings.NewReader("log content"),
+						closeErr: errors.New("close failure"),
+					}, nil
+				}
 			},
 			expectedOut: "log content",
 			wantErr:     true,
@@ -626,7 +653,6 @@ func TestStreamTurnsLog(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expectedOut, out.String())
 			}
-			mFS.AssertExpectations(t)
 		})
 	}
 }
@@ -647,19 +673,26 @@ func (s *stubDiagComposer) GetHealthManager() ports.HealthCheckManager { return 
 // mockUIRendererForDiag embeds StubUIRenderer and overrides methods needed for RunDiagnostics assertions.
 type mockUIRendererForDiag struct {
 	agenttest.StubUIRenderer
-	mock.Mock
+	SetUseColorFunc        func(use bool)
+	IsTerminalContextFunc  func() bool
+	RenderHealthReportFunc func(ctx context.Context, report *ports.HealthReport)
 }
 
 func (m *mockUIRendererForDiag) SetUseColor(use bool) {
-	m.Called(use)
+	if m.SetUseColorFunc != nil {
+		m.SetUseColorFunc(use)
+	}
 }
-
 func (m *mockUIRendererForDiag) IsTerminalContext() bool {
-	return m.Called().Bool(0)
+	if m.IsTerminalContextFunc != nil {
+		return m.IsTerminalContextFunc()
+	}
+	return false
 }
-
 func (m *mockUIRendererForDiag) RenderHealthReport(ctx context.Context, report *ports.HealthReport) {
-	m.Called(ctx, report)
+	if m.RenderHealthReportFunc != nil {
+		m.RenderHealthReportFunc(ctx, report)
+	}
 }
 
 func TestRunDiagnostics(t *testing.T) {
@@ -680,43 +713,52 @@ func TestRunDiagnostics(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		jsonOutput bool
-		setupMock  func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag)
-		wantErr    bool
-		errMsg     string
-		checkOut   func(t *testing.T, stdout string)
+		name           string
+		jsonOutput     bool
+		expectCheckAll bool
+		setupMock      func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag)
+		wantErr        bool
+		errMsg         string
+		checkOut       func(t *testing.T, stdout string)
 	}{
 		{
-			name:       "success UI output",
-			jsonOutput: false,
+			name:           "success UI output",
+			jsonOutput:     false,
+			expectCheckAll: true,
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 				deps.HealthManager = hcm
 
-				hcm.On("CheckAll", mock.Anything).Return(healthyReport, nil)
+				hcm.CheckAllFunc = func(ctx context.Context) (*ports.HealthReport, error) {
+					return healthyReport, nil
+				}
 
-				uir.On("IsTerminalContext").Return(false)
-				uir.On("SetUseColor", false).Return()
-				uir.On("RenderHealthReport", mock.Anything, healthyReport).Return()
+				uir.IsTerminalContextFunc = func() bool { return false }
+				uir.SetUseColorFunc = func(use bool) {}
+				uir.RenderHealthReportFunc = func(ctx context.Context, report *ports.HealthReport) {}
 			},
 		},
 		{
-			name:       "success JSON output",
-			jsonOutput: true,
+			name:           "success JSON output",
+			jsonOutput:     true,
+			expectCheckAll: true,
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 				deps.HealthManager = hcm
 
-				hcm.On("CheckAll", mock.Anything).Return(healthyReport, nil)
+				hcm.CheckAllFunc = func(ctx context.Context) (*ports.HealthReport, error) {
+					return healthyReport, nil
+				}
 			},
 			checkOut: func(t *testing.T, stdout string) {
 				t.Helper()
@@ -725,12 +767,14 @@ func TestRunDiagnostics(t *testing.T) {
 			},
 		},
 		{
-			name:       "JSON marshal error",
-			jsonOutput: true,
+			name:           "JSON marshal error",
+			jsonOutput:     true,
+			expectCheckAll: true,
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 				deps.HealthManager = hcm
@@ -749,7 +793,9 @@ func TestRunDiagnostics(t *testing.T) {
 						},
 					},
 				}
-				hcm.On("CheckAll", mock.Anything).Return(unmarshalableReport, nil)
+				hcm.CheckAllFunc = func(ctx context.Context) (*ports.HealthReport, error) {
+					return unmarshalableReport, nil
+				}
 			},
 			wantErr: true,
 			errMsg:  "failed to serialize health report",
@@ -757,8 +803,9 @@ func TestRunDiagnostics(t *testing.T) {
 		{
 			name: "build deps error",
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(nil, nil, (func(context.Context) error)(nil), errBuild)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return nil, nil, nil, errBuild
+				}
 			},
 			wantErr: true,
 			errMsg:  "build error",
@@ -766,9 +813,10 @@ func TestRunDiagnostics(t *testing.T) {
 		{
 			name: "nil health manager",
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 			},
@@ -776,36 +824,44 @@ func TestRunDiagnostics(t *testing.T) {
 			errMsg:  "health check manager not available",
 		},
 		{
-			name: "CheckAll error",
+			name:           "CheckAll error",
+			expectCheckAll: true,
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 				deps.HealthManager = hcm
 
-				hcm.On("CheckAll", mock.Anything).Return(nil, errCheck)
+				hcm.CheckAllFunc = func(ctx context.Context) (*ports.HealthReport, error) {
+					return nil, errCheck
+				}
 			},
 			wantErr: true,
 			errMsg:  "health check failed: check error",
 		},
 		{
-			name:       "unhealthy report",
-			jsonOutput: false,
+			name:           "unhealthy report",
+			jsonOutput:     false,
+			expectCheckAll: true,
 			setupMock: func(sf *agentinternal.MockSessionLifecycleManager, deps *stubDiagComposer, bus *agenttest.StubEventBus, hcm *agenttest.MockHealthCheckManager, uir *mockUIRendererForDiag) {
-				cfg := &config.Config{Mode: "assistant"}
 				cleanup := func(context.Context) error { return nil }
-				sf.On("BuildSessionDependencies", mock.Anything, cfg, "config.yaml", false, nil).Return(deps, nil, cleanup, nil)
+				sf.BuildSessionDepsFunc = func(ctx context.Context, c *config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return deps, nil, cleanup, nil
+				}
 
 				deps.EventBus = bus
 				deps.HealthManager = hcm
 
-				hcm.On("CheckAll", mock.Anything).Return(unhealthyReport, nil)
+				hcm.CheckAllFunc = func(ctx context.Context) (*ports.HealthReport, error) {
+					return unhealthyReport, nil
+				}
 
-				uir.On("IsTerminalContext").Return(false)
-				uir.On("SetUseColor", false).Return()
-				uir.On("RenderHealthReport", mock.Anything, unhealthyReport).Return()
+				uir.IsTerminalContextFunc = func() bool { return false }
+				uir.SetUseColorFunc = func(use bool) {}
+				uir.RenderHealthReportFunc = func(ctx context.Context, report *ports.HealthReport) {}
 			},
 			wantErr: true,
 			errMsg:  "system health check failed",
@@ -847,20 +903,28 @@ func TestRunDiagnostics(t *testing.T) {
 				tt.checkOut(t, stdout.String())
 			}
 
-			sf.AssertExpectations(t)
-			hcm.AssertExpectations(t)
-			uir.AssertExpectations(t)
+			snap := sf.Snapshot()
+			assert.Equal(t, 1, snap["BuildSessionDependencies"])
+			checkAllCalls, _, _ := hcm.Snapshot()
+			if tt.expectCheckAll {
+				assert.Equal(t, 1, checkAllCalls)
+			} else {
+				assert.Equal(t, 0, checkAllCalls)
+			}
 		})
 	}
 }
 
 // mockHistoryBrowser is a mock implementation of ports.HistoryBrowser for testing.
 type mockHistoryBrowser struct {
-	mock.Mock
+	BrowseFunc func(ctx context.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error
 }
 
 func (m *mockHistoryBrowser) Browse(ctx context.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error {
-	return m.Called(ctx, provider, hManager).Error(0)
+	if m.BrowseFunc != nil {
+		return m.BrowseFunc(ctx, provider, hManager)
+	}
+	return nil
 }
 
 func TestBrowseHistory(t *testing.T) {
@@ -889,7 +953,9 @@ func TestBrowseHistory(t *testing.T) {
 			browser := &mockHistoryBrowser{}
 			mockHM := &mockHistoryManagerForRetry{}
 
-			browser.On("Browse", ctx, mock.Anything, mockHM).Return(tt.browseErr)
+			browser.BrowseFunc = func(ctx context.Context, provider ports.UnifiedHistoryProvider, hManager ports.HistoryManager) error {
+				return tt.browseErr
+			}
 
 			service := agent.NewChatService(
 				"home", "v1", io.Discard, io.Discard, nil,
@@ -904,8 +970,6 @@ func TestBrowseHistory(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
-
-			browser.AssertExpectations(t)
 		})
 	}
 }
@@ -998,8 +1062,9 @@ func TestChatService_StreamTurnsLog_EmptyMode(t *testing.T) {
 	// found" message.  (The empty-path guard — service.go:214 — is tested
 	// separately in TestChatService_StreamTurnsLog_EmptyPath.)
 	mFS := new(mockFileSystemStream)
-	logPath := persistence.ResolvePaths("/nonexistent", "").TurnsLogPath
-	mFS.On("Open", mock.Anything, logPath).Return(nil, os.ErrNotExist)
+	mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+		return nil, os.ErrNotExist
+	}
 
 	service := agent.NewChatService(
 		"/nonexistent", "v1", io.Discard, io.Discard, nil,
@@ -1013,7 +1078,6 @@ func TestChatService_StreamTurnsLog_EmptyMode(t *testing.T) {
 	// Empty mode → default mode; file doesn't exist → graceful message, no error.
 	assert.NoError(t, err)
 	assert.Equal(t, "No turns log found for this session yet.\n", out.String())
-	mFS.AssertExpectations(t)
 }
 
 func TestChatService_StreamTurnsLog_EmptyPath(t *testing.T) {


### PR DESCRIPTION
Closes #711.

## Summary
Migrate 4 consumer test files in `internal/agent/` and `internal/agent/orchestrator/` to use hand-rolled mock APIs, replacing testify/mock. Also converts `MockSessionLifecycleManager` (Phase 1 gap) as a precondition.

### Files changed (6)
| File | Change |
|------|--------|
| `agentinternal/accessor.go` | Convert MockSessionLifecycleManager to hand-rolled |
| `agentinternal/accessor_test.go` | Update self-tests to Snapshot() assertions |
| `internal_bridge_test.go` | Replace mockCostTracker with agenttest.MockCostTracker |
| `engine_coverage_test.go` | Replace mockToolExecutor with agenttest.MockAgentExecutor |
| `engine_test.go` | Replace testify mockTurnHook with counter-based version |
| `service_test.go` | Convert 5 mock types (33 .On() calls, 12 AssertExpectations) |

## Verification
| Check | Status |
|-------|--------|
| testify/mock imports (5 files) | 0 ✓ |
| .On() / .Return() / .AssertExpectations() | 0 ✓ |
| .Called() | 0 ✓ |
| go test -race ./internal/agent/ | PASS ✓ |
| go test -race ./internal/agent/agentinternal/ | PASS ✓ |
| go test -race ./internal/agent/orchestrator/ | PASS ✓ |
| No Snapshot().methods assertions | ✓ |
