### PR TITLE
fix(ui): decompose LogToolCall and updateSystemMetrics to complexity ≤7 (#774)

### DIFF
--- a/internal/ui/renderer_metrics.go
+++ b/internal/ui/renderer_metrics.go
@@ -99,10 +99,41 @@ func (r *stdUIRenderer) renderMetricsLineLocked(ui uiState, m *llm.Metrics, star
 		ui.c(colorGray), timestamp, modelStr, miss, ui.c(hColor), m.CachedTokens, ui.c(colorGray), m.ResponseTokens, thStr, costStr, ui.c(colorGray), timingStr, ui.c(colorReset))
 }
 
+// metrics_shouldSample returns true if at least one second has elapsed since
+// the last sample, or if no sample has ever been taken.
+// Caller must hold at least r.mu.RLock.
+func (r *stdUIRenderer) metrics_shouldSample(now time.Time) bool {
+	return now.Sub(r.lastSampleTime) >= time.Second || r.lastSampleTime.IsZero()
+}
+
+// metrics_computeCPU calculates CPU usage percentage from raw counter deltas.
+// When idleTicks > 0, host-level tick-based computation is used (1 - idle/total).
+// Otherwise agent-level CPU-seconds are divided by wall-clock time per core.
+func metrics_computeCPU(now time.Time, lastSampleTime time.Time, currentTotal, lastCPUTime, currentIdle, lastIdleTime int64) float64 {
+	if lastSampleTime.IsZero() {
+		return 0
+	}
+	if currentIdle > 0 {
+		dTotal := float64(currentTotal - lastCPUTime)
+		dIdle := float64(currentIdle - lastIdleTime)
+		if dTotal > 0 {
+			return (1.0 - (dIdle / dTotal)) * 100.0
+		}
+		return 0
+	}
+	// Agent-level from runtime/metrics
+	dt := now.Sub(lastSampleTime).Seconds()
+	if dt > 0 {
+		dCPU := float64(currentTotal-lastCPUTime) / 1e9
+		return (dCPU / dt) * 100.0 / float64(runtime.NumCPU())
+	}
+	return 0
+}
+
 func (r *stdUIRenderer) updateSystemMetrics(now time.Time) (float64, float64) {
 	// 1. Check if update is needed under RLock
 	r.mu.RLock()
-	needsUpdate := now.Sub(r.lastSampleTime) >= time.Second || r.lastSampleTime.IsZero()
+	needsUpdate := r.metrics_shouldSample(now)
 	cpuPercent := r.lastCPUPercent
 	hostMemPercent := r.lastMemPercent
 	r.mu.RUnlock()
@@ -117,24 +148,8 @@ func (r *stdUIRenderer) updateSystemMetrics(now time.Time) (float64, float64) {
 		defer r.mu.Unlock()
 
 		// Re-check update condition under write lock
-		if now.Sub(r.lastSampleTime) >= time.Second || r.lastSampleTime.IsZero() {
-			if !r.lastSampleTime.IsZero() {
-				if currentIdle > 0 {
-					// Host-level metrics
-					dTotal := float64(currentTotal - r.lastCPUTime)
-					dIdle := float64(currentIdle - r.lastIdleTime)
-					if dTotal > 0 {
-						cpuPercent = (1.0 - (dIdle / dTotal)) * 100.0
-					}
-				} else {
-					// Agent-level from runtime/metrics
-					dt := now.Sub(r.lastSampleTime).Seconds()
-					if dt > 0 {
-						dCPU := float64(currentTotal-r.lastCPUTime) / 1e9 // seconds
-						cpuPercent = (dCPU / dt) * 100.0 / float64(runtime.NumCPU())
-					}
-				}
-			}
+		if r.metrics_shouldSample(now) {
+			cpuPercent = metrics_computeCPU(now, r.lastSampleTime, currentTotal, r.lastCPUTime, currentIdle, r.lastIdleTime)
 			hostMemPercent = currentMem
 			r.lastCPUTime = currentTotal
 			r.lastIdleTime = currentIdle
@@ -245,6 +260,42 @@ func (r *stdUIRenderer) LogUsage(ctx context.Context, m *llm.Metrics, logFile st
 	}
 }
 
+// metrics_truncateArg truncates valStr to at most 189 characters, appending
+// "..." when truncation occurs. This mirrors the truncation used for tool
+// call argument values in the [Tool Action] line.
+func metrics_truncateArg(valStr string) string {
+	if len(valStr) > 189 {
+		return valStr[:186] + "..."
+	}
+	return valStr
+}
+
+// metrics_formatToolCallArgLine builds a comma-separated "key: value" string
+// from the function call arguments, excluding the "reason" key which is
+// rendered separately as [Tool Reason]. Values longer than 189 characters
+// are truncated.
+func metrics_formatToolCallArgLine(args map[string]interface{}) string {
+	var parts []string
+	for k, v := range args {
+		if k == "reason" {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s: %v", k, metrics_truncateArg(fmt.Sprintf("%v", v))))
+	}
+	return strings.Join(parts, ", ")
+}
+
+// metrics_logToolReason prints a [Tool Reason] line to stderr if the function
+// call contains a non-empty "reason" argument. Caller must hold r.ioMu.
+func (r *stdUIRenderer) metrics_logToolReason(ui uiState, fc *llm.FunctionCall, ts string) {
+	reason, ok := fc.Args["reason"].(string)
+	if !ok || reason == "" {
+		return
+	}
+	_, _ = fmt.Fprintf(ui.stderr, "%s[%s] [Tool Reason] %s%s\n",
+		ui.c(colorGray), ts, reason, ui.c(colorReset))
+}
+
 func (r *stdUIRenderer) LogToolCall(ctx context.Context, calls []*llm.FunctionCall, turn, maxTurns int, showTools bool) {
 	if r.locker != nil {
 		r.locker.TerminalLock()
@@ -263,25 +314,10 @@ func (r *stdUIRenderer) LogToolCall(ctx context.Context, calls []*llm.FunctionCa
 
 	if showTools {
 		for _, fc := range calls {
-			// Extract and display the reason if present
-			if reason, ok := fc.Args["reason"].(string); ok && reason != "" {
-				_, _ = fmt.Fprintf(stderr, "%s[%s] [Tool Reason] %s%s\n",
-					ui.c(colorGray), ts, reason, ui.c(colorReset))
-			}
+			r.metrics_logToolReason(ui, fc, ts)
 
-			var argParts []string
-			for k, v := range fc.Args {
-				if k == "reason" {
-					continue // Already shown as [Tool Reason]
-				}
-				valStr := fmt.Sprintf("%v", v)
-				if len(valStr) > 189 {
-					valStr = valStr[:186] + "..."
-				}
-				argParts = append(argParts, fmt.Sprintf("%s: %v", k, valStr))
-			}
 			_, _ = fmt.Fprintf(stderr, "%s[%s] [Tool Action] %s(%s)%s\n",
-				ui.c(colorMagenta), ts, fc.Name, strings.Join(argParts, ", "), ui.c(colorReset))
+				ui.c(colorMagenta), ts, fc.Name, metrics_formatToolCallArgLine(fc.Args), ui.c(colorReset))
 		}
 	}
 }

--- a/internal/ui/renderer_metrics.go
+++ b/internal/ui/renderer_metrics.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"os"
 	"runtime"
 	"strings"
@@ -109,9 +110,12 @@ func (r *stdUIRenderer) metrics_shouldSample(now time.Time) bool {
 // metrics_computeCPU calculates CPU usage percentage from raw counter deltas.
 // When idleTicks > 0, host-level tick-based computation is used (1 - idle/total).
 // Otherwise agent-level CPU-seconds are divided by wall-clock time per core.
+// Returns math.NaN() as a sentinel when the computation cannot produce a valid
+// update (e.g., zero delta-time or counter rollover). Callers must check with
+// math.IsNaN before using the result.
 func metrics_computeCPU(now time.Time, lastSampleTime time.Time, currentTotal, lastCPUTime, currentIdle, lastIdleTime int64) float64 {
 	if lastSampleTime.IsZero() {
-		return 0
+		return math.NaN()
 	}
 	if currentIdle > 0 {
 		dTotal := float64(currentTotal - lastCPUTime)
@@ -119,7 +123,7 @@ func metrics_computeCPU(now time.Time, lastSampleTime time.Time, currentTotal, l
 		if dTotal > 0 {
 			return (1.0 - (dIdle / dTotal)) * 100.0
 		}
-		return 0
+		return math.NaN()
 	}
 	// Agent-level from runtime/metrics
 	dt := now.Sub(lastSampleTime).Seconds()
@@ -127,7 +131,7 @@ func metrics_computeCPU(now time.Time, lastSampleTime time.Time, currentTotal, l
 		dCPU := float64(currentTotal-lastCPUTime) / 1e9
 		return (dCPU / dt) * 100.0 / float64(runtime.NumCPU())
 	}
-	return 0
+	return math.NaN()
 }
 
 func (r *stdUIRenderer) updateSystemMetrics(now time.Time) (float64, float64) {
@@ -149,7 +153,9 @@ func (r *stdUIRenderer) updateSystemMetrics(now time.Time) (float64, float64) {
 
 		// Re-check update condition under write lock
 		if r.metrics_shouldSample(now) {
-			cpuPercent = metrics_computeCPU(now, r.lastSampleTime, currentTotal, r.lastCPUTime, currentIdle, r.lastIdleTime)
+			if cpu := metrics_computeCPU(now, r.lastSampleTime, currentTotal, r.lastCPUTime, currentIdle, r.lastIdleTime); !math.IsNaN(cpu) {
+				cpuPercent = cpu
+			}
 			hostMemPercent = currentMem
 			r.lastCPUTime = currentTotal
 			r.lastIdleTime = currentIdle

--- a/internal/ui/renderer_metrics_test.go
+++ b/internal/ui/renderer_metrics_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ui
+
+import (
+	"math"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func TestMetrics_computeCPU_EdgeCasesReturnNaN(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 1, 0, time.UTC)
+	validSampleTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("ZeroSampleTime returns NaN", func(t *testing.T) {
+		got := metrics_computeCPU(now, time.Time{}, 1000, 500, 0, 0)
+		if !math.IsNaN(got) {
+			t.Errorf("expected NaN for zero sample time, got %f", got)
+		}
+	})
+
+	t.Run("HostLevel_dTotalZero returns NaN", func(t *testing.T) {
+		// dTotal = currentTotal - lastCPUTime = 0
+		got := metrics_computeCPU(now, validSampleTime, 1000, 1000, 500, 400)
+		if !math.IsNaN(got) {
+			t.Errorf("expected NaN for dTotal <= 0, got %f", got)
+		}
+	})
+
+	t.Run("HostLevel_dTotalNegative returns NaN", func(t *testing.T) {
+		// dTotal = currentTotal - lastCPUTime < 0 (counter rollover simulation)
+		got := metrics_computeCPU(now, validSampleTime, 500, 1000, 500, 400)
+		if !math.IsNaN(got) {
+			t.Errorf("expected NaN for dTotal < 0, got %f", got)
+		}
+	})
+
+	t.Run("AgentLevel_dtZero returns NaN", func(t *testing.T) {
+		// dt = now.Sub(lastSampleTime) = 0
+		got := metrics_computeCPU(validSampleTime, validSampleTime, 2000, 1000, 0, 0)
+		if !math.IsNaN(got) {
+			t.Errorf("expected NaN for dt <= 0, got %f", got)
+		}
+	})
+
+	t.Run("AgentLevel_dtNegative returns NaN", func(t *testing.T) {
+		// now is before lastSampleTime (clock skew)
+		earlier := validSampleTime.Add(-1 * time.Second)
+		got := metrics_computeCPU(earlier, validSampleTime, 2000, 1000, 0, 0)
+		if !math.IsNaN(got) {
+			t.Errorf("expected NaN for dt < 0, got %f", got)
+		}
+	})
+}
+
+func TestMetrics_computeCPU_ValidCases(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 1, 0, time.UTC)
+	validSampleTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	t.Run("HostLevel_normal computes CPU percentage", func(t *testing.T) {
+		// dTotal = 1000, dIdle = 200 → (1 - 200/1000) * 100 = 80%
+		got := metrics_computeCPU(now, validSampleTime, 2000, 1000, 1000, 800)
+		want := 80.0
+		if math.Abs(got-want) > 0.01 {
+			t.Errorf("expected %.1f%%, got %.1f%%", want, got)
+		}
+	})
+
+	t.Run("AgentLevel_normal computes CPU percentage", func(t *testing.T) {
+		// dCPU = (2000 - 1000) / 1e9 = 1e-6 seconds
+		// dt = 1 second
+		// cpu = (1e-6 / 1) * 100 / NumCPU
+		dCPUNano := int64(0.5 * float64(runtime.NumCPU()) * 1e9) // 0.5 * NumCPU seconds
+		got := metrics_computeCPU(now, validSampleTime, 1000+dCPUNano, 1000, 0, 0)
+		want := 50.0
+		if math.Abs(got-want) > 0.01 {
+			t.Errorf("expected %.1f%%, got %.1f%%", want, got)
+		}
+	})
+}
+
+func TestUpdateSystemMetrics_PreservesCachedCPUOnNaN(t *testing.T) {
+	// Simulates the regression: after a valid CPU reading is cached,
+	// a subsequent edge case (dTotal=0) must preserve the cached value
+	// instead of overwriting with 0.
+
+	// Pre-populate with a valid cached CPU value.
+	validCPUPercent := 75.0
+	now := time.Date(2026, 1, 1, 12, 0, 2, 0, time.UTC)
+
+	r := &stdUIRenderer{
+		lastSampleTime: time.Date(2026, 1, 1, 12, 0, 1, 0, time.UTC),
+		lastCPUTime:    1000,
+		lastIdleTime:   500,
+		lastCPUPercent: validCPUPercent,
+		lastMemPercent: 60.0,
+	}
+
+	// Set up a mock provider that returns the same total/idle (dTotal=0 edge case).
+	r.metricsProvider = &mockMetricsProviderForTest{
+		total: 1000,
+		idle:  500,
+		mem:   60.0,
+	}
+
+	cpu, mem := r.updateSystemMetrics(now)
+
+	if cpu != validCPUPercent {
+		t.Errorf("expected cached CPU %.1f%% to be preserved, got %.1f%%", validCPUPercent, cpu)
+	}
+	if mem != 60.0 {
+		t.Errorf("expected cached MEM 60.0%%, got %.1f%%", mem)
+	}
+}
+
+// mockMetricsProviderForTest is a simple mock for internal testing.
+type mockMetricsProviderForTest struct {
+	total int64
+	idle  int64
+	mem   float64
+}
+
+func (m *mockMetricsProviderForTest) GetCPUStats() (int64, int64) {
+	return m.total, m.idle
+}
+
+func (m *mockMetricsProviderForTest) GetMemoryPercent() float64 {
+	return m.mem
+}


### PR DESCRIPTION
Closes #774.

## Summary
Decomposed two functions in `internal/ui/renderer_metrics.go` from complexity 9 to ≤7:

| Function | Before | After |
|----------|--------|-------|
| `LogToolCall` | 9 | **4** |
| `updateSystemMetrics` | 9 | **3** |

Extracted 5 helpers with consistent `metrics_` prefix:
- `metrics_shouldSample` (receiver, complexity 2) — deduplicated time-since-last-sample predicate
- `metrics_computeCPU` (pure func, complexity 5) — CPU % from host ticks or agent seconds
- `metrics_truncateArg` (pure func, complexity 2) — arg value truncation at 189 chars
- `metrics_formatToolCallArgLine` (pure func, complexity 3) — builds key:value string from args, excludes reason
- `metrics_logToolReason` (receiver, complexity 3) — prints [Tool Reason] with early-return guard

Follows decomposition patterns from PRs #761, #762, #763.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage (internal/ui) | 94.0% |
| No test regression | ✅ |
| Complexity target met | ✅ |