### PR TITLE
fix(ado): close error-handling coverage gaps with tests (#791)

### DIFF
--- a/internal/tools/integrations/ado/azure_devops_pr_test.go
+++ b/internal/tools/integrations/ado/azure_devops_pr_test.go
@@ -223,6 +223,48 @@ func TestAdoListPullRequests(t *testing.T) {
 		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.NoError(t, err)
 	})
+
+	t.Run("Top Clamped To 1000", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			q := r.URL.Query()
+			assert.Equal(t, "1000", q.Get("$top")) // clamped, not 2000
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"value": []}`))
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoListPullRequests(context.Background(), map[string]interface{}{
+			"organization": "myorg", "project": "myproj", "repository": "myrepo", "top": 2000,
+		}, nil)
+		assert.NoError(t, err)
+	})
+
+	t.Run("Malformed JSON Response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid`))
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoListPullRequests(context.Background(), map[string]interface{}{
+			"organization": "o", "project": "p", "repository": "r",
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode response")
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoListPullRequests(context.Background(), map[string]interface{}{
+			"organization": "myorg", "project": "myproj", "repository": "myrepo",
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "forbidden")
+	})
 }
 
 func TestAdoGetPrDiff(t *testing.T) {
@@ -373,6 +415,126 @@ func TestAdoGetPrThreads(t *testing.T) {
 		result, err := m.AdoGetPrThreads(context.Background(), args, nil)
 		assert.NoError(t, err)
 		assert.Equal(t, "No discussion threads found in this pull request.", result.Text)
+	})
+
+	t.Run("All System Threads", func(t *testing.T) {
+		t.Parallel()
+		m := &AdoManager{}
+		threadData := adoThreadResponse{
+			Value: []struct {
+				Comments []struct {
+					Author struct {
+						DisplayName string `json:"displayName"`
+					} `json:"author"`
+					Content       string `json:"content"`
+					PublishedDate string `json:"publishedDate"`
+					CommentType   string `json:"commentType"`
+				} `json:"comments"`
+				IsDeleted bool `json:"isDeleted"`
+			}{
+				{
+					IsDeleted: false,
+					Comments: []struct {
+						Author struct {
+							DisplayName string `json:"displayName"`
+						} `json:"author"`
+						Content       string `json:"content"`
+						PublishedDate string `json:"publishedDate"`
+						CommentType   string `json:"commentType"`
+					}{
+						{Author: struct {
+							DisplayName string `json:"displayName"`
+						}{DisplayName: "System"}, Content: "Build succeeded.", CommentType: "system"},
+					},
+				},
+				{
+					IsDeleted: true,
+					Comments:  nil,
+				},
+			},
+		}
+		result := m.formatPrThreads(123, threadData)
+		assert.Equal(t, "No discussion threads found in this pull request.", result)
+	})
+
+	t.Run("Empty Comment Content", func(t *testing.T) {
+		t.Parallel()
+		m := &AdoManager{}
+		threadData := adoThreadResponse{
+			Value: []struct {
+				Comments []struct {
+					Author struct {
+						DisplayName string `json:"displayName"`
+					} `json:"author"`
+					Content       string `json:"content"`
+					PublishedDate string `json:"publishedDate"`
+					CommentType   string `json:"commentType"`
+				} `json:"comments"`
+				IsDeleted bool `json:"isDeleted"`
+			}{
+				{
+					IsDeleted: false,
+					Comments: []struct {
+						Author struct {
+							DisplayName string `json:"displayName"`
+						} `json:"author"`
+						Content       string `json:"content"`
+						PublishedDate string `json:"publishedDate"`
+						CommentType   string `json:"commentType"`
+					}{
+						{Author: struct {
+							DisplayName string `json:"displayName"`
+						}{DisplayName: "Bot"}, Content: "", CommentType: "text"},
+						{Author: struct {
+							DisplayName string `json:"displayName"`
+						}{DisplayName: "User"}, Content: "Real comment.", CommentType: "text"},
+					},
+				},
+			},
+		}
+		result := m.formatPrThreads(123, threadData)
+		assert.Contains(t, result, "Real comment.")
+		assert.NotContains(t, result, "Bot:") // empty content comment is skipped
+	})
+
+	t.Run("Malformed JSON Response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{invalid`))
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoGetPrThreads(context.Background(), map[string]interface{}{
+			"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to decode response")
+	})
+
+	t.Run("Unauthorized", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoGetPrThreads(context.Background(), map[string]interface{}{
+			"organization": "myorg", "project": "myproj", "repository": "myrepo", "pull_request_id": 123,
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unauthorized")
+	})
+
+	t.Run("Forbidden", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(server.Close)
+		m := NewADOManager(sm, WithBaseURL(server.URL), WithToken("test-pat"))
+		_, err := m.AdoGetPrThreads(context.Background(), map[string]interface{}{
+			"organization": "myorg", "project": "myproj", "repository": "myrepo", "pull_request_id": 123,
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "forbidden")
 	})
 }
 

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -934,4 +934,107 @@ func TestAdoManager_FinalErrorPaths(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "parsing get pr statuses args")
 	})
+
+	// Gap 4: AdoGetPrThreads — tools.UnmarshalArgs fails on type mismatch.
+	// No HTTP server needed; fails before any network call.
+	t.Run("AdoGetPrThreads - unmarshal error", func(t *testing.T) {
+		// t.Setenv already at top-level, no t.Parallel() due to t.Setenv
+		m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true}, WithToken("test-pat"))
+		_, err := m.AdoGetPrThreads(context.Background(), map[string]interface{}{
+			"organization": "o", "project": "p", "repository": "r", "pull_request_id": "not-an-int",
+		}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "parsing get pr threads args")
+	})
+}
+
+// TestAdoManager_ListPullRequests_URLParseError covers the error propagation
+// through AdoListPullRequests when buildListPullRequestsURL fails due to
+// url.Parse rejecting a malformed BaseURL containing a control character.
+// No HTTP server needed — url.Parse fails before any network call.
+func TestAdoManager_ListPullRequests_URLParseError(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true},
+		WithBaseURL("http://x\ny"), WithToken("test-pat"))
+	_, err := m.AdoListPullRequests(context.Background(), map[string]interface{}{
+		"organization": "o", "project": "p", "repository": "r",
+	}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "building list pull requests URL")
+}
+
+// TestAdoManager_GetPipelineLogContent_MissingParams covers the explicit
+// missing-params validation in getPipelineLogContent (~line 299) that
+// requires organization, project, pipeline_id, run_id, and log_id.
+// No HTTP server is needed — the validation fails before any network call.
+func TestAdoManager_GetPipelineLogContent_MissingParams(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	m := NewADOManager(sm, WithToken("test-pat"))
+
+	_, err := m.getPipelineLogContent(context.Background(), map[string]interface{}{
+		"organization": "o",
+		// project, pipeline_id, run_id, log_id intentionally omitted — all zero
+	}, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestAdoManager_GetTaskLog_MissingParams covers the explicit missing-params
+// validation in getTaskLog (~line 322) that requires organization, project,
+// build_id, and log_id. No HTTP server is needed.
+func TestAdoManager_GetTaskLog_MissingParams(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	m := NewADOManager(sm, WithToken("test-pat"))
+
+	_, err := m.getTaskLog(context.Background(), map[string]interface{}{
+		"organization": "o",
+		// project, build_id, log_id intentionally omitted — all zero
+	}, nil)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "required")
+}
+
+// TestAdoManager_ListPipelineRuns_URLParseError covers the error propagation
+// through ListPipelineRuns when buildListPipelineRunsURL fails due to
+// url.Parse rejecting a malformed BaseURL containing a control character.
+// No HTTP server needed — url.Parse fails before any network call.
+func TestAdoManager_ListPipelineRuns_URLParseError(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true},
+		WithBaseURL("http://x\ny"), WithToken("test-pat"))
+	_, _, err := m.ListPipelineRuns(context.Background(), map[string]interface{}{
+		"organization": "o", "project": "p", "pipeline_id": 1,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "building list pipeline runs URL")
+}
+
+// TestAdoManager_GetTaskLog_ProcessError covers the error propagation through
+// getTaskLog when processLogContent encounters a scanner buffer overflow
+// (line > 1MB). Follows the same pattern as the existing
+// "Fetch Log Content - processLogContent error (scanner.Err)" subtest in
+// TestAdoManager_ListPipelineLogs_Errors but exercises the build-variant path.
+func TestAdoManager_GetTaskLog_ProcessError(t *testing.T) {
+	t.Setenv("AZURE_PAT_ALL", "test-pat")
+	tooLong := make([]byte, 1*1024*1024+1)
+	for i := range tooLong {
+		tooLong[i] = 'A'
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(tooLong)
+	}))
+	defer ts.Close()
+
+	m := NewADOManager(&toolstest.MockSecurityManager{AllowAll: true},
+		WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
+	_, err := m.getTaskLog(context.Background(), map[string]interface{}{
+		"organization": "o", "project": "p", "build_id": 1, "log_id": 1,
+	}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to process log content")
 }

--- a/internal/tools/integrations/ado/pipeline_logs_test.go
+++ b/internal/tools/integrations/ado/pipeline_logs_test.go
@@ -206,4 +206,27 @@ func TestStreamFunctions_EdgeCases(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 		assert.Equal(t, 1, count) // first line triggers error
 	})
+
+	t.Run("streamPagination - startLine beyond total", func(t *testing.T) {
+		t.Parallel()
+		result, err := streamPagination(context.Background(), strings.NewReader("line1\nline2\n"), 10, 10, nil)
+		assert.NoError(t, err)
+		assert.Contains(t, result.Content, "Start line 10 is beyond total lines 2")
+	})
+
+	t.Run("streamPagination - maxLines unlimited", func(t *testing.T) {
+		t.Parallel()
+		result, err := streamPagination(context.Background(), strings.NewReader("line1\nline2\n"), 1, 0, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "line1\nline2", result.Content)
+		assert.Equal(t, 2, result.TotalLines)
+	})
+
+	t.Run("streamRegexFilter - no matches found", func(t *testing.T) {
+		t.Parallel()
+		opts := logFilterOptions{MaxLines: 100, ContextLines: 0}
+		result, err := streamRegexFilter(context.Background(), strings.NewReader("line1\nline2\n"), "zzz_not_present", opts, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, "No matches found for filter_query.", result.Content)
+	})
 }

--- a/internal/tools/integrations/ado/registry_test.go
+++ b/internal/tools/integrations/ado/registry_test.go
@@ -6,7 +6,9 @@ package ado
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
@@ -273,6 +275,27 @@ func TestRegister(t *testing.T) {
 		assert.Len(t, r.registered, 20)
 	})
 
+	t.Run("Success with AZURE_PAT_ALL set exercises WithToken path", func(t *testing.T) {
+		t.Setenv("AZURE_PAT_ALL", "test-pat")
+		r := &mockRegistry{}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+		err := Register(r, sm, nil)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, r.registered)
+		assert.Len(t, r.registered, 20)
+	})
+
+	t.Run("Success with client exercises WithHTTPClient path", func(t *testing.T) {
+		r := &mockRegistry{}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
+		client := &http.Client{Timeout: 5 * time.Second}
+		err := Register(r, sm, client)
+		require.NoError(t, err)
+		assert.Len(t, r.registered, 20)
+	})
+
 	t.Run("Error propagation stops registration", func(t *testing.T) {
 		// Use a mockRegistry where RegisterToToolkit succeeds once and fails
 		// on the second call.
@@ -300,4 +323,73 @@ func (f *failingRegistry) RegisterToToolkit(toolkit string, def *tools.ToolDecla
 	f.callNum++
 	f.registered = append(f.registered, registeredTool{toolkit, def.Name, handler})
 	return nil
+}
+
+// ============================================================================
+// marshalIndentResult
+// ============================================================================
+
+func TestMarshalIndentResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   interface{}
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "unmarshalable value returns error",
+			input:   make(chan int),
+			wantErr: true,
+			errMsg:  "marshaling response",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := marshalIndentResult(tt.input)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// ============================================================================
+// appendTruncationNote
+// ============================================================================
+
+func TestAppendTruncationNote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  logContent
+		assert func(t *testing.T, result string)
+	}{
+		{
+			name:  "appends note when truncated",
+			input: logContent{Content: "data", Truncated: true, TotalLines: 100},
+			assert: func(t *testing.T, result string) {
+				assert.Contains(t, result, "[NOTE to LLM")
+				assert.Contains(t, result, "truncated after 100 lines")
+				assert.Contains(t, result, "data")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := appendTruncationNote(tt.input)
+			tt.assert(t, result)
+		})
+	}
 }


### PR DESCRIPTION
Closes #791.

## Summary
Added comprehensive test coverage for error-handling paths across 5 ADO integration files, closing 16 identified coverage gaps. Coverage improved from 97.3% to **98.5%** with zero regressions.

### Files Changed (test-only)
| File | Gaps Closed |
|------|-------------|
| `internal/tools/integrations/ado/registry_test.go` | `marshalIndentResult`, `appendTruncationNote`, `Register` |
| `internal/tools/integrations/ado/negative_test.go` | validation, URL-parse, processLogContent, unmarshal errors |
| `internal/tools/integrations/ado/azure_devops_pr_test.go` | formatter branches, JSON decode, HTTP status errors |
| `internal/tools/integrations/ado/pipeline_logs_test.go` | stream filter/pagination edge cases |

### Remaining Gaps (Documented Infallible Guards)
- `executeRunPipeline`/`executeCreatePipeline`: `json.Marshal` on simple structs (cannot fail)
- `fetchPipelines`: `singleflight.Group.Do` error + inner cache re-check (dead code)
- `UpdateBuildDefinitionVariables`: `buildVariablesUpdatePayload` on JSON-decoded map
- `streamPagination`: Coverage instrumentation boundary artifact

## Verification
| Check | Status |
|-------|--------|
| make fmt | PASS |
| make tidy | PASS |
| make build | PASS |
| make lint | PASS (0 issues) |
| make vulncheck | PASS |
| make test | PASS |
| Target coverage | 98.5% (from 97.3%) |
