### PR TITLE
fix(analysis): close error-handling gaps in types, info, mermaid, wellknown (#794)

### DIFF
--- a/internal/tools/analysis/info.go
+++ b/internal/tools/analysis/info.go
@@ -64,6 +64,7 @@ func (m *infoManager) recordGoStats(ctx context.Context, path string, info os.Fi
 	} else if loc, err := m.countLines(ctx, path); err == nil {
 		stats.totalLOC += loc
 	}
+	// countLines errors are intentionally silent: LOC is best-effort.
 }
 
 func (m *infoManager) sendHeartbeat(hb chan<- struct{}, count int) {
@@ -133,6 +134,8 @@ func (m *infoManager) GetProjectSummary(ctx context.Context, args map[string]int
 
 func (m *infoManager) resolveModuleInfo(ctx context.Context) string {
 	var sb strings.Builder
+	// Best-effort: go.mod may not exist (non-Go project) or may be
+	// unreadable. Both cases result in an empty module info string.
 	if content, err := m.FS.ReadFile(ctx, "go.mod"); err == nil {
 		lines := strings.Split(string(content), "\n")
 		for _, line := range lines {
@@ -213,6 +216,8 @@ func (m *infoManager) publishGoDocEvent(ctx context.Context, symbol string) {
 	}
 	if err := events.SafePublish(ctx, m.Events, evt); err != nil {
 		if !errors.Is(err, events.ErrBusNotInitialized) {
+			// Falls back to the default logger; production code should
+			// inject a configured slog.Logger via the infoManager.
 			slog.Default().Error("event_publish_failed",
 				slog.String("event_type", string(evt.Type())),
 				slog.Any("error", err))
@@ -244,7 +249,11 @@ func (m *infoManager) startGoDocHeartbeat(hb chan<- struct{}) chan struct{} {
 
 func (m *infoManager) formatDocOutput(out []byte, err error) tools.ToolResult {
 	if err != nil {
-		return tools.ToolResult{Text: fmt.Sprintf("Error running go doc: %v\nOutput: %s", err, string(out))}
+		msg := fmt.Sprintf("Error running go doc: %v", err)
+		if len(out) > 0 {
+			msg += fmt.Sprintf("\nOutput: %s", string(out))
+		}
+		return tools.ToolResult{Text: msg}
 	}
 	return tools.ToolResult{Text: string(out)}
 }

--- a/internal/tools/analysis/info_test.go
+++ b/internal/tools/analysis/info_test.go
@@ -485,13 +485,26 @@ func TestPublishGoDocEvent_NilEvents(t *testing.T) {
 func TestFormatDocOutput_Error(t *testing.T) {
 	t.Parallel()
 	m := &infoManager{Policy: infra_persistence.NewWorkspacePolicy()}
-	result := m.formatDocOutput([]byte("partial output"), fmt.Errorf("go doc failed"))
-	if !strings.Contains(result.Text, "Error running go doc") {
-		t.Errorf("expected error message in output, got: %s", result.Text)
-	}
-	if !strings.Contains(result.Text, "partial output") {
-		t.Errorf("expected partial output in result, got: %s", result.Text)
-	}
+
+	t.Run("error with partial output", func(t *testing.T) {
+		result := m.formatDocOutput([]byte("partial output"), fmt.Errorf("go doc failed"))
+		if !strings.Contains(result.Text, "Error running go doc") {
+			t.Errorf("expected error message in output, got: %s", result.Text)
+		}
+		if !strings.Contains(result.Text, "partial output") {
+			t.Errorf("expected partial output in result, got: %s", result.Text)
+		}
+	})
+
+	t.Run("error with empty output omits Output label", func(t *testing.T) {
+		result := m.formatDocOutput(nil, fmt.Errorf("go doc failed"))
+		if !strings.Contains(result.Text, "Error running go doc") {
+			t.Errorf("expected error message in output, got: %s", result.Text)
+		}
+		if strings.Contains(result.Text, "Output:") {
+			t.Errorf("expected no 'Output:' label when output is empty, got: %s", result.Text)
+		}
+	})
 }
 
 // TestInfoManager_RemainingErrorPaths covers error branches not exercised by other tests.

--- a/internal/tools/analysis/mermaid.go
+++ b/internal/tools/analysis/mermaid.go
@@ -25,6 +25,10 @@ var defaultstyleRules = []styleRule{
 
 // GenerateMermaid transforms a dependency map into a Mermaid.js diagram.
 func generateMermaid(graph map[string][]string) string {
+	// The graph may contain edges to nodes not present as keys
+	// (e.g., external packages, stdlib). These produce dangling
+	// references in the Mermaid output, which is acceptable —
+	// Mermaid renders them as external nodes without styling.
 	var builder strings.Builder
 	builder.WriteString("graph TD\n")
 
@@ -163,6 +167,10 @@ func (d *cycleDetector) dfs(u string) {
 }
 
 func (d *cycleDetector) buildCycle(v string) []string {
+	// Under DFS invariants, v is guaranteed to be on d.path when
+	// buildCycle is called from a back-edge. If the invariant is
+	// violated (e.g., concurrent mutation), nil is returned and
+	// the caller silently skips the malformed cycle.
 	for i, node := range d.path {
 		if node == v {
 			cycle := make([]string, len(d.path)-i+1)

--- a/internal/tools/analysis/mermaid_formatter.go
+++ b/internal/tools/analysis/mermaid_formatter.go
@@ -22,6 +22,9 @@ type formatState struct {
 
 // Format transforms a slice of callFrame into a Mermaid sequence diagram string.
 func (f *mermaidFormatter) Format(frames []callFrame) string {
+	// Empty frames produce a minimal valid sequenceDiagram with
+	// no participants or interactions. The zero-value formatState
+	// (inLoop=false) ensures no unbalanced loop-end is emitted.
 	var b strings.Builder
 	b.WriteString("sequenceDiagram\n")
 

--- a/internal/tools/analysis/types.go
+++ b/internal/tools/analysis/types.go
@@ -63,7 +63,10 @@ func (m *defaultTypeManager) GetTypeInfo(ctx context.Context, args map[string]in
 	}
 
 	locs, err := m.Indexer.Lookup(ctx, typename, hb)
-	if err != nil || len(locs) == 0 {
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("lookup type %s: %w", typename, err)
+	}
+	if len(locs) == 0 {
 		return tools.ToolResult{Text: "Type not found."}, nil
 	}
 
@@ -265,11 +268,16 @@ func (m *defaultTypeManager) findMethodsInPackage(ctx context.Context, dir, type
 }
 
 func (m *defaultTypeManager) makeMethodWalkFunc(ctx context.Context, typeName string, hb chan<- struct{}, methods *[]string, count *int) filepath.WalkFunc {
-	return func(p string, i os.FileInfo, e error) error {
+	return func(p string, i os.FileInfo, walkErr error) error {
+		// Propagate filesystem-level walk errors (permission denied,
+		// broken symlink) — these are not parse skips.
+		if walkErr != nil {
+			return walkErr
+		}
 		if err := m.checkCancellation(ctx); err != nil {
 			return err
 		}
-		if m.shouldSkipFile(p, i, e) {
+		if m.shouldSkipFile(p, i, nil) {
 			return nil
 		}
 
@@ -277,6 +285,9 @@ func (m *defaultTypeManager) makeMethodWalkFunc(ctx context.Context, typeName st
 
 		ff, _, err := m.Cache.Get(p)
 		if err != nil {
+			// Tolerate parse errors in individual files; method
+			// discovery is best-effort and a single corrupt .go
+			// file must not block the entire walk.
 			return nil
 		}
 		*methods = append(*methods, m.extractMethodsFromFile(ff, typeName)...)
@@ -287,7 +298,7 @@ func (m *defaultTypeManager) makeMethodWalkFunc(ctx context.Context, typeName st
 func (m *defaultTypeManager) extractMethodsFromFile(f *ast.File, typeName string) []string {
 	var methods []string
 	for _, d := range f.Decls {
-		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil && len(fd.Recv.List) > 0 {
 			recvType := exprToString(fd.Recv.List[0].Type)
 			if strings.TrimPrefix(recvType, "*") == typeName {
 				methods = append(methods, getFuncSignature(fd))
@@ -403,11 +414,16 @@ func (m *defaultTypeManager) matchSymbolInFile(f *ast.File, fset *token.FileSet,
 func (m *defaultTypeManager) collectSymbols(ctx context.Context, root, query string, exportedOnly bool, hb chan<- struct{}) ([]string, error) {
 	var results []string
 	count := 0
-	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+	walkErr := filepath.Walk(root, func(p string, info os.FileInfo, walkErr error) error {
+		// Propagate filesystem-level walk errors (permission denied,
+		// broken symlink) — these are not parse skips.
+		if walkErr != nil {
+			return walkErr
+		}
 		if err := m.checkCancellation(ctx); err != nil {
 			return err
 		}
-		if m.shouldSkipFile(p, info, err) {
+		if m.shouldSkipFile(p, info, nil) {
 			return nil
 		}
 
@@ -415,12 +431,15 @@ func (m *defaultTypeManager) collectSymbols(ctx context.Context, root, query str
 
 		f, fset, err := m.Cache.Get(p)
 		if err != nil {
+			// Tolerate parse errors in individual files; symbol
+			// collection is best-effort and a single corrupt .go
+			// file must not block the entire walk.
 			return nil
 		}
 		results = append(results, m.matchSymbolInFile(f, fset, p, query, exportedOnly)...)
 		return nil
 	})
-	return results, err
+	return results, walkErr
 }
 
 func (m *defaultTypeManager) resolvePath(path string) (string, error) {
@@ -446,11 +465,17 @@ func (m *defaultTypeManager) checkCancellation(ctx context.Context) error {
 	}
 }
 
-func (m *defaultTypeManager) shouldSkipFile(p string, info os.FileInfo, err error) bool {
-	return err != nil || info.IsDir() || filepath.Ext(p) != ".go"
+func (m *defaultTypeManager) shouldSkipFile(p string, info os.FileInfo, _ error) bool {
+	// The error parameter is retained for signature compatibility with
+	// filepath.WalkFunc but is always nil at this point — walk errors
+	// are intercepted by the caller before shouldSkipFile is invoked.
+	return info.IsDir() || filepath.Ext(p) != ".go"
 }
 
 func (m *defaultTypeManager) handleHeartbeat(hb chan<- struct{}, count *int) {
+	if count == nil {
+		return
+	}
 	*count++
 	if *count%10 == 0 && hb != nil {
 		select {

--- a/internal/tools/analysis/types_error_test.go
+++ b/internal/tools/analysis/types_error_test.go
@@ -108,12 +108,16 @@ func TestGetTypeInfo_LookupError(t *testing.T) {
 	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
 
 	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "Foo"}, nil)
-	if err != nil {
-		t.Errorf("unexpected error: %v", err)
+	if err == nil {
+		t.Fatal("expected error from Lookup failure, got nil")
 	}
-	if !strings.Contains(res.Text, "Type not found.") {
-		t.Errorf("expected 'Type not found.', got: %s", res.Text)
+	if !errors.Is(err, errSentinel) {
+		t.Errorf("expected error to wrap errSentinel, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "lookup type Foo") {
+		t.Errorf("expected error message to contain 'lookup type Foo', got: %v", err)
+	}
+	_ = res
 }
 
 // TestGetTypeInfo_LookupEmpty verifies that when Lookup returns zero locations
@@ -255,4 +259,169 @@ func TestGetTypeInfo_ShortCircuit(t *testing.T) {
 			t.Errorf("expected empty Text on UnmarshalArgs error, got %q", res.Text)
 		}
 	})
+}
+
+// TestCollectSymbols_SkipsUnparseableFile verifies that collectSymbols
+// gracefully tolerates a .go file with a syntax error and continues
+// collecting symbols from valid files in the same tree.
+func TestCollectSymbols_SkipsUnparseableFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// Write a valid go.mod so the indexer can operate.
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// valid.go: a well-formed Go file with one exported function.
+	validSrc := filepath.Join(tmpDir, "valid.go")
+	if err := os.WriteFile(validSrc, []byte(`package test
+
+func ValidFunc() string { return "ok" }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// broken.go: syntactically invalid Go.
+	brokenSrc := filepath.Join(tmpDir, "broken.go")
+	if err := os.WriteFile(brokenSrc, []byte(`package test
+
+func broken() { // missing closing brace
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &analysistest.MockSymbolIndex{}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": tmpDir}, nil)
+	if err != nil {
+		t.Fatalf("ListSymbols should not fail when one file is unparseable: %v", err)
+	}
+
+	// ValidFunc from valid.go must appear.
+	if !strings.Contains(res.Text, "ValidFunc") {
+		t.Errorf("expected ValidFunc in output, got:\n%s", res.Text)
+	}
+	// broken.go symbols must not appear.
+	if strings.Contains(res.Text, "broken") {
+		t.Errorf("expected no symbols from broken.go, got:\n%s", res.Text)
+	}
+}
+
+// TestFindMethodsInPackage_SkipsUnparseableFile verifies that
+// findMethodsInPackage gracefully tolerates a .go file with a syntax
+// error and still discovers methods from valid files in the same tree.
+func TestFindMethodsInPackage_SkipsUnparseableFile(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// valid.go: a struct with a method.
+	if err := os.WriteFile(filepath.Join(tmpDir, "valid.go"), []byte(`package test
+
+type MyStruct struct{}
+
+func (s *MyStruct) Greet() string { return "hi" }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// broken.go: syntactically invalid Go.
+	if err := os.WriteFile(filepath.Join(tmpDir, "broken.go"), []byte(`package test
+
+func broken() { // missing closing brace
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return []analysis.Location{{Path: filepath.Join(tmpDir, "valid.go"), Line: 2, Column: 6}}, nil
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	res, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "MyStruct"}, nil)
+	if err != nil {
+		t.Fatalf("GetTypeInfo should not fail when one file is unparseable: %v", err)
+	}
+	if !strings.Contains(res.Text, "Greet") {
+		t.Errorf("expected method Greet in output, got:\n%s", res.Text)
+	}
+}
+
+// TestCollectSymbols_PropagatesWalkError verifies that filesystem-level
+// walk errors (e.g., permission denied) are propagated rather than
+// silently skipped.
+func TestCollectSymbols_PropagatesWalkError(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	validSrc := filepath.Join(tmpDir, "valid.go")
+	if err := os.WriteFile(validSrc, []byte(`package test
+
+func ValidFunc() string { return "ok" }
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a subdirectory and make it unreadable.
+	lockedDir := filepath.Join(tmpDir, "locked")
+	if err := os.Mkdir(lockedDir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockedDir, 0700) })
+
+	m := analysis.NewTypeManager(
+		&analysistest.MockSymbolIndex{},
+		analysis.NewASTCache("."),
+		&analysistest.MockSecurityProvider{},
+	)
+
+	_, err := m.ListSymbols(context.Background(), map[string]interface{}{"path": tmpDir}, nil)
+	if err == nil {
+		t.Error("expected walk error from unreadable directory, got nil")
+	}
+}
+
+// TestGetTypeInfo_PropagatesWalkError verifies that filesystem-level
+// walk errors during method discovery propagate through GetTypeInfo.
+func TestGetTypeInfo_PropagatesWalkError(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "valid.go"), []byte(`package test
+
+type MyStruct struct{}
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	lockedDir := filepath.Join(tmpDir, "locked")
+	if err := os.Mkdir(lockedDir, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(lockedDir, 0700) })
+
+	idx := &mockTypeIndex{
+		LookupFunc: func(ctx context.Context, symbol string, hb chan<- struct{}) ([]analysis.Location, error) {
+			return []analysis.Location{{Path: filepath.Join(tmpDir, "valid.go"), Line: 2, Column: 6}}, nil
+		},
+	}
+	m := analysis.NewTypeManager(idx, analysis.NewASTCache("."), &analysistest.MockSecurityProvider{})
+
+	_, err := m.GetTypeInfo(context.Background(), map[string]interface{}{"typename": "MyStruct"}, nil)
+	if err == nil {
+		t.Error("expected walk error from unreadable directory during findMethodsInPackage, got nil")
+	}
 }

--- a/internal/tools/analysis/types_test.go
+++ b/internal/tools/analysis/types_test.go
@@ -438,4 +438,11 @@ func TestTypeManager_ErrorPaths(t *testing.T) {
 			t.Error("expected error from resolvePath rejection")
 		}
 	})
+
+	t.Run("handleHeartbeat nil count does not panic", func(t *testing.T) {
+		t.Parallel()
+		m := &defaultTypeManager{}
+		// Must not panic when count is nil.
+		m.handleHeartbeat(nil, nil)
+	})
 }

--- a/internal/tools/analysis/wellknown.go
+++ b/internal/tools/analysis/wellknown.go
@@ -144,6 +144,10 @@ func signatureMatches(sig *types.Signature, want wellKnownContractSignature) boo
 // http.Handler). Such methods must be protected from being flagged as
 // DEAD/PRIVATE because the call site never names them.
 func (a *defaultDeadCodeAnalyzer) isWellKnownContract(obj types.Object) bool {
+	// Only *types.Func objects can match a well-known contract signature.
+	// Two distinct failure modes return false silently:
+	//   1. Not a function (variable, type, constant)
+	//   2. Function with a non-signature type (builtin, invalid)
 	fn, ok := obj.(*types.Func)
 	if !ok {
 		return false


### PR DESCRIPTION
Closes #794.

## Summary
Closed 20 error-handling gaps across 5 files in `internal/tools/analysis/`:
- **types.go** (11 gaps): Propagate index lookup errors, separate walk errors from parse skips, defensive nil/len guards, cleanup shouldSkipFile
- **info.go** (5 gaps): Document silent error paths, fix formatDocOutput empty-output guard, document best-effort patterns
- **mermaid.go** (2 gaps): Document buildCycle invariant, dangling edge references
- **mermaid_formatter.go** (1 gap): Document empty frames behavior
- **wellknown.go** (1 gap): Document type assertion branches

6 new tests added covering error propagation and graceful degradation.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (0 issues) |
| analysis coverage | 95.8% |
| race detection | PASS |
| vulncheck | No vulnerabilities |