### PR TITLE
fix(llm): decompose ResilientClient.Generate from complexity 9 to 4 (#776)

### DIFF
--- a/internal/infrastructure/llm/resilient_client.go
+++ b/internal/infrastructure/llm/resilient_client.go
@@ -40,6 +40,28 @@ func (r *resilientClient) wrapError(err error) error {
 	return llmerr.Classify(err)
 }
 
+// handleConnectionReset resets the underlying client's connection pool
+// when the error is transient (retryable via rate-limit or 5xx) or when
+// this is the final internal retry attempt, to prevent reusing poisoned
+// keep-alive connections.
+func (r *resilientClient) handleConnectionReset(wrapped error, attempt int) {
+	if llm.IsTransient(wrapped) || attempt == 1 {
+		if cr, ok := r.client.(connectionResetter); ok {
+			cr.ResetConnections()
+		}
+	}
+}
+
+// handleAuthRetry attempts to refresh authentication when an ErrAuth
+// is encountered on the first attempt. It returns true if the refresh
+// succeeded and the caller should retry the SendChat request.
+func (r *resilientClient) handleAuthRetry(wrapped error, attempt int) bool {
+	if errors.Is(wrapped, llm.ErrAuth) && attempt == 0 {
+		return r.client.RefreshAuth() == nil
+	}
+	return false
+}
+
 // Generate handles the LLM interaction logic synchronously.
 func (r *resilientClient) Generate(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
 	ctx, span := otel.Tracer("llm").Start(ctx, "llm.generate_content")
@@ -53,19 +75,11 @@ func (r *resilientClient) Generate(ctx context.Context, input []*llm.Content, to
 		}
 
 		wrapped := r.wrapError(err)
-		if errors.Is(wrapped, llm.ErrAuth) && attempt == 0 {
-			if refreshErr := r.client.RefreshAuth(); refreshErr == nil {
-				continue // Fixed! Retry once.
-			}
+		if r.handleAuthRetry(wrapped, attempt) {
+			continue
 		}
 
-		// Infrastructure-level resilience: reset connections on transient network errors (e.g., 502/504),
-		// rate limits, or on the final internal retry attempt to prevent reusing poisoned keep-alive connections.
-		if llm.IsTransient(wrapped) || attempt == 1 {
-			if cr, ok := r.client.(connectionResetter); ok {
-				cr.ResetConnections()
-			}
-		}
+		r.handleConnectionReset(wrapped, attempt)
 
 		lastErr = wrapped
 		break // Let the TurnEngine handle transient/terminal retries


### PR DESCRIPTION
Closes #776.

## Summary
Decomposed `ResilientClient.Generate` (hot path for all LLM calls) from cyclomatic complexity **9 → 4** by extracting two private helper methods following the PR #761 decomposition pattern (`classifyHTTP` → `httpStatusToDomain`):

| Method | Complexity | Responsibility |
|--------|-----------|----------------|
| `handleConnectionReset(wrapped, attempt)` | 4 | Connection pool reset on transient/rate-limit errors or final attempt |
| `handleAuthRetry(wrapped, attempt) bool` | 3 | Auth refresh decision on first-attempt `ErrAuth` |

### Acceptance Criteria
- ✅ Decompose to cyclomatic complexity ≤ 7 → **Achieved: 4**
- ✅ No test coverage regression → **All 29 tests pass, zero test file changes**
- ✅ Follow decomposition patterns from PRs #761, #762, #763 → **Pattern: extract pure decision helpers**
- ⚠️ Manual review by second engineer required before merge

## Verification
| Check | Status |
|-------|--------|
| make check-full | ✅ PASS (all 10 steps) |
| lint | 0 issues |
| vulncheck | No vulnerabilities |
| test-race | All pass |
| coverage (internal/infrastructure/llm) | 100% |
