### PR TITLE
fix(ui): close error-handling gaps in prompt capturer and model tests (#788)

### DIFF
--- a/internal/ui/tui/prompt/model_test.go
+++ b/internal/ui/tui/prompt/model_test.go
@@ -342,6 +342,37 @@ func TestModel_Update(t *testing.T) {
 			},
 			wantCmd: false,
 		},
+		{
+			name: "tab_no_suggestions_falls_through",
+			setupModel: func() PromptModel {
+				m := NewModel(&mockSuggestionSvc{}, 1*time.Millisecond).(*promptModel)
+				m.suggester.Suggestions = []string{}
+				m.suggester.Index = -1
+				m.input.SetValue("hello")
+				return m
+			},
+			msg: tea.KeyMsg{Type: tea.KeyTab},
+			assertState: func(t *testing.T, m PromptModel) {
+				t.Helper()
+				assertSubmitted(t, m, false)
+				assertAborted(t, m, false)
+			},
+			wantCmd: false,
+		},
+		{
+			name: "enter_without_alt_does_not_submit",
+			setupModel: func() PromptModel {
+				m := NewModel(&mockSuggestionSvc{}, 1*time.Millisecond).(*promptModel)
+				m.input.SetValue("hello")
+				return m
+			},
+			msg: tea.KeyMsg{Type: tea.KeyEnter},
+			assertState: func(t *testing.T, m PromptModel) {
+				t.Helper()
+				assertSubmitted(t, m, false)
+			},
+			wantCmd: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -623,6 +654,21 @@ func TestModel_GetSuggestions_ContextCancelledDuringFetch(t *testing.T) {
 
 	if msg != nil {
 		t.Errorf("expected nil msg for cancelled-context error, got %T", msg)
+	}
+}
+
+func TestNewModel_ZeroDebounceDuration(t *testing.T) {
+	m := NewModel(&mockSuggestionSvc{}, 0)
+	defer m.Destroy()
+
+	pm, ok := m.(*promptModel)
+	if !ok {
+		t.Fatal("NewModel did not return *promptModel")
+	}
+
+	if pm.debounceDuration != DefaultDebounceDuration {
+		t.Errorf("debounceDuration = %v, want %v (DefaultDebounceDuration)",
+			pm.debounceDuration, DefaultDebounceDuration)
 	}
 }
 

--- a/internal/ui/tui/prompt_capturer_test.go
+++ b/internal/ui/tui/prompt_capturer_test.go
@@ -35,6 +35,15 @@ func (m *mockBaseCapturer) ReadLine(ctx context.Context) (string, error)      { 
 func (m *mockBaseCapturer) ReadSingleKey(ctx context.Context) (string, error) { return "", nil }
 func (m *mockBaseCapturer) Close(ctx context.Context) error                   { return nil }
 
+// mockBaseCapturerWithCloseError returns an error from Close.
+type mockBaseCapturerWithCloseError struct {
+	mockBaseCapturer
+}
+
+func (m *mockBaseCapturerWithCloseError) Close(ctx context.Context) error {
+	return errors.New("base close failed")
+}
+
 type mockSuggestionService struct {
 	recordedPrompts []string
 }
@@ -48,6 +57,15 @@ func (m *mockSuggestionService) RecordPrompt(ctx context.Context, prompt string)
 }
 func (m *mockSuggestionService) Close(ctx context.Context) error {
 	return nil
+}
+
+// mockSuggestionServiceWithRecordError returns an error from RecordPrompt.
+type mockSuggestionServiceWithRecordError struct {
+	mockSuggestionService
+}
+
+func (m *mockSuggestionServiceWithRecordError) RecordPrompt(ctx context.Context, prompt string) error {
+	return errors.New("record failed")
 }
 
 func TestPromptCapturer_CapturePrompt_Fallback(t *testing.T) {
@@ -287,5 +305,47 @@ func TestRunTUI_ProvidesFeedback(t *testing.T) {
 	}
 	if result != "test prompt" {
 		t.Errorf("expected 'test prompt', got %q", result)
+	}
+}
+
+func TestPromptCapturer_ProvideFeedback_Empty(t *testing.T) {
+	base := &mockBaseCapturer{}
+	svc := &mockSuggestionService{}
+	capturer := NewPromptCapturer(base, svc)
+
+	// Calling provideFeedback with empty string should be a no-op
+	capturer.provideFeedback(context.Background(), "")
+
+	// Verify no RecordPrompt call was made
+	if len(svc.recordedPrompts) != 0 {
+		t.Errorf("expected 0 recorded prompts for empty input, got %d: %v", len(svc.recordedPrompts), svc.recordedPrompts)
+	}
+}
+
+func TestPromptCapturer_ProvideFeedback_RecordError(t *testing.T) {
+	base := &mockBaseCapturer{}
+	svc := &mockSuggestionServiceWithRecordError{}
+	capturer := NewPromptCapturer(base, svc)
+
+	// Calling provideFeedback with non-empty prompt when RecordPrompt fails
+	// should NOT panic — the error is logged, not propagated.
+	capturer.provideFeedback(context.Background(), "hello world")
+
+	// The error path is fire-and-forget; the function returns normally.
+	// No assertion needed on the log output — just verifying no panic.
+}
+
+func TestPromptCapturer_Close_BaseError(t *testing.T) {
+	base := &mockBaseCapturerWithCloseError{}
+	svc := &mockSuggestionService{}
+	capturer := NewPromptCapturer(base, svc)
+
+	err := capturer.Close(context.Background())
+
+	if err == nil {
+		t.Fatal("expected error from Close when base.Close fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "base close failed") {
+		t.Errorf("expected error to contain 'base close failed', got: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #788.

## Summary
Closed 5 error-handling gaps across `internal/ui/tui/prompt_capturer.go` (3 gaps) and `internal/ui/tui/prompt/model.go` (2 gaps) by adding targeted test coverage:

| Gap | File | Function | Branch | Status |
|-----|------|----------|--------|:---:|
| G1 | prompt_capturer.go:82 | CapturePrompt | empty+SkipTTYWait | Unreachable (covered via downstream test) |
| G2a | prompt_capturer.go:124 | provideFeedback | empty early return | ✅ |
| G2b | prompt_capturer.go:128-130 | provideFeedback | RecordPrompt error | ✅ |
| G3 | prompt_capturer.go:165 | Close | base.Close error | ✅ |
| G4 | prompt/model.go:64 | NewModel | zero debounce default | ✅ |
| G5a | prompt/model.go:129 | handleKeyMsg | Tab no suggestions | ✅ |
| G5b | prompt/model.go:143 | handleKeyMsg | Enter without Alt | ✅ |

## Changes
- `internal/ui/tui/prompt_capturer_test.go` — +60 lines (3 test functions, 2 new mock types)
- `internal/ui/tui/prompt/model_test.go` — +46 lines (1 test function, 2 table-driven rows)

No production code modified.

## Coverage

| Package | Before | After |
|---------|:------:|:-----:|
| `internal/ui/tui` | 92.5% | **93.0%** |
| `internal/ui/tui/prompt` | 97.4% | **99.1%** |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (1 pre-existing flake in unrelated workspace test) |
| lint | 0 issues |
| vulncheck | No vulnerabilities |
| target coverage | ≥93.0% / ≥99.1% |