### PR TITLE
fix(workspace): add phase 4 error-handling test coverage (#755)

### DIFF
--- a/internal/domain/events/event_bus_lifecycle_whitebox_test.go
+++ b/internal/domain/events/event_bus_lifecycle_whitebox_test.go
@@ -141,4 +141,3 @@ func TestFlush_BusShutdownDuringFlush(t *testing.T) {
 		t.Errorf("expected ErrBusClosed, got %v", err)
 	}
 }
-

--- a/internal/infrastructure/history/unified_provider_test.go
+++ b/internal/infrastructure/history/unified_provider_test.go
@@ -245,6 +245,52 @@ func TestUnifiedProvider_GetHistoryStream(t *testing.T) {
 	}
 }
 
+func TestEncodeNextCursor(t *testing.T) {
+	provider := &unifiedProvider{}
+
+	tests := []struct {
+		name       string
+		nextOffset int64
+		items      []ports.HistoryViewDTO
+		want       string
+	}{
+		{
+			name:       "empty items returns EOF",
+			nextOffset: 10,
+			items:      nil,
+			want:       "EOF",
+		},
+		{
+			name:       "zero offset returns EOF",
+			nextOffset: 0,
+			items:      []ports.HistoryViewDTO{{Role: "user"}},
+			want:       "EOF",
+		},
+		{
+			name:       "both trigger EOF",
+			nextOffset: 0,
+			items:      nil,
+			want:       "EOF",
+		},
+		{
+			name:       "happy path returns numeric cursor",
+			nextOffset: 42,
+			items:      []ports.HistoryViewDTO{{Role: "user"}},
+			want:       "archive:42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := provider.encodeNextCursor(tt.nextOffset, tt.items)
+			if got != tt.want {
+				t.Errorf("encodeNextCursor(%d, %+v) = %q; want %q",
+					tt.nextOffset, tt.items, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUnifiedProvider_ToDTO_ExtraCases(t *testing.T) {
 	// Testing parts like thoughts and tool calls which weren't fully covered in the main test.
 	mockActive := &mockHistoryManager{}

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -354,6 +354,15 @@ func TestWithinParent(t *testing.T) {
 			want:   false,
 		},
 		{
+			name:   "rel error returns false",
+			parent: "",
+			target: "/foo/bar",
+			want:   false,
+			// filepath.Rel("", "/foo/bar") cleans "" to ".", then
+			// cannot compute a relative path between a relative and an
+			// absolute path → error → withinParent returns false.
+		},
+		{
 			name:    "different drives error",
 			parent:  "C:\\foo",
 			target:  "D:\\bar",

--- a/internal/tools/workspace/search_test.go
+++ b/internal/tools/workspace/search_test.go
@@ -8,10 +8,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
@@ -330,6 +333,81 @@ func TestCreateSearchMatcher_RegexInvalid(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// getDefinitionMatcher — regex query edge cases
+// ---------------------------------------------------------------------------
+
+func TestGetDefinitionMatcher_RegexQueryFiltersNonMatchingDef(t *testing.T) {
+	t.Parallel()
+
+	compiledDefs := getCompiledPatterns()
+
+	tests := []struct {
+		name      string
+		reQuery   *regexp.Regexp
+		path      string
+		line      string
+		wantMatch string
+		wantOK    bool
+	}{
+		{
+			name:      "regex query filters non-matching def",
+			reQuery:   regexp.MustCompile("otherFunc"),
+			path:      "main.go",
+			line:      "func main() {}",
+			wantMatch: "",
+			wantOK:    false,
+		},
+		{
+			name:      "regex query matches def line",
+			reQuery:   regexp.MustCompile("main"),
+			path:      "main.go",
+			line:      "func main() {}",
+			wantMatch: "",
+			wantOK:    true,
+		},
+		{
+			name:      "nil query passes all defs",
+			reQuery:   nil,
+			path:      "main.go",
+			line:      "func main() {}",
+			wantMatch: "",
+			wantOK:    true,
+		},
+		{
+			name:      "non-def line with query",
+			reQuery:   regexp.MustCompile("x"),
+			path:      "main.go",
+			line:      "var x = 1",
+			wantMatch: "",
+			wantOK:    false,
+		},
+		{
+			name:      "unsupported extension",
+			reQuery:   nil,
+			path:      "script.rb",
+			line:      "def foo",
+			wantMatch: "",
+			wantOK:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			matcher := getDefinitionMatcher(tt.reQuery, compiledDefs)
+			gotMatch, gotOK := matcher(tt.path, tt.line)
+			if gotMatch != tt.wantMatch {
+				t.Errorf("match = %q, want %q", gotMatch, tt.wantMatch)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("ok = %v, want %v", gotOK, tt.wantOK)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // checkConcurrentSearchError tests
 // ---------------------------------------------------------------------------
 
@@ -408,6 +486,33 @@ func TestGrepDefinitions_ConcurrentSearchError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "walk failure") {
 		t.Errorf("expected 'walk failure' in error, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// grepDefinitions — UnmarshalArgs failure
+// ---------------------------------------------------------------------------
+
+func TestGrepDefinitions_UnmarshalArgsFailure(t *testing.T) {
+	s := &fileSearcher{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	// A nested map cannot be unmarshaled into the Path string field.
+	args := map[string]interface{}{
+		"path": map[string]interface{}{"nested": "value"},
+	}
+
+	result, err := s.grepDefinitions(ctx, args, nil)
+	if err == nil {
+		t.Fatal("expected error from UnmarshalArgs")
+	}
+	// grepDefinitions returns (tools.ToolResult{}, err) on unmarshal failure.
+	if result.Text != "" || result.Error != nil {
+		t.Errorf("expected zero-value ToolResult, got %+v", result)
 	}
 }
 
@@ -517,6 +622,32 @@ func TestSearchFiles_ConcurrentSearchError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "walk failure") {
 		t.Errorf("expected 'walk failure', got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// searchFiles — UnmarshalArgs failure
+// ---------------------------------------------------------------------------
+
+func TestSearchFiles_UnmarshalArgsFailure(t *testing.T) {
+	s := &fileSearcher{
+		sm:     &toolstest.MockSecurityManager{AllowAll: true},
+		fs:     persistencetest.NewPlainOSFileSystem(),
+		policy: infra_persistence.NewWorkspacePolicy(),
+	}
+	ctx := context.Background()
+
+	// "not_a_bool" cannot be unmarshaled into the IsRegex bool field.
+	args := map[string]interface{}{
+		"is_regex": "not_a_bool",
+	}
+
+	result, err := s.searchFiles(ctx, args, nil)
+	if err == nil {
+		t.Fatal("expected error from UnmarshalArgs")
+	}
+	if !reflect.DeepEqual(result, tools.ToolResult{}) {
+		t.Errorf("expected zero-value ToolResult, got %+v", result)
 	}
 }
 

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -1142,3 +1142,76 @@ func TestWindowsShellWrapper_Wrap_PwshFound(t *testing.T) {
 		t.Errorf("expected UTF-8 prefix, got %q", got[4])
 	}
 }
+
+// TestShellTool_ExecuteCommand_UnmarshalError covers the error-handling path
+// in ExecuteCommand when tools.UnmarshalArgs fails (shell.go:207-209).
+// Passing "not_an_int" for the Timeout (int) field triggers a JSON unmarshal
+// failure, which the function must surface as a non-nil ToolResult.Error
+// with an "Error:"-prefixed Text and a nil Go error.
+func TestShellTool_ExecuteCommand_UnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+	tool := newTestShellTool(sm, &toolstest.MockCommandValidator{})
+	ctx := context.Background()
+
+	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
+		"timeout": "not_an_int",
+	}, nil)
+
+	if err != nil {
+		t.Errorf("expected nil Go error (domain outcome), got: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected res.Error to be non-nil")
+	}
+	if !strings.Contains(res.Text, "Error:") {
+		t.Errorf("expected 'Error:' prefix in Text, got: %q", res.Text)
+	}
+}
+
+// TestShellTool_PipeCommands_SplitPipelineError covers the splitPipeline
+// error-handling path in PipeCommands (shell.go:306-308). When
+// authorizeAndAuditPipeline passes but splitPipeline fails on a command,
+// the function must return a non-nil ToolResult.Error with an "Error:"-
+// prefixed Text and a nil Go error.
+func TestShellTool_PipeCommands_SplitPipelineError(t *testing.T) {
+	t.Parallel()
+
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	sm.SetBypassActive(true)
+
+	// SplitFunc fails for empty-string commands, triggering the
+	// splitPipeline error branch inside PipeCommands.
+	validator := &toolstest.MockCommandValidator{
+		SplitFunc: func(cmd string) ([]string, error) {
+			if cmd == "" {
+				return nil, fmt.Errorf("split: empty command")
+			}
+			return strings.Fields(cmd), nil
+		},
+	}
+	tool := newTestShellTool(sm, validator)
+	ctx := context.Background()
+
+	// Two entries pass len(commands) >= 2 in authorizeAndAuditPipeline,
+	// but the second is empty and will fail Split in splitPipeline.
+	res, err := tool.PipeCommands(ctx, map[string]interface{}{
+		"commands": []interface{}{"echo hello", ""},
+		"reason":   "testing split pipeline error",
+	}, nil)
+
+	if err != nil {
+		t.Errorf("expected nil Go error (domain outcome), got: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected res.Error to be non-nil from splitPipeline failure")
+	}
+	if !strings.Contains(res.Text, "Error:") {
+		t.Errorf("expected 'Error:' prefix in Text, got: %q", res.Text)
+	}
+	if !strings.Contains(res.Error.Error(), "split: empty command") {
+		t.Errorf("expected 'split: empty command' in res.Error, got: %v", res.Error)
+	}
+}

--- a/internal/tools/workspace/toolkit_tools_test.go
+++ b/internal/tools/workspace/toolkit_tools_test.go
@@ -130,3 +130,43 @@ func TestHandleLoadToolkit(t *testing.T) {
 		})
 	}
 }
+
+// TestHandleLoadToolkit_UnmarshalError verifies that passing malformed args
+// (where "names" is not []string) triggers an UnmarshalArgs failure, and the
+// returned ToolResult is zero-valued.
+func TestHandleLoadToolkit_UnmarshalError(t *testing.T) {
+	t.Parallel()
+
+	sp := &mockToolkitSessionProvider{
+		info: ports.SessionInfo{},
+	}
+	mp := &mockMetadataProvider{
+		toolkits: []string{"core", "git"},
+	}
+
+	pt := newpersistenceTools(sp, mp)
+
+	// "names" should be []string but we pass an int
+	args := map[string]interface{}{
+		"names": 42,
+	}
+
+	res, err := pt.handleLoadToolkit(context.Background(), args, nil)
+	if err == nil {
+		t.Fatal("expected error for malformed args, got nil")
+	}
+
+	// ToolResult should be zero-valued on error
+	if res.Text != "" {
+		t.Errorf("expected empty Text on error, got %q", res.Text)
+	}
+	if res.Error != nil {
+		t.Errorf("expected nil Error field, got %v", res.Error)
+	}
+	if len(res.BinaryData) != 0 {
+		t.Errorf("expected empty BinaryData, got %v", res.BinaryData)
+	}
+	if len(res.Metadata) != 0 {
+		t.Errorf("expected empty Metadata, got %v", res.Metadata)
+	}
+}

--- a/internal/tools/workspace/utils_test.go
+++ b/internal/tools/workspace/utils_test.go
@@ -6,6 +6,7 @@ package workspace
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -340,5 +341,128 @@ func TestWalkHeartbeat(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestShouldSkipEntry(t *testing.T) {
+	t.Parallel()
+
+	cancelCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	policy := infra_persistence.NewWorkspacePolicy()
+
+	regularFile := &mockFileInfo{name: "main.go", isDir: false}
+	normalDir := &mockFileInfo{name: "src", isDir: true}
+	dotGitDir := &mockFileInfo{name: ".git", isDir: true}
+
+	tests := []struct {
+		name     string
+		ctx      context.Context
+		info     os.FileInfo
+		err      error
+		wantSkip bool
+		wantErr  error
+	}{
+		{
+			name:     "walk error returns skip",
+			ctx:      context.Background(),
+			info:     nil,
+			err:      errors.New("walk error"),
+			wantSkip: true,
+			wantErr:  nil,
+		},
+		{
+			name:     "cancelled context returns skip with Canceled",
+			ctx:      cancelCtx,
+			info:     nil,
+			err:      nil,
+			wantSkip: true,
+			wantErr:  context.Canceled,
+		},
+		{
+			name:     "regular file not skipped",
+			ctx:      context.Background(),
+			info:     regularFile,
+			err:      nil,
+			wantSkip: false,
+			wantErr:  nil,
+		},
+		{
+			name:     "directory skipped without error",
+			ctx:      context.Background(),
+			info:     normalDir,
+			err:      nil,
+			wantSkip: true,
+			wantErr:  nil,
+		},
+		{
+			name:     "ignored directory returns SkipDir",
+			ctx:      context.Background(),
+			info:     dotGitDir,
+			err:      nil,
+			wantSkip: true,
+			wantErr:  filepath.SkipDir,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotSkip, gotErr := shouldSkipEntry(tt.ctx, tt.info, tt.err, policy)
+
+			if gotSkip != tt.wantSkip {
+				t.Errorf("skip = %v, want %v", gotSkip, tt.wantSkip)
+			}
+			if gotErr != tt.wantErr {
+				t.Errorf("err = %v, want %v", gotErr, tt.wantErr)
+			}
+		})
+	}
+}
+
+// isPathSafeErrorSM is a test double that embeds MockSecurityManager and
+// overrides IsPathSafe to always return an error, simulating a security rejection.
+type isPathSafeErrorSM struct {
+	toolstest.MockSecurityManager
+}
+
+func (m *isPathSafeErrorSM) IsPathSafe(path string) (string, error) {
+	return "", fmt.Errorf("path rejected")
+}
+
+func TestConcurrentSearch_IsPathSafeError(t *testing.T) {
+	t.Parallel()
+
+	sm := &isPathSafeErrorSM{}
+
+	ctx := context.Background()
+	resChan, errChan := ConcurrentSearch(ctx, sm, nil, "/tmp/test", nil, nil, infra_persistence.NewWorkspacePolicy())
+
+	// Read the error from errChan
+	err := <-errChan
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if err.Error() != "path rejected" {
+		t.Errorf("expected error %q, got %q", "path rejected", err.Error())
+	}
+
+	// Verify result channel is closed (should read zero value + ok=false)
+	result, ok := <-resChan
+	if ok {
+		t.Errorf("expected result channel to be closed, got %q (ok=%v)", result, ok)
+	}
+}
+
+func TestSearchPipeline_WalkFunc_ErrorSkip(t *testing.T) {
+	t.Parallel()
+
+	p := &searchPipeline{}
+	err := p.walkFunc("", nil, errors.New("permission denied"))
+	if err != nil {
+		t.Errorf("expected nil, got %v", err)
 	}
 }


### PR DESCRIPTION
Closes #755.

## Summary
Added error-handling test coverage for Phase 4 remaining gaps across `internal/tools/workspace` and `internal/infrastructure/history` packages. 10 testable error-handling gaps closed across 6 source files.

### Packages covered
| Package | Error-Handling Gaps Closed | Coverage |
|---------|---------------------------|----------|
| `internal/tools/workspace` | 9 | 96.9% |
| `internal/infrastructure/history` | 1 | 99.3% |
| `internal/agent/executor` | 0 (BUSINESS_LOGIC only) | 98.5% |
| `internal/agent/orchestrator` | 0 (BUSINESS_LOGIC only) | 98.6% |
| `internal/agent/session/context` | already 100% | 100.0% |
| `internal/infrastructure/factory` | already 100% | 100.0% |
| `internal/infrastructure/registry` | already 100% | 100.0% |

### Remaining gaps
~19 gaps are structurally unreachable (fresh exec.Cmd pipes, os.Getwd on functioning systems, Windows-only Cancel branches, json.Marshal on string-only structs) or BUSINESS_LOGIC/OTHER branches.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| -race across all 7 target packages | PASS |
| Coverage target >=95% | PASS (workspace 96.9%, all others >=98.5%) |
