### PR TITLE
fix(security): close actionable error-handling coverage gaps (#754)

### DIFF
--- a/internal/domain/events/event_bus_lifecycle_whitebox_test.go
+++ b/internal/domain/events/event_bus_lifecycle_whitebox_test.go
@@ -141,4 +141,3 @@ func TestFlush_BusShutdownDuringFlush(t *testing.T) {
 		t.Errorf("expected ErrBusClosed, got %v", err)
 	}
 }
-

--- a/internal/infrastructure/security/interaction_test.go
+++ b/internal/infrastructure/security/interaction_test.go
@@ -294,3 +294,13 @@ func TestMockInteractor_Errors(t *testing.T) {
 		t.Error("Expected error in ReadLine")
 	}
 }
+
+func TestNoOpInteractor_WarnAndPrompt(t *testing.T) {
+	t.Parallel()
+	ni := &noOpInteractor{}
+	// Must not panic — these are no-ops
+	ni.Warn("test warning")
+	ni.Prompt("test prompt")
+	ni.Warn("")
+	ni.Prompt("")
+}

--- a/internal/infrastructure/security/paths_test.go
+++ b/internal/infrastructure/security/paths_test.go
@@ -312,6 +312,43 @@ func TestPathPolicy_IsSystemDirectory_Internal(t *testing.T) {
 	}
 }
 
+// TestCheckSystemDirectoryMatch_CaseInsensitive directly tests the
+// case-insensitive branch of checkSystemDirectoryMatch (paths.go:229-234).
+// On Linux, isCaseSensitive() returns true, so this branch is never reached
+// through the normal isSystemDirectory → checkSystemDirectoryMatch call path.
+// This test calls checkSystemDirectoryMatch with caseSensitive=false to
+// achieve coverage of the strings.ToLower normalization logic.
+func TestCheckSystemDirectoryMatch_CaseInsensitive(t *testing.T) {
+	t.Parallel()
+	p := newPathPolicy(nil)
+
+	tests := []struct {
+		name          string
+		absPath       string
+		sysDir        string
+		caseSensitive bool
+		want          bool
+	}{
+		{"exact match case-insensitive", "/etc/passwd", "/etc/passwd", false, true},
+		{"prefix match", "/etc/passwd", "/etc", false, true},
+		{"uppercase exact match", "/ETC/PASSWD", "/etc/passwd", false, true},
+		{"uppercase prefix match", "/ETC/SUB/FILE", "/etc", false, true},
+		{"no match", "/home/user", "/etc", false, false},
+		{"shorter target", "/etc", "/etc/passwd", false, false},
+		{"case-sensitive mismatch", "/ETC/PASSWD", "/etc/passwd", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := p.checkSystemDirectoryMatch(tt.absPath, tt.sysDir, tt.caseSensitive)
+			if got != tt.want {
+				t.Errorf("checkSystemDirectoryMatch(%q, %q, %v) = %v, want %v",
+					tt.absPath, tt.sysDir, tt.caseSensitive, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPathPolicy_RegisterPath_Idempotency(t *testing.T) {
 	t.Parallel()
 	p := newPathPolicy(nil)
@@ -712,4 +749,58 @@ func TestBoundaryChecks_ErrorLogging(t *testing.T) {
 	// pass filepath.Abs without error. These branches exist as defensive
 	// coding but cannot be triggered in normal or test operation.
 	t.Log("[DOCUMENTED] checkDefaultBoundaries error-log branches are unreachable: all default boundaries are always valid paths")
+}
+
+// TestResolveSymlinks_RecursiveFallback covers the recursive fallback branch
+// of resolveSymlinks (paths.go:328-332). When filepath.EvalSymlinks fails
+// because a path component doesn't exist, resolveSymlinks walks up the
+// directory tree recursively until it finds a resolvable ancestor, then
+// reconstructs the path with filepath.Join.
+//
+// The function never returns an error — it's a fail-secure best-effort
+// resolver. Verification: result is non-empty and preserves the base filename.
+func TestResolveSymlinks_RecursiveFallback(t *testing.T) {
+	t.Parallel()
+	p := newPathPolicy(nil)
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{
+			name: "non-existent subdir — recursive resolution",
+			path: filepath.Join(tmpDir, "nonexistent_subdir", "file.txt"),
+		},
+		{
+			name: "deeply nested non-existent",
+			path: filepath.Join(tmpDir, "a", "b", "c", "d.txt"),
+		},
+		{
+			name: "non-existent file at root — dir==path stops recursion",
+			path: func() string {
+				if runtime.GOOS == "windows" {
+					return `C:\nonexistent_root_file_xyz`
+				}
+				return "/nonexistent_root_file_xyz"
+			}(),
+		},
+		{
+			name: "bare filename — dir==. stops recursion",
+			path: "nonexistent_file_xyz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := p.resolveSymlinks(tt.path)
+			if result == "" {
+				t.Error("resolveSymlinks returned empty string")
+			}
+			if filepath.Base(result) != filepath.Base(tt.path) {
+				t.Errorf("resolveSymlinks(%q) base = %q, want %q",
+					tt.path, filepath.Base(result), filepath.Base(tt.path))
+			}
+		})
+	}
 }

--- a/internal/infrastructure/security/policy_test.go
+++ b/internal/infrastructure/security/policy_test.go
@@ -674,6 +674,36 @@ func TestRegisterPolicyTools_RegistrationError(t *testing.T) {
 	}
 }
 
+// plainRegisterErrorRegistry implements tools.Registry.
+// RegisterWithOptions succeeds (allowing tools with opts to pass through),
+// but plain Register fails — triggering the uncovered error path in the
+// RegisterPolicyTools loop for tools that use the standard Register path.
+type plainRegisterErrorRegistry struct {
+	tools.Registry
+}
+
+func (r *plainRegisterErrorRegistry) Register(decl *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return fmt.Errorf("plain register rejected")
+}
+
+func (r *plainRegisterErrorRegistry) RegisterWithOptions(decl *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return nil
+}
+
+func TestRegisterPolicyTools_PlainRegisterError(t *testing.T) {
+	t.Parallel()
+	sm, p, _ := setupPolicyTest(t)
+	r := &plainRegisterErrorRegistry{}
+
+	err := sm.RegisterPolicyTools(r, p.kv)
+	if err == nil {
+		t.Error("expected error from failed plain Register, got nil")
+	}
+	if !strings.Contains(err.Error(), "plain register rejected") {
+		t.Errorf("expected 'plain register rejected' error, got: %v", err)
+	}
+}
+
 func TestNewPolicyTool_ValidationErrors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #754.

## Summary
Closed all actionable error-handling coverage gaps in `internal/infrastructure/security` identified by the Phase 3 issue. Remaining gaps are all documented as `[SYSTEM-DEPENDENT]` — defensive branches unreachable on Linux with `modernc.org/sqlite`.

### Changes
| Test | Function | Before → After |
|------|----------|----------------|
| `TestNoOpInteractor_WarnAndPrompt` | `Warn`/`Prompt` | Confirmed false positive (0-statement functions) |
| `TestCheckSystemDirectoryMatch_CaseInsensitive` | `checkSystemDirectoryMatch` | 63.6% → 100.0% |
| `TestResolveSymlinks_RecursiveFallback` | `resolveSymlinks` | 85.7% → 100.0% |
| `TestRegisterPolicyTools_PlainRegisterError` | `RegisterPolicyTools` | 81.8% → 90.9% |

### Coverage
- Security package: 94.8% → **95.6%**
- Persistence package: 97.7% (no change — all gaps `[SYSTEM-DEPENDENT]`)
- Overall: 96.0% → **96.4%**

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, vulncheck) | ✅ PASS |
| `go test ./...` | ✅ PASS (1 pre-existing flaky test in workspace, passes on retry) |
| `go test -race ./...` | ✅ PASS |
| Coverage regression | ✅ None (96.0% → 96.4%) |
| Dead code | ✅ None