### PR TITLE
fix(agenttest): unexport StubSessionFinalizer (#736)

### DIFF
--- a/internal/agent/agenttest/helpers.go
+++ b/internal/agent/agenttest/helpers.go
@@ -318,19 +318,19 @@ func (s *StubChatterComposer) GetTurnsLogger() ports.TurnsLogger         { retur
 func (s *StubChatterComposer) GetSecurityManager() security.Manager      { return s.SecurityManager }
 func (s *StubChatterComposer) GetRegistry() (tools.Registry, error)      { return s.Registry, s.RegistryErr }
 
-// StubSessionFinalizer is a manual stub implementing ports.SessionFinalizer.
+// stubSessionFinalizer is a manual stub implementing ports.SessionFinalizer.
 // Use this when a test only needs to finalize a session (record costs).
-type StubSessionFinalizer struct {
+type stubSessionFinalizer struct {
 	Tracker          pricing.CostTracker
 	Paths            *persistence.Paths
 	PricingOverrides map[string]pricing.ModelPricing
 }
 
-var _ ports.SessionFinalizer = (*StubSessionFinalizer)(nil)
+var _ ports.SessionFinalizer = (*stubSessionFinalizer)(nil)
 
-func (s *StubSessionFinalizer) GetTracker() pricing.CostTracker { return s.Tracker }
-func (s *StubSessionFinalizer) GetPaths() *persistence.Paths    { return s.Paths }
-func (s *StubSessionFinalizer) GetPricingOverrides() map[string]pricing.ModelPricing {
+func (s *stubSessionFinalizer) GetTracker() pricing.CostTracker { return s.Tracker }
+func (s *stubSessionFinalizer) GetPaths() *persistence.Paths    { return s.Paths }
+func (s *stubSessionFinalizer) GetPricingOverrides() map[string]pricing.ModelPricing {
 	return s.PricingOverrides
 }
 

--- a/internal/agent/agenttest/helpers_test.go
+++ b/internal/agent/agenttest/helpers_test.go
@@ -351,10 +351,10 @@ func TestStubChatterComposer_NilFields_Registry(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// E. StubSessionFinalizer (3 getters)
+// E. stubSessionFinalizer (3 getters)
 // ---------------------------------------------------------------------------
 
-func TestStubSessionFinalizer_Getters(t *testing.T) {
+func Test_stubSessionFinalizer_Getters(t *testing.T) {
 	t.Parallel()
 
 	tracker := new(MockCostTracker)
@@ -363,7 +363,7 @@ func TestStubSessionFinalizer_Getters(t *testing.T) {
 		"claude": {Hit: 0.01, Miss: 0.05},
 	}
 
-	s := &StubSessionFinalizer{
+	s := &stubSessionFinalizer{
 		Tracker:          tracker,
 		Paths:            p,
 		PricingOverrides: overrides,
@@ -380,10 +380,10 @@ func TestStubSessionFinalizer_Getters(t *testing.T) {
 	}
 }
 
-func TestStubSessionFinalizer_NilFields(t *testing.T) {
+func Test_stubSessionFinalizer_NilFields(t *testing.T) {
 	t.Parallel()
 
-	s := &StubSessionFinalizer{}
+	s := &stubSessionFinalizer{}
 
 	if s.GetTracker() != nil {
 		t.Error("nil Tracker should return nil")


### PR DESCRIPTION
Closes #736.

## Summary
Unexport `StubSessionFinalizer` → `stubSessionFinalizer` in `internal/agent/agenttest/`. Rename constructor `NewStubSessionFinalizer` → `newStubSessionFinalizer` (N/A — constructor never existed).

## Changes
| File | Change |
|------|--------|
| `internal/agent/agenttest/helpers.go` | Type definition + comment + interface assertion + 3 method receivers |
| `internal/agent/agenttest/helpers_test.go` | 2 test function names (`Test_stubSessionFinalizer_*`) + 2 struct literals + 1 section comment |

## Verification
| Check | Status |
|-------|--------|
| `go fmt` | PASS |
| `go mod tidy` | PASS |
| `go build` | PASS |
| `golangci-lint` | 0 issues |
| `go test ./...` | ALL PASS |
| `go test -race ./...` | ALL PASS |
| `govulncheck` | No vulnerabilities |
| `make verify-architecture` | PASS |
| Coverage (`agenttest`) | 94.4% |