### PR TITLE
fix(analysis): wrap error-handling paths with context (#796)

### DIFF
--- a/internal/tools/analysis/changes.go
+++ b/internal/tools/analysis/changes.go
@@ -33,7 +33,7 @@ func (a *defaultChangeAnalyzer) SemanticDiff(ctx context.Context, args map[strin
 		Target string `json:"target"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("semantic diff: %w", err)
 	}
 
 	if params.Target == "" {

--- a/internal/tools/analysis/changes_test.go
+++ b/internal/tools/analysis/changes_test.go
@@ -321,41 +321,28 @@ func TestGetDiffMetadata_StatError(t *testing.T) {
 
 func TestSemanticDiff_UnmarshalArgsError(t *testing.T) {
 	t.Parallel()
-	// Use a no-op analyzer — UnmarshalArgs fails before cache/exec are touched
 	analyzer := newChangeAnalyzer(nil, nil)
 
-	tests := []struct {
-		name    string
-		args    map[string]interface{}
-		wantErr string
-	}{
-		{
-			name:    "nil args",
-			args:    nil,
-			wantErr: "", // any error is acceptable
-		},
-		{
-			name:    "missing target",
-			args:    map[string]interface{}{},
-			wantErr: "target",
-		},
-		{
-			name:    "target wrong type",
-			args:    map[string]interface{}{"target": 42},
-			wantErr: "", // any error is acceptable
-		},
-	}
+	t.Run("nil args", func(t *testing.T) {
+		t.Parallel()
+		_, err := analyzer.SemanticDiff(context.Background(), nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "args must not be nil")
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			_, err := analyzer.SemanticDiff(context.Background(), tt.args, nil)
-			require.Error(t, err, "expected error for args: %v", tt.args)
-			if tt.wantErr != "" {
-				assert.Contains(t, err.Error(), tt.wantErr)
-			}
-		})
-	}
+	t.Run("missing target", func(t *testing.T) {
+		t.Parallel()
+		_, err := analyzer.SemanticDiff(context.Background(), map[string]interface{}{}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "missing required argument: target")
+	})
+
+	t.Run("target wrong type wraps with semantic diff context", func(t *testing.T) {
+		t.Parallel()
+		_, err := analyzer.SemanticDiff(context.Background(), map[string]interface{}{"target": 42}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "semantic diff")
+	})
 }
 
 func TestSemanticDiff_InvalidTarget(t *testing.T) {

--- a/internal/tools/analysis/move.go
+++ b/internal/tools/analysis/move.go
@@ -28,11 +28,11 @@ func newMoveTransform(plan *movePlan) *moveTransform {
 func (t *moveTransform) Apply(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
 	srcFile, ok := files[t.Plan.SrcFile]
 	if !ok {
-		return fmt.Errorf("source file %s not loaded", t.Plan.SrcFile)
+		return fmt.Errorf("move %s: source file %s not loaded", t.Plan.Symbol, t.Plan.SrcFile)
 	}
 	dstFile, ok := files[t.Plan.DstFile]
 	if !ok {
-		return fmt.Errorf("destination file %s not loaded", t.Plan.DstFile)
+		return fmt.Errorf("move %s: destination file %s not loaded", t.Plan.Symbol, t.Plan.DstFile)
 	}
 
 	var toMove []ast.Decl
@@ -51,7 +51,7 @@ func (t *moveTransform) Apply(ctx context.Context, fset *token.FileSet, files ma
 	}
 
 	if !symbolFound {
-		return fmt.Errorf("symbol %s not found in %s", t.Plan.Symbol, t.Plan.SrcFile)
+		return fmt.Errorf("move %s: symbol not found in %s", t.Plan.Symbol, t.Plan.SrcFile)
 	}
 
 	// Update source and destination

--- a/internal/tools/analysis/move_test.go
+++ b/internal/tools/analysis/move_test.go
@@ -6,6 +6,9 @@ import (
 	"go/parser"
 	"go/token"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMoveTransform(t *testing.T) {
@@ -160,4 +163,62 @@ func TestMovePlanDescription(t *testing.T) {
 	if desc != "Move Foo from a.go to b.go" {
 		t.Errorf("unexpected description: %q", desc)
 	}
+}
+
+func TestMoveTransform_ErrorContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("source_not_loaded_includes_symbol", func(t *testing.T) {
+		t.Parallel()
+		plan := &movePlan{Symbol: "MyFunc", SrcFile: "missing.go", DstFile: "dst.go"}
+		tr := newMoveTransform(plan)
+
+		fset := token.NewFileSet()
+		files := map[string]*ast.File{
+			"dst.go": {},
+		}
+
+		err := tr.Apply(context.Background(), fset, files)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "move MyFunc")
+		assert.Contains(t, err.Error(), "source file missing.go not loaded")
+	})
+
+	t.Run("dest_not_loaded_includes_symbol", func(t *testing.T) {
+		t.Parallel()
+		plan := &movePlan{Symbol: "MyFunc", SrcFile: "src.go", DstFile: "missing.go"}
+		tr := newMoveTransform(plan)
+
+		fset, srcFile, err := parseTestMoveFile("package a\nfunc MyFunc() {}")
+		require.NoError(t, err)
+		_ = fset
+		files := map[string]*ast.File{
+			"src.go": srcFile,
+		}
+
+		err = tr.Apply(context.Background(), token.NewFileSet(), files)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "move MyFunc")
+		assert.Contains(t, err.Error(), "destination file missing.go not loaded")
+	})
+
+	t.Run("symbol_not_found_includes_symbol", func(t *testing.T) {
+		t.Parallel()
+		plan := &movePlan{Symbol: "NonExistent", SrcFile: "src.go", DstFile: "dst.go"}
+		tr := newMoveTransform(plan)
+
+		fset, srcFile, err := parseTestMoveFile("package a\nfunc Hello() {}")
+		require.NoError(t, err)
+		_ = fset
+		_, dstFile, _ := parseTestMoveFile("package a")
+		files := map[string]*ast.File{
+			"src.go": srcFile,
+			"dst.go": dstFile,
+		}
+
+		err = tr.Apply(context.Background(), token.NewFileSet(), files)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "move NonExistent")
+		assert.Contains(t, err.Error(), "symbol not found")
+	})
 }

--- a/internal/tools/analysis/refactor.go
+++ b/internal/tools/analysis/refactor.go
@@ -34,9 +34,9 @@ func (tx *transaction) Add(t transform) {
 }
 
 func (tx *transaction) Commit(ctx context.Context) error {
-	for _, t := range tx.transforms {
+	for i, t := range tx.transforms {
 		if err := t.Apply(ctx, tx.fset, tx.files); err != nil {
-			return err
+			return fmt.Errorf("transform %d: %w", i, err)
 		}
 	}
 
@@ -46,13 +46,13 @@ func (tx *transaction) Commit(ctx context.Context) error {
 		f, err := os.Create(tmpPath)
 		if err != nil {
 			tx.rollback(writtenFiles)
-			return err
+			return fmt.Errorf("create temp file %s: %w", tmpPath, err)
 		}
 		if err := tx.safeFormat(f, file); err != nil {
 			_ = f.Close()
 			_ = os.Remove(tmpPath)
 			tx.rollback(writtenFiles)
-			return err
+			return fmt.Errorf("format %s: %w", path, err)
 		}
 		_ = f.Close()
 		writtenFiles = append(writtenFiles, path)
@@ -97,7 +97,7 @@ func (tx *transaction) LoadFile(path string) (*ast.File, error) {
 
 	f, err := parser.ParseFile(tx.fset, path, nil, parser.ParseComments)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}
 
 	tx.files[path] = f

--- a/internal/tools/analysis/refactor_manager.go
+++ b/internal/tools/analysis/refactor_manager.go
@@ -26,7 +26,7 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 		Reason  string `json:"reason"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition: %w", err)
 	}
 
 	plan := &movePlan{
@@ -38,24 +38,21 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 	// Security Check
 	resolvedSrc, err := m.SP.IsPathWritable(plan.SrcFile)
 	if err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition src path %s: %w", plan.SrcFile, err)
 	}
 	resolvedDst, err := m.SP.IsPathWritable(plan.DstFile)
 	if err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition dst path %s: %w", plan.DstFile, err)
 	}
 	plan.SrcFile = resolvedSrc
 	plan.DstFile = resolvedDst
 
 	tx := newTransaction()
 	if _, err := tx.LoadFile(plan.SrcFile); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition load src %s: %w", plan.SrcFile, err)
 	}
 	if _, err := tx.LoadFile(plan.DstFile); err != nil {
-		// Handle non-existent destination
-		// For simplicity in this implementation we assume it exists or fail
-		// Real implementation should handle it
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition load dst %s: %w", plan.DstFile, err)
 	}
 
 	tx.Add(newMoveTransform(plan))
@@ -63,7 +60,7 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 	tx.Add(newImportCleanupTransform(plan.DstFile))
 
 	if err := tx.Commit(ctx); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("move definition commit %s: %w", plan.Symbol, err)
 	}
 
 	return tools.ToolResult{Text: fmt.Sprintf("Successfully moved %s from %s to %s", plan.Symbol, plan.SrcFile, plan.DstFile)}, nil
@@ -98,7 +95,7 @@ func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]inte
 		Reason  string `json:"reason"`
 	}
 	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("rename symbol: %w", err)
 	}
 	if params.Path == "" {
 		params.Path = "."
@@ -107,13 +104,13 @@ func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]inte
 	// Resolve and validate the target directory.
 	resolvedDir, err := m.SP.IsPathWritable(params.Path)
 	if err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("rename symbol path %s: %w", params.Path, err)
 	}
 
 	// Discover and load all Go source files into a transaction.
 	goFiles, tx, err := m.loadGoFilesForRename(resolvedDir)
 	if err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("rename symbol %s→%s: %w", params.OldName, params.NewName, err)
 	}
 
 	plan := &renamePlan{OldName: params.OldName, NewName: params.NewName}
@@ -123,7 +120,7 @@ func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]inte
 	}
 
 	if err := tx.Commit(ctx); err != nil {
-		return tools.ToolResult{}, err
+		return tools.ToolResult{}, fmt.Errorf("rename symbol %s→%s commit: %w", params.OldName, params.NewName, err)
 	}
 
 	// Build a compact list of filenames for the result.

--- a/internal/tools/analysis/refactor_manager_test.go
+++ b/internal/tools/analysis/refactor_manager_test.go
@@ -79,7 +79,7 @@ func TestMoveDefinition(t *testing.T) {
 			"reason":   "testing",
 		}
 		_, err := mgr.MoveDefinition(ctx, args, nil)
-		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "move definition src path")
 	})
 
 	tests := []struct {
@@ -336,7 +336,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.MoveDefinition(ctx, args, nil)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "dst not writable")
+		assert.Contains(t, err.Error(), "move definition dst path")
 	})
 
 	t.Run("src file load error", func(t *testing.T) {
@@ -351,6 +351,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.MoveDefinition(ctx, args, nil)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "move definition load src")
 	})
 
 	t.Run("Commit error (symbol not found)", func(t *testing.T) {
@@ -367,6 +368,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.MoveDefinition(ctx, args, nil)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "move definition commit")
 		assert.Contains(t, err.Error(), "not found")
 	})
 }
@@ -399,6 +401,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.RenameSymbol(ctx, args, nil)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename symbol path")
 		assert.Contains(t, err.Error(), "path not writable")
 	})
 
@@ -415,6 +418,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.RenameSymbol(ctx, args, nil)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename symbol")
 		assert.Contains(t, err.Error(), "no .go files found")
 	})
 
@@ -435,6 +439,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 		}
 		_, err := mgr.RenameSymbol(ctx, args, nil)
 		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename symbol")
 		assert.Contains(t, err.Error(), "load broken.go:")
 	})
 }

--- a/internal/tools/analysis/refactor_test.go
+++ b/internal/tools/analysis/refactor_test.go
@@ -5,6 +5,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"go/ast"
 	"go/token"
 	"os"
@@ -158,5 +159,66 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		// .tmp cleaned (rollback)
 		_, statErr := os.Stat(path + ".tmp")
 		assert.True(t, os.IsNotExist(statErr))
+	})
+
+	t.Run("transform_apply_error_is_wrapped", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "test.go")
+		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
+
+		tx := newTransaction()
+		_, err := tx.LoadFile(path)
+		require.NoError(t, err)
+
+		tx.Add(&mockTransform{
+			applyFn: func(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
+				return fmt.Errorf("simulated transform failure")
+			},
+		})
+
+		err = tx.Commit(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transform 0")
+		assert.Contains(t, err.Error(), "simulated transform failure")
+	})
+
+	t.Run("create_temp_file_error_is_wrapped", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "test.go")
+		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
+
+		tx := newTransaction()
+		_, err := tx.LoadFile(path)
+		require.NoError(t, err)
+
+		tx.Add(&mockTransform{
+			applyFn: func(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
+				return nil
+			},
+		})
+
+		// Make the directory read-only so os.Create fails on the .tmp file
+		require.NoError(t, os.Chmod(tmpDir, 0500))
+		t.Cleanup(func() { _ = os.Chmod(tmpDir, 0700) })
+
+		err = tx.Commit(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "create temp file")
+		assert.Contains(t, err.Error(), ".tmp")
+	})
+
+	t.Run("load_file_parse_error_is_wrapped", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		path := filepath.Join(tmpDir, "broken.go")
+		require.NoError(t, os.WriteFile(path, []byte("not valid go {{{"), 0644))
+
+		tx := newTransaction()
+		_, err := tx.LoadFile(path)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "parse")
+		assert.Contains(t, err.Error(), "broken.go")
 	})
 }

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -4,6 +4,7 @@
 package analysis
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
@@ -339,11 +340,11 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 	for _, spec := range specs {
 		if spec.opts != nil {
 			if err := r.RegisterWithOptions(spec.decl, spec.handler, *spec.opts); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("register tool %q: %w", spec.decl.Name, err)
 			}
 		} else {
 			if err := r.Register(spec.decl, spec.handler); err != nil {
-				return nil, err
+				return nil, fmt.Errorf("register tool %q: %w", spec.decl.Name, err)
 			}
 		}
 	}

--- a/internal/tools/analysis/registration_test.go
+++ b/internal/tools/analysis/registration_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stubRegistry implements tools.Registry minimally for testing Register errors.
+type stubRegistry struct {
+	registerErr            error
+	registerWithOptionsErr error
+}
+
+func (s *stubRegistry) Register(def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return s.registerErr
+}
+
+func (s *stubRegistry) RegisterWithOptions(def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return s.registerWithOptionsErr
+}
+
+func (s *stubRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc) error {
+	return nil
+}
+
+func (s *stubRegistry) RegisterToToolkitWithOptions(toolkit string, def *tools.ToolDeclaration, handler tools.ToolFunc, opts tools.ToolOptions) error {
+	return nil
+}
+
+func (s *stubRegistry) Execute(ctx context.Context, name string, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	return tools.ToolResult{}, nil
+}
+
+func (s *stubRegistry) IsSerial(name string) bool      { return false }
+func (s *stubRegistry) IsLongRunning(name string) bool { return false }
+
+func (s *stubRegistry) GetOptions(name string) tools.ToolOptions {
+	return tools.ToolOptions{}
+}
+
+func (s *stubRegistry) GetDeclarations() []*tools.ToolDeclaration     { return nil }
+func (s *stubRegistry) GetCoreDeclarations() []*tools.ToolDeclaration { return nil }
+func (s *stubRegistry) GetDeclarationsByToolkits(toolkits []string) []*tools.ToolDeclaration {
+	return nil
+}
+func (s *stubRegistry) ListAvailableToolkits() []string { return nil }
+
+// stubEventBus implements events.EventBus minimally.
+type stubEventBus struct{}
+
+func (s *stubEventBus) Publish(ctx context.Context, e events.Event) error { return nil }
+func (s *stubEventBus) Subscribe(sub func(context.Context, events.Event)) {}
+func (s *stubEventBus) Shutdown(ctx context.Context) error                { return nil }
+func (s *stubEventBus) Flush(ctx context.Context) error                   { return nil }
+func (s *stubEventBus) Listen(ctx context.Context) error                  { return nil }
+func (s *stubEventBus) WaitStarted()                                      {}
+
+// stubFileSystem implements persistence.FileSystem minimally.
+type stubFileSystem struct{}
+
+func (s *stubFileSystem) ReadDir(ctx context.Context, name string) ([]os.DirEntry, error) {
+	return nil, nil
+}
+func (s *stubFileSystem) ReadFile(ctx context.Context, name string) ([]byte, error) { return nil, nil }
+func (s *stubFileSystem) WriteFile(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+	return nil
+}
+func (s *stubFileSystem) AtomicWrite(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+	return nil
+}
+func (s *stubFileSystem) MkdirAll(ctx context.Context, path string, perm os.FileMode) error {
+	return nil
+}
+func (s *stubFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
+	return nil, nil
+}
+func (s *stubFileSystem) Open(ctx context.Context, name string) (persistence.File, error) {
+	return nil, nil
+}
+func (s *stubFileSystem) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (persistence.File, error) {
+	return nil, nil
+}
+func (s *stubFileSystem) Remove(ctx context.Context, name string) error    { return nil }
+func (s *stubFileSystem) RemoveAll(ctx context.Context, path string) error { return nil }
+func (s *stubFileSystem) Walk(ctx context.Context, root string, fn persistence.WalkFunc) error {
+	return nil
+}
+
+// stubWorkspacePolicy implements services.WorkspacePolicy minimally.
+type stubWorkspacePolicy struct{}
+
+func (s *stubWorkspacePolicy) ShouldIgnoreDir(name string) bool  { return false }
+func (s *stubWorkspacePolicy) ShouldIgnorePath(path string) bool { return false }
+
+// Compile-time interface satisfaction checks.
+var (
+	_ tools.Registry           = (*stubRegistry)(nil)
+	_ events.EventBus          = (*stubEventBus)(nil)
+	_ persistence.FileSystem   = (*stubFileSystem)(nil)
+	_ services.WorkspacePolicy = (*stubWorkspacePolicy)(nil)
+	_ security.Manager         = (*mockSecurityProvider)(nil)
+	_ tools.CommandExecutor    = (*mockExecutor)(nil)
+)
+
+func TestRegister_ErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	t.Run("RegisterWithOptions failure includes tool name", func(t *testing.T) {
+		t.Parallel()
+
+		r := &stubRegistry{
+			registerWithOptionsErr: errors.New("simulated registration failure"),
+		}
+		sp := &mockSecurityProvider{}
+		bus := &stubEventBus{}
+		exec := &mockExecutor{}
+		fs := &stubFileSystem{}
+		wp := &stubWorkspacePolicy{}
+
+		_, err := Register(r, sp, bus, exec, fs, wp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "register tool")
+		// First tool with opts is "verify_architecture"
+		assert.Contains(t, err.Error(), "verify_architecture")
+		assert.Contains(t, err.Error(), "simulated registration failure")
+	})
+
+	t.Run("Register failure includes tool name", func(t *testing.T) {
+		t.Parallel()
+
+		r := &stubRegistry{
+			registerErr: errors.New("simulated registration failure"),
+		}
+		sp := &mockSecurityProvider{}
+		bus := &stubEventBus{}
+		exec := &mockExecutor{}
+		fs := &stubFileSystem{}
+		wp := &stubWorkspacePolicy{}
+
+		_, err := Register(r, sp, bus, exec, fs, wp)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "register tool")
+		// First tool without opts is "list_symbols"
+		assert.Contains(t, err.Error(), "list_symbols")
+		assert.Contains(t, err.Error(), "simulated registration failure")
+	})
+}

--- a/internal/tools/analysis/rename.go
+++ b/internal/tools/analysis/rename.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"go/ast"
 	"go/token"
+	"path/filepath"
+	"sort"
 )
 
 // renamePlan describes a symbol rename operation within a package directory.
@@ -53,7 +55,13 @@ func (t *renameTransform) Apply(_ context.Context, _ *token.FileSet, files map[s
 	}
 
 	if renamed == 0 {
-		return fmt.Errorf("symbol %q not found in any loaded file", t.Plan.OldName)
+		fileNames := make([]string, 0, len(files))
+		for path := range files {
+			fileNames = append(fileNames, filepath.Base(path))
+		}
+		sort.Strings(fileNames)
+		return fmt.Errorf("rename %s→%s: symbol %q not found in %d files: %v",
+			t.Plan.OldName, t.Plan.NewName, t.Plan.OldName, len(files), fileNames)
 	}
 
 	return nil

--- a/internal/tools/analysis/rename_test.go
+++ b/internal/tools/analysis/rename_test.go
@@ -1,6 +1,13 @@
 package analysis
 
-import "testing"
+import (
+	"context"
+	"go/ast"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
 
 func TestRenamePlanDescription(t *testing.T) {
 	t.Parallel()
@@ -10,4 +17,47 @@ func TestRenamePlanDescription(t *testing.T) {
 	if desc != expected {
 		t.Errorf("Description() = %q, want %q", desc, expected)
 	}
+}
+
+func TestRenameTransform_ErrorContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("identical_names_error", func(t *testing.T) {
+		t.Parallel()
+		plan := &renamePlan{OldName: "Foo", NewName: "Foo"}
+		tr := newRenameTransform(plan)
+		err := tr.Apply(context.TODO(), nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "identical")
+		assert.Contains(t, err.Error(), "Foo")
+	})
+
+	t.Run("empty_new_name_error", func(t *testing.T) {
+		t.Parallel()
+		plan := &renamePlan{OldName: "Foo", NewName: ""}
+		tr := newRenameTransform(plan)
+		err := tr.Apply(context.TODO(), nil, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "must not be empty")
+	})
+
+	t.Run("symbol_not_found_lists_scanned_files", func(t *testing.T) {
+		t.Parallel()
+		plan := &renamePlan{OldName: "NonExistent", NewName: "Whatever"}
+		tr := newRenameTransform(plan)
+
+		files := map[string]*ast.File{
+			"/tmp/pkg/alpha.go": {Name: ast.NewIdent("p")},
+			"/tmp/pkg/beta.go":  {Name: ast.NewIdent("p")},
+			"/tmp/pkg/gamma.go": {Name: ast.NewIdent("p")},
+		}
+
+		err := tr.Apply(context.TODO(), nil, files)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "rename NonExistent→Whatever")
+		assert.Contains(t, err.Error(), "not found in 3 files")
+		assert.Contains(t, err.Error(), "alpha.go")
+		assert.Contains(t, err.Error(), "beta.go")
+		assert.Contains(t, err.Error(), "gamma.go")
+	})
 }


### PR DESCRIPTION
Closes #796.

## Summary
Close 11 error-handling gaps across 6 files in `internal/tools/analysis/`:

| File | Gaps | Changes |
|------|------|---------|
| `refactor.go` | 2 | Wrap `t.Apply`, `os.Create`, `safeFormat`, `parser.ParseFile` errors |
| `move.go` | 3 | Add symbol context to `Apply` error messages |
| `rename.go` | 1 | Include scanned file list in symbol-not-found error |
| `refactor_manager.go` | 3 | Wrap all 10 bare error returns with operation context |
| `changes.go` | 1 | Wrap `UnmarshalArgs` in `SemanticDiff` |
| `registration.go` | 1 | Wrap `Register`/`RegisterWithOptions` with tool name (0% → 91.7% coverage) |

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| Lint | ✅ 0 issues |
| Tests | ✅ All pass |
| Race | ✅ All pass |
| Coverage | ✅ 95.7% → 96.3% |
| Vulncheck | ✅ No vulnerabilities |
| Dead code | ✅ None found