### PR TITLE
fix(analysis): decompose buildGraph from complexity 9 to 6 (#769)

### DIFF
--- a/internal/tools/analysis/dependency.go
+++ b/internal/tools/analysis/dependency.go
@@ -57,6 +57,37 @@ func (a *defaultDependencyAnalyzer) GetPackageGraph(ctx context.Context, args ma
 	return tools.ToolResult{Text: a.renderGraph(graph, format)}, nil
 }
 
+// buildGraph_processPackage resolves internal imports for a single package
+// directory and records the result in the shared graph map under a mutex.
+// Extracted from buildGraph to reduce cyclomatic complexity.
+func (a *defaultDependencyAnalyzer) buildGraph_processPackage(
+	ctx context.Context,
+	path string,
+	modRoot string,
+	modPrefix string,
+	graph map[string][]string,
+	mu *sync.Mutex,
+) error {
+	imports, err := a.getImports(ctx, path, modPrefix)
+	if err != nil {
+		return err
+	}
+
+	rel, err := filepathRelFn(modRoot, path)
+	if err != nil {
+		return err
+	}
+	pkgImportPath := modPrefix
+	if rel != "." {
+		pkgImportPath = filepath.ToSlash(filepath.Join(modPrefix, rel))
+	}
+
+	mu.Lock()
+	graph[pkgImportPath] = imports
+	mu.Unlock()
+	return nil
+}
+
 func (a *defaultDependencyAnalyzer) buildGraph(ctx context.Context) (map[string][]string, error) {
 	modPrefix, err := a.resolveModulePrefix(ctx)
 	if err != nil {
@@ -80,24 +111,7 @@ func (a *defaultDependencyAnalyzer) buildGraph(ctx context.Context) (map[string]
 	for _, p := range pkgPaths {
 		path := p
 		g.Go(func() error {
-			imports, err := a.getImports(groupCtx, path, modPrefix)
-			if err != nil {
-				return err
-			}
-
-			rel, err := filepathRelFn(modRoot, path)
-			if err != nil {
-				return err
-			}
-			pkgImportPath := modPrefix
-			if rel != "." {
-				pkgImportPath = filepath.ToSlash(filepath.Join(modPrefix, rel))
-			}
-
-			mu.Lock()
-			graph[pkgImportPath] = imports
-			mu.Unlock()
-			return nil
+			return a.buildGraph_processPackage(groupCtx, path, modRoot, modPrefix, graph, &mu)
 		})
 	}
 


### PR DESCRIPTION
Closes #769.

## Summary
Extracted `buildGraph_processPackage` helper method from the goroutine body in `buildGraph` to reduce cyclomatic complexity from 9 to 6. The new helper handles import resolution for a single package path, following the same decomposition pattern established in PR #761.

## Changes
- `internal/tools/analysis/dependency.go`: Added `buildGraph_processPackage` helper (complexity 4), simplified `buildGraph` (complexity 6)

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| buildGraph complexity | 6 (target ≤ 7) |
| buildGraph_processPackage complexity | 4 (target ≤ 7) |
| go test -race ./internal/tools/analysis/... | PASS |
| golangci-lint | 0 issues |
| No behavioral change | ✅ |
| No test modifications | ✅ |