### PR TITLE
fix(tests): migrate testify/mock consumers to hand-rolled mocks (#717)

### DIFF
--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	domaintools "github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
@@ -17,21 +17,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
-
-type mockSessionProvider struct {
-	mock.Mock
-}
-
-func (m *mockSessionProvider) GetInfo() ports.SessionInfo {
-	return m.Called().Get(0).(ports.SessionInfo)
-}
-func (m *mockSessionProvider) SetInfo(info ports.SessionInfo)        { m.Called(info) }
-func (m *mockSessionProvider) Close() error                          { return m.Called().Error(0) }
-func (m *mockSessionProvider) GetTasks() ports.TaskStore             { return nil }
-func (m *mockSessionProvider) GetSettings() ports.KVStore            { return nil }
-func (m *mockSessionProvider) GetHealthChecker() ports.HealthChecker { return nil }
 
 func TestNewToolRegistry(t *testing.T) {
 	t.Parallel()
@@ -60,7 +46,7 @@ func TestRegisterAll_WithSessionProvider(t *testing.T) {
 	t.Parallel()
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	r := registry.New()
-	sp := &mockSessionProvider{}
+	sp := &agenttest.MockSessionProvider{}
 	if err := tools.RegisterAll(tools.ToolRegistrationParams{
 		HealthManager:   nil,
 		Registry:        r,
@@ -235,28 +221,28 @@ func TestRegisterAll_Errors(t *testing.T) {
 			name:      "fail in workspace.RegisterPersistence",
 			failAfter: 21,
 			setup: func(p *tools.ToolRegistrationParams) {
-				p.SessionProvider = &mockSessionProvider{}
+				p.SessionProvider = &agenttest.MockSessionProvider{}
 			},
 		},
 		{
 			name:      "fail in analysis.Register",
 			failAfter: 25,
 			setup: func(p *tools.ToolRegistrationParams) {
-				p.SessionProvider = &mockSessionProvider{}
+				p.SessionProvider = &agenttest.MockSessionProvider{}
 			},
 		},
 		{
 			name:      "fail in developer.Register",
 			failAfter: 46,
 			setup: func(p *tools.ToolRegistrationParams) {
-				p.SessionProvider = &mockSessionProvider{}
+				p.SessionProvider = &agenttest.MockSessionProvider{}
 			},
 		},
 		{
 			name:      "fail in integrations.RegisterAll",
 			failAfter: 53,
 			setup: func(p *tools.ToolRegistrationParams) {
-				p.SessionProvider = &mockSessionProvider{}
+				p.SessionProvider = &agenttest.MockSessionProvider{}
 			},
 		},
 	}

--- a/tests/integration/agent/agent_integration_test.go
+++ b/tests/integration/agent/agent_integration_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -839,16 +838,12 @@ func TestNewAgent_ToolRegistrationFailure(t *testing.T) {
 	h := &agenttest.MockHistoryManager{}
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
-	// Use testify mock for the registry to simulate failures
-	mockRegistry := &mockToolRegistryWithExpectations{}
+	// Use hand-rolled mock registry to simulate registration failure
+	mockRegistry := agenttest.NewMockToolRegistry()
 	expectedErr := errors.New("duplicate tool schema")
+	mockRegistry.SetRegisterErr(expectedErr)
 
-	// Force the mock's registration method to return a predefined error
-	// Architectural Instruction: The pattern provided uses "RegisterInternal".
-	// Since session.RegisterInternal calls RegisterWithOptions, we bridge them here.
-	mockRegistry.On("RegisterInternal", mock.Anything).Return(expectedErr)
-
-	// Attempt to create the agent (adjust parameters to match your actual constructor)
+	// Attempt to create the agent
 	agentObj, err := agent.NewAgent(mockClient, bus, mockRegistry,
 		agent.WithHistoryManager(h),
 		agent.WithProviderName("test-provider"),
@@ -856,52 +851,9 @@ func TestNewAgent_ToolRegistrationFailure(t *testing.T) {
 		agent.WithInternalTools(),
 	)
 
-	// Architectural mandate: Ensure initialization fails fast and propagates the error
+	// Ensure initialization fails fast and propagates the error
 	assert.ErrorIs(t, err, expectedErr)
 	assert.Nil(t, agentObj)
-	mockRegistry.AssertExpectations(t)
-}
-
-// mockToolRegistryWithExpectations implements Registry using testify/mock.
-type mockToolRegistryWithExpectations struct {
-	mock.Mock
-}
-
-func (m *mockToolRegistryWithExpectations) Register(declaration *tools.ToolDeclaration, implementation tools.ToolFunc) error {
-	args := m.Called(declaration, implementation)
-	return args.Error(0)
-}
-
-func (m *mockToolRegistryWithExpectations) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
-	// To satisfy the required pattern "On('RegisterInternal', ...)",
-	// we delegate to a mockable RegisterInternal method.
-	return m.RegisterInternal(def)
-}
-
-func (m *mockToolRegistryWithExpectations) RegisterInternal(declaration interface{}) error {
-	args := m.Called(declaration)
-	return args.Error(0)
-}
-
-func (m *mockToolRegistryWithExpectations) Execute(ctx context.Context, name string, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
-	call := m.Called(ctx, name, args)
-	return call.Get(0).(tools.ToolResult), call.Error(1)
-}
-
-func (m *mockToolRegistryWithExpectations) GetDeclarations() []*tools.ToolDeclaration {
-	args := m.Called()
-	if args.Get(0) == nil {
-		return nil
-	}
-	return args.Get(0).([]*tools.ToolDeclaration)
-}
-
-func (m *mockToolRegistryWithExpectations) IsSerial(name string) bool {
-	return m.Called(name).Bool(0)
-}
-
-func (m *mockToolRegistryWithExpectations) IsLongRunning(name string) bool {
-	return m.Called(name).Bool(0)
 }
 
 func TestAgent_Shutdown_FlushError(t *testing.T) {
@@ -928,28 +880,4 @@ func TestAgent_Shutdown_FlushError(t *testing.T) {
 	output := buf.String()
 	require.Contains(t, output, "event bus flush incomplete during shutdown")
 	require.Contains(t, output, "flush failed")
-}
-
-func (m *mockToolRegistryWithExpectations) GetOptions(name string) tools.ToolOptions {
-	return tools.ToolOptions{Serial: m.IsSerial(name), LongRunning: m.IsLongRunning(name)}
-}
-
-func (m *mockToolRegistryWithExpectations) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
-	return m.Register(def, handler)
-}
-
-func (m *mockToolRegistryWithExpectations) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
-	return m.RegisterWithOptions(def, handler, opts)
-}
-
-func (m *mockToolRegistryWithExpectations) GetCoreDeclarations() []*tools.ToolDeclaration {
-	return m.GetDeclarations()
-}
-
-func (m *mockToolRegistryWithExpectations) GetDeclarationsByToolkits(toolkits []string) []*tools.ToolDeclaration {
-	return m.GetDeclarations()
-}
-
-func (m *mockToolRegistryWithExpectations) ListAvailableToolkits() []string {
-	return []string{"core"}
 }

--- a/tests/integration/agent/orchestrator/turn_engine_integration_test.go
+++ b/tests/integration/agent/orchestrator/turn_engine_integration_test.go
@@ -26,34 +26,31 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 // integrationMockExecutor defines a mock for ToolExecutor interaction.
 type integrationMockExecutor struct {
-	mock.Mock
+	ExecuteFn func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error)
 }
 
 func (m *integrationMockExecutor) Execute(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
-	args := m.Called(ctx, respContent, turn, maxToolTurns)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+	if m.ExecuteFn != nil {
+		return m.ExecuteFn(ctx, respContent, turn, maxToolTurns)
 	}
-	return args.Get(0).(*llm.Content), args.Error(1)
+	return nil, nil
 }
 
 // integrationMockLLMGateway defines a mock for LLM interaction.
 type integrationMockLLMGateway struct {
-	mock.Mock
+	GenerateFn func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error)
 }
 
 func (m *integrationMockLLMGateway) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
-	args := m.Called(ctx, input, tools, resolver)
-	if args.Get(0) == nil {
-		return nil, nil, args.Error(2)
+	if m.GenerateFn != nil {
+		return m.GenerateFn(ctx, input, tools, resolver)
 	}
-	return args.Get(0).(*llm.Content), args.Get(1).(*llm.Metrics), args.Error(2)
+	return nil, nil, nil
 }
 
 func (m *integrationMockLLMGateway) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
@@ -128,11 +125,15 @@ func TestTurnEngine_TruncationIntegration(t *testing.T) {
 
 		// 2. Action: Model returns tool call
 		modelResp := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "read_files", Args: map[string]interface{}{"path": "huge.txt"}}}}}
-		gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(modelResp, &llm.Metrics{PromptTokens: 100}, nil)
+		gw.GenerateFn = func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return modelResp, &llm.Metrics{PromptTokens: 100}, nil
+		}
 
 		// 3. Action: Tool returns massive payload
 		toolResp := &llm.Content{Role: "user", Parts: []*llm.Part{{FunctionResponse: &llm.FunctionResponse{Name: "read_files", Response: map[string]any{"content": "massive string..."}}}}}
-		exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(toolResp, nil)
+		exec.ExecuteFn = func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+			return toolResp, nil
+		}
 
 		// Set counter to return 6000 when it sees toolResp
 		counter.trigger = toolResp
@@ -213,12 +214,16 @@ func TestTurnEngine_TruncationIntegration(t *testing.T) {
 
 		// 2. Action: Model returns tool call
 		modelResp := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "search", Args: map[string]interface{}{"q": "something"}}}}}
-		gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(modelResp, &llm.Metrics{PromptTokens: 8500}, nil)
+		gw.GenerateFn = func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return modelResp, &llm.Metrics{PromptTokens: 8500}, nil
+		}
 
 		// 3. Action: Tool returns moderate payload (1000 tokens)
 		// Total will be 8500 + 1000 = 9500. 90% of 10000 is 9000. 9500 > 9000 -> Truncate.
 		toolResp := &llm.Content{Role: "user", Parts: []*llm.Part{{FunctionResponse: &llm.FunctionResponse{Name: "search", Response: map[string]any{"results": "some results"}}}}}
-		exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(toolResp, nil)
+		exec.ExecuteFn = func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+			return toolResp, nil
+		}
 
 		// Set counter for toolResponse (Scenario B)
 		counter.trigger = toolResp
@@ -324,7 +329,9 @@ func TestTurnEngine_CancellationIntegration(t *testing.T) {
 			{FunctionCall: &llm.FunctionCall{Name: "tool2", Args: map[string]any{"id": 2}}},
 		},
 	}
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(modelResp, &llm.Metrics{PromptTokens: 100}, nil)
+	gw.GenerateFn = func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+		return modelResp, &llm.Metrics{PromptTokens: 100}, nil
+	}
 
 	// 3. Execute turn in goroutine
 	errCh := make(chan error, 1)

--- a/tests/integration/agent/orchestrator/turn_engine_limit_test.go
+++ b/tests/integration/agent/orchestrator/turn_engine_limit_test.go
@@ -5,6 +5,7 @@ package orchestrator_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -19,19 +20,20 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 type limitMockLLMGateway struct {
-	mock.Mock
+	GenerateQueue []func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error)
+	generateIdx   int
 }
 
 func (m *limitMockLLMGateway) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
-	args := m.Called(ctx, input, tools, resolver)
-	if args.Get(0) == nil {
-		return nil, nil, args.Error(2)
+	if m.generateIdx < len(m.GenerateQueue) {
+		fn := m.GenerateQueue[m.generateIdx]
+		m.generateIdx++
+		return fn(ctx, input, tools, resolver)
 	}
-	return args.Get(0).(*llm.Content), args.Get(1).(*llm.Metrics), args.Error(2)
+	return nil, nil, errors.New("unexpected Generate call: queue exhausted")
 }
 
 func (m *limitMockLLMGateway) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
@@ -45,66 +47,19 @@ func (m *limitMockLLMGateway) GenerateImages(ctx context.Context, model, prompt 
 func (m *limitMockLLMGateway) RefreshAuth() error { return nil }
 
 type limitMockExecutor struct {
-	mock.Mock
+	ExecuteFn        func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error)
+	ExecuteCallCount int
 }
 
-func (m *limitMockExecutor) Execute(ctx context.Context, respContent *llm.Content, Turn int, maxToolTurns int) (*llm.Content, error) {
-	args := m.Called(ctx, respContent, Turn, maxToolTurns)
-	if args.Get(0) == nil {
-		return nil, args.Error(1)
+func (m *limitMockExecutor) Execute(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+	m.ExecuteCallCount++
+	if m.ExecuteFn != nil {
+		return m.ExecuteFn(ctx, respContent, turn, maxToolTurns)
 	}
-	return args.Get(0).(*llm.Content), args.Error(1)
+	return nil, nil
 }
 
-func TestTurnEngine_MaxTurnsLimit(t *testing.T) {
-	t.Parallel()
-	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-	eventstest.CleanupBus(t, bus)
-	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
-	h := history.NewManager(persistencetest.NewPlainOSFileSystem(), historyPath, historyPath+".archive")
-
-	counter := &sessctx.HeuristicTokenCounter{}
-	strategy := sessctx.NewStrategy(counter)
-	strategy.SetLimits(1000, 2, 10) // Limit to 2 tool turns
-
-	gw := &limitMockLLMGateway{}
-	exec := &limitMockExecutor{}
-
-	// Pipeline factory
-	factory := &sessctx.Factory{
-		History:   h,
-		Events:    bus,
-		Estimator: strategy,
-	}
-
-	cm := sessctx.NewManager(strategy, h, bus, factory)
-	cm.Pipeline = factory.BuildStandardPipeline(events.Limits{MaxHistoryTokens: 1000, MaxToolTurns: 2, MaxHistoryTurns: 10})
-
-	reg := &limitMockRegistry{}
-	engine := orchestrator.NewEngine(gw, exec, cm, reg, bus, counter)
-
-	ctx := context.Background()
-
-	// Initial user prompt
-	_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "initial prompt"}}})
-
-	// Turn 0, 1, 2: Model returns a tool call with unique arguments to avoid loop detector
-	for i := 0; i < 3; i++ {
-		modelResp := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "test", Args: map[string]interface{}{"n": i}}}}}
-		gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(modelResp, &llm.Metrics{}, nil).Once()
-	}
-
-	exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, 2).Return(&llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil).Times(3)
-
-	// Turn 2: Should be rejected by checkLimits
-	err := engine.Run(ctx, time.Now())
-	assert.Error(t, err)
-	assert.ErrorIs(t, err, llm.ErrMaxTurnsReached)
-}
-
-type limitMockRegistry struct {
-	mock.Mock
-}
+type limitMockRegistry struct{}
 
 func (m *limitMockRegistry) GetDeclarations() []*tools.ToolDeclaration {
 	return nil
@@ -128,6 +83,81 @@ func (m *limitMockRegistry) IsSerial(name string) bool {
 
 func (m *limitMockRegistry) IsLongRunning(name string) bool {
 	return false
+}
+
+func (m *limitMockRegistry) GetOptions(name string) tools.ToolOptions {
+	return tools.ToolOptions{Serial: m.IsSerial(name), LongRunning: m.IsLongRunning(name)}
+}
+
+func (m *limitMockRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return m.Register(def, handler)
+}
+
+func (m *limitMockRegistry) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return m.RegisterWithOptions(def, handler, opts)
+}
+
+func (m *limitMockRegistry) GetCoreDeclarations() []*tools.ToolDeclaration {
+	return m.GetDeclarations()
+}
+
+func (m *limitMockRegistry) GetDeclarationsByToolkits(toolkits []string) []*tools.ToolDeclaration {
+	return m.GetDeclarations()
+}
+
+func (m *limitMockRegistry) ListAvailableToolkits() []string {
+	return []string{"core"}
+}
+
+func TestTurnEngine_MaxTurnsLimit(t *testing.T) {
+	t.Parallel()
+	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+	historyPath := filepath.Join(t.TempDir(), "history.jsonl")
+	h := history.NewManager(persistencetest.NewPlainOSFileSystem(), historyPath, historyPath+".archive")
+
+	counter := &sessctx.HeuristicTokenCounter{}
+	strategy := sessctx.NewStrategy(counter)
+	strategy.SetLimits(1000, 2, 10) // Limit to 2 tool turns
+
+	gw := &limitMockLLMGateway{}
+	exec := &limitMockExecutor{
+		ExecuteFn: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+			return &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil
+		},
+	}
+
+	// Pipeline factory
+	factory := &sessctx.Factory{
+		History:   h,
+		Events:    bus,
+		Estimator: strategy,
+	}
+
+	cm := sessctx.NewManager(strategy, h, bus, factory)
+	cm.Pipeline = factory.BuildStandardPipeline(events.Limits{MaxHistoryTokens: 1000, MaxToolTurns: 2, MaxHistoryTurns: 10})
+
+	reg := &limitMockRegistry{}
+	engine := orchestrator.NewEngine(gw, exec, cm, reg, bus, counter)
+
+	ctx := context.Background()
+
+	// Initial user prompt
+	_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "initial prompt"}}})
+
+	// Turn 0, 1, 2: Model returns a tool call with unique arguments to avoid loop detector
+	for i := 0; i < 3; i++ {
+		modelResp := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "test", Args: map[string]interface{}{"n": i}}}}}
+		resp := modelResp
+		gw.GenerateQueue = append(gw.GenerateQueue, func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return resp, &llm.Metrics{}, nil
+		})
+	}
+
+	// Turn 2: Should be rejected by checkLimits
+	err := engine.Run(ctx, time.Now())
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, llm.ErrMaxTurnsReached)
 }
 
 func TestTurnEngine_ValidatePayloadLimits(t *testing.T) {
@@ -186,10 +216,11 @@ func TestTurnEngine_ValidatePayloadLimits(t *testing.T) {
 			bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 			eventstest.CleanupBus(t, bus)
 
-			exec := &limitMockExecutor{}
-			// ExecutionStep.Process calls Execute, then validatePayloadLimits.
-			// We mock Execute to return our toolResponse.
-			exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(toolResponse, nil)
+			exec := &limitMockExecutor{
+				ExecuteFn: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+					return toolResponse, nil
+				},
+			}
 
 			Turn := &orchestrator.Turn{
 				CtxManager:   cm,
@@ -226,28 +257,4 @@ func TestTurnEngine_ValidatePayloadLimits(t *testing.T) {
 			}
 		})
 	}
-}
-
-func (m *limitMockRegistry) GetOptions(name string) tools.ToolOptions {
-	return tools.ToolOptions{Serial: m.IsSerial(name), LongRunning: m.IsLongRunning(name)}
-}
-
-func (m *limitMockRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
-	return m.Register(def, handler)
-}
-
-func (m *limitMockRegistry) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
-	return m.RegisterWithOptions(def, handler, opts)
-}
-
-func (m *limitMockRegistry) GetCoreDeclarations() []*tools.ToolDeclaration {
-	return m.GetDeclarations()
-}
-
-func (m *limitMockRegistry) GetDeclarationsByToolkits(toolkits []string) []*tools.ToolDeclaration {
-	return m.GetDeclarations()
-}
-
-func (m *limitMockRegistry) ListAvailableToolkits() []string {
-	return []string{"core"}
 }

--- a/tests/integration/agent/orchestrator/turn_engine_loop_test.go
+++ b/tests/integration/agent/orchestrator/turn_engine_loop_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/history"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func TestTurnEngine_MultiStepLoopDetection(t *testing.T) {
@@ -29,8 +29,36 @@ func TestTurnEngine_MultiStepLoopDetection(t *testing.T) {
 	h := history.NewManager(persistencetest.NewPlainOSFileSystem(), historyPath, historyPath+".archive")
 	counter := &sessctx.HeuristicTokenCounter{}
 	strategy := sessctx.NewStrategy(counter)
-	gw := &limitMockLLMGateway{}
-	exec := &limitMockExecutor{}
+
+	// Sequence of responses: A -> B -> A
+	resp0 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response A"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
+	resp1 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response B"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
+	resp2 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response A"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
+	resp3 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response C"}}}
+
+	gw := &limitMockLLMGateway{
+		GenerateQueue: []func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error){
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp0, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp1, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp2, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp3, &llm.Metrics{}, nil
+			},
+		},
+	}
+
+	exec := &limitMockExecutor{
+		ExecuteFn: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+			return &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil
+		},
+	}
+
 	reg := &limitMockRegistry{}
 
 	factory := &sessctx.Factory{
@@ -45,28 +73,6 @@ func TestTurnEngine_MultiStepLoopDetection(t *testing.T) {
 	ctx := context.Background()
 
 	_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "initial"}}})
-
-	// Sequence of responses: A -> B -> A
-	// Turn 0: returns "A"
-	resp0 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response A"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
-
-	// Turn 1: returns "B"
-	resp1 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response B"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
-
-	// Turn 2: returns "A" again
-	resp2 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response A"}, {FunctionCall: &llm.FunctionCall{Name: "test"}}}}
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp0, &llm.Metrics{}, nil).Once()
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp1, &llm.Metrics{}, nil).Once()
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp2, &llm.Metrics{}, nil).Once()
-
-	// Turn 3: final response after loop breaker
-	resp3 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response C"}}}
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp3, &llm.Metrics{}, nil).Once()
-
-	exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil)
 
 	err := engine.Run(ctx, time.Now())
 	assert.NoError(t, err)
@@ -91,8 +97,36 @@ func TestTurnEngine_ToolCallLoopDetection(t *testing.T) {
 	h := history.NewManager(persistencetest.NewPlainOSFileSystem(), historyPath, historyPath+".archive")
 	counter := &sessctx.HeuristicTokenCounter{}
 	strategy := sessctx.NewStrategy(counter)
-	gw := &limitMockLLMGateway{}
-	exec := &limitMockExecutor{}
+
+	// Sequence of tool-only responses: Tool A -> Tool B -> Tool A
+	resp0 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_a"}}}}
+	resp1 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_b"}}}}
+	resp2 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_a"}}}}
+	resp3 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response Final"}}}
+
+	gw := &limitMockLLMGateway{
+		GenerateQueue: []func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error){
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp0, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp1, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp2, &llm.Metrics{}, nil
+			},
+			func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+				return resp3, &llm.Metrics{}, nil
+			},
+		},
+	}
+
+	exec := &limitMockExecutor{
+		ExecuteFn: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+			return &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil
+		},
+	}
+
 	reg := &limitMockRegistry{}
 
 	factory := &sessctx.Factory{
@@ -107,28 +141,6 @@ func TestTurnEngine_ToolCallLoopDetection(t *testing.T) {
 	ctx := context.Background()
 
 	_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "initial"}}})
-
-	// Sequence of tool-only responses: Tool A -> Tool B -> Tool A
-	// Turn 0: returns Tool A
-	resp0 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_a"}}}}
-
-	// Turn 1: returns Tool B
-	resp1 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_b"}}}}
-
-	// Turn 2: returns Tool A again
-	resp2 := &llm.Content{Role: "model", Parts: []*llm.Part{{FunctionCall: &llm.FunctionCall{Name: "tool_a"}}}}
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp0, &llm.Metrics{}, nil).Once()
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp1, &llm.Metrics{}, nil).Once()
-
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp2, &llm.Metrics{}, nil).Once()
-
-	// Turn 3: final response after loop breaker
-	resp3 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "Response Final"}}}
-	gw.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(resp3, &llm.Metrics{}, nil).Once()
-
-	exec.On("Execute", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&llm.Content{Role: "user", Parts: []*llm.Part{{Text: "result"}}}, nil)
 
 	err := engine.Run(ctx, time.Now())
 	assert.NoError(t, err)

--- a/tests/integration/agent/service_integration_test.go
+++ b/tests/integration/agent/service_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/agent/agentinternal"
 	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -28,7 +29,9 @@ func TestChatService_Initialization_Failures(t *testing.T) {
 		{
 			name: "Build Session Dependencies Failure",
 			setup: func(sf *agentinternal.MockSessionLifecycleManager) {
-				sf.On("BuildSessionDependencies", context.Background(), &config.Config{}, "config.yaml", false, nil).Return(nil, nil, func(context.Context) error { return nil }, errBuild)
+				sf.BuildSessionDepsFunc = func(_ context.Context, _ *config.Config, _ string, _ bool, _ agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+					return nil, nil, func(context.Context) error { return nil }, errBuild
+				}
 			},
 			wantErr: "build error",
 		},

--- a/tests/integration/agent/session/spinner_integration_test.go
+++ b/tests/integration/agent/session/spinner_integration_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 	"github.com/gosharplite/tell-me-go/internal/ui"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 // controlledTicker allows us to trigger ticks manually for spinner frames.
@@ -106,19 +105,14 @@ func TestSpinner_E2E_Visibility(t *testing.T) {
 	// When Chat is called, it will emit events via the event bus.
 	// Since we are testing the SessionManager's wiring, we need to capture the bridge's handleEvent function.
 	var capturedHandler func(context.Context, events.Event)
-	mChatter.On("Subscribe", mock.Anything).Run(func(args mock.Arguments) {
-		sub := args.Get(0).(func(context.Context, events.Event))
+	mChatter.SubscribeFn = func(sub func(context.Context, events.Event)) {
 		capturedHandler = sub
-	}).Return()
+	}
 
-	mChatter.On("SetLimits", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mChatter.On("Shutdown", mock.Anything).Return(nil)
-	mCapturer.On("IsTTY", mock.Anything).Return(true)
+	mCapturer.IsTTYFn = func(v any) bool { return true }
 
 	// Simulate a "Thinking" process during Chat
-	mChatter.On("Chat", mock.Anything, mock.Anything, "hello").Run(func(args mock.Arguments) {
-		ctx := args.Get(0).(context.Context)
-
+	mChatter.ChatFn = func(ctx context.Context, s *ports.Session, prompt string) error {
 		// Phase A: Inference Starts
 		capturedHandler(ctx, events.InferenceStartedEvent{})
 
@@ -149,7 +143,8 @@ func TestSpinner_E2E_Visibility(t *testing.T) {
 		capturedHandler(ctx, events.ResponseEvent{
 			Content: &llm.Content{Parts: []*llm.Part{{Text: "The Answer"}}},
 		})
-	}).Return(nil)
+		return nil
+	}
 
 	// 3. Execution
 	sCfg := session.NewSessionConfig("", false, 0, 0, false, "hello", &config.Config{

--- a/tests/integration/agent/session/summarize_test.go
+++ b/tests/integration/agent/session/summarize_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/llm/gemini"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
-	"github.com/stretchr/testify/mock"
 	"google.golang.org/genai"
 )
 
@@ -256,8 +255,11 @@ func TestSummarizeRange_Logging(t *testing.T) {
 	bus := &eventstest.TestEventBus{}
 
 	// Use real summarizer but mock gateway
-	mockG := &agenttest.MockGateway{}
-	mockG.On("Generate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(&domain_llm.Content{Role: "model", Parts: []*domain_llm.Part{{Text: "summary"}}}, &domain_llm.Metrics{}, nil)
+	mockG := &agenttest.MockGateway{
+		GenerateFunc: func(ctx context.Context, input []*domain_llm.Content, _ []*tools.ToolDeclaration, _ domain_llm.AssetResolver) (*domain_llm.Content, *domain_llm.Metrics, error) {
+			return &domain_llm.Content{Role: "model", Parts: []*domain_llm.Part{{Text: "summary"}}}, &domain_llm.Metrics{}, nil
+		},
+	}
 	summarizerImpl := llm.NewSummarizer(mockG, bus)
 
 	cm := sessctx.NewManager(strategy, hManager, bus, nil)


### PR DESCRIPTION
Closes #717.

## Summary

Replace all `.On()`/`.Return()`/`.Run()`/`.Called()`/`.AssertExpectations()` testify/mock patterns in 8 consumer test files with Phase 1 hand-rolled mock function fields.

| File | Migration |
|------|-----------|
| `internal/tools/tools_test.go` | `mockSessionProvider` → `agenttest.MockSessionProvider` |
| `tests/integration/agent/agent_integration_test.go` | `mockToolRegistryWithExpectations` → `MockToolRegistry` |
| `tests/integration/agent/orchestrator/turn_engine_integration_test.go` | `integrationMock*` → function-field structs |
| `tests/integration/agent/orchestrator/turn_engine_limit_test.go` | `limitMock*` → response-queue + call-counter |
| `tests/integration/agent/orchestrator/turn_engine_loop_test.go` | Multi-step `.Once()` → `GenerateQueue` |
| `tests/integration/agent/session/spinner_integration_test.go` | `.Run()` callbacks → `SubscribeFn`/`ChatFn` |
| `tests/integration/agent/session/summarize_test.go` | `.On().Return()` → `GenerateFunc` |
| `tests/integration/agent/service_integration_test.go` | `.On()` → `BuildSessionDepsFunc` |

## Verification

| Check | Status |
|-------|--------|
| Zero `testify/mock` imports in target paths | ✅ |
| Zero `.On()`/`.Return()`/etc. calls | ✅ |
| `go test -race ./internal/tools/... ./tests/integration/...` | PASS |
| `go vet ./internal/tools/... ./tests/integration/...` | PASS |
| Net line change | -60 (189 added, 249 removed) |