### PR TITLE
fix(analysis): decompose trackExternalUsages from complexity 9 to 5 (#772)

### DIFF
--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -300,6 +300,27 @@ func (a *defaultDeadCodeAnalyzer) protectContractSymbol(state *scanState, id str
 	state.externalUses[id]++
 }
 
+// trackExternalUsages_isExternalUsage determines whether a single usage
+// location qualifies as an external (cross-package or test-package) usage.
+// Extracted from trackExternalUsages to reduce cyclomatic complexity
+// below the project threshold of 7 (Issue #772).
+func (a *defaultDeadCodeAnalyzer) trackExternalUsages_isExternalUsage(
+	loc location,
+	fileToPkg map[string]string,
+	targetModule string,
+	objBase string,
+) bool {
+	usagePkg, ok := fileToPkg[loc.Path]
+	if !ok {
+		return false
+	}
+	if !strings.HasPrefix(usagePkg, targetModule) {
+		return false
+	}
+	pkgBase := getBasePkgPath(usagePkg)
+	return pkgBase != objBase || strings.Contains(usagePkg, ".test]") || strings.HasSuffix(usagePkg, "_test")
+}
+
 func (a *defaultDeadCodeAnalyzer) trackExternalUsages(ctx context.Context, state *scanState, id string, meta *symMeta, fileToPkg map[string]string, resolvedPath string, hb chan<- struct{}) error {
 	if !a.idx.IsSymbolUsed(ctx, id, hb) {
 		return nil
@@ -313,16 +334,7 @@ func (a *defaultDeadCodeAnalyzer) trackExternalUsages(ctx context.Context, state
 	objBase := getBasePkgPath(meta.pkgPath)
 
 	for _, loc := range allUsages {
-		usagePkg, ok := fileToPkg[loc.Path]
-		if !ok {
-			continue
-		}
-		if !strings.HasPrefix(usagePkg, state.targetModule) {
-			continue
-		}
-		pkgBase := getBasePkgPath(usagePkg)
-
-		if pkgBase != objBase || strings.Contains(usagePkg, ".test]") || strings.HasSuffix(usagePkg, "_test") {
+		if a.trackExternalUsages_isExternalUsage(loc, fileToPkg, state.targetModule, objBase) {
 			state.externalUses[id]++
 		}
 	}


### PR DESCRIPTION
Closes #772.

## Summary
Extracted `trackExternalUsages_isExternalUsage` helper from `trackExternalUsages` to reduce cyclomatic complexity from 9 to 5. The new function is a pure predicate that determines whether a usage location qualifies as cross-package or test-package. The original function is now a thin orchestrator.

### Changes
- `internal/tools/analysis/dead_code.go`: Added `trackExternalUsages_isExternalUsage` helper (complexity 5), simplified `trackExternalUsages` loop body (complexity 5, was 9).

### Acceptance Criteria
| Criterion | Status |
|-----------|--------|
| Complexity <= 7 | PASS (both functions at 5) |
| No test regression | PASS (all tests pass) |
| Follow PR #762 pattern | PASS (pure predicate extraction) |
| Prefix `trackExternalUsages_` | PASS |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage (analysis) | 95.7% |
