### PR TITLE
fix(workspace): decompose readFiles and processLine to complexity ≤7 (#773)

### DIFF
--- a/internal/tools/workspace/reader.go
+++ b/internal/tools/workspace/reader.go
@@ -214,6 +214,22 @@ func (r *fileReader) processSingleFile(ctx context.Context, path string, sb *str
 	return nil
 }
 
+// processOnePath processes a single file path within the readFiles loop.
+// It handles heartbeat emission (every 5th file) and the processSingleFileFn
+// test override. Extracted from readFiles to keep cyclomatic complexity
+// ≤ 7 (PR #773).
+func (r *fileReader) processOnePath(ctx context.Context, i int, path string, sb *strings.Builder, hb chan<- struct{}) error {
+	if i%5 == 0 && hb != nil {
+		sendHeartbeat(ctx, hb)
+	}
+
+	psf := r.processSingleFile
+	if r.processSingleFileFn != nil {
+		psf = r.processSingleFileFn
+	}
+	return psf(ctx, path, sb)
+}
+
 func (r *fileReader) readFiles(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		FilePaths []string `json:"filepaths"`
@@ -234,16 +250,7 @@ func (r *fileReader) readFiles(ctx context.Context, args map[string]interface{},
 
 	var sb strings.Builder
 	for i, path := range params.FilePaths {
-		// Emit heartbeat every 5 files
-		if i%5 == 0 && hb != nil {
-			sendHeartbeat(ctx, hb)
-		}
-
-		psf := r.processSingleFile
-		if r.processSingleFileFn != nil {
-			psf = r.processSingleFileFn
-		}
-		if err := psf(ctx, path, &sb); err != nil {
+		if err := r.processOnePath(ctx, i, path, &sb, hb); err != nil {
 			return tools.ToolResult{}, err
 		}
 	}

--- a/internal/tools/workspace/stream_processor.go
+++ b/internal/tools/workspace/stream_processor.go
@@ -27,6 +27,23 @@ type streamProcessor struct {
 	file          *os.File
 }
 
+// buildLineContent constructs the content string and feedback message for a
+// single output line. It is extracted from processLine to keep cyclomatic
+// complexity below the threshold (PR #773).
+func buildLineContent(rawLine []byte, prefix string, feedback io.Writer) (content string, feedbackMsg string) {
+	content = string(rawLine) + "\n"
+	if feedback != nil {
+		feedbackMsg = fmt.Sprintf("  %s\n", rawLine)
+	}
+	if prefix != "" {
+		content = fmt.Sprintf("%s %s", prefix, content)
+		if feedback != nil {
+			feedbackMsg = fmt.Sprintf("  %s %s\n", prefix, rawLine)
+		}
+	}
+	return
+}
+
 func (sp *streamProcessor) processLine(sb *strings.Builder, rawLine []byte, prefix string, feedback io.Writer) {
 	sp.mu.Lock()
 	defer sp.mu.Unlock()
@@ -37,18 +54,7 @@ func (sp *streamProcessor) processLine(sb *strings.Builder, rawLine []byte, pref
 		sp.wt.Write(sp.file, lineWithNL)
 	}
 
-	content := string(rawLine) + "\n"
-	feedbackMsg := ""
-	if feedback != nil {
-		feedbackMsg = fmt.Sprintf("  %s\n", rawLine)
-	}
-
-	if prefix != "" {
-		content = fmt.Sprintf("%s %s", prefix, content)
-		if feedback != nil {
-			feedbackMsg = fmt.Sprintf("  %s %s\n", prefix, rawLine)
-		}
-	}
+	content, feedbackMsg := buildLineContent(rawLine, prefix, feedback)
 
 	remaining := sp.maxCapture - *sp.totalCaptured
 	if remaining > 0 {


### PR DESCRIPTION
Closes #773.

## Summary
Decomposed two functions in `internal/tools/workspace/` to reduce cyclomatic complexity from 9 to ≤7:

- **`readFiles`** (reader.go): Extracted loop body (heartbeat + file processing) into `processOnePath` method. Complexity: 9 → 6.
- **`processLine`** (stream_processor.go): Extracted content/feedback-message construction into `buildLineContent` pure helper. Complexity: 9 → 6.

Both follow the extract-helper pattern from PR #762.

## Changes
| File | Change |
|------|--------|
| `reader.go` | Added `processOnePath` method, simplified `readFiles` loop |
| `stream_processor.go` | Added `buildLineContent` function, simplified `processLine` |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint | 0 issues |
| processLine complexity | 6 (target ≤7) |
| readFiles complexity | 6 (target ≤7) |
| buildLineContent complexity | 4 |
| processOnePath complexity | 4 |
| All tests | PASS |
| No coverage regression | ✅