### PR TITLE
fix(agent): decompose high-complexity mock and test helper tests (#742)

### DIFF
--- a/internal/agent/agentinternal/accessor_test.go
+++ b/internal/agent/agentinternal/accessor_test.go
@@ -546,96 +546,89 @@ func TestAgentInternal_Actions(t *testing.T) {
 	}
 }
 
-// TestMockSessionLifecycleManager verifies that the testify-based
-// mockSessionLifecycleManager (defined in accessor.go) behaves correctly
-// with the standard .On(...).Return(...) pattern. In particular, it
-// exercises the nil-guarded type assertions in BuildSessionDependencies
-// to ensure they don't panic when testify returns nil values.
-func TestMockSessionLifecycleManager(t *testing.T) {
-	t.Run("BuildSessionDependencies", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
-			return nil, nil, nil, nil
-		}
-		_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		snap := m.Snapshot()
-		if snap["BuildSessionDependencies"] != 1 {
-			t.Errorf("BuildSessionDependencies calls: got %d, want 1", snap["BuildSessionDependencies"])
-		}
-		if snap["FinalizeSession"] != 0 {
-			t.Errorf("FinalizeSession calls: got %d, want 0", snap["FinalizeSession"])
-		}
-	})
+func TestMockSessionLifecycleManager_BuildSessionDeps(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return nil, nil, nil, nil
+	}
+	_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	snap := m.Snapshot()
+	if snap["BuildSessionDependencies"] != 1 {
+		t.Errorf("BuildSessionDependencies calls: got %d, want 1", snap["BuildSessionDependencies"])
+	}
+	if snap["FinalizeSession"] != 0 {
+		t.Errorf("FinalizeSession calls: got %d, want 0", snap["FinalizeSession"])
+	}
+}
 
-	t.Run("BuildSessionDependencies returns values", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		wantCleanup := func(context.Context) error { return nil }
-		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
-			return nil, nil, wantCleanup, nil
-		}
-		_, _, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if cleanup == nil {
-			t.Fatal("cleanup should not be nil")
-		}
-	})
+func TestMockSessionLifecycleManager_BuildSessionDeps_ReturnsValues(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	wantCleanup := func(context.Context) error { return nil }
+	m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return nil, nil, wantCleanup, nil
+	}
+	_, _, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup should not be nil")
+	}
+}
 
-	t.Run("BuildSessionDependencies returns error", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		wantErr := errors.New("build failed")
-		m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
-			return nil, nil, nil, wantErr
-		}
-		_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
-		if err != wantErr {
-			t.Errorf("got %v; want %v", err, wantErr)
-		}
-	})
+func TestMockSessionLifecycleManager_BuildSessionDeps_ReturnsError(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	wantErr := errors.New("build failed")
+	m.BuildSessionDepsFunc = func(ctx context.Context, cfg *domain_config.Config, configPath string, newSession bool, capturer agent.CapturerInteractor) (ports.ChatterComposer, ports.HistoryManager, func(context.Context) error, error) {
+		return nil, nil, nil, wantErr
+	}
+	_, _, _, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+	if err != wantErr {
+		t.Errorf("got %v; want %v", err, wantErr)
+	}
+}
 
-	t.Run("FinalizeSession", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
-			return nil
-		}
-		err := m.FinalizeSession(context.Background(), nil, nil, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		snap := m.Snapshot()
-		if snap["FinalizeSession"] != 1 {
-			t.Errorf("FinalizeSession calls: got %d, want 1", snap["FinalizeSession"])
-		}
-	})
+func TestMockSessionLifecycleManager_FinalizeSession(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
+		return nil
+	}
+	err := m.FinalizeSession(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	snap := m.Snapshot()
+	if snap["FinalizeSession"] != 1 {
+		t.Errorf("FinalizeSession calls: got %d, want 1", snap["FinalizeSession"])
+	}
+}
 
-	t.Run("FinalizeSession returns error", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		wantErr := errors.New("finalize failed")
-		m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
-			return wantErr
-		}
-		err := m.FinalizeSession(context.Background(), nil, nil, nil)
-		if err != wantErr {
-			t.Errorf("got %v; want %v", err, wantErr)
-		}
-	})
+func TestMockSessionLifecycleManager_FinalizeSession_Error(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	wantErr := errors.New("finalize failed")
+	m.FinalizeSessionFunc = func(ctx context.Context, hManager ports.HistoryManager, deps ports.SessionFinalizer, cfg *domain_config.Config) error {
+		return wantErr
+	}
+	err := m.FinalizeSession(context.Background(), nil, nil, nil)
+	if err != wantErr {
+		t.Errorf("got %v; want %v", err, wantErr)
+	}
+}
 
-	t.Run("default behavior when Fn is nil", func(t *testing.T) {
-		m := new(MockSessionLifecycleManager)
-		deps, hm, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if deps != nil || hm != nil || cleanup != nil {
-			t.Error("expected nil returns when Fn is nil")
-		}
-		err = m.FinalizeSession(context.Background(), nil, nil, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-	})
+func TestMockSessionLifecycleManager_DefaultBehavior(t *testing.T) {
+	m := new(MockSessionLifecycleManager)
+	deps, hm, cleanup, err := m.BuildSessionDependencies(context.Background(), nil, "", false, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if deps != nil || hm != nil || cleanup != nil {
+		t.Error("expected nil returns when Fn is nil")
+	}
+	err = m.FinalizeSession(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/internal/agent/agenttest/mock_llm_client_test.go
+++ b/internal/agent/agenttest/mock_llm_client_test.go
@@ -15,11 +15,11 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-func TestMockLLMClient_SendChat_Default(t *testing.T) {
+func TestMockLLMClient_SendChat_Default_ReturnsError(t *testing.T) {
 	t.Parallel()
 
 	m := &MockLLMClient{}
-	content, metrics, err := m.SendChat(context.Background(), nil, nil, nil)
+	_, _, err := m.SendChat(context.Background(), nil, nil, nil)
 
 	if err == nil {
 		t.Fatal("expected error, got nil")
@@ -27,12 +27,28 @@ func TestMockLLMClient_SendChat_Default(t *testing.T) {
 	if !strings.Contains(err.Error(), "not implemented") {
 		t.Errorf("got error %q; want 'not implemented'", err.Error())
 	}
+}
+
+func TestMockLLMClient_SendChat_Default_ReturnsNilValues(t *testing.T) {
+	t.Parallel()
+
+	m := &MockLLMClient{}
+	content, metrics, _ := m.SendChat(context.Background(), nil, nil, nil)
+
 	if content != nil {
 		t.Errorf("got content %+v; want nil", content)
 	}
 	if metrics != nil {
 		t.Errorf("got metrics %+v; want nil", metrics)
 	}
+}
+
+func TestMockLLMClient_SendChat_Default_RecordsSnapshot(t *testing.T) {
+	t.Parallel()
+
+	m := &MockLLMClient{}
+	_, _, err := m.SendChat(context.Background(), nil, nil, nil)
+	_ = err
 
 	sendChat, genImg, refreshAuth, generate, methods := m.snapshot()
 	if sendChat != 1 {
@@ -52,7 +68,7 @@ func TestMockLLMClient_SendChat_Default(t *testing.T) {
 	}
 }
 
-func TestMockLLMClient_SendChat_Override(t *testing.T) {
+func TestMockLLMClient_SendChat_Override_ReturnsCustomValues(t *testing.T) {
 	t.Parallel()
 
 	wantContent := &llm.Content{Role: "assistant"}
@@ -77,8 +93,27 @@ func TestMockLLMClient_SendChat_Override(t *testing.T) {
 			t.Fatalf("got metrics %+v; want %+v", metrics, wantMetrics)
 		}
 	}
+}
 
-	sendChat, genImg, refreshAuth, generate, methods := m.snapshot()
+func TestMockLLMClient_SendChat_Override_TracksCallCount(t *testing.T) {
+	t.Parallel()
+
+	wantContent := &llm.Content{Role: "assistant"}
+	wantMetrics := &llm.Metrics{PromptTokens: 10}
+
+	m := &MockLLMClient{
+		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return wantContent, wantMetrics, nil
+		},
+	}
+
+	// Call twice.
+	for range 2 {
+		_, _, err := m.SendChat(context.Background(), nil, nil, nil)
+		_ = err
+	}
+
+	sendChat, genImg, refreshAuth, generate, _ := m.snapshot()
 	if sendChat != 2 {
 		t.Errorf("sendChat = %d; want 2", sendChat)
 	}
@@ -91,6 +126,27 @@ func TestMockLLMClient_SendChat_Override(t *testing.T) {
 	if generate != 0 {
 		t.Errorf("generate = %d; want 0", generate)
 	}
+}
+
+func TestMockLLMClient_SendChat_Override_RecordsMethods(t *testing.T) {
+	t.Parallel()
+
+	wantContent := &llm.Content{Role: "assistant"}
+	wantMetrics := &llm.Metrics{PromptTokens: 10}
+
+	m := &MockLLMClient{
+		SendChatFn: func(ctx context.Context, history []*llm.Content, tl []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return wantContent, wantMetrics, nil
+		},
+	}
+
+	// Call twice.
+	for range 2 {
+		_, _, err := m.SendChat(context.Background(), nil, nil, nil)
+		_ = err
+	}
+
+	_, _, _, _, methods := m.snapshot()
 	if len(methods) != 2 {
 		t.Fatalf("len(methods) = %d; want 2", len(methods))
 	}

--- a/internal/agent/agenttest/mock_ui_renderer_test.go
+++ b/internal/agent/agenttest/mock_ui_renderer_test.go
@@ -666,7 +666,7 @@ func TestMockUIRenderer_IsTerminalContext(t *testing.T) {
 // Snapshot integration test
 // ---------------------------------------------------------------------------
 
-func TestMockUIRenderer_Snapshot_AllMethods(t *testing.T) {
+func TestMockUIRenderer_Snapshot_CalledMethods(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -697,6 +697,22 @@ func TestMockUIRenderer_Snapshot_AllMethods(t *testing.T) {
 	if snap.LogToolCall != 1 {
 		t.Errorf("LogToolCall = %d; want 1", snap.LogToolCall)
 	}
+}
+
+func TestMockUIRenderer_Snapshot_UncalledMethods(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := &MockUIRenderer{}
+
+	// Call one method from each sub-interface.
+	m.SetUseColor(true)                                     // RendererConfigurator
+	m.StartSpinner(ctx)                                     // ResponseRenderer
+	m.LogTurnStatus(ctx, events.TurnStatus{})               // StatusLogger
+	m.LogUsage(ctx, &llm.Metrics{}, "/tmp/log", time.Now()) // UsageLogger
+	m.LogToolCall(ctx, nil, 0, 0, false)                    // ToolLogger
+
+	snap := m.Snapshot()
 
 	// Uncalled counters must be 0.
 	if snap.StartSpinnerWithStatus != 0 {
@@ -723,6 +739,22 @@ func TestMockUIRenderer_Snapshot_AllMethods(t *testing.T) {
 	if snap.IsTerminalContext != 0 {
 		t.Errorf("IsTerminalContext = %d; want 0", snap.IsTerminalContext)
 	}
+}
+
+func TestMockUIRenderer_Snapshot_MethodOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	m := &MockUIRenderer{}
+
+	// Call one method from each sub-interface.
+	m.SetUseColor(true)                                     // RendererConfigurator
+	m.StartSpinner(ctx)                                     // ResponseRenderer
+	m.LogTurnStatus(ctx, events.TurnStatus{})               // StatusLogger
+	m.LogUsage(ctx, &llm.Metrics{}, "/tmp/log", time.Now()) // UsageLogger
+	m.LogToolCall(ctx, nil, 0, 0, false)                    // ToolLogger
+
+	snap := m.Snapshot()
 
 	// Methods slice must have correct order and length.
 	wantMethods := []string{"SetUseColor", "StartSpinner", "LogTurnStatus", "LogUsage", "LogToolCall"}


### PR DESCRIPTION
Closes #742.

## Summary
Decomposed 4 high-complexity test functions in the agent mock and test helper layer from up to 17 down to less than or equal to 9 cyclomatic complexity via extraction to standalone top-level test functions. Zero behavioral changes.

| Original Function | Before | After | Functions Created |
|---|---|---|---|
| TestMockLLMClient_SendChat_Default | 11 | max 7 | 3 |
| TestMockLLMClient_SendChat_Override | 12 | max 6 | 3 |
| TestMockUIRenderer_Snapshot_AllMethods | 17 | max 9 | 3 |
| TestMockSessionLifecycleManager | 15 | max 6 | 6 |

Key insight: t.Run subtest decomposition does not reduce gocyclo complexity because closures are part of the parent function AST node. The fix extracts each scenario to a standalone top-level Test* function.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Lint (golangci-lint) | 0 issues |
| Race detection | PASS |
| All 4 functions complexity target met | PASS |