### PR TITLE
refactor(llm): decompose high-complexity test functions (#741)

### DIFF
--- a/internal/domain/ports/factory_test.go
+++ b/internal/domain/ports/factory_test.go
@@ -24,53 +24,36 @@ func TestClientFactoryFunc_NewClient(t *testing.T) {
 		logger Logger
 	)
 
-	tests := []struct {
-		name      string
-		factory   ClientFactoryFunc
-		wantNil   bool
-		wantErr   bool
-		errTarget error
-	}{
-		{
-			name: "success: returns client and nil error",
-			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
-				return nil, nil
-			},
-			wantNil: true,
-			wantErr: false,
-		},
-		{
-			name: "error: returns nil client and error",
-			factory: func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
-				return nil, ErrHistoryNotFound
-			},
-			wantNil:   true,
-			wantErr:   true,
-			errTarget: ErrHistoryNotFound,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			client, err := tt.factory.NewClient(cfg, pd, bus, logger)
-
-			if tt.wantNil && client != nil {
-				t.Errorf("expected nil client, got %+v", client)
-			}
-			if !tt.wantNil && client == nil {
-				t.Error("expected non-nil client, got nil")
-			}
-			if tt.wantErr && err == nil {
-				t.Error("expected error, got nil")
-			}
-			if !tt.wantErr && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-			if tt.errTarget != nil && err != tt.errTarget {
-				t.Errorf("expected error %v, got %v", tt.errTarget, err)
-			}
+	t.Run("success: returns client and nil error", func(t *testing.T) {
+		factory := ClientFactoryFunc(func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+			return nil, nil
 		})
-	}
+		client, err := factory.NewClient(cfg, pd, bus, logger)
+
+		if client != nil {
+			t.Errorf("expected nil client, got %+v", client)
+		}
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("error: returns nil client and error", func(t *testing.T) {
+		factory := ClientFactoryFunc(func(cfg *config.Config, pd pricing.PricingData, bus events.EventBus, logger Logger) (llm.ExtendedClient, error) {
+			return nil, ErrHistoryNotFound
+		})
+		client, err := factory.NewClient(cfg, pd, bus, logger)
+
+		if client != nil {
+			t.Errorf("expected nil client, got %+v", client)
+		}
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if err != ErrHistoryNotFound {
+			t.Errorf("expected error %v, got %v", ErrHistoryNotFound, err)
+		}
+	})
 }
 
 func TestClientFactoryFunc_NewFailoverChain(t *testing.T) {

--- a/internal/infrastructure/llm/factory_test.go
+++ b/internal/infrastructure/llm/factory_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
+	domainLLM "github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 )
@@ -519,13 +520,67 @@ func TestFactory_MaxTokensAboveSoftCeiling_EmitsWarning(t *testing.T) {
 	}
 }
 
+// newOpenAIMockServer creates an httptest server that responds with a minimal
+// valid OpenAI chat completion response.
+func newOpenAIMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// newTestBus creates a simple synchronous event bus for tests.
+func newTestBus(t *testing.T) events.EventBus {
+	t.Helper()
+	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+	return bus
+}
+
+// assertNewClientError validates the error-path contract for DefaultClientFactory.NewClient:
+// returns nil client and non-nil error when createAuthenticator fails.
+func assertNewClientError(t *testing.T, client domainLLM.ExtendedClient, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error for provider with missing API key")
+	}
+	if client != nil {
+		t.Errorf("expected nil client on error, got %v", client)
+	}
+}
+
+// assertFailoverChainAuthError validates the error-path contract for
+// DefaultClientFactory.NewFailoverChain when a provider has a missing API key.
+func assertFailoverChainAuthError(t *testing.T, gw domainLLM.ExtendedClient, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error for provider with missing API key")
+	}
+	if !strings.Contains(err.Error(), `failover chain`) {
+		t.Errorf("expected error to contain 'failover chain', got: %v", err)
+	}
+	if gw != nil {
+		t.Errorf("expected nil gateway on error, got %v", gw)
+	}
+}
+
+// assertFailoverChainEmptyOrder validates the empty failover order contract:
+// returns non-nil gateway (Go nil-interface quirk documented in code) and nil error.
+func assertFailoverChainEmptyOrder(t *testing.T, gw domainLLM.ExtendedClient, err error) {
+	t.Helper()
+	if gw != nil {
+		t.Log("known Go nil-interface behavior: nil *FailoverGateway stored in llm.ExtendedClient is non-nil")
+	}
+	if err != nil {
+		t.Errorf("expected nil error for empty failover order, got %v", err)
+	}
+}
+
 func TestDefaultClientFactory(t *testing.T) {
 	t.Run("NewClient delegates and returns client", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			SelectedProvider: "openai",
 			Providers: map[string]config.LLMProvider{
@@ -537,9 +592,7 @@ func TestDefaultClientFactory(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		factory := &DefaultClientFactory{}
 		client, err := factory.NewClient(cfg, pricing.PricingData{}, bus, nil)
 		if err != nil {
@@ -548,8 +601,6 @@ func TestDefaultClientFactory(t *testing.T) {
 		if client == nil {
 			t.Fatal("NewClient() returned nil client")
 		}
-
-		// Verify the client is functional.
 		_, _, sendErr := client.SendChat(context.Background(), nil, nil, nil)
 		if sendErr != nil {
 			t.Errorf("SendChat on constructed client failed: %v", sendErr)
@@ -566,25 +617,14 @@ func TestDefaultClientFactory(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		factory := &DefaultClientFactory{}
 		client, err := factory.NewClient(cfg, pricing.PricingData{}, bus, nil)
-		if err == nil {
-			t.Fatal("expected error for provider with missing API key")
-		}
-		if client != nil {
-			t.Errorf("expected nil client on error, got %v", client)
-		}
+		assertNewClientError(t, client, err)
 	})
 
 	t.Run("NewFailoverChain delegates and returns gateway", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			FailoverOrder: []string{"openai"},
 			Providers: map[string]config.LLMProvider{
@@ -596,9 +636,7 @@ func TestDefaultClientFactory(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		factory := &DefaultClientFactory{}
 		gw, err := factory.NewFailoverChain(cfg, pricing.PricingData{}, bus, nil)
 		if err != nil {
@@ -607,8 +645,6 @@ func TestDefaultClientFactory(t *testing.T) {
 		if gw == nil {
 			t.Fatal("NewFailoverChain() returned nil gateway")
 		}
-
-		// Verify the gateway is functional.
 		_, _, sendErr := gw.SendChat(context.Background(), nil, nil, nil)
 		if sendErr != nil {
 			t.Errorf("SendChat on constructed gateway failed: %v", sendErr)
@@ -616,26 +652,15 @@ func TestDefaultClientFactory(t *testing.T) {
 	})
 
 	t.Run("NewFailoverChain returns nil,nil for empty order", func(t *testing.T) {
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		factory := &DefaultClientFactory{}
 		cfg := &config.Config{FailoverOrder: nil}
 		gw, err := factory.NewFailoverChain(cfg, pricing.PricingData{}, bus, nil)
-		if gw != nil {
-			t.Log("known Go nil-interface behavior: nil *FailoverGateway stored in llm.ExtendedClient is non-nil")
-		}
-		if err != nil {
-			t.Errorf("expected nil error for empty failover order, got %v", err)
-		}
+		assertFailoverChainEmptyOrder(t, gw, err)
 	})
 
 	t.Run("NewFailoverChain returns error for auth failure", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			FailoverOrder: []string{"openai", "anthropic"},
 			Providers: map[string]config.LLMProvider{
@@ -652,21 +677,58 @@ func TestDefaultClientFactory(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		factory := &DefaultClientFactory{}
 		gw, err := factory.NewFailoverChain(cfg, pricing.PricingData{}, bus, nil)
-		if err == nil {
-			t.Fatal("expected error for provider with missing API key")
-		}
-		if !strings.Contains(err.Error(), `failover chain`) {
-			t.Errorf("expected error to contain 'failover chain', got: %v", err)
+		assertFailoverChainAuthError(t, gw, err)
+	})
+}
+
+// assertNewFailoverChainEmpty validates the empty failover order result:
+// gw must be nil, err must be nil.
+func assertNewFailoverChainEmpty(t *testing.T, gw *FailoverGateway, err error) {
+	t.Helper()
+	if gw != nil {
+		t.Errorf("expected nil gateway for empty failover order, got %v", gw)
+	}
+	if err != nil {
+		t.Errorf("expected nil error for empty failover order, got %v", err)
+	}
+}
+
+// assertNewFailoverChainAuthError validates the auth error result:
+// gw must be nil, err must contain the expected wrapped message.
+func assertNewFailoverChainAuthError(t *testing.T, gw *FailoverGateway, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error for provider with missing API key")
+	}
+	if !strings.Contains(err.Error(), `failover chain: provider "anthropic"`) {
+		t.Errorf("expected error to contain 'failover chain: provider \"anthropic\"', got: %v", err)
+	}
+	if gw != nil {
+		t.Errorf("expected nil gateway on error, got %v", gw)
+	}
+}
+
+// assertNewFailoverChainGeminiResult validates the Gemini SDK init result.
+// When ADC is available the SDK init succeeds (gw non-nil, err nil);
+// when ADC is unavailable it fails with a wrapped error.
+func assertNewFailoverChainGeminiResult(t *testing.T, gw *FailoverGateway, err error) {
+	t.Helper()
+	if err != nil {
+		if !strings.Contains(err.Error(), `failover chain: provider "gemini"`) {
+			t.Errorf("expected error to contain 'failover chain: provider \"gemini\"', got: %v", err)
 		}
 		if gw != nil {
 			t.Errorf("expected nil gateway on error, got %v", gw)
 		}
-	})
+	} else {
+		t.Log("ADC available — Gemini SDK init succeeded, error path not hit")
+		if gw == nil {
+			t.Error("expected non-nil gateway when SDK init succeeds")
+		}
+	}
 }
 
 func TestNewFailoverChain(t *testing.T) {
@@ -674,24 +736,13 @@ func TestNewFailoverChain(t *testing.T) {
 		cfg := &config.Config{
 			FailoverOrder: nil,
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		gw, err := newFailoverChain(cfg, pricing.PricingData{}, bus, nil)
-		if gw != nil {
-			t.Errorf("expected nil gateway for empty failover order, got %v", gw)
-		}
-		if err != nil {
-			t.Errorf("expected nil error for empty failover order, got %v", err)
-		}
+		assertNewFailoverChainEmpty(t, gw, err)
 	})
 
 	t.Run("single valid provider constructs gateway", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			FailoverOrder: []string{"openai"},
 			Providers: map[string]config.LLMProvider{
@@ -703,9 +754,7 @@ func TestNewFailoverChain(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		gw, err := newFailoverChain(cfg, pricing.PricingData{}, bus, nil)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -713,8 +762,6 @@ func TestNewFailoverChain(t *testing.T) {
 		if gw == nil {
 			t.Fatal("expected non-nil gateway")
 		}
-
-		// Verify the gateway is functional by calling SendChat.
 		_, _, sendErr := gw.SendChat(context.Background(), nil, nil, nil)
 		if sendErr != nil {
 			t.Errorf("SendChat on constructed gateway failed: %v", sendErr)
@@ -722,11 +769,7 @@ func TestNewFailoverChain(t *testing.T) {
 	})
 
 	t.Run("auth error in chain provider returns wrapped error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			FailoverOrder: []string{"openai", "anthropic"},
 			Providers: map[string]config.LLMProvider{
@@ -743,27 +786,13 @@ func TestNewFailoverChain(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		gw, err := newFailoverChain(cfg, pricing.PricingData{}, bus, nil)
-		if err == nil {
-			t.Fatal("expected error for provider with missing API key")
-		}
-		if !strings.Contains(err.Error(), `failover chain: provider "anthropic"`) {
-			t.Errorf("expected error to contain 'failover chain: provider \"anthropic\"', got: %v", err)
-		}
-		if gw != nil {
-			t.Errorf("expected nil gateway on error, got %v", gw)
-		}
+		assertNewFailoverChainAuthError(t, gw, err)
 	})
 
 	t.Run("Gemini SDK init error in chain provider returns wrapped error", func(t *testing.T) {
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
-		}))
-		defer server.Close()
-
+		server := newOpenAIMockServer(t)
 		cfg := &config.Config{
 			FailoverOrder: []string{"openai", "gemini"},
 			Providers: map[string]config.LLMProvider{
@@ -781,22 +810,8 @@ func TestNewFailoverChain(t *testing.T) {
 				},
 			},
 		}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
+		bus := newTestBus(t)
 		gw, err := newFailoverChain(cfg, pricing.PricingData{}, bus, nil)
-		if err != nil {
-			if !strings.Contains(err.Error(), `failover chain: provider "gemini"`) {
-				t.Errorf("expected error to contain 'failover chain: provider \"gemini\"', got: %v", err)
-			}
-			if gw != nil {
-				t.Errorf("expected nil gateway on error, got %v", gw)
-			}
-		} else {
-			t.Log("ADC available — Gemini SDK init succeeded, error path not hit")
-			if gw == nil {
-				t.Error("expected non-nil gateway when SDK init succeeds")
-			}
-		}
+		assertNewFailoverChainGeminiResult(t, gw, err)
 	})
 }

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -793,109 +793,167 @@ func (l *captureErrorLogger) Error(msg string, args ...any) {
 	}
 }
 
+// runApplyThinkingBudgetWithCanceledCtx creates a Client with thinkingBudget=3000,
+// maxThinkingBudget=1024, and a captureErrorLogger. It calls applyThinkingBudget
+// with a canceled context and returns the captured log message, KV args, and the
+// config (so callers can inspect the capped budget).
+func runApplyThinkingBudgetWithCanceledCtx(t *testing.T) (capturedMsg string, capturedKV []any, config *genai.ThinkingConfig) {
+	t.Helper()
+
+	captureLogger := &captureErrorLogger{
+		errorFn: func(msg string, args ...any) {
+			capturedMsg = msg
+			capturedKV = args
+		},
+	}
+
+	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+
+	c := &Client{
+		eventBus:          bus,
+		logger:            captureLogger,
+		thinkingBudget:    3000,
+		maxThinkingBudget: 1024,
+		model:             "test-model",
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	config = &genai.ThinkingConfig{}
+	c.applyThinkingBudget(ctx, config, 3000, 1024, "test-model")
+
+	return capturedMsg, capturedKV, config
+}
+
+// newThinkingCaptureServer creates an httptest server that captures the
+// thinkingConfig from the incoming request's generationConfig and responds
+// with a minimal valid GenerateContentResponse.
+// Returns the server and a pointer to the captured config map.
+func newThinkingCaptureServer(t *testing.T) (*httptest.Server, *map[string]any) {
+	t.Helper()
+	var captured map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("failed to decode request body: %v", err)
+		}
+		if gc, ok := body["generationConfig"].(map[string]any); ok {
+			if tc, ok := gc["thinkingConfig"].(map[string]any); ok {
+				captured = tc
+			}
+		}
+		resp := genai.GenerateContentResponse{
+			Candidates: []*genai.Candidate{{
+				Content: &genai.Content{Parts: []*genai.Part{{Text: "OK"}}},
+			}},
+		}
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			t.Errorf("failed to encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server, &captured
+}
+
+// newGeminiClientForThinking creates a Client pointed at the given server
+// with standard Vertex AI URL construction and common options.
+func newGeminiClientForThinking(t *testing.T, server *httptest.Server, opts ...geminiOption) *Client {
+	t.Helper()
+	apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
+	authenticator := &auth.BearerAuth{Token: "test-token"}
+	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+	opts = append(opts, WithEventBus(bus), WithTimeout(5*time.Second))
+	client, err := NewClient(apiURL, "test-model", authenticator, opts...)
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	return client
+}
+
+// assertThinkingConfigLevelOnly validates the captured thinking config
+// for the "level-only, budget=0" scenario.
+func assertThinkingConfigLevelOnly(t *testing.T, captured *map[string]any) {
+	t.Helper()
+	if *captured == nil {
+		t.Fatal("expected thinkingConfig in request")
+	}
+	if includeThoughts, _ := (*captured)["includeThoughts"].(bool); !includeThoughts {
+		t.Error("expected includeThoughts=true")
+	}
+	if level, _ := (*captured)["thinkingLevel"].(string); level != "high" {
+		t.Errorf("expected thinkingLevel='high', got %q", level)
+	}
+	if _, hasBudget := (*captured)["thinkingBudget"]; hasBudget {
+		t.Error("expected thinkingBudget to be absent when budget=0")
+	}
+}
+
+// assertNoThinkingConfig validates that no thinkingConfig was sent.
+func assertNoThinkingConfig(t *testing.T, captured *map[string]any) {
+	t.Helper()
+	if *captured != nil {
+		t.Errorf("expected no thinkingConfig, got %+v", *captured)
+	}
+}
+
+// assertLogArgsContainEventTypeAndError validates that the captured KV log args
+// contain event_type=SystemMessageEvent and an error key.
+func assertLogArgsContainEventTypeAndError(t *testing.T, capturedKV []any) {
+	t.Helper()
+	var foundEventType, foundError bool
+	for i := 0; i+1 < len(capturedKV); i += 2 {
+		key, ok := capturedKV[i].(string)
+		if !ok {
+			continue
+		}
+		switch key {
+		case "event_type":
+			if val, ok := capturedKV[i+1].(string); ok && val == "SystemMessageEvent" {
+				foundEventType = true
+			}
+		case "error":
+			foundError = true
+		}
+	}
+	if !foundEventType {
+		t.Error("expected event_type=SystemMessageEvent in log args")
+	}
+	if !foundError {
+		t.Error("expected error key in log args")
+	}
+}
+
 func TestApplyThinkingBudget_PublishError(t *testing.T) {
 	t.Run("logs error when SafePublish returns non-ErrBusNotInitialized error", func(t *testing.T) {
-		var capturedMsg string
-		var capturedKV []any
-		captureLogger := &captureErrorLogger{
-			errorFn: func(msg string, args ...any) {
-				capturedMsg = msg
-				capturedKV = args
-			},
-		}
 
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
-		c := &Client{
-			eventBus:          bus,
-			logger:            captureLogger,
-			thinkingBudget:    3000,
-			maxThinkingBudget: 1024,
-			model:             "test-model",
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		config := &genai.ThinkingConfig{}
-		c.applyThinkingBudget(ctx, config, 3000, 1024, "test-model")
-
-		// Budget must still be capped
-		if config.ThinkingBudget == nil || *config.ThinkingBudget != 1024 {
-			t.Errorf("expected budget capped at 1024, got %v", config.ThinkingBudget)
-		}
-
-		// Logger.Error must have been called with "event_publish_failed"
-		if capturedMsg != "event_publish_failed" {
-			t.Errorf("expected Error log 'event_publish_failed', got %q", capturedMsg)
-		}
-
-		// Verify KV args contain expected keys
-		var foundEventType, foundError bool
-		for i := 0; i+1 < len(capturedKV); i += 2 {
-			key, ok := capturedKV[i].(string)
-			if !ok {
-				continue
+		t.Run("caps_budget_at_max", func(t *testing.T) {
+			_, _, config := runApplyThinkingBudgetWithCanceledCtx(t)
+			if config.ThinkingBudget == nil || *config.ThinkingBudget != 1024 {
+				t.Errorf("expected budget capped at 1024, got %v", config.ThinkingBudget)
 			}
-			switch key {
-			case "event_type":
-				if val, ok := capturedKV[i+1].(string); ok && val == "SystemMessageEvent" {
-					foundEventType = true
-				}
-			case "error":
-				foundError = true
+		})
+
+		t.Run("logs_event_publish_failed", func(t *testing.T) {
+			capturedMsg, _, _ := runApplyThinkingBudgetWithCanceledCtx(t)
+			if capturedMsg != "event_publish_failed" {
+				t.Errorf("expected Error log 'event_publish_failed', got %q", capturedMsg)
 			}
-		}
-		if !foundEventType {
-			t.Error("expected event_type=SystemMessageEvent in log args")
-		}
-		if !foundError {
-			t.Error("expected error key in log args")
-		}
+		})
+
+		t.Run("log_args_contain_event_type_and_error", func(t *testing.T) {
+			_, capturedKV, _ := runApplyThinkingBudgetWithCanceledCtx(t)
+			assertLogArgsContainEventTypeAndError(t, capturedKV)
+		})
 	})
 }
 
 func TestConfigureThinking_LevelOnly(t *testing.T) {
-	t.Run("level-only activates ThinkingLevel without budget", func(t *testing.T) {
-		var capturedThinkingConfig map[string]any
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Errorf("failed to decode request body: %v", err)
-			}
-			if gc, ok := body["generationConfig"].(map[string]any); ok {
-				if tc, ok := gc["thinkingConfig"].(map[string]any); ok {
-					capturedThinkingConfig = tc
-				}
-			}
-
-			resp := genai.GenerateContentResponse{
-				Candidates: []*genai.Candidate{{
-					Content: &genai.Content{Parts: []*genai.Part{{Text: "OK"}}},
-				}},
-			}
-			if err := json.NewEncoder(w).Encode(resp); err != nil {
-				t.Errorf("failed to encode response: %v", err)
-			}
-		}))
-		t.Cleanup(server.Close)
-
-		apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-		authenticator := &auth.BearerAuth{Token: "test-token"}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
-		client, err := NewClient(
-			apiURL, "test-model", authenticator,
-			WithThinking(0, "high", 0),
-			WithEventBus(bus),
-			WithTimeout(5*time.Second),
-		)
-		if err != nil {
-			t.Fatalf("failed to create client: %v", err)
-		}
+	t.Run("level_only", func(t *testing.T) {
+		server, captured := newThinkingCaptureServer(t)
+		client := newGeminiClientForThinking(t, server, WithThinking(0, "high", 0))
 
 		history := []*llm.Content{
 			{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}},
@@ -908,58 +966,12 @@ func TestConfigureThinking_LevelOnly(t *testing.T) {
 			t.Errorf("expected 'OK', got %q", content.Parts[0].Text)
 		}
 
-		if capturedThinkingConfig == nil {
-			t.Fatal("expected thinkingConfig in request")
-		}
-		if includeThoughts, _ := capturedThinkingConfig["includeThoughts"].(bool); !includeThoughts {
-			t.Error("expected includeThoughts=true")
-		}
-		if level, _ := capturedThinkingConfig["thinkingLevel"].(string); level != "high" {
-			t.Errorf("expected thinkingLevel='high', got %q", level)
-		}
-		if _, hasBudget := capturedThinkingConfig["thinkingBudget"]; hasBudget {
-			t.Error("expected thinkingBudget to be absent when budget=0")
-		}
+		assertThinkingConfigLevelOnly(t, captured)
 	})
 
-	t.Run("no thinking config when both budget and level are zero/empty", func(t *testing.T) {
-		var capturedThinkingConfig map[string]any
-
-		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			var body map[string]any
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Errorf("failed to decode request body: %v", err)
-			}
-			if gc, ok := body["generationConfig"].(map[string]any); ok {
-				if tc, ok := gc["thinkingConfig"].(map[string]any); ok {
-					capturedThinkingConfig = tc
-				}
-			}
-
-			resp := genai.GenerateContentResponse{
-				Candidates: []*genai.Candidate{{
-					Content: &genai.Content{Parts: []*genai.Part{{Text: "OK"}}},
-				}},
-			}
-			if err := json.NewEncoder(w).Encode(resp); err != nil {
-				t.Errorf("failed to encode response: %v", err)
-			}
-		}))
-		t.Cleanup(server.Close)
-
-		apiURL := server.URL + "/aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models"
-		authenticator := &auth.BearerAuth{Token: "test-token"}
-		bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, bus)
-
-		client, err := NewClient(
-			apiURL, "test-model", authenticator,
-			WithEventBus(bus),
-			WithTimeout(5*time.Second),
-		)
-		if err != nil {
-			t.Fatalf("failed to create client: %v", err)
-		}
+	t.Run("zero_empty", func(t *testing.T) {
+		server, captured := newThinkingCaptureServer(t)
+		client := newGeminiClientForThinking(t, server) // no WithThinking
 
 		history := []*llm.Content{
 			{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}},
@@ -972,9 +984,7 @@ func TestConfigureThinking_LevelOnly(t *testing.T) {
 			t.Errorf("expected 'OK', got %q", content.Parts[0].Text)
 		}
 
-		if capturedThinkingConfig != nil {
-			t.Errorf("expected no thinkingConfig, got %+v", capturedThinkingConfig)
-		}
+		assertNoThinkingConfig(t, captured)
 	})
 }
 


### PR DESCRIPTION
Closes #741.

## Summary
Decomposed 5 high-complexity test functions in the LLM infrastructure layer into focused `t.Run` subtests with extracted helper functions. All functions now meet the ≤10 cyclomatic complexity target.

| Function | File | Before | After |
|---|---|---|---|
| TestClientFactoryFunc_NewClient | ports/factory_test.go | 12 | **6** |
| TestApplyThinkingBudget_PublishError | gemini/gemini_test.go | 12 | **4** |
| TestConfigureThinking_LevelOnly | gemini/gemini_test.go | 20 | **5** |
| TestDefaultClientFactory | factory_test.go | 14 | **7** |
| TestNewFailoverChain | factory_test.go | 13 | **4** |

## Verification
| Check | Status |
|---|---|
| make check-full | PASS |
| Race detection | PASS |
| Lint (golangci-lint) | 0 issues |
| No behavioral changes | ✅ Every assertion preserved |