### PR TITLE
fix(ui): close error-handling test coverage gaps (#753)

### DIFF
--- a/internal/agent/session/ui/backpressure_test.go
+++ b/internal/agent/session/ui/backpressure_test.go
@@ -223,7 +223,7 @@ func TestUIBridge_HandleEvent_AlreadyShutdown(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer)
-	ctx, _, _ := startListen(t, bridge)
+	ctx, _, _, _ := startListen(t, bridge)
 	bridge.WaitStarted()
 
 	// Shutdown the bridge

--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -101,8 +101,12 @@ type Bridge struct {
 	wg                 sync.WaitGroup
 	cleanupTimeout     time.Duration
 	queueCapacity      int
-	started            chan struct{}
-	startOnce          sync.Once
+	// cleanupWaitFn is nil in production. Tests set it to replace b.wg.Wait()
+	// with a function that can panic, enabling deterministic coverage of the
+	// Cleanup goroutine's panic-recovery path.
+	cleanupWaitFn func() //nolint:unused // test hook
+	started       chan struct{}
+	startOnce     sync.Once
 }
 
 // NewBridge creates a new Bridge.
@@ -170,7 +174,11 @@ func (b *Bridge) Cleanup() {
 					close(done)
 				}
 			}()
-			b.wg.Wait()
+			if b.cleanupWaitFn != nil {
+				b.cleanupWaitFn()
+			} else {
+				b.wg.Wait()
+			}
 			close(done)
 		}()
 

--- a/internal/agent/session/ui/bridge_test.go
+++ b/internal/agent/session/ui/bridge_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,7 +35,7 @@ func newStartedTestBridge(t *testing.T) (*Bridge, context.CancelFunc, *agenttest
 		WithBridgeLogFile("log.txt"),
 		WithBridgeLogger(slog.Default()),
 	)
-	_, cancel, _ := startListen(t, bridge)
+	_, cancel, _, _ := startListen(t, bridge)
 	bridge.WaitStarted()
 	return bridge, cancel, mRenderer
 }
@@ -308,7 +309,7 @@ func TestUIBridge_HandleEvent(t *testing.T) {
 				WithBridgeLogFile("log.txt"),
 				WithBridgeLogger(slog.Default()),
 			)
-			_, _, _ = startListen(t, bridge)
+			_, _, _, _ = startListen(t, bridge)
 			bridge.WaitStarted()
 			defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 			// Set up expectations BEFORE preSetup
@@ -362,7 +363,7 @@ func TestUIBridge_Concurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	ctx, _, _ := startListen(t, bridge)
+	ctx, _, _, _ := startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
@@ -427,7 +428,7 @@ func TestUIBridge_LogicalRace(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	ctx, _, _ := startListen(t, bridge)
+	ctx, _, _, _ := startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
@@ -461,7 +462,7 @@ func TestUIBridge_AbortedTurn_SpinnerCleanup(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
@@ -490,7 +491,7 @@ func TestUIBridge_Retry_Spinner(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
@@ -544,7 +545,7 @@ func TestUIBridge_CleanupOnUnexpectedExit(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 
 	spinnerStarted := make(chan struct{})
@@ -621,7 +622,7 @@ func TestUIBridge_SpinnerConcurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 
 	var activeSpinners int32
@@ -659,7 +660,7 @@ func TestUIBridge_NilLoggerFallback(t *testing.T) {
 	mRenderer := new(agenttest.MockUIRenderer)
 	// Instantiate without WithLogger
 	bridge := NewBridge(mRenderer)
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() { bridge.CloseInput(); bridge.Cleanup() }()
 
@@ -668,21 +669,92 @@ func TestUIBridge_NilLoggerFallback(t *testing.T) {
 
 func TestUIBridge_CleanupTimeout(t *testing.T) {
 	t.Parallel()
+
+	tests := []struct {
+		name      string
+		unblockWG bool // if true, call wg.Done() after cancel to hit the fast <-done path
+		wantLog   string
+	}{
+		{
+			name:      "slow path — timeout fires, wg stays hung",
+			unblockWG: false,
+			wantLog:   "UI Bridge cleanup timed out",
+		},
+		{
+			name:      "fast path — cancel unblocks wg before 100ms elapses",
+			unblockWG: true,
+			wantLog:   "UI Bridge cleanup timed out",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mRenderer := new(agenttest.MockUIRenderer)
+			logger := new(testfixtures.SpyLogger)
+
+			bridge := NewBridge(mRenderer,
+				withBridgeCleanupTimeout(10*time.Millisecond),
+				WithBridgeLogger(logger),
+			)
+			_, _, _, _ = startListen(t, bridge)
+			bridge.WaitStarted()
+			bridgeCtx := bridge.getLoopContext()
+
+			// Hang the WaitGroup to force the timeout path
+			bridge.wg.Add(1)
+
+			// If testing the fast path, schedule a wg.Done() after a short delay
+			// so the goroutine unblocks after cancel() fires but before 100ms.
+			if tt.unblockWG {
+				time.AfterFunc(50*time.Millisecond, func() { bridge.wg.Done() })
+			} else {
+				defer bridge.wg.Done() // prevent goroutine leak
+			}
+
+			done := make(chan struct{})
+			go func() {
+				bridge.CloseInput()
+				bridge.Cleanup()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(1 * time.Second):
+				t.Fatal("Cleanup did not return within expected timeout")
+			}
+
+			// Verify context was cancelled
+			assert.Error(t, bridgeCtx.Err(), "Context should be cancelled after Cleanup timeout")
+
+			// Verify the Warn log
+			if tt.wantLog != "" {
+				assert.True(t, logger.CalledWith("Warn", tt.wantLog),
+					"expected Warn log %q", tt.wantLog)
+			}
+		})
+	}
+}
+
+func TestUIBridge_Cleanup_PanicInWaitGoroutine(t *testing.T) {
+	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
+	logger := new(testfixtures.SpyLogger)
 
-	// Initialize bridge with a very small timeout via functional option
 	bridge := NewBridge(mRenderer,
-		withBridgeCleanupTimeout(10*time.Millisecond),
+		withBridgeCleanupTimeout(50*time.Millisecond),
+		WithBridgeLogger(logger),
 	)
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
-	bridgeCtx := bridge.getLoopContext() // Use the internal loop context for verification
 
-	// Force a waitgroup hang to simulate a deadlocked renderer or long-running loop
-	bridge.wg.Add(1)
-	defer bridge.wg.Done() // Ensure the hung WaitGroup is eventually released to prevent goroutine leaks in the test suite.
+	// Replace wg.Wait() with a function that panics.
+	bridge.SetCleanupWaitFn(func() {
+		panic("injected wg.Wait panic")
+	})
 
-	// Execute Cleanup. It should timeout after 10ms and return normally.
 	done := make(chan struct{})
 	go func() {
 		bridge.CloseInput()
@@ -692,13 +764,13 @@ func TestUIBridge_CleanupTimeout(t *testing.T) {
 
 	select {
 	case <-done:
-		// Success: Cleanup returned even with a hung WaitGroup
 	case <-time.After(1 * time.Second):
-		t.Fatal("Cleanup did not return within expected timeout")
+		t.Fatal("Cleanup did not return after injected panic in wait goroutine")
 	}
 
-	// VERIFY: context should be cancelled now
-	assert.Error(t, bridgeCtx.Err(), "Context should be cancelled after Cleanup timeout")
+	// The panic recovery must have logged the error and closed the done channel.
+	assert.True(t, logger.CalledWith("Error", "panic in UI bridge cleanup wait"),
+		"expected Error log for panic in cleanup wait goroutine")
 }
 
 func TestUIBridge_HandleEvent_ContextCancelled(t *testing.T) {
@@ -870,4 +942,16 @@ func TestWithBridgeClock(t *testing.T) {
 	defer bridge.Cleanup()
 
 	assert.NotNil(t, bridge.clock, "bridge.clock should not be nil after WithBridgeClock")
+}
+
+func TestUIBridge_WithBridgeLoggerNil_FallbackToDefault(t *testing.T) {
+	t.Parallel()
+	mRenderer := new(agenttest.MockUIRenderer)
+	// Explicitly inject a typed nil ports.Logger — NOT just omitting WithBridgeLogger.
+	bridge := NewBridge(mRenderer, WithBridgeLogger(nil))
+	bridge.AbortStart()
+	defer bridge.Cleanup()
+
+	// The nil-logger guard must restore slog.Default().
+	assert.NotNil(t, bridge.logger, "Logger should fall back to slog.Default() when WithBridgeLogger(nil) is passed")
 }

--- a/internal/agent/session/ui/concurrency_test.go
+++ b/internal/agent/session/ui/concurrency_test.go
@@ -20,7 +20,7 @@ func TestUIBridge_StressConcurrency(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 
 	var activeSpinners int32
@@ -70,7 +70,7 @@ func TestUIBridge_LogicalStateVerification(t *testing.T) {
 
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() {
 		bridge.CloseInput()

--- a/internal/agent/session/ui/consent_test.go
+++ b/internal/agent/session/ui/consent_test.go
@@ -31,7 +31,7 @@ func TestUIBridge_ConsentSpinnerLeak(t *testing.T) {
 	// StartSpinnerWithStatusFn: nil → no-op (replaces .Maybe())
 
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() {
 		bridge.CloseInput()
@@ -57,7 +57,7 @@ func TestUIBridge_SystemMessageDuringConsent(t *testing.T) {
 	t.Parallel()
 	mRenderer := new(agenttest.MockUIRenderer)
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() {
 		bridge.CloseInput()
@@ -116,7 +116,7 @@ func TestUIBridge_SpinnerConsentCollision(t *testing.T) {
 	testCtx := context.Background()
 
 	bridge := NewBridge(mRenderer, WithBridgeThoughts(true), WithBridgeTools(true), WithBridgeRawOutput(false), WithBridgeColor(true), WithBridgeLogFile("log.txt"), WithBridgeLogger(slog.Default()))
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 	defer func() {
 		bridge.CloseInput()
@@ -190,7 +190,7 @@ func TestUIBridge_DeadConsumer_Unblocks(t *testing.T) {
 	bridge := NewBridge(mRenderer)
 
 	// Start the bridge to initialize everything
-	_, cancel, _ := startListen(t, bridge)
+	_, cancel, _, _ := startListen(t, bridge)
 	bridge.WaitStarted()
 	bridge.WaitStarted()
 

--- a/internal/agent/session/ui/export_test.go
+++ b/internal/agent/session/ui/export_test.go
@@ -19,9 +19,9 @@ func SyncBridge(t *testing.T, b *Bridge, m *agenttest.MockUIRenderer) {
 // StartListen is the exported wrapper around startListen for use by external
 // test packages (package ui_test). It launches bridge.Listen in a goroutine,
 // registers a t.Cleanup that surfaces non-cancellation errors, and returns
-// the listen context, its cancel function, and a channel that closes when
-// Listen exits.
-func StartListen(t *testing.T, b *Bridge) (context.Context, context.CancelFunc, <-chan struct{}) {
+// the listen context, its cancel function, a channel that closes when
+// Listen exits, and a channel that receives the exact error from Listen().
+func StartListen(t *testing.T, b *Bridge) (context.Context, context.CancelFunc, <-chan struct{}, <-chan error) {
 	t.Helper()
 	return startListen(t, b)
 }
@@ -39,4 +39,11 @@ func (b *Bridge) Wg() *sync.WaitGroup {
 // The hook is nil by default and has zero overhead in production.
 func (b *Bridge) SetBeforeBlockingSendHook(fn func()) {
 	b.queue.(*eventQueue).beforeBlockingSendHook = fn
+}
+
+// SetCleanupWaitFn installs a function that replaces b.wg.Wait() during
+// Cleanup. Nil in production; tests use it to inject panics for coverage
+// of the Cleanup goroutine's panic-recovery path.
+func (b *Bridge) SetCleanupWaitFn(fn func()) {
+	b.cleanupWaitFn = fn
 }

--- a/internal/agent/session/ui/fixture_test.go
+++ b/internal/agent/session/ui/fixture_test.go
@@ -75,7 +75,11 @@ type uiBridgeFixture struct {
 }
 
 // startListen launches bridge.Listen in a goroutine and registers a t.Cleanup
-// that fails the test if Listen returned a non-cancellation error.
+// that fails the test if Listen returned an unexpected non-cancellation error.
+//
+// The returned error channel receives the exact error from Listen(), including
+// "uibridge panicked:" errors. Tests that intentionally trigger panics can
+// assert on this value.
 //
 // The returned cancel function should be deferred or called explicitly to
 // shut down the listener; t.Cleanup will then read the error channel exactly
@@ -83,35 +87,34 @@ type uiBridgeFixture struct {
 //
 // The returned done channel closes when Listen returns. Tests that need to
 // wait for Listen to exit mid-test (e.g., after a panic) can select on done.
-func startListen(t *testing.T, b *Bridge) (ctx context.Context, cancel context.CancelFunc, done <-chan struct{}) {
+func startListen(t *testing.T, b *Bridge) (ctx context.Context, cancel context.CancelFunc, done <-chan struct{}, errCh <-chan error) {
 	t.Helper()
 	ctx, cancel = context.WithCancel(context.Background())
-	errCh := make(chan error, 1)
+	errChInternal := make(chan error, 1)
 	doneCh := make(chan struct{})
 	go func() {
-		defer close(errCh)
+		defer close(errChInternal)
 		defer close(doneCh)
-		if err := b.Listen(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			// Panics recovered by the bridge's internal recovery are
-			// expected when tests intentionally trigger panics. The
-			// test surfaces these via the done channel instead.
-			if !strings.Contains(err.Error(), "uibridge panicked:") {
-				errCh <- err
-			}
+		err := b.Listen(ctx)
+		if err != nil {
+			errChInternal <- err
 		}
 	}()
 	t.Cleanup(func() {
 		cancel()
 		select {
-		case err, ok := <-errCh:
+		case err, ok := <-errChInternal:
 			if ok && err != nil {
-				t.Errorf("Listen returned unexpected error: %v", err)
+				// Surface unexpected errors (not context.Canceled, not uibridge panicked).
+				if !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "uibridge panicked:") {
+					t.Errorf("Listen returned unexpected error: %v", err)
+				}
 			}
 		case <-time.After(2 * time.Second):
 			t.Errorf("Listen did not exit within 2s of cancel()")
 		}
 	})
-	return ctx, cancel, doneCh
+	return ctx, cancel, doneCh, errChInternal
 }
 
 // newUIBridgeFixture initializes a bridge with a controllable renderer and starts its listen loop.
@@ -128,7 +131,7 @@ func newUIBridgeFixture(t *testing.T, opts ...bridgeOption) *uiBridgeFixture {
 	opts = append(opts, WithBridgeLogger(logger))
 
 	bridge := NewBridge(renderer, opts...)
-	ctx, cancel, _ := startListen(t, bridge)
+	ctx, cancel, _, _ := startListen(t, bridge)
 
 	f := &uiBridgeFixture{
 		bridge:   bridge,

--- a/internal/agent/session/ui/idempotency_test.go
+++ b/internal/agent/session/ui/idempotency_test.go
@@ -26,7 +26,7 @@ func TestUIBridge_Cleanup_Idempotent(t *testing.T) {
 		WithBridgeLogger(slog.Default()),
 		withBridgeCleanupTimeout(10*time.Millisecond),
 	)
-	_, _, _ = startListen(t, bridge)
+	_, _, _, _ = startListen(t, bridge)
 	bridge.WaitStarted()
 
 	const numCalls = 100

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type panicMockRenderer struct {
@@ -74,7 +75,7 @@ func TestUIBridge_PanicResilience(t *testing.T) {
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	bridge := ui.NewBridge(mock, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
-	_, _, done := ui.StartListen(t, bridge)
+	_, _, done, _ := ui.StartListen(t, bridge)
 	defer func() {
 		bridge.CloseInput()
 		bridge.Cleanup()
@@ -117,7 +118,7 @@ func TestUIBridge_PanicRecoveryLogging(t *testing.T) {
 	}
 
 	bridge := ui.NewBridge(mockRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
-	ctx, _, done := ui.StartListen(t, bridge)
+	ctx, _, done, _ := ui.StartListen(t, bridge)
 	defer func() {
 		bridge.CloseInput()
 		bridge.Cleanup()
@@ -157,7 +158,7 @@ func TestUIBridge_PanicInStopSpinner(t *testing.T) {
 	// Silence noise in test output
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
-	_, _, done := ui.StartListen(t, bridge)
+	_, _, done, _ := ui.StartListen(t, bridge)
 	defer func() {
 		bridge.CloseInput()
 		bridge.Cleanup()
@@ -201,7 +202,7 @@ func TestUIBridge_PoisonPill(t *testing.T) {
 	}
 
 	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
-	ctx, _, _ := ui.StartListen(t, bridge)
+	ctx, _, _, _ := ui.StartListen(t, bridge)
 	bridge.WaitStarted()
 
 	// Send two events
@@ -228,7 +229,7 @@ func TestUIBridge_SendToClosedChannel(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	bridge := ui.NewBridge(mRenderer, ui.WithBridgeThoughts(true), ui.WithBridgeTools(true), ui.WithBridgeRawOutput(false), ui.WithBridgeColor(true), ui.WithBridgeLogFile("test.log"), ui.WithBridgeLogger(logger))
-	ctx, _, _ := ui.StartListen(t, bridge)
+	ctx, _, _, _ := ui.StartListen(t, bridge)
 	bridge.WaitStarted()
 
 	// Close the input to simulate a shutdown sequence.
@@ -252,4 +253,48 @@ func TestUIBridge_SendToClosedChannel(t *testing.T) {
 
 	// Clean up.
 	bridge.Cleanup()
+}
+
+func TestUIBridge_PanicErrorReturnValue(t *testing.T) {
+	t.Parallel()
+
+	mRenderer := new(agenttest.MockUIRenderer)
+	mRenderer.StartSpinnerWithStatusFn = func(ctx context.Context, status string) func() {
+		panic("intentional test panic for error return")
+	}
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	bridge := ui.NewBridge(mRenderer,
+		ui.WithBridgeThoughts(true),
+		ui.WithBridgeTools(true),
+		ui.WithBridgeRawOutput(false),
+		ui.WithBridgeColor(true),
+		ui.WithBridgeLogFile("test.log"),
+		ui.WithBridgeLogger(logger),
+	)
+	ctx, _, done, errCh := ui.StartListen(t, bridge)
+	defer func() {
+		bridge.CloseInput()
+		bridge.Cleanup()
+	}()
+
+	// Trigger the panic
+	_ = bridge.HandleEvent(ctx, events.InferenceStartedEvent{})
+
+	// Wait for shutdown
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for bridge to shutdown after panic")
+	}
+
+	// Read the error from Listen
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "uibridge panicked:")
+		assert.Contains(t, err.Error(), "intentional test panic for error return")
+	case <-time.After(1 * time.Second):
+		t.Fatal("Timeout waiting for Listen error")
+	}
 }

--- a/internal/domain/events/event_bus_lifecycle_whitebox_test.go
+++ b/internal/domain/events/event_bus_lifecycle_whitebox_test.go
@@ -141,4 +141,3 @@ func TestFlush_BusShutdownDuringFlush(t *testing.T) {
 		t.Errorf("expected ErrBusClosed, got %v", err)
 	}
 }
-


### PR DESCRIPTION
Closes #753.

## Summary
Closed all 5 remaining error-handling test gaps in `internal/agent/session/ui`:

| Task | Test | Gap Closed |
|------|------|------------|
| GAP-01 | `TestUIBridge_WithBridgeLoggerNil_FallbackToDefault` | `NewBridge` nil-logger defensive guard |
| GAP-02 | `TestUIBridge_Cleanup_PanicInWaitGoroutine` | `Cleanup()` goroutine panic recovery |
| GAP-03 | `TestUIBridge_CleanupTimeout` (fast-path subtest) | `Cleanup()` forced-cancellation `<-done` branch |
| GAP-04 | `TestUIBridge_CleanupTimeout` (Warn log assertion) | `Cleanup()` timeout Warn log |
| GAP-05 | `TestUIBridge_PanicErrorReturnValue` | `Listen()` panic error return value |

**Additional changes:**
- Added `cleanupWaitFn` test seam to `Bridge` struct (nil in production, follows `beforeBlockingSendHook` pattern)
- Updated `startListen` helper to return 4 values, exposing the error channel for panic error assertions
- Updated 26 callers of `startListen`/`StartListen` across 6 files

## Verification
| Check | Status |
|-------|--------|
| Coverage (`internal/agent/session/ui`) | 98.9% → **100%** |
| `make check-full` | PASS (all 10 steps) |
| `-race` | Clean |
| Lint | 0 issues |
| Dead code | None |
| Vulncheck | No vulnerabilities |