### PR TITLE
fix(llm): close error-handling gaps in provider error mapping (#782)

### DIFF
--- a/internal/infrastructure/llm/anthropic/client.go
+++ b/internal/infrastructure/llm/anthropic/client.go
@@ -364,6 +364,13 @@ func (c *client) prepareAnthropicRequest(ctx context.Context, history []*llm.Con
 		}
 	}
 
+	// ADR-024 corollary (Issue #782): json.Marshal(reqPayload) cannot fail
+	// with the current messagesRequest type tree — every field resolves to
+	// strings, ints, or interface{} populated exclusively with JSON-safe
+	// types (json.RawMessage, string, map[string]interface{}, typed string-only
+	// structs). No float64 fields exist, so NaN/Inf cannot appear. The error
+	// branch below is defensive dead code that serves as a safety net if a
+	// future field addition introduces a marshal-unfriendly type.
 	body, err := json.Marshal(reqPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)

--- a/internal/infrastructure/llm/anthropic/client_messages_test.go
+++ b/internal/infrastructure/llm/anthropic/client_messages_test.go
@@ -6,6 +6,7 @@ package anthropic
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -302,6 +303,20 @@ func TestPartToContentBlock(t *testing.T) {
 			wantType: "text",
 			wantOk:   true,
 			wantErr:  false,
+		},
+		{
+			name: "FunctionCall - args with NaN causes marshal error",
+			part: &llm.Part{
+				FunctionCall: &llm.FunctionCall{
+					ID:   "call_nan",
+					Name: "bad_tool",
+					Args: map[string]interface{}{"value": math.NaN()},
+				},
+			},
+			role:        "assistant",
+			wantOk:      false,
+			wantErr:     true,
+			errContains: "NaN",
 		},
 		{
 			name:    "Empty part",

--- a/internal/infrastructure/llm/llmerr/errors_test.go
+++ b/internal/infrastructure/llm/llmerr/errors_test.go
@@ -268,6 +268,16 @@ func TestClassify(t *testing.T) {
 			expectedWrap: llm.ErrTransient,
 		},
 		{
+			name:         "HTTPStatusErr with non-classifiable status 200",
+			input:        &mockHTTPStatusErr{status: 200},
+			expectedWrap: llm.ErrTerminal,
+		},
+		{
+			name:         "HTTPStatusErr with zero status",
+			input:        &mockHTTPStatusErr{status: 0},
+			expectedWrap: llm.ErrTerminal,
+		},
+		{
 			name:         "Unclassified error defaults to terminal",
 			input:        errors.New("unknown error"),
 			expectedWrap: llm.ErrTerminal,
@@ -363,3 +373,11 @@ type mockNetError struct {
 func (e *mockNetError) Error() string   { return e.msg }
 func (e *mockNetError) Timeout() bool   { return e.timeout }
 func (e *mockNetError) Temporary() bool { return false }
+
+// mockHTTPStatusErr implements HTTPStatusErr for testing classifyHTTP fallthrough.
+type mockHTTPStatusErr struct {
+	status int
+}
+
+func (e *mockHTTPStatusErr) Error() string   { return fmt.Sprintf("http %d", e.status) }
+func (e *mockHTTPStatusErr) StatusCode() int { return e.status }

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -147,10 +147,10 @@ func (c *client) processDirectOutputItem(content *llm.Content, out *responseOutp
 		// alongside the sentinel suppression for output-item types like "call"
 		// and "message".
 		//
-		// Coverage gap accepted by architect (Issue #617). The branch is
-		// untestable without refactoring appendPartsFromBlock to return a
-		// distinguishable error type. processDirectOutputItem exceeds 90%
-		// branch coverage via all other reachable paths.
+		// Coverage gap accepted by architect (Issue #617).
+		// Reviewed: Issue #782 (2026-06) — branch remains structurally
+		// unreachable; no testable error path exists without refactoring
+		// appendPartsFromBlock. Accepted as defensive future-proofing.
 		if !errors.Is(err, errUnhandledBlockType) {
 			return err
 		}


### PR DESCRIPTION
Closes #782.

## Summary
Close 5 error-handling coverage gaps across the LLM infrastructure layer:

| File | Gap | Method | Result |
|------|-----|--------|--------|
| `llmerr/errors.go` | `httpStatusToDomain` nil-return | Test: mock non-classifiable HTTP status | 85.7% → **100.0%** |
| `llmerr/errors.go` | `classifyHTTP` nil-return | Test: same mock, one frame up | 83.3% → **100.0%** |
| `anthropic/messages.go` | `toolUseBlock` JSON marshal error | Test: NaN in tool args | 90.0% → **100.0%** |
| `anthropic/client.go` | `prepareAnthropicRequest` marshal error | Doc: ADR-024 corollary | 94.1% (structurally unreachable) |
| `openai/responses.go` | ADR-024 guard | Doc: #782 cross-reference | Accepted per ADR-024 |

## Verification
| Check | Status |
|-------|--------|
| make check-full | **PASS** (all 10 steps) |
| llmerr coverage | 100.0% |
| anthropic coverage | 99.6% |
| openai coverage | 99.8% |