### PR TITLE
fix(persistence): decompose high-complexity test functions (#743)

### DIFF
--- a/internal/infrastructure/persistence/memory_store_test.go
+++ b/internal/infrastructure/persistence/memory_store_test.go
@@ -642,30 +642,48 @@ func TestMemoryListStore_ReadAll_CompletedTruncation(t *testing.T) {
 	}
 
 	t.Run("total_count", func(t *testing.T) {
-		if len(items) != 502 {
-			t.Errorf("expected 502 items (2 active + 500 most recent completed), got %d", len(items))
-		}
+		runReadAllTotalCount(t, items)
 	})
-
 	t.Run("active_present", func(t *testing.T) {
-		if len(items) < 2 {
-			t.Fatalf("expected at least 2 items, got %d", len(items))
-		}
-		if items[0].ID != 1 || items[0].Status != "pending" {
-			t.Errorf("first item should be active task ID 1, got ID %d status %s", items[0].ID, items[0].Status)
-		}
-		if items[1].ID != 2 || items[1].Status != "pending" {
-			t.Errorf("second item should be active task ID 2, got ID %d status %s", items[1].ID, items[1].Status)
-		}
+		runReadAllActivePresent(t, items)
 	})
-
 	t.Run("completed_truncation", func(t *testing.T) {
-		// The remaining 500 should be completed tasks IDs 103–602
-		completedSlice := items[2:]
+		runReadAllCompletedTruncation(t, items)
+	})
+}
+
+func runReadAllTotalCount(t *testing.T, items []ports.Task) {
+	t.Helper()
+	if len(items) != 502 {
+		t.Errorf("expected 502 items (2 active + 500 most recent completed), got %d", len(items))
+	}
+}
+
+func runReadAllActivePresent(t *testing.T, items []ports.Task) {
+	t.Helper()
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 items, got %d", len(items))
+	}
+	if items[0].ID != 1 || items[0].Status != "pending" {
+		t.Errorf("first item should be active task ID 1, got ID %d status %s", items[0].ID, items[0].Status)
+	}
+	if items[1].ID != 2 || items[1].Status != "pending" {
+		t.Errorf("second item should be active task ID 2, got ID %d status %s", items[1].ID, items[1].Status)
+	}
+}
+
+func runReadAllCompletedTruncation(t *testing.T, items []ports.Task) {
+	t.Helper()
+	// The remaining 500 should be completed tasks IDs 103–602
+	completedSlice := items[2:]
+
+	t.Run("slice_length", func(t *testing.T) {
 		if len(completedSlice) != 500 {
 			t.Fatalf("expected 500 completed items, got %d", len(completedSlice))
 		}
+	})
 
+	t.Run("slice_boundaries", func(t *testing.T) {
 		// Verify first completed is ID 103 (oldest retained)
 		if completedSlice[0].ID != 103 {
 			t.Errorf("first completed item should be ID 103, got ID %d", completedSlice[0].ID)
@@ -674,14 +692,18 @@ func TestMemoryListStore_ReadAll_CompletedTruncation(t *testing.T) {
 		if completedSlice[499].ID != 602 {
 			t.Errorf("last completed item should be ID 602, got ID %d", completedSlice[499].ID)
 		}
+	})
 
+	t.Run("all_status_completed", func(t *testing.T) {
 		// Verify all items in completed slice have status "completed"
 		for _, item := range completedSlice {
 			if item.Status != "completed" {
 				t.Errorf("item ID %d has status %q, want %q", item.ID, item.Status, "completed")
 			}
 		}
+	})
 
+	t.Run("oldest_truncated", func(t *testing.T) {
 		// Verify oldest completed tasks (IDs 3–102) are NOT present
 		ids := make(map[int64]bool, len(items))
 		for _, item := range items {

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -214,6 +214,22 @@ func TestSessionState_HydrateInfo_CorruptedStateFile(t *testing.T) {
 
 	info := state.GetInfo()
 
+	t.Run("env_defaults", func(t *testing.T) {
+		runHydrateInfoCheckEnv(t, info)
+	})
+	t.Run("paths_defaults", func(t *testing.T) {
+		runHydrateInfoCheckPaths(t, info, tempDir)
+	})
+	t.Run("active_toolkits_default", func(t *testing.T) {
+		runHydrateInfoCheckToolkits(t, info)
+	})
+	t.Run("model_provider_defaults", func(t *testing.T) {
+		runHydrateInfoCheckModelProvider(t, info)
+	})
+}
+
+func runHydrateInfoCheckEnv(t *testing.T, info ports.SessionInfo) {
+	t.Helper()
 	// Corrupted unmarshal is silently swallowed; defaults must be populated.
 	if info.Env == nil {
 		t.Error("expected non-nil Env map (default fallback)")
@@ -221,21 +237,30 @@ func TestSessionState_HydrateInfo_CorruptedStateFile(t *testing.T) {
 	if info.Env["STORAGE_TYPE"] != "sqlite" {
 		t.Errorf("expected STORAGE_TYPE to be sqlite, got %s", info.Env["STORAGE_TYPE"])
 	}
+}
 
+func runHydrateInfoCheckPaths(t *testing.T, info ports.SessionInfo, tempDir string) {
+	t.Helper()
 	if info.Paths == nil {
 		t.Error("expected non-nil Paths map (default fallback)")
 	}
 	if info.Paths["config_dir"] != tempDir {
 		t.Errorf("expected config_dir to be %s, got %s", tempDir, info.Paths["config_dir"])
 	}
+}
 
+func runHydrateInfoCheckToolkits(t *testing.T, info ports.SessionInfo) {
+	t.Helper()
 	if info.ActiveToolkits == nil {
 		t.Error("expected non-nil ActiveToolkits slice (default fallback)")
 	}
 	if len(info.ActiveToolkits) != 0 {
 		t.Errorf("expected empty ActiveToolkits, got %v", info.ActiveToolkits)
 	}
+}
 
+func runHydrateInfoCheckModelProvider(t *testing.T, info ports.SessionInfo) {
+	t.Helper()
 	if info.Model != "" {
 		t.Errorf("expected Model to be empty, got %q", info.Model)
 	}


### PR DESCRIPTION
Closes #743.

## Summary
Decomposed 2 high-complexity test functions in the persistence layer into standalone helper functions, following the existing codebase pattern (`runKV*`, `runList*`).

| Function | Before | After | Method |
|----------|:---:|:---:|---|
| `TestMemoryListStore_ReadAll_CompletedTruncation` | **17** | **3** | Extracted into `runReadAllTotalCount`, `runReadAllActivePresent`, `runReadAllCompletedTruncation` |
| `TestSessionState_HydrateInfo_CorruptedStateFile` | **11** | **3** | Extracted into `runHydrateInfoCheckEnv`, `runHydrateInfoCheckPaths`, `runHydrateInfoCheckToolkits`, `runHydrateInfoCheckModelProvider` |

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | PASS |
| Complexity (both ≤10) | ✅ 3 each |
| `go test ./internal/infrastructure/persistence/...` | PASS |
| No behavioral changes | ✅ All assertions preserved verbatim |
