### PR TITLE
fix(tools): close error-handling gaps across cli, application, and tools/integrations (#799)

### DIFF
--- a/internal/application/suggestions/service.go
+++ b/internal/application/suggestions/service.go
@@ -34,6 +34,14 @@ type multiSourceSuggestionService struct {
 	policy    services.WorkspacePolicy
 }
 
+// warnf centralizes warning output. It writes to s.logger if non-nil.
+func (s *multiSourceSuggestionService) warnf(format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	if s.logger != nil {
+		_, _ = fmt.Fprint(s.logger, msg)
+	}
+}
+
 // NewMultiSourceSuggestionService creates a new suggestion service and pre-loads the history.
 func NewMultiSourceSuggestionService(ctx context.Context, fs persistence.FileSystem, tracker ports.PromptTracker, recentHistory []string, logger io.Writer, policy services.WorkspacePolicy) (ports.SuggestionService, error) {
 	if logger == nil {
@@ -52,7 +60,7 @@ func NewMultiSourceSuggestionService(ctx context.Context, fs persistence.FileSys
 	topPrompts, err := tracker.LoadTopN(ctx, 50)
 	if err != nil {
 		// Log error but continue with what we have
-		_, _ = fmt.Fprintf(s.logger, "Warning: failed to load top prompts: %v\n", err)
+		s.warnf("Warning: failed to load top prompts: %v\n", err)
 	}
 
 	seen := make(map[string]bool)
@@ -158,7 +166,7 @@ func (s *multiSourceSuggestionService) RecordPrompt(ctx context.Context, prompt 
 
 		if err := s.tracker.Append(bgCtx, p); err != nil {
 			// Since this is background, we can only log the error
-			_, _ = fmt.Fprintf(s.logger, "Warning: failed to record prompt to global tracker: %v\n", err)
+			s.warnf("Warning: failed to record prompt to global tracker: %v\n", err)
 		}
 	}(ctx, prompt)
 

--- a/internal/application/suggestions/service_test.go
+++ b/internal/application/suggestions/service_test.go
@@ -655,3 +655,48 @@ func TestRecordPrompt_AfterClose(t *testing.T) {
 		}
 	}
 }
+
+func TestMultiSourceSuggestionService_Warnf(t *testing.T) {
+	var buf strings.Builder
+	failTracker := &failingAppendTracker{}
+	fs := persistence.NewMockFileSystem()
+
+	service, err := suggestions.NewMultiSourceSuggestionService(
+		context.Background(), fs, failTracker, nil, &buf, infra_persistence.NewWorkspacePolicy(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+
+	// Trigger a background RecordPrompt with a failing tracker
+	_ = service.RecordPrompt(context.Background(), "test-prompt")
+
+	// Close drains the background goroutine
+	_ = service.Close(context.Background())
+
+	got := buf.String()
+	if !strings.Contains(got, "failed to record prompt to global tracker") {
+		t.Errorf("expected logger to contain warning about failed record, got: %q", got)
+	}
+}
+
+func TestNewService_LoadTopN_LogsWarning(t *testing.T) {
+	var buf strings.Builder
+	tracker := &errorPromptTracker{}
+	fs := persistence.NewMockFileSystem()
+
+	service, err := suggestions.NewMultiSourceSuggestionService(
+		context.Background(), fs, tracker, nil, &buf, infra_persistence.NewWorkspacePolicy(),
+	)
+	if err != nil {
+		t.Fatalf("failed to create service: %v", err)
+	}
+	if service == nil {
+		t.Fatal("service is nil")
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "failed to load top prompts") {
+		t.Errorf("expected logger to contain warning about failed load, got: %q", got)
+	}
+}

--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -47,6 +47,12 @@ func (c *chatCommand) newCapturer(stdin io.Reader, stdout, stderr io.Writer, sm 
 	return ui.NewCapturer(stdin, stdout, stderr, sm, clk, mockPrompt, mockAnswer, disableEscapeSequences)
 }
 
+// warnf writes a formatted warning message to stderr; errors from Fprintf are
+// deliberately discarded because there is no recovery path for logging failures.
+func (c *chatCommand) warnf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(c.Stderr, format, args...)
+}
+
 type cliOptions struct {
 	configPath   string
 	newSession   bool
@@ -101,7 +107,7 @@ func newChatCommand(ctx *context, opts *cliOptions) *cobra.Command {
 		Short: "Start a chat session (Default)",
 		Long:  `The chat command initiates a session with the AI assistant. You can provide a prompt directly as an argument or enter an interactive session.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath, _ := cmd.Flags().GetString("config")
+			configPath, _ := cmd.Flags().GetString("config") // flag guaranteed by root command; never errors
 			opts.configPath = configPath
 			return c.executeChat(cmd.Context(), opts, args)
 		},
@@ -183,7 +189,7 @@ func (c *chatCommand) getCapturer(ctx stdctx.Context, cfg *domain_config.Config,
 	if c.capturerOverride != nil {
 		return c.capturerOverride, func(shutdownCtx stdctx.Context) error {
 			if err := c.capturerOverride.Close(shutdownCtx); err != nil {
-				_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+				c.warnf("Warning: failed to close capturer: %v\n", err)
 				return err
 			}
 			return nil
@@ -260,7 +266,7 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 
 		if err != nil {
 			// Log warning and fall back to the base capturer (no suggestions)
-			_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to initialize suggestions: %v\n", err)
+			c.warnf("Warning: failed to initialize suggestions: %v\n", err)
 			capturer = baseCapturer
 			cleanup = func(ctx stdctx.Context) error {
 				return capturer.Close(ctx)
@@ -269,7 +275,7 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 			capturer = tui.NewPromptCapturer(baseCapturer, svc)
 			cleanup = func(ctx stdctx.Context) error {
 				if err := capturer.Close(ctx); err != nil {
-					_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+					c.warnf("Warning: failed to close capturer: %v\n", err)
 					return err
 				}
 				return nil
@@ -290,7 +296,7 @@ func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Con
 	if c.capturerOverride != nil {
 		return c.capturerOverride, func(ctx stdctx.Context) error {
 			if err := c.capturerOverride.Close(ctx); err != nil {
-				_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+				c.warnf("Warning: failed to close capturer: %v\n", err)
 				return err
 			}
 			return nil
@@ -305,7 +311,7 @@ func (c *chatCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.Con
 	c.Interactor.set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		if err := capturer.Close(ctx); err != nil {
-			_, _ = fmt.Fprintf(c.Stderr, "Warning: failed to close capturer: %v\n", err)
+			c.warnf("Warning: failed to close capturer: %v\n", err)
 			return err
 		}
 		return nil

--- a/internal/cli/cmd_browse.go
+++ b/internal/cli/cmd_browse.go
@@ -31,12 +31,18 @@ func (c *browseCommand) newCapturer(stdin io.Reader, stdout, stderr io.Writer, s
 	return ui.NewCapturer(stdin, stdout, stderr, sm, clk, mockPrompt, mockAnswer, disableEscapeSequences)
 }
 
+// warnf writes a formatted warning message to stderr; errors from Fprintf are
+// deliberately discarded because there is no recovery path for logging failures.
+func (c *browseCommand) warnf(format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(c.ctx.Stderr, format, args...)
+}
+
 // getCapturer returns the override if set (test path), otherwise creates a real capturer.
 func (c *browseCommand) getCapturer() (agent.CapturerInteractor, func(stdctx.Context) error, error) {
 	if c.capturerOverride != nil {
 		return c.capturerOverride, func(ctx stdctx.Context) error {
 			if err := c.capturerOverride.Close(ctx); err != nil {
-				_, _ = fmt.Fprintf(c.ctx.Stderr, "Warning: failed to close capturer: %v\n", err)
+				c.warnf("Warning: failed to close capturer: %v\n", err)
 				return err
 			}
 			return nil
@@ -53,7 +59,7 @@ func newBrowseCommand(ctx *context) *cobra.Command {
 		Short: "Interactive history browser using Bubble Tea",
 		Long:  "Launches an interactive TUI to browse through active and archived chat history.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath, _ := cmd.Flags().GetString("config")
+			configPath, _ := cmd.Flags().GetString("config") // flag guaranteed by root command; never errors
 			return c.runBrowse(cmd.Context(), configPath)
 		},
 	}
@@ -105,7 +111,7 @@ func (c *browseCommand) setupCapturer() (agent.CapturerInteractor, func(stdctx.C
 	c.ctx.Interactor.set(capturer)
 	return capturer, func(ctx stdctx.Context) error {
 		if err := capturer.Close(ctx); err != nil {
-			_, _ = fmt.Fprintf(c.ctx.Stderr, "Warning: failed to close capturer: %v\n", err)
+			c.warnf("Warning: failed to close capturer: %v\n", err)
 			return err
 		}
 		return nil

--- a/internal/cli/cmd_env.go
+++ b/internal/cli/cmd_env.go
@@ -29,7 +29,7 @@ func newEnvCommand(ctx *context) *cobra.Command {
 		Short: "Print the fully resolved configuration",
 		Long:  `The env command loads the configuration, masks sensitive fields like API keys, and prints the resulting YAML to standard output.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			configPath, _ := cmd.Flags().GetString("config")
+			configPath, _ := cmd.Flags().GetString("config") // flag guaranteed by root command; never errors
 			return c.execute(cmd.Context(), configPath)
 		},
 	}

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -72,15 +72,15 @@ func (m *ConfluenceManager) fetchPageContent(ctx context.Context, pageID string)
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		_ = resp.Body.Close()
+		_ = drainAndClose(resp.Body) // Drain to enable connection reuse; close errors on error paths are non-actionable.
 		return nil, fmt.Errorf("confluence page not found: %s", pageID)
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		_ = resp.Body.Close()
+		_ = drainAndClose(resp.Body) // Drain to enable connection reuse; close errors on error paths are non-actionable.
 		return nil, fmt.Errorf("authentication failed: %s", resp.Status)
 	}
 	if resp.StatusCode != http.StatusOK {
-		_ = resp.Body.Close()
+		_ = drainAndClose(resp.Body) // Drain to enable connection reuse; close errors on error paths are non-actionable.
 		return nil, fmt.Errorf("confluence API returned status: %s", resp.Status)
 	}
 
@@ -88,7 +88,7 @@ func (m *ConfluenceManager) fetchPageContent(ctx context.Context, pageID string)
 }
 
 func (m *ConfluenceManager) readAndValidateBody(respBody io.ReadCloser) ([]byte, error) {
-	defer func() { _ = respBody.Close() }()
+	defer func() { _ = respBody.Close() }() // body fully consumed by io.ReadAll above; close errors are non-actionable
 	const maxPageSize = 5 * 1024 * 1024
 	body, err := io.ReadAll(io.LimitReader(respBody, int64(maxPageSize)+1))
 	if err != nil {
@@ -167,7 +167,7 @@ func (m *ConfluenceManager) getCurrentPageVersion(ctx context.Context, pageID st
 	if err != nil {
 		return nil, fmt.Errorf("version fetch request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = resp.Body.Close() }() // body consumed by json.Decoder; close error non-actionable
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failed to fetch current version, status: %s", resp.Status)
@@ -203,7 +203,9 @@ func (m *ConfluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 	if err != nil {
 		return fmt.Errorf("update request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_ = drainAndClose(resp.Body) // Write path: drain to enable connection reuse
+	}()
 
 	if resp.StatusCode == http.StatusConflict {
 		return fmt.Errorf("conflict: page version changed during update; please retry")
@@ -272,6 +274,14 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen] + "..."
+}
+
+// drainAndClose drains any remaining bytes from the response body to enable
+// connection reuse, then closes it. The close error is returned; drain errors
+// are discarded (they are always expected when draining after a partial read).
+func drainAndClose(body io.ReadCloser) error {
+	_, _ = io.Copy(io.Discard, body)
+	return body.Close()
 }
 
 type confluenceSecurity interface {

--- a/internal/tools/integrations/atlassian/confluence_search.go
+++ b/internal/tools/integrations/atlassian/confluence_search.go
@@ -56,7 +56,10 @@ func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string)
 	if err != nil {
 		return "", err
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body) // drain to enable connection reuse
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode == http.StatusNotFound {
 		return "", fmt.Errorf("space key '%s' not found", spaceKey)
@@ -93,7 +96,10 @@ func (m *ConfluenceManager) FetchSearchPage(ctx context.Context, url string) (*s
 	if err != nil {
 		return nil, fmt.Errorf("request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		body, err := io.ReadAll(resp.Body)

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -125,6 +125,11 @@ func (m *mediaManager) saveImagesToDisk(ctx context.Context, images [][]byte, pr
 }
 
 func (m *mediaManager) readImage(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	// readImage is a synchronous read operation (not registered as LongRunning),
+	// so heartbeat is intentionally not started. The hb parameter is required by
+	// the tools.ToolFunc interface signature.
+	_ = hb
+
 	var a struct {
 		Filepath string `json:"filepath"`
 	}

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -546,6 +546,48 @@ func TestRegisterAll_ErrorPropagation(t *testing.T) {
 	})
 }
 
+func TestRegisterAll_ErrorWrapping(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	fs := &mockFileSystem{}
+	client := &mockLLMClient{}
+	tmpDir := t.TempDir()
+
+	tests := []struct {
+		name          string
+		failAfter     int
+		wantSubstring string
+	}{
+		{
+			name:          "registerMedia wraps error",
+			failAfter:     0,
+			wantSubstring: "registerMedia",
+		},
+		{
+			name:          "registerNetwork wraps error",
+			failAfter:     2,
+			wantSubstring: "registerNetwork",
+		},
+		{
+			name:          "registerTeams wraps error",
+			failAfter:     4,
+			wantSubstring: "registerTeams",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := newFaultyRegistry(registry.New(), tt.failAfter)
+			err := RegisterAll(r, fs, sm, client, tmpDir)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstring) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantSubstring)
+			}
+		})
+	}
+}
+
 func TestRegisterMedia_ErrorPaths(t *testing.T) {
 	sm := newMediaMockSecurityManager()
 	fs := &mockFileSystem{}

--- a/internal/tools/integrations/network.go
+++ b/internal/tools/integrations/network.go
@@ -107,6 +107,20 @@ func truncateUTF8(s string, maxBytes int) string {
 	return strings.ToValidUTF8(s, "")
 }
 
+// drainAndClose drains remaining bytes from a response body to enable HTTP
+// connection reuse, then closes it. The close error is returned; drain errors
+// are discarded (they are expected when draining after a partial read).
+func drainAndClose(body io.ReadCloser) error {
+	_, _ = io.Copy(io.Discard, body)
+	return body.Close()
+}
+
+// mustFprintf is fmt.Fprintf for strings.Builder, which never returns an error.
+// It eliminates the noisy _, _ = pattern at call sites.
+func mustFprintf(sb *strings.Builder, format string, args ...interface{}) {
+	_, _ = fmt.Fprintf(sb, format, args...)
+}
+
 func (t *networkTool) sanitizeHTML(content string) string {
 	var sb strings.Builder
 	z := html.NewTokenizer(strings.NewReader(content))
@@ -169,7 +183,7 @@ func (t *networkTool) HttpRequest(ctx context.Context, args map[string]interface
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("request failed: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = drainAndClose(resp.Body) }() // drain+close; error non-actionable after read
 
 	bodyContent, truncated, err := t.readResponseWithLimit(resp.Body, maxHttpRequestSize)
 	if err != nil {
@@ -180,10 +194,10 @@ func (t *networkTool) HttpRequest(ctx context.Context, args map[string]interface
 	}
 
 	var sb strings.Builder
-	_, _ = fmt.Fprintf(&sb, "Status: %s\n", resp.Status)
+	mustFprintf(&sb, "Status: %s\n", resp.Status)
 	sb.WriteString("Headers:\n")
 	for k, v := range resp.Header {
-		_, _ = fmt.Fprintf(&sb, "  %s: %s\n", k, strings.Join(v, ", "))
+		mustFprintf(&sb, "  %s: %s\n", k, strings.Join(v, ", "))
 	}
 	sb.WriteString("\nBody:\n")
 	sb.WriteString(bodyContent)
@@ -216,7 +230,7 @@ func (t *networkTool) ReadExternalDocs(ctx context.Context, args map[string]inte
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("failed to fetch URL: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() { _ = drainAndClose(resp.Body) }()
 
 	if resp.StatusCode != http.StatusOK {
 		return tools.ToolResult{}, fmt.Errorf("unexpected status code: %d", resp.StatusCode)

--- a/internal/tools/integrations/registration.go
+++ b/internal/tools/integrations/registration.go
@@ -4,6 +4,8 @@
 package integrations
 
 import (
+	"fmt"
+
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
@@ -16,33 +18,33 @@ import (
 func RegisterAll(r tools.Registry, fs persistence.FileSystem, sm domain_security.Manager, client llm.LLMClient, assetsDir string) error {
 	// Register Media Tools
 	if err := registerMedia(r, fs, sm, client, assetsDir); err != nil {
-		return err
+		return fmt.Errorf("registerMedia: %w", err)
 	}
 
 	// Register Network Tools
 	net := newnetworkTool(sm, nil)
 	if err := registerNetwork(r, net); err != nil {
-		return err
+		return fmt.Errorf("registerNetwork: %w", err)
 	}
 
 	// Register Teams Tools
 	if err := registerTeams(r, sm, nil); err != nil {
-		return err
+		return fmt.Errorf("registerTeams: %w", err)
 	}
 
 	// Register Confluence Tools
 	if err := atlassian.RegisterConfluence(r, sm, nil); err != nil {
-		return err
+		return fmt.Errorf("atlassian.RegisterConfluence: %w", err)
 	}
 
 	// Register Jira Tools
 	if err := atlassian.RegisterJira(r, sm, nil); err != nil {
-		return err
+		return fmt.Errorf("atlassian.RegisterJira: %w", err)
 	}
 
 	// Register Azure DevOps Tools
 	if err := ado.Register(r, sm, nil); err != nil {
-		return err
+		return fmt.Errorf("ado.Register: %w", err)
 	}
 
 	return nil

--- a/internal/tools/integrations/teams.go
+++ b/internal/tools/integrations/teams.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -64,16 +65,27 @@ func (m *teamsManager) sendTeamsMessage(ctx context.Context, args map[string]int
 }
 
 func buildTeamsRequestBody(message, reason string) ([]byte, error) {
+	body := []map[string]interface{}{
+		{
+			"type": "TextBlock",
+			"text": message,
+			"wrap": true,
+		},
+	}
+	if reason != "" {
+		body = append(body, map[string]interface{}{
+			"type":     "TextBlock",
+			"text":     fmt.Sprintf("Reason: %s", reason),
+			"wrap":     true,
+			"spacing":  "Small",
+			"size":     "Small",
+			"isSubtle": true,
+		})
+	}
 	payload := map[string]interface{}{
 		"type":    "AdaptiveCard",
 		"version": "1.2",
-		"body": []map[string]interface{}{
-			{
-				"type": "TextBlock",
-				"text": message,
-				"wrap": true,
-			},
-		},
+		"body":    body,
 		"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	}
 	return json.Marshal(payload)
@@ -89,7 +101,10 @@ func (m *teamsManager) postToWebhook(ctx context.Context, url string, body []byt
 	if err != nil {
 		return "", fmt.Errorf("failed to send message: %w", err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body) // drain to enable connection reuse
+		_ = resp.Body.Close()                 // close error non-critical after status check
+	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return "", fmt.Errorf("failed to send message to Teams, status: %s", resp.Status)

--- a/internal/tools/integrations/teams_test.go
+++ b/internal/tools/integrations/teams_test.go
@@ -5,7 +5,6 @@ package integrations
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -148,17 +147,27 @@ func TestTeamsManager_Timeout(t *testing.T) {
 }
 
 func TestBuildTeamsRequestBody(t *testing.T) {
-	body, err := buildTeamsRequestBody("hello", "reason")
-	if err != nil {
-		t.Fatalf("buildTeamsRequestBody failed: %v", err)
-	}
-	var payload map[string]interface{}
-	if err := json.Unmarshal(body, &payload); err != nil {
-		t.Fatalf("Failed to unmarshal body: %v", err)
-	}
-	if payload["type"] != "AdaptiveCard" {
-		t.Errorf("Expected type AdaptiveCard, got %v", payload["type"])
-	}
+	t.Run("includes reason when provided", func(t *testing.T) {
+		body, err := buildTeamsRequestBody("hello", "testing reason")
+		if err != nil {
+			t.Fatalf("buildTeamsRequestBody failed: %v", err)
+		}
+		bodyStr := string(body)
+		if !strings.Contains(bodyStr, "Reason: testing reason") {
+			t.Errorf("Expected reason in body, got: %s", bodyStr)
+		}
+	})
+
+	t.Run("omits reason when empty", func(t *testing.T) {
+		body, err := buildTeamsRequestBody("hello", "")
+		if err != nil {
+			t.Fatalf("buildTeamsRequestBody failed: %v", err)
+		}
+		bodyStr := string(body)
+		if strings.Contains(bodyStr, "Reason:") {
+			t.Errorf("Expected no reason in body when reason is empty, got: %s", bodyStr)
+		}
+	})
 }
 
 func TestPostToWebhook_RequestError(t *testing.T) {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -63,22 +63,22 @@ func RegisterAll(params ToolRegistrationParams) error {
 		return err
 	}
 	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager); err != nil {
-		return err
+		return fmt.Errorf("workspace.Register: %w", err)
 	}
 	if params.SessionProvider != nil {
 		if err := workspace.RegisterPersistence(params.Registry, params.SessionProvider); err != nil {
-			return err
+			return fmt.Errorf("workspace.RegisterPersistence: %w", err)
 		}
 	}
 	archVerify, err := analysis.Register(params.Registry, params.SecurityManager, params.EventBus, params.CommandExecutor, params.FileSystem, params.WorkspacePolicy)
 	if err != nil {
-		return err
+		return fmt.Errorf("analysis.Register: %w", err)
 	}
 	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify); err != nil {
-		return err
+		return fmt.Errorf("developer.Register: %w", err)
 	}
 	if err := integrations.RegisterAll(params.Registry, params.FileSystem, params.SecurityManager, params.Client, params.AssetsDir); err != nil {
-		return err
+		return fmt.Errorf("integrations.RegisterAll: %w", err)
 	}
 	return nil
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -269,6 +269,76 @@ func TestRegisterAll_Errors(t *testing.T) {
 	}
 }
 
+func TestRegisterAll_ErrorWrapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		failAfter     int
+		setup         func(*tools.ToolRegistrationParams)
+		wantSubstring string
+	}{
+		{
+			name:          "workspace.Register wraps error",
+			failAfter:     0,
+			wantSubstring: "workspace.Register",
+		},
+		{
+			name:      "workspace.RegisterPersistence wraps error",
+			failAfter: 23,
+			setup: func(p *tools.ToolRegistrationParams) {
+				p.SessionProvider = &agenttest.MockSessionProvider{}
+			},
+			wantSubstring: "workspace.RegisterPersistence",
+		},
+		{
+			name:      "analysis.Register wraps error",
+			failAfter: 26,
+			setup: func(p *tools.ToolRegistrationParams) {
+				p.SessionProvider = &agenttest.MockSessionProvider{}
+			},
+			wantSubstring: "analysis.Register",
+		},
+		{
+			name:      "developer.Register wraps error",
+			failAfter: 47,
+			setup: func(p *tools.ToolRegistrationParams) {
+				p.SessionProvider = &agenttest.MockSessionProvider{}
+			},
+			wantSubstring: "developer.Register",
+		},
+		{
+			name:      "integrations.RegisterAll wraps error",
+			failAfter: 54,
+			setup: func(p *tools.ToolRegistrationParams) {
+				p.SessionProvider = &agenttest.MockSessionProvider{}
+			},
+			wantSubstring: "integrations.RegisterAll",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			mockReg := &MockRegistry{failAfter: tt.failAfter}
+			params := tools.ToolRegistrationParams{
+				Registry:        mockReg,
+				SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
+				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
+				HealthManager:   nil,
+			}
+			if tt.setup != nil {
+				tt.setup(&params)
+			}
+
+			err := tools.RegisterAll(params)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantSubstring)
+		})
+	}
+}
+
 func (m *MockRegistry) GetOptions(name string) domaintools.ToolOptions {
 	return domaintools.ToolOptions{}
 }


### PR DESCRIPTION
Closes #799.

## Summary
Closed all 17 error-handling gaps across 11 files identified in Phase 4 cleanup:

- **Error wrapping**: Added `fmt.Errorf` context to bare `return err` in `tools/tools.go` and `integrations/registration.go`
- **HTTP body draining**: Added `drainAndClose` helpers and replaced bare `_ = resp.Body.Close()` in `confluence.go`, `confluence_search.go`, `network.go`, and `teams.go`
- **Warning centralization**: Extracted `warnf` helpers in `chat_command.go`, `cmd_browse.go`, and `suggestions/service.go`
- **Dead code**: Used unused `reason` parameter in `buildTeamsRequestBody`, documented unused `hb` parameter in `readImage`
- **Comments**: Documented `configPath, _` Cobra pattern across all CLI files

## Verification
| Check | Status |
|-------|--------|
| go build | PASS |
| golangci-lint | PASS (0 issues) |
| go test ./... | PASS |
| go vet | PASS |
| Existing coverage | No reduction |