### PR TITLE
fix(test): decompose high-complexity test functions (#744)

### DIFF
--- a/internal/cli/cmd_browse_test.go
+++ b/internal/cli/cmd_browse_test.go
@@ -207,21 +207,48 @@ func TestBrowseCommand_NilInteractorRef_DoesNotPanic(t *testing.T) {
 	// Should not panic with nil InteractorRef
 }
 
+// assertSnapHistoryManagerError asserts bootstrapper snapshot for the
+// "history manager error" case: GetHistoryManager was called once but
+// GetUnifiedHistoryProvider was never reached.
+func assertSnapHistoryManagerError(t *testing.T, snap clitest.BootstrapperSnapshot) {
+	t.Helper()
+	if snap.GetHistoryManager != 1 {
+		t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
+	}
+	if snap.GetUnifiedHistoryProvider != 0 {
+		t.Errorf("GetUnifiedHistoryProvider: expected 0, got %d", snap.GetUnifiedHistoryProvider)
+	}
+}
+
+// assertSnapBothCalled asserts bootstrapper snapshot for cases where both
+// GetHistoryManager and GetUnifiedHistoryProvider are expected to be called once.
+func assertSnapBothCalled(t *testing.T, snap clitest.BootstrapperSnapshot) {
+	t.Helper()
+	if snap.GetHistoryManager != 1 {
+		t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
+	}
+	if snap.GetUnifiedHistoryProvider != 1 {
+		t.Errorf("GetUnifiedHistoryProvider: expected 1, got %d", snap.GetUnifiedHistoryProvider)
+	}
+}
+
 func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		setupMocks  func(ml *configtest.MockConfigLoader, mb *clitest.MockBootstrapper, ms *clitest.MockChatService)
-		wantErr     string
-		wantNoError bool
+		name           string
+		setupMocks     func(ml *configtest.MockConfigLoader, mb *clitest.MockBootstrapper, ms *clitest.MockChatService)
+		wantErr        string
+		wantNoError    bool
+		assertSnapshot func(t *testing.T, snap clitest.BootstrapperSnapshot)
 	}{
 		{
 			name: "config load error",
 			setupMocks: func(ml *configtest.MockConfigLoader, mb *clitest.MockBootstrapper, ms *clitest.MockChatService) {
 				ml.LoadFunc = func(path string) (*config.Config, error) { return nil, errors.New("config not found") }
 			},
-			wantErr: "error loading config",
+			wantErr:        "error loading config",
+			assertSnapshot: nil,
 		},
 		{
 			name: "history manager error",
@@ -231,7 +258,8 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 					return nil, errors.New("hm failed")
 				}
 			},
-			wantErr: "failed to get history manager",
+			wantErr:        "failed to get history manager",
+			assertSnapshot: assertSnapHistoryManagerError,
 		},
 		{
 			name: "history provider error",
@@ -244,7 +272,8 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 					return nil, errors.New("provider failed")
 				}
 			},
-			wantErr: "failed to get unified history provider",
+			wantErr:        "failed to get unified history provider",
+			assertSnapshot: assertSnapBothCalled,
 		},
 		{
 			name: "BrowseHistory error",
@@ -260,7 +289,8 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 					return errors.New("browse crash")
 				}
 			},
-			wantErr: "browse crash",
+			wantErr:        "browse crash",
+			assertSnapshot: assertSnapBothCalled,
 		},
 		{
 			name: "success",
@@ -276,7 +306,8 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 					return nil
 				}
 			},
-			wantNoError: true,
+			wantNoError:    true,
+			assertSnapshot: assertSnapBothCalled,
 		},
 	}
 
@@ -321,23 +352,8 @@ func TestBrowseCommand_RunBrowse_PostTTY(t *testing.T) {
 				t.Errorf("BuildSessionDependencies: expected 0, got %d", snap.BuildSessionDependencies)
 			}
 
-			switch tt.name {
-			case "config load error":
-				// Config load fails before bootstrapper is reached.
-			case "history manager error":
-				if snap.GetHistoryManager != 1 {
-					t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
-				}
-				if snap.GetUnifiedHistoryProvider != 0 {
-					t.Errorf("GetUnifiedHistoryProvider: expected 0, got %d", snap.GetUnifiedHistoryProvider)
-				}
-			case "history provider error", "BrowseHistory error", "success":
-				if snap.GetHistoryManager != 1 {
-					t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
-				}
-				if snap.GetUnifiedHistoryProvider != 1 {
-					t.Errorf("GetUnifiedHistoryProvider: expected 1, got %d", snap.GetUnifiedHistoryProvider)
-				}
+			if tt.assertSnapshot != nil {
+				tt.assertSnapshot(t, snap)
 			}
 		})
 	}

--- a/internal/domain/config/configtest/mock_config_loader_test.go
+++ b/internal/domain/config/configtest/mock_config_loader_test.go
@@ -10,77 +10,82 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 )
 
+func TestMockConfigLoader_Load_Success(t *testing.T) {
+	t.Parallel()
+	var called bool
+	m := &MockConfigLoader{
+		LoadFunc: func(path string) (*config.Config, error) {
+			called = true
+			return &config.Config{}, nil
+		},
+	}
+	cfg, err := m.Load("/test/config.yaml")
+	if cfg == nil {
+		t.Error("expected non-nil config")
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected LoadFunc to be called")
+	}
+}
+
+func TestMockConfigLoader_Load_Error(t *testing.T) {
+	t.Parallel()
+	wantErr := errors.New("load failed")
+	m := &MockConfigLoader{
+		LoadFunc: func(path string) (*config.Config, error) {
+			return nil, wantErr
+		},
+	}
+	cfg, err := m.Load("/test/error.yaml")
+	if cfg != nil {
+		t.Error("expected nil config on error")
+	}
+	if err != wantErr {
+		t.Errorf("got %v, want %v", err, wantErr)
+	}
+}
+
+func TestMockConfigLoader_Load_DefensiveNilUnset(t *testing.T) {
+	t.Parallel()
+	m := &MockConfigLoader{} // zero value — LoadFunc is nil
+	cfg, err := m.Load("/test/defensive.yaml")
+	if cfg != nil {
+		t.Error("expected nil config when LoadFunc is nil")
+	}
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+}
+
+func TestMockConfigLoader_Load_DefensiveNilSet(t *testing.T) {
+	t.Parallel()
+	var called bool
+	m := &MockConfigLoader{
+		LoadFunc: func(path string) (*config.Config, error) {
+			called = true
+			return nil, nil
+		},
+	}
+	cfg, err := m.Load("/test/defensive-set.yaml")
+	if cfg != nil {
+		t.Error("expected nil config when LoadFunc returns nil")
+	}
+	if err != nil {
+		t.Errorf("expected nil error, got %v", err)
+	}
+	if !called {
+		t.Error("expected LoadFunc to be called")
+	}
+}
+
 func TestMockConfigLoader_Load(t *testing.T) {
 	t.Parallel()
 
-	t.Run("success path", func(t *testing.T) {
-		t.Parallel()
-		var called bool
-		m := &MockConfigLoader{
-			LoadFunc: func(path string) (*config.Config, error) {
-				called = true
-				return &config.Config{}, nil
-			},
-		}
-		cfg, err := m.Load("/test/config.yaml")
-		if cfg == nil {
-			t.Error("expected non-nil config")
-		}
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-		if !called {
-			t.Error("expected LoadFunc to be called")
-		}
-	})
-
-	t.Run("error path", func(t *testing.T) {
-		t.Parallel()
-		wantErr := errors.New("load failed")
-		m := &MockConfigLoader{
-			LoadFunc: func(path string) (*config.Config, error) {
-				return nil, wantErr
-			},
-		}
-		cfg, err := m.Load("/test/error.yaml")
-		if cfg != nil {
-			t.Error("expected nil config on error")
-		}
-		if err != wantErr {
-			t.Errorf("got %v, want %v", err, wantErr)
-		}
-	})
-
-	t.Run("defensive nil path (LoadFunc unset)", func(t *testing.T) {
-		t.Parallel()
-		m := &MockConfigLoader{} // zero value — LoadFunc is nil
-		cfg, err := m.Load("/test/defensive.yaml")
-		if cfg != nil {
-			t.Error("expected nil config when LoadFunc is nil")
-		}
-		if err != nil {
-			t.Errorf("expected nil error, got %v", err)
-		}
-	})
-
-	t.Run("defensive nil path (LoadFunc set, returns nil,nil)", func(t *testing.T) {
-		t.Parallel()
-		var called bool
-		m := &MockConfigLoader{
-			LoadFunc: func(path string) (*config.Config, error) {
-				called = true
-				return nil, nil
-			},
-		}
-		cfg, err := m.Load("/test/defensive-set.yaml")
-		if cfg != nil {
-			t.Error("expected nil config when LoadFunc returns nil")
-		}
-		if err != nil {
-			t.Errorf("expected nil error, got %v", err)
-		}
-		if !called {
-			t.Error("expected LoadFunc to be called")
-		}
-	})
+	t.Run("success path", TestMockConfigLoader_Load_Success)
+	t.Run("error path", TestMockConfigLoader_Load_Error)
+	t.Run("defensive nil path (LoadFunc unset)", TestMockConfigLoader_Load_DefensiveNilUnset)
+	t.Run("defensive nil path (LoadFunc set, returns nil,nil)", TestMockConfigLoader_Load_DefensiveNilSet)
 }

--- a/internal/tools/workspace/process_executor_unit_test.go
+++ b/internal/tools/workspace/process_executor_unit_test.go
@@ -551,66 +551,56 @@ type stubCloser struct{ err error }
 func (s *stubCloser) Close() error { return s.err }
 
 func TestCloseFile(t *testing.T) {
-	tests := []struct {
-		name      string
-		closeErr  error
-		priorErr  error
-		wantErr   bool
-		wantPrior bool // true: prior error preserved; false: close error promoted
-	}{
-		{
-			name:     "close succeeds with no prior error",
-			closeErr: nil,
-			priorErr: nil,
-			wantErr:  false,
-		},
-		{
-			name:      "close fails with no prior error - promoted",
-			closeErr:  fmt.Errorf("disk full"),
-			priorErr:  nil,
-			wantErr:   true,
-			wantPrior: false,
-		},
-		{
-			name:      "close fails with prior error - close error suppressed",
-			closeErr:  fmt.Errorf("disk full"),
-			priorErr:  fmt.Errorf("command failed"),
-			wantErr:   true,
-			wantPrior: true,
-		},
-		{
-			name:      "close succeeds with prior error - prior error preserved",
-			closeErr:  nil,
-			priorErr:  fmt.Errorf("command failed"),
-			wantErr:   true,
-			wantPrior: true,
-		},
-	}
+	t.Run("close succeeds with no prior error", func(t *testing.T) {
+		closer := &stubCloser{err: nil}
+		err := error(nil)
+		closeFile(closer, &err)
+		if err != nil {
+			t.Fatalf("closeFile() err = %v, want nil", err)
+		}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			closer := &stubCloser{err: tt.closeErr}
-			err := tt.priorErr
-			closeFile(closer, &err)
+	t.Run("close fails with no prior error - promoted", func(t *testing.T) {
+		closeErr := fmt.Errorf("disk full")
+		closer := &stubCloser{err: closeErr}
+		err := error(nil)
+		closeFile(closer, &err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to close output file") {
+			t.Errorf("expected 'failed to close output file' in error, got %v", err)
+		}
+		if !strings.Contains(err.Error(), closeErr.Error()) {
+			t.Errorf("expected wrapped close error, got %v", err)
+		}
+	})
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("closeFile() err = %v, wantErr = %v", err, tt.wantErr)
-			}
-			if tt.wantErr && tt.wantPrior {
-				if !errors.Is(err, tt.priorErr) {
-					t.Errorf("expected prior error %v preserved, got %v", tt.priorErr, err)
-				}
-			}
-			if tt.wantErr && !tt.wantPrior && tt.priorErr == nil {
-				if !strings.Contains(err.Error(), "failed to close output file") {
-					t.Errorf("expected 'failed to close output file' in error, got %v", err)
-				}
-				if !strings.Contains(err.Error(), tt.closeErr.Error()) {
-					t.Errorf("expected wrapped close error, got %v", err)
-				}
-			}
-		})
-	}
+	t.Run("close fails with prior error - close error suppressed", func(t *testing.T) {
+		priorErr := fmt.Errorf("command failed")
+		closer := &stubCloser{err: fmt.Errorf("disk full")}
+		err := priorErr
+		closeFile(closer, &err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, priorErr) {
+			t.Errorf("expected prior error %v preserved, got %v", priorErr, err)
+		}
+	})
+
+	t.Run("close succeeds with prior error - prior error preserved", func(t *testing.T) {
+		priorErr := fmt.Errorf("command failed")
+		closer := &stubCloser{err: nil}
+		err := priorErr
+		closeFile(closer, &err)
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !errors.Is(err, priorErr) {
+			t.Errorf("expected prior error %v preserved, got %v", priorErr, err)
+		}
+	})
 }
 
 // TestNewPipelineCmd_CancelGuard verifies that newPipelineCmd sets the


### PR DESCRIPTION
Closes #744.

## Summary
Decomposed 3 high-complexity test functions (cyclomatic complexity 11 → ≤10) via .Run$ subtest decomposition. Zero behavioral changes — every assertion preserved exactly.

| # | Function | Before | After | Strategy |
|---:|---|---:|---:|---|
| 1 | `TestBrowseCommand_RunBrowse_PostTTY` | 11 | **5** | Per-case `assertSnapshot` closures |
| 2 | `TestCloseFile` | 11 | **9** | Dissolved table into standalone `t.Run` |
| 3 | `TestMockConfigLoader_Load` | 11 | **1** | Promoted closures to top-level `Test*` functions |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| `go test ./internal/cli/... ./internal/tools/workspace/... ./internal/domain/config/...` | PASS |
| All 3 functions ≤ 10 cyclomatic complexity | ✅ |