### PR TITLE
fix(ado): close error-handling gaps in policy and format (#790)

### DIFF
--- a/internal/tools/integrations/ado/pipeline_format_test.go
+++ b/internal/tools/integrations/ado/pipeline_format_test.go
@@ -198,3 +198,91 @@ func TestFormatPipelineLogList(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatRepositoryItems(t *testing.T) {
+	tests := []struct {
+		name        string
+		scopePath   string
+		version     string
+		response    adoRepositoryItemsResponse
+		expect      string   // exact match
+		contains    []string // substrings that must appear
+		notContains []string // substrings that must NOT appear
+	}{
+		{
+			name:      "Empty Value slice returns sentinel",
+			scopePath: "/",
+			version:   "main",
+			response: adoRepositoryItemsResponse{
+				Value: nil,
+				Count: 0,
+			},
+			expect: "No items found.",
+		},
+		{
+			name:      "Single item matching scopePath, len==1 shows the item",
+			scopePath: "/",
+			version:   "main",
+			response: adoRepositoryItemsResponse{
+				Value: []struct {
+					Path     string `json:"path"`
+					IsFolder bool   `json:"isFolder"`
+				}{
+					{Path: "/", IsFolder: true},
+				},
+				Count: 1,
+			},
+			contains: []string{"[DIR]  /"},
+		},
+		{
+			name:      "Two items, first matches scopePath, len>1 skips root dir",
+			scopePath: "/",
+			version:   "main",
+			response: adoRepositoryItemsResponse{
+				Value: []struct {
+					Path     string `json:"path"`
+					IsFolder bool   `json:"isFolder"`
+				}{
+					{Path: "/", IsFolder: true},
+					{Path: "/src/main.go", IsFolder: false},
+				},
+				Count: 2,
+			},
+			contains:    []string{"[FILE] /src/main.go"},
+			notContains: []string{"[DIR]  /"},
+		},
+		{
+			name:      "Non-matching scopePath, no filtering",
+			scopePath: "/src",
+			version:   "main",
+			response: adoRepositoryItemsResponse{
+				Value: []struct {
+					Path     string `json:"path"`
+					IsFolder bool   `json:"isFolder"`
+				}{
+					{Path: "/src/main.go", IsFolder: false},
+				},
+				Count: 1,
+			},
+			contains: []string{"[FILE] /src/main.go"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := formatRepositoryItems(tt.scopePath, tt.version, tt.response)
+
+			if tt.expect != "" {
+				assert.Equal(t, tt.expect, result.Text)
+			}
+			for _, s := range tt.contains {
+				assert.Contains(t, result.Text, s)
+			}
+			for _, s := range tt.notContains {
+				assert.NotContains(t, result.Text, s)
+			}
+		})
+	}
+}

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -459,7 +459,7 @@ func registerPolicy(r tools.Registry, m *AdoManager, _ PipelineFormatter) error 
 
 	for _, spec := range specs {
 		if err := r.RegisterToToolkit("ado", spec.decl, spec.handler); err != nil {
-			return err
+			return fmt.Errorf("registering policy tool %q: %w", spec.decl.Name, err)
 		}
 	}
 

--- a/internal/tools/integrations/ado/policy_test.go
+++ b/internal/tools/integrations/ado/policy_test.go
@@ -4,8 +4,15 @@
 package ado
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestFormatBranchPolicies(t *testing.T) {
@@ -272,5 +279,470 @@ func newMatchingScope(repoId, refName string) map[string]interface{} {
 				"refName":      refName,
 			},
 		},
+	}
+}
+
+func TestAdoGetPrStatuses_Errors(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	tests := []struct {
+		name        string
+		args        map[string]interface{}
+		baseURL     string
+		setupServer func() *httptest.Server
+		expectedErr string
+	}{
+		{
+			name:        "param validation error",
+			args:        map[string]interface{}{},
+			expectedErr: "organization, project, repository, and pull_request_id are required",
+		},
+		{
+			name:        "url.Parse error in fetchPrStatuses",
+			args:        map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
+			baseURL:     "http://x\ny",
+			expectedErr: "failed to parse statuses base URL",
+		},
+		{
+			name: "ExecuteRequest error in fetchPrStatuses",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+				}))
+			},
+			expectedErr: "returned status: 500",
+		},
+		{
+			name: "json.Decode error in fetchPrStatuses",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{invalid`))
+				}))
+			},
+			expectedErr: "failed to decode response",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var m *AdoManager
+			if tt.setupServer != nil {
+				ts := tt.setupServer()
+				t.Cleanup(ts.Close)
+				m = NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+			} else if tt.baseURL != "" {
+				m = NewADOManager(sm, WithBaseURL(tt.baseURL), WithToken("test-pat"))
+			} else {
+				m = NewADOManager(sm)
+			}
+
+			_, err := m.AdoGetPrStatuses(context.Background(), tt.args, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestAdoGetPrPolicyEvaluations_Errors(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	tests := []struct {
+		name        string
+		args        map[string]interface{}
+		baseURL     string
+		setupServer func() *httptest.Server
+		expectedErr string
+	}{
+		{
+			name:        "UnmarshalArgs error",
+			args:        map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": "not-an-int"},
+			expectedErr: "parsing get pr policy evaluations args",
+		},
+		{
+			name:        "param validation error",
+			args:        map[string]interface{}{},
+			expectedErr: "organization, project, repository, and pull_request_id are required",
+		},
+		{
+			name: "fetchPrProjectID - HTTP error",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusNotFound)
+				}))
+			},
+			expectedErr: "resource not found",
+		},
+		{
+			name: "fetchPrProjectID - json.Decode error",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{invalid`))
+				}))
+			},
+			expectedErr: "failed to decode PR metadata",
+		},
+		{
+			name: "fetchPrProjectID - empty project ID",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{"repository":{"project":{"id":""}}}`))
+				}))
+			},
+			expectedErr: "could not find project ID",
+		},
+		{
+			name:        "fetchPolicyEvaluations - url.Parse error",
+			args:        map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			baseURL:     "http://x\ny",
+			expectedErr: "failed to create request",
+		},
+		{
+			name: "performPolicyEvaluationRequest - HTTP error",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if strings.Contains(r.URL.Path, "/pullrequests/123") {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"repository":{"project":{"id":"proj-id"}}}`))
+						return
+					}
+					w.WriteHeader(http.StatusUnauthorized)
+				}))
+			},
+			expectedErr: "unauthorized",
+		},
+		{
+			name: "performPolicyEvaluationRequest - json.Decode error",
+			args: map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123},
+			setupServer: func() *httptest.Server {
+				return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if strings.Contains(r.URL.Path, "/pullrequests/123") {
+						w.WriteHeader(http.StatusOK)
+						_, _ = w.Write([]byte(`{"repository":{"project":{"id":"proj-id"}}}`))
+						return
+					}
+					w.WriteHeader(http.StatusOK)
+					_, _ = w.Write([]byte(`{bad`))
+				}))
+			},
+			expectedErr: "failed to decode response",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var m *AdoManager
+			if tt.setupServer != nil {
+				ts := tt.setupServer()
+				t.Cleanup(ts.Close)
+				m = NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+			} else if tt.baseURL != "" {
+				m = NewADOManager(sm, WithBaseURL(tt.baseURL), WithToken("test-pat"))
+			} else {
+				m = NewADOManager(sm)
+			}
+
+			_, err := m.AdoGetPrPolicyEvaluations(context.Background(), tt.args, nil)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
+}
+
+func TestAdoListBranchPolicies_UnmarshalError(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithToken("test-pat"))
+
+	args := map[string]interface{}{"organization": 123, "project": "p", "repository": "r", "branch_name": "b"}
+	_, err := m.adoListBranchPolicies(context.Background(), args, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parsing list branch policies args")
+}
+
+func TestFormatPrStatuses(t *testing.T) {
+	m := &AdoManager{}
+
+	tests := []struct {
+		name       string
+		prID       int
+		statusData adoStatusResponse
+		assertFn   func(t *testing.T, result string)
+	}{
+		{
+			name: "empty slice",
+			prID: 1,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Equal(t, "No statuses found for this pull request.", result)
+			},
+		},
+		{
+			name: "item with genre",
+			prID: 10,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{
+					{
+						State:   "succeeded",
+						Context: adoContext{Name: "build", Genre: "ci"},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Contains(t, result, "ci/build")
+			},
+		},
+		{
+			name: "item with description",
+			prID: 20,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{
+					{
+						State:       "succeeded",
+						Context:     adoContext{Name: "build"},
+						Description: "Build completed successfully",
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Contains(t, result, "Build completed successfully")
+			},
+		},
+		{
+			name: "item with TargetUrl",
+			prID: 30,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{
+					{
+						State:     "succeeded",
+						Context:   adoContext{Name: "build"},
+						TargetUrl: "https://example.com/details",
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Contains(t, result, "Details: https://example.com/details")
+			},
+		},
+		{
+			name: "item with all fields populated",
+			prID: 40,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{
+					{
+						State:       "failed",
+						Context:     adoContext{Name: "tests", Genre: "ci"},
+						Description: "Unit tests failed",
+						TargetUrl:   "https://example.com/logs",
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Contains(t, result, "ci/tests")
+				assert.Contains(t, result, "Unit tests failed")
+				assert.Contains(t, result, "Details: https://example.com/logs")
+			},
+		},
+		{
+			name: "multiple items",
+			prID: 42,
+			statusData: adoStatusResponse{
+				Value: []adoStatusItem{
+					{
+						State:   "succeeded",
+						Context: adoContext{Name: "Build", Genre: "ci"},
+					},
+					{
+						State:   "pending",
+						Context: adoContext{Name: "CodeReview"},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result string) {
+				assert.Contains(t, result, "Pull Request #42 Statuses:")
+				assert.Contains(t, result, "ci/Build")
+				assert.Contains(t, result, "CodeReview")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := m.formatPrStatuses(tt.prID, tt.statusData)
+			tt.assertFn(t, result)
+		})
+	}
+}
+
+func TestFormatPolicyEvaluations(t *testing.T) {
+	m := &AdoManager{}
+
+	tests := []struct {
+		name       string
+		prID       int
+		policyData adoPolicyResponse
+		assertFn   func(t *testing.T, result tools.ToolResult, err error)
+	}{
+		{
+			name: "empty Value slice",
+			prID: 1,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "No active policies found for this pull request.", result.Text)
+			},
+		},
+		{
+			name: "disabled config skipped",
+			prID: 2,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{
+					{
+						Status: "approved",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  false,
+							IsBlocking: true,
+							Type:       adoPolicyType{DisplayName: "Build"},
+						},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "No active policies found for this pull request.", result.Text)
+			},
+		},
+		{
+			name: "queued status",
+			prID: 3,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{
+					{
+						Status: "queued",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  true,
+							IsBlocking: false,
+							Type:       adoPolicyType{DisplayName: "Build"},
+						},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, result.Text, "⏳")
+			},
+		},
+		{
+			name: "running status",
+			prID: 4,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{
+					{
+						Status: "running",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  true,
+							IsBlocking: false,
+							Type:       adoPolicyType{DisplayName: "Build"},
+						},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, result.Text, "⏳")
+			},
+		},
+		{
+			name: "IsBlocking=true shows REQUIRED",
+			prID: 5,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{
+					{
+						Status: "approved",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  true,
+							IsBlocking: true,
+							Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
+						},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				assert.Contains(t, result.Text, " [REQUIRED]")
+			},
+		},
+		{
+			name: "multiple policies mixed",
+			prID: 6,
+			policyData: adoPolicyResponse{
+				Value: []adoPolicyEvaluation{
+					{
+						Status: "approved",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  false, // disabled — should be skipped
+							IsBlocking: true,
+							Type:       adoPolicyType{DisplayName: "DisabledPolicy"},
+						},
+					},
+					{
+						Status: "queued",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  true,
+							IsBlocking: true,
+							Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
+						},
+					},
+					{
+						Status: "approved",
+						Configuration: adoPolicyConfig{
+							IsEnabled:  true,
+							IsBlocking: false,
+							Type:       adoPolicyType{DisplayName: "Build"},
+						},
+					},
+				},
+			},
+			assertFn: func(t *testing.T, result tools.ToolResult, err error) {
+				assert.NoError(t, err)
+				// Disabled policy should not appear
+				assert.NotContains(t, result.Text, "DisabledPolicy")
+				// Queued+blocking: ⏳ emoji and [REQUIRED]
+				assert.Contains(t, result.Text, "⏳")
+				assert.Contains(t, result.Text, "RequiredReviewer")
+				assert.Contains(t, result.Text, " [REQUIRED]")
+				// Approved non-blocking: ✅ emoji, no [REQUIRED] on that line
+				assert.Contains(t, result.Text, "✅")
+				assert.Contains(t, result.Text, "Build")
+				// Exactly 2 policy entries (count "**" pairs — each policy has two: **Name**)
+				assert.Equal(t, 4, strings.Count(result.Text, "**"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := m.formatPolicyEvaluations(tt.prID, tt.policyData)
+			tt.assertFn(t, result, err)
+		})
 	}
 }

--- a/internal/tools/integrations/ado/repo.go
+++ b/internal/tools/integrations/ado/repo.go
@@ -4,6 +4,8 @@
 package ado
 
 import (
+	"fmt"
+
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
@@ -57,7 +59,7 @@ func registerRepository(r tools.Registry, m *AdoManager, _ PipelineFormatter) er
 
 	for _, spec := range specs {
 		if err := r.RegisterToToolkit("ado", spec.decl, spec.handler); err != nil {
-			return err
+			return fmt.Errorf("registering repository tool %q: %w", spec.decl.Name, err)
 		}
 	}
 


### PR DESCRIPTION
Closes #790.

## Summary
Closed all error-handling gaps across 4 target files in `internal/tools/integrations/ado/`:

- **policy.go** — Added comprehensive error-path tests for `AdoGetPrStatuses` (4 paths), `AdoGetPrPolicyEvaluations` (8 paths), `adoListBranchPolicies` (UnmarshalArgs). Added format tests for `formatPrStatuses` (6 cases) and `formatPolicyEvaluations` (6 cases). Wrapped `RegisterToToolkit` error with context.
- **repo.go** — Wrapped `RegisterToToolkit` error with context (`[REFACTOR]`).
- **azure_devops.go** — `ExecuteRequest` `NewRequestWithContext` error path now covered (via Task 2 case 6).
- **pipeline_format.go** — Added `TestFormatRepositoryItems` covering 4 edge cases (empty slice, single-item skip guard, multi-item skip, non-matching scopePath).

All 4 target files now at 100% coverage on the gapped functions.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps including race detection) |
| Target coverage | 100% on gapped functions, no regression |