### PR TITLE
fix(agent): add test coverage for 15 untested executor/orchestrator paths (#829)

### DIFF
--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 	"testing"
 	"time"
 
@@ -595,15 +594,17 @@ func TestForwardHeartbeat_SuccessfulSend(t *testing.T) {
 		t.Parallel()
 		ch := make(chan struct{})
 		received := make(chan struct{})
+		ready := make(chan struct{})
 
 		go func() {
+			close(ready) // signal: receiver is now blocked on <-ch
 			<-ch
 			close(received)
 		}()
 
-		// Yield the scheduler so the receiver goroutine can start and
-		// block on <-ch before the non-blocking send.
-		runtime.Gosched()
+		// Deterministic barrier: block until the receiver goroutine is
+		// guaranteed to be waiting on <-ch before the non-blocking send.
+		<-ready
 		forwardHeartbeat(ch, struct{}{})
 
 		select {

--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -594,25 +594,24 @@ func TestForwardHeartbeat_SuccessfulSend(t *testing.T) {
 		t.Parallel()
 		ch := make(chan struct{})
 		received := make(chan struct{})
-		ready := make(chan struct{})
 
 		go func() {
-			close(ready) // signal: receiver is now blocked on <-ch
 			<-ch
 			close(received)
 		}()
 
-		// Deterministic barrier: block until the receiver goroutine is
-		// guaranteed to be waiting on <-ch before the non-blocking send.
-		<-ready
-		forwardHeartbeat(ch, struct{}{})
-
-		select {
-		case <-received:
-			// Receiver got the heartbeat
-		case <-time.After(1 * time.Second):
-			t.Fatal("timeout waiting for receiver to get heartbeat on unbuffered channel")
-		}
+		// Poll until the receiver is actually waiting and the non-blocking send succeeds.
+		// forwardHeartbeat does not return a value, so we poll it and check if
+		// the receiver unblocked and closed the 'received' channel.
+		require.Eventually(t, func() bool {
+			forwardHeartbeat(ch, struct{}{})
+			select {
+			case <-received:
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 5*time.Millisecond)
 	})
 
 	t.Run("nil_channel_no_panic", func(t *testing.T) {
@@ -671,9 +670,6 @@ func TestDrainHeartbeats_DrainsChannel(t *testing.T) {
 		// protection is against the tool goroutine's defer close(hbCh) racing
 		// with the drain. We verify the goroutine exits by ensuring no panic
 		// propagates to the test process.
-		//
-		// Give the goroutine time to process the close and exit.
-		time.Sleep(10 * time.Millisecond) // Simulating latency: wait for goroutine exit after close
 	})
 }
 
@@ -704,6 +700,7 @@ func TestMonitorLiveness_TimerFires_CancelsContext(t *testing.T) {
 		BlockCh:    make(chan struct{}),
 		Heartbeats: 0, // no heartbeats → timer will fire
 	}
+	defer close(next.BlockCh)
 
 	decorator := newSafetyDecorator(
 		next,

--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAuthDecorator(t *testing.T) {
@@ -570,4 +572,178 @@ func TestHandlePanic_EventBusError_Logged(t *testing.T) {
 
 	assert.Equal(t, "panic_tool", attrs["tool_name"])
 	assert.ErrorContains(t, attrs["error"].(error), "channel full")
+}
+
+func TestForwardHeartbeat_SuccessfulSend(t *testing.T) {
+	t.Parallel()
+
+	t.Run("buffered_channel_with_capacity", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan struct{}, 1)
+		forwardHeartbeat(ch, struct{}{})
+
+		select {
+		case v := <-ch:
+			// Successfully received the heartbeat value
+			_ = v
+		default:
+			t.Error("expected heartbeat to be sent successfully on buffered channel with capacity")
+		}
+	})
+
+	t.Run("unbuffered_channel_with_concurrent_receiver", func(t *testing.T) {
+		t.Parallel()
+		ch := make(chan struct{})
+		received := make(chan struct{})
+
+		go func() {
+			<-ch
+			close(received)
+		}()
+
+		// Yield the scheduler so the receiver goroutine can start and
+		// block on <-ch before the non-blocking send.
+		runtime.Gosched()
+		forwardHeartbeat(ch, struct{}{})
+
+		select {
+		case <-received:
+			// Receiver got the heartbeat
+		case <-time.After(1 * time.Second):
+			t.Fatal("timeout waiting for receiver to get heartbeat on unbuffered channel")
+		}
+	})
+
+	t.Run("nil_channel_no_panic", func(t *testing.T) {
+		t.Parallel()
+		// Must not panic, must return immediately
+		assert.NotPanics(t, func() {
+			forwardHeartbeat(nil, struct{}{})
+		})
+	})
+}
+
+// TestDrainHeartbeats_DrainsChannel verifies that the drainHeartbeats
+// goroutine drains all buffered values from hbCh without blocking, and
+// that the recover() guard catches any panic that might arise (e.g., from
+// a hypothetical double-close race).
+func TestDrainHeartbeats_DrainsChannel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drains_all_values_without_blocking", func(t *testing.T) {
+		t.Parallel()
+		hbCh := make(chan struct{}, 3)
+		hbCh <- struct{}{}
+		hbCh <- struct{}{}
+		hbCh <- struct{}{}
+
+		drainHeartbeats(hbCh)
+
+		// The goroutine should drain all values; closing the channel
+		// after a brief yield should let the drain complete cleanly.
+		require.Eventually(t, func() bool {
+			return len(hbCh) == 0
+		}, 500*time.Millisecond, 5*time.Millisecond,
+			"drainHeartbeats goroutine should consume all buffered values")
+
+		// Close the channel so the drain goroutine's for-range exits.
+		close(hbCh)
+	})
+
+	t.Run("recovers_from_double_close", func(t *testing.T) {
+		t.Parallel()
+		hbCh := make(chan struct{}, 1)
+		hbCh <- struct{}{}
+
+		drainHeartbeats(hbCh)
+
+		// Wait for the drain to consume the value
+		require.Eventually(t, func() bool {
+			return len(hbCh) == 0
+		}, 500*time.Millisecond, 5*time.Millisecond)
+
+		// Close the channel — the drain goroutine's for-range exits cleanly.
+		close(hbCh)
+
+		// The recover() is protecting against a hypothetical double-close.
+		// Since drainHeartbeats itself never closes the channel, the real
+		// protection is against the tool goroutine's defer close(hbCh) racing
+		// with the drain. We verify the goroutine exits by ensuring no panic
+		// propagates to the test process.
+		//
+		// Give the goroutine time to process the close and exit.
+		time.Sleep(10 * time.Millisecond) // Simulating latency: wait for goroutine exit after close
+	})
+}
+
+// TestMonitorLiveness_TimerFires_CancelsContext covers the case <-timer.channel() branch
+// in monitorLiveness (decorators.go:266). When the liveness timer fires before any
+// heartbeat arrives, handleLivenessTimeout is called, which logs "tool_liveness_timeout"
+// and cancels the tool context.
+func TestMonitorLiveness_TimerFires_CancelsContext(t *testing.T) {
+	t.Parallel()
+
+	logger := &capturingLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+
+	// Use a registry that reports a very short liveness threshold
+	reg := &mockZombieRegistry{
+		livenessThreshold: 1 * time.Millisecond,
+		isLongRunningFn:   func(name string) bool { return true },
+	}
+
+	// Mock executor sends zero heartbeats and blocks until context cancelled
+	// (simulating a tool that stops sending heartbeats, causing the liveness
+	// timer to fire).
+	next := &mockExecutor{
+		Result:     tools.ToolResult{Text: "should_not_appear"},
+		Delay:      1, // triggers blocking on BlockCh
+		BlockCh:    make(chan struct{}),
+		Heartbeats: 0, // no heartbeats → timer will fire
+	}
+
+	decorator := newSafetyDecorator(
+		next,
+		reg,
+		logger,
+		bus,
+		zombie,
+		5*time.Second, // long tool timeout — must NOT be the one that fires
+		5*time.Second, // long long-running timeout
+		10*time.Millisecond,
+	).(*safetyDecorator)
+
+	result, _ := decorator.Execute(
+		context.Background(),
+		&tools.ToolDeclaration{Name: "zombie_tool"},
+		&llm.FunctionCall{Name: "zombie_tool"},
+		nil,
+	)
+
+	// The liveness timer should fire, causing handleLivenessTimeout to cancel
+	// the tool's context. The tool then returns ctx.Err().
+	assert.Error(t, result.Error)
+	assert.True(t,
+		errors.Is(result.Error, context.Canceled) ||
+			errors.Is(result.Error, context.DeadlineExceeded),
+		"expected context.Canceled or context.DeadlineExceeded, got: %v", result.Error)
+
+	// Verify the logger captured the liveness timeout
+	assert.True(t, logger.errorCalled,
+		"expected Error to be called for tool_liveness_timeout")
+	assert.Equal(t, "tool_liveness_timeout", logger.lastMsg)
+
+	// Verify the tool name is in the log args
+	attrs := make(map[string]any)
+	for i := 0; i < len(logger.lastArgs); i += 2 {
+		if i+1 < len(logger.lastArgs) {
+			key, ok := logger.lastArgs[i].(string)
+			if ok {
+				attrs[key] = logger.lastArgs[i+1]
+			}
+		}
+	}
+	assert.Equal(t, "zombie_tool", attrs["tool_name"])
 }

--- a/internal/agent/executor/decorators_timeout_test.go
+++ b/internal/agent/executor/decorators_timeout_test.go
@@ -87,6 +87,8 @@ func TestSafetyDecorator_DynamicTimeout(t *testing.T) {
 					close(next.BlockCh)
 				})
 				defer timer.Stop()
+			} else if tt.nextDelay > 0 {
+				defer close(next.BlockCh)
 			}
 
 			decorator := newSafetyDecorator(
@@ -165,6 +167,9 @@ func TestSafetyDecorator_DynamicTimeout_NonNumericType(t *testing.T) {
 				Result:  tools.ToolResult{Text: "ok"},
 				Delay:   tt.nextDelay,
 				BlockCh: make(chan struct{}),
+			}
+			if tt.nextDelay > 0 {
+				defer close(next.BlockCh)
 			}
 
 			decorator := newSafetyDecorator(

--- a/internal/agent/executor/decorators_timeout_test.go
+++ b/internal/agent/executor/decorators_timeout_test.go
@@ -116,3 +116,76 @@ func TestSafetyDecorator_DynamicTimeout(t *testing.T) {
 		})
 	}
 }
+
+func TestSafetyDecorator_DynamicTimeout_NonNumericType(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	tests := []struct {
+		name        string
+		timeoutArg  interface{}
+		defaultTO   time.Duration
+		nextDelay   time.Duration
+		expectError bool
+	}{
+		{
+			name:        "string_timeout_falls_back_to_default",
+			timeoutArg:  "fast",
+			defaultTO:   50 * time.Millisecond,
+			nextDelay:   100 * time.Millisecond,
+			expectError: true,
+		},
+		{
+			name:        "bool_timeout_falls_back_to_default",
+			timeoutArg:  true,
+			defaultTO:   50 * time.Millisecond,
+			nextDelay:   100 * time.Millisecond,
+			expectError: true,
+		},
+		{
+			name:        "nil_timeout_falls_back_to_default",
+			timeoutArg:  nil,
+			defaultTO:   50 * time.Millisecond,
+			nextDelay:   100 * time.Millisecond,
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			next := &mockExecutor{
+				Result:  tools.ToolResult{Text: "ok"},
+				Delay:   tt.nextDelay,
+				BlockCh: make(chan struct{}),
+			}
+
+			decorator := newSafetyDecorator(
+				next, registry, logger, bus, zombie,
+				tt.defaultTO, tt.defaultTO, 10*time.Millisecond,
+			)
+
+			args := map[string]interface{}{"timeout": tt.timeoutArg}
+			res, _ := decorator.Execute(
+				context.Background(),
+				&tools.ToolDeclaration{Name: "test"},
+				&llm.FunctionCall{Name: "test", Args: args},
+				nil,
+			)
+
+			if tt.expectError {
+				assert.Error(t, res.Error, "expected timeout error when non-numeric timeout arg falls back to default")
+				assert.Contains(t, res.Text, "timed out")
+			} else {
+				assert.NoError(t, res.Error)
+			}
+		})
+	}
+}

--- a/internal/agent/executor/executor_test.go
+++ b/internal/agent/executor/executor_test.go
@@ -984,6 +984,30 @@ func TestSuggestTool(t *testing.T) {
 			validTools:   []string{"write_file", "read_file", "delete_file"},
 			want:         "read_file",
 		},
+		{
+			name:         "short name close match within distance 1",
+			hallucinated: "cot",
+			validTools:   []string{"bat", "cat", "dog"},
+			want:         "cat",
+		},
+		{
+			name:         "short name no match exceeds distance 1",
+			hallucinated: "zzz",
+			validTools:   []string{"bat", "cat", "dog"},
+			want:         "",
+		},
+		{
+			name:         "medium name close match within distance 2",
+			hallucinated: "delte",
+			validTools:   []string{"create", "delete", "update"},
+			want:         "delete",
+		},
+		{
+			name:         "medium name no match exceeds distance 2",
+			hallucinated: "xyzabc",
+			validTools:   []string{"create", "delete", "update"},
+			want:         "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -1207,4 +1231,314 @@ func TestHandleBatchResults_ToolError_NotPromoted(t *testing.T) {
 	// the error text to the LLM.
 	require.Equal(t, "write failed", results[0].Text)
 	require.ErrorIs(t, results[0].Error, toolErr)
+}
+
+func TestDispatcher_SetConcurrency_NoopShortCircuit(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockToolRegistry{}
+	exec, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true},
+		&mockEventBus{}, &ports.NoOpLogger{},
+		&mockLogger{CriticalLogs: make(chan string, 10)})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		initialMax    int
+		setTo         int
+		wantUnchanged bool // true means the config pointer should be the SAME after SetConcurrency
+	}{
+		{
+			name:          "zero_value_noop",
+			initialMax:    5,
+			setTo:         0,
+			wantUnchanged: true,
+		},
+		{
+			name:          "negative_value_noop",
+			initialMax:    5,
+			setTo:         -1,
+			wantUnchanged: true,
+		},
+		{
+			name:          "same_value_noop",
+			initialMax:    5,
+			setTo:         5,
+			wantUnchanged: true,
+		},
+		{
+			name:          "different_value_changes",
+			initialMax:    5,
+			setTo:         3,
+			wantUnchanged: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Reset to known state: set concurrency to initialMax first
+			exec.SetConcurrency(tt.initialMax)
+			beforeState := exec.state.Load()
+
+			// Now call with tt.setTo
+			exec.SetConcurrency(tt.setTo)
+			afterState := exec.state.Load()
+
+			if tt.wantUnchanged {
+				// Config pointer must be identical (CAS short-circuited)
+				assert.Same(t, beforeState, afterState,
+					"state pointer should not change when SetConcurrency is a no-op")
+				// Config value must still be initialMax
+				assert.Equal(t, tt.initialMax, afterState.config.MaxConcurrentTools)
+			} else {
+				// Config must have changed
+				assert.NotSame(t, beforeState, afterState,
+					"state pointer should change when concurrency differs")
+				assert.Equal(t, tt.setTo, afterState.config.MaxConcurrentTools)
+			}
+		})
+	}
+}
+
+func TestDispatcher_Execute_EmptyFunctionCalls_ReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockToolRegistry{}
+	exec, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true},
+		&mockEventBus{}, &ports.NoOpLogger{},
+		&mockLogger{CriticalLogs: make(chan string, 10)})
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		content *llm.Content
+	}{
+		{
+			name: "text_only_no_function_calls",
+			content: &llm.Content{
+				Role:  "model",
+				Parts: []*llm.Part{{Text: "Hello, how can I help?"}},
+			},
+		},
+		{
+			name: "empty_parts_slice",
+			content: &llm.Content{
+				Role:  "model",
+				Parts: []*llm.Part{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := exec.Execute(context.Background(), tt.content, 0, 10)
+
+			assert.Nil(t, result, "result must be nil when no function calls")
+			assert.NoError(t, err, "err must be nil when no function calls")
+		})
+	}
+}
+
+func TestEvaluateBatchOutcome_ParallelSuccess_ReturnsNoError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		isSerial   bool
+		ctxCancel  bool
+		wantHalt   bool
+		wantErrNil bool
+	}{
+		{
+			name:       "parallel_batch_success_no_context_error",
+			isSerial:   false,
+			ctxCancel:  false,
+			wantHalt:   false,
+			wantErrNil: true,
+		},
+		{
+			name:       "serial_batch_success_no_context_error",
+			isSerial:   true,
+			ctxCancel:  false,
+			wantHalt:   false,
+			wantErrNil: true,
+		},
+		{
+			name:       "parallel_batch_context_cancelled",
+			isSerial:   false,
+			ctxCancel:  true,
+			wantHalt:   true,
+			wantErrNil: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &mockToolPipeline{
+				IsSerialFunc: func(name string) bool { return tt.isSerial },
+			}
+
+			ctx := context.Background()
+			if tt.ctxCancel {
+				var cancel context.CancelFunc
+				ctx, cancel = context.WithCancel(ctx)
+				cancel()
+			}
+
+			d := &Dispatcher{
+				pipeline: mock,
+				logger:   &ports.NoOpLogger{},
+			}
+			d.state.Store(&dispatcherState{
+				config: dispatcherConfig{MaxConcurrentTools: 5},
+			})
+
+			calls := []*llm.FunctionCall{{Name: "test_tool"}}
+			results := []tools.ToolResult{{Text: "success"}}
+			batches := []taskBatch{{isSerial: tt.isSerial, tasks: []int{0}}}
+
+			halt, err := d.evaluateBatchOutcome(ctx, 0, batches[0], batches, calls, results)
+
+			assert.Equal(t, tt.wantHalt, halt, "halt flag mismatch")
+			if tt.wantErrNil {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestFailRemainingTasks_SkipsAlreadyFilledSlots(t *testing.T) {
+	t.Parallel()
+
+	mock := &mockToolPipeline{}
+	d := &Dispatcher{
+		pipeline: mock,
+		logger:   &ports.NoOpLogger{},
+	}
+
+	t.Run("skips_slot_with_existing_text", func(t *testing.T) {
+		t.Parallel()
+
+		calls := []*llm.FunctionCall{{Name: "a"}, {Name: "b"}}
+		results := []tools.ToolResult{
+			{Text: "already filled", Error: nil}, // slot 0 pre-filled
+			{},                                   // slot 1 empty
+		}
+		batches := []taskBatch{
+			{isSerial: false, tasks: []int{0, 1}},
+		}
+
+		d.failRemainingTasks(batches, 0, -1, calls, results,
+			errors.New("ctx cancelled"), "batch interrupted")
+
+		// Slot 0 must be UNCHANGED (skip guard fired)
+		assert.Equal(t, "already filled", results[0].Text)
+		assert.NoError(t, results[0].Error)
+
+		// Slot 1 must be FILLED
+		assert.Contains(t, results[1].Text, "batch interrupted")
+		assert.Error(t, results[1].Error)
+	})
+
+	t.Run("skips_slot_with_existing_error", func(t *testing.T) {
+		t.Parallel()
+
+		calls := []*llm.FunctionCall{{Name: "a"}, {Name: "b"}}
+		results := []tools.ToolResult{
+			{Text: "", Error: errors.New("previous failure")}, // slot 0 has error
+			{}, // slot 1 empty
+		}
+		batches := []taskBatch{
+			{isSerial: false, tasks: []int{0, 1}},
+		}
+
+		d.failRemainingTasks(batches, 0, -1, calls, results,
+			errors.New("ctx cancelled"), "batch interrupted")
+
+		// Slot 0 must be UNCHANGED
+		assert.Empty(t, results[0].Text)
+		assert.EqualError(t, results[0].Error, "previous failure")
+
+		// Slot 1 must be FILLED
+		assert.Contains(t, results[1].Text, "batch interrupted")
+		assert.Error(t, results[1].Error)
+	})
+}
+
+func TestHandleBatchResults_SentinelWithNilError_NotPromoted(t *testing.T) {
+	t.Parallel()
+
+	e := &Dispatcher{strategy: &markdownStrategy{}}
+	resultsCh := make(chan toolExecResult, 1)
+
+	// Sentinel with index: -1 but nil Error — defensive guard must NOT promote it
+	resultsCh <- toolExecResult{
+		index: -1,
+		name:  "context_cancelled",
+		tr:    tools.ToolResult{Text: "skipped: context cancelled", Error: nil},
+	}
+	close(resultsCh)
+
+	results := make([]tools.ToolResult, 1)
+	planErrors := e.handleBatchResults(context.Background(), resultsCh, results, nil)
+
+	// planErrors must be empty — nil errors from sentinels are silently dropped
+	require.Len(t, planErrors, 0)
+
+	// results must be untouched (index -1 doesn't write to results)
+	assert.Empty(t, results[0].Text)
+	assert.NoError(t, results[0].Error)
+}
+
+func TestDispatcher_Execute_MaxTurnsZero_FirstTurnExceeds(t *testing.T) {
+	t.Parallel()
+
+	bus := &mockEventBus{}
+	reg := &mockToolRegistry{}
+
+	exec, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true},
+		bus, &ports.NoOpLogger{},
+		&mockLogger{CriticalLogs: make(chan string, 10)})
+	require.NoError(t, err)
+
+	respContent := &llm.Content{
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{Name: "test_tool"}},
+		},
+	}
+
+	// turn=0, maxToolTurns=0: turn >= maxToolTurns is true even on the first turn
+	result, execErr := exec.Execute(context.Background(), respContent, 0, 0)
+
+	// Result must be nil
+	assert.Nil(t, result, "result should be nil when max turns is 0")
+
+	// Error must be ErrMaxTurnsReached
+	assert.Error(t, execErr)
+	assert.True(t, errors.Is(execErr, llm.ErrMaxTurnsReached),
+		"error should be ErrMaxTurnsReached")
+
+	// Verify the SystemMessageEvent was published
+	bus.mu.Lock()
+	defer bus.mu.Unlock()
+	var foundSystemMsg bool
+	for _, e := range bus.Published {
+		if sme, ok := e.(events.SystemMessageEvent); ok {
+			foundSystemMsg = true
+			assert.Contains(t, sme.Message, "Maximum tool execution turns (0) reached")
+			assert.Equal(t, "error", sme.Level)
+		}
+	}
+	assert.True(t, foundSystemMsg, "expected SystemMessageEvent to be published")
 }

--- a/internal/agent/executor/resolver_test.go
+++ b/internal/agent/executor/resolver_test.go
@@ -5,40 +5,89 @@ package executor
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolver_Resolve_ToolNotFound_ReturnsSentinel(t *testing.T) {
 	t.Parallel()
 
-	reg := &mockToolRegistry{
-		getDeclarationsFn: func() []*tools.ToolDeclaration {
-			return []*tools.ToolDeclaration{
-				{Name: "read_file"},
-				{Name: "write_file"},
-				{Name: "delete_file"},
-			}
+	tests := []struct {
+		name           string
+		toolName       string
+		registryTools  []string
+		wantSentinel   bool
+		wantSuggestion string // empty means "no did-you-mean expected"
+	}{
+		{
+			name:           "far_mismatch_no_suggestion",
+			toolName:       "nonexistent_tool",
+			registryTools:  []string{"read_file", "write_file", "delete_file"},
+			wantSentinel:   true,
+			wantSuggestion: "",
+		},
+		{
+			name:           "close_mismatch_with_suggestion",
+			toolName:       "read_files",
+			registryTools:  []string{"read_file", "write_file", "delete_file"},
+			wantSentinel:   true,
+			wantSuggestion: "read_file",
+		},
+		{
+			name:           "case_insensitive_close_match",
+			toolName:       "READ_FILE",
+			registryTools:  []string{"read_file", "write_file", "delete_file"},
+			wantSentinel:   true,
+			wantSuggestion: "read_file",
+		},
+		{
+			name:           "very_distant_no_suggestion",
+			toolName:       "zzzzzzzzz",
+			registryTools:  []string{"read_file", "write_file", "delete_file"},
+			wantSentinel:   true,
+			wantSuggestion: "",
 		},
 	}
 
-	r := newToolResolutionService(reg)
-	_, err := r.Resolve(&llm.FunctionCall{Name: "nonexistent_tool"})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if err == nil {
-		t.Fatal("expected error for nonexistent tool, got nil")
-	}
+			reg := &mockToolRegistry{
+				getDeclarationsFn: func() []*tools.ToolDeclaration {
+					decls := make([]*tools.ToolDeclaration, len(tt.registryTools))
+					for i, name := range tt.registryTools {
+						decls[i] = &tools.ToolDeclaration{Name: name}
+					}
+					return decls
+				},
+			}
 
-	if !errors.Is(err, errToolNotFound) {
-		t.Errorf("expected errors.Is(err, errToolNotFound) to be true, got false; err=%v", err)
-	}
+			r := newToolResolutionService(reg)
+			_, err := r.Resolve(&llm.FunctionCall{Name: tt.toolName})
 
-	// Also verify the descriptive message is preserved
-	if err.Error() == errToolNotFound.Error() {
-		t.Error("expected error message to contain descriptive details beyond the sentinel")
+			require.Error(t, err)
+			require.True(t, errors.Is(err, errToolNotFound), "must wrap errToolNotFound sentinel")
+
+			if tt.wantSuggestion != "" {
+				expected := fmt.Sprintf("; did you mean %q?", tt.wantSuggestion)
+				assert.Contains(t, err.Error(), expected,
+					"error should contain suggestion for close match")
+			} else {
+				assert.NotContains(t, err.Error(), "did you mean",
+					"error should NOT contain suggestion for distant mismatch")
+			}
+
+			// Verify descriptive details are present beyond the sentinel
+			assert.NotEqual(t, errToolNotFound.Error(), err.Error(),
+				"error should contain descriptive details beyond the sentinel")
+		})
 	}
 }
 

--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -1011,12 +1011,23 @@ func TestInferenceStep_UpdateState_NilMetrics(t *testing.T) {
 	assert.False(t, turn.State.HasToolCalls)
 }
 
+type responseEventFaultBus struct {
+	eventstest.TestEventBus
+}
+
+func (b *responseEventFaultBus) Publish(ctx context.Context, e events.Event) error {
+	if _, ok := e.(events.ResponseEvent); ok {
+		return errors.New("response event publish failure")
+	}
+	return b.TestEventBus.Publish(ctx, e)
+}
+
 func TestInferenceStep_InvokeModel_ResponseEvent_PublishError(t *testing.T) {
 	t.Parallel()
 
-	// Setup a faulting event bus that will cause the ResponseEvent publish to fail
-	bus := &eventstest.TestEventBus{}
-	bus.SetPublishErr(errors.New("response event publish failure"))
+	// Setup a faulting event bus that will ONLY cause the ResponseEvent publish to fail,
+	// to make the test intent explicit (InferenceStartedEvent will succeed).
+	bus := &responseEventFaultBus{}
 
 	// Spy logger to capture the error log
 	sl := &testfixtures.SpyLogger{}

--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -19,7 +19,9 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExecuteTurn_TraceEvent(t *testing.T) {
@@ -306,6 +308,14 @@ func TestInferenceStep_TDT(t *testing.T) {
 			expectedPh: PhasePersisting,
 		},
 		{
+			name: "SessionProvider with empty ActiveToolkits",
+			apiResponse: &llm.Content{
+				Role:  "model",
+				Parts: []*llm.Part{{Text: "Hello from core tools"}},
+			},
+			expectedPh: PhasePersisting,
+		},
+		{
 			name: "Tool call with non-string reason arg",
 			apiResponse: &llm.Content{
 				Role: "model",
@@ -315,6 +325,46 @@ func TestInferenceStep_TDT(t *testing.T) {
 						Args: map[string]any{"reason": 42.0},
 					},
 				}},
+			},
+			expectedPh: PhaseExecuting,
+		},
+		{
+			name: "Tool call with string reason arg",
+			apiResponse: &llm.Content{
+				Role: "model",
+				Parts: []*llm.Part{{
+					FunctionCall: &llm.FunctionCall{
+						Name: "test_tool",
+						Args: map[string]any{"reason": "User requested file analysis"},
+					},
+				}},
+			},
+			expectedPh: PhaseExecuting,
+		},
+		{
+			name: "Multiple tool calls with mixed reasons",
+			apiResponse: &llm.Content{
+				Role: "model",
+				Parts: []*llm.Part{
+					{
+						FunctionCall: &llm.FunctionCall{
+							Name: "tool_a",
+							Args: map[string]any{"reason": "First analysis pass"},
+						},
+					},
+					{
+						FunctionCall: &llm.FunctionCall{
+							Name: "tool_b",
+							Args: map[string]any{"other_arg": 42},
+						},
+					},
+					{
+						FunctionCall: &llm.FunctionCall{
+							Name: "tool_c",
+							Args: map[string]any{"reason": "Final cleanup"},
+						},
+					},
+				},
 			},
 			expectedPh: PhaseExecuting,
 		},
@@ -344,7 +394,8 @@ func TestInferenceStep_TDT(t *testing.T) {
 			reg := &agenttest.MockToolRegistry{}
 
 			var cm *sessctx.Manager
-			if tt.name == "Toolkits active — GetDeclarationsByToolkits called" {
+			switch tt.name {
+			case "Toolkits active — GetDeclarationsByToolkits called":
 				// Register tools in a non-core toolkit so that
 				// GetDeclarationsByToolkits returns a non-empty list
 				// while GetCoreDeclarations (ToolkitMap["core"]) returns nil.
@@ -360,7 +411,21 @@ func TestInferenceStep_TDT(t *testing.T) {
 					info: ports.SessionInfo{ActiveToolkits: []string{"test_toolkit"}},
 				}
 				cm = sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil, sessctx.WithSessionProvider(sp))
-			} else {
+			case "SessionProvider with empty ActiveToolkits":
+				// Register a tool in "core" toolkit so GetCoreDeclarations returns it
+				if err := reg.RegisterToToolkit("core", &tools.ToolDeclaration{
+					Name:        "core_tool",
+					Description: "A core tool",
+				}, func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+					return tools.ToolResult{}, nil
+				}); err != nil {
+					t.Fatalf("RegisterToToolkit(core): %v", err)
+				}
+				sp := &mockSessionProvider{
+					info: ports.SessionInfo{ActiveToolkits: []string{}}, // empty!
+				}
+				cm = sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil, sessctx.WithSessionProvider(sp))
+			default:
 				cm = sessctx.NewManager(sessctx.NewStrategy(&agenttest.MockTokenCounter{}), hMock, bus, nil)
 			}
 
@@ -389,6 +454,17 @@ func TestInferenceStep_TDT(t *testing.T) {
 			if tt.name == "Tool call with non-string reason arg" {
 				assert.True(t, turn.State.HasToolCalls, "HasToolCalls must be true for a FunctionCall response")
 				assert.Empty(t, turn.State.ToolReasons, "non-string reason arg must be skipped, ToolReasons must be empty")
+			}
+
+			// Verify ToolReasons for cases that exercise reason extraction
+			switch tt.name {
+			case "Tool call with string reason arg":
+				require.Len(t, turn.State.ToolReasons, 1)
+				assert.Equal(t, "User requested file analysis", turn.State.ToolReasons[0])
+			case "Multiple tool calls with mixed reasons":
+				require.Len(t, turn.State.ToolReasons, 2)
+				assert.Equal(t, "First analysis pass", turn.State.ToolReasons[0])
+				assert.Equal(t, "Final cleanup", turn.State.ToolReasons[1])
 			}
 		})
 	}
@@ -933,4 +1009,52 @@ func TestInferenceStep_UpdateState_NilMetrics(t *testing.T) {
 	assert.Nil(t, turn.State.Metrics, "Metrics must remain nil when gateway returns nil metrics")
 	assert.Equal(t, 0, turn.State.Tokens, "Tokens must remain 0 when metrics is nil")
 	assert.False(t, turn.State.HasToolCalls)
+}
+
+func TestInferenceStep_InvokeModel_ResponseEvent_PublishError(t *testing.T) {
+	t.Parallel()
+
+	// Setup a faulting event bus that will cause the ResponseEvent publish to fail
+	bus := &eventstest.TestEventBus{}
+	bus.SetPublishErr(errors.New("response event publish failure"))
+
+	// Spy logger to capture the error log
+	sl := &testfixtures.SpyLogger{}
+
+	// Gateway that returns a valid response so InvokeModel succeeds,
+	// ensuring we reach the defer block on the happy path
+	gw := &agenttest.MockGateway{
+		GenerateFunc: func(ctx context.Context, input []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}}, &llm.Metrics{}, nil
+		},
+	}
+
+	counter := &agenttest.MockTokenCounter{}
+	hMock := &agenttest.MockHistoryManager{}
+	cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
+	reg := agenttest.NewMockToolRegistry()
+
+	turn := &Turn{
+		Events:     bus,
+		Logger:     sl,
+		Model:      "test-model",
+		Gateway:    gw,
+		CtxManager: cm,
+		Registry:   reg,
+		State:      &TurnState{},
+	}
+
+	step := &InferenceStep{}
+
+	// InvokeModel should succeed (no error returned) because the ResponseEvent
+	// publish failure is logged but not promoted to an error
+	respContent, metrics, err := step.InvokeModel(context.Background(), turn)
+
+	assert.NoError(t, err, "InvokeModel must not return error when ResponseEvent publish fails")
+	assert.NotNil(t, respContent)
+	assert.NotNil(t, metrics)
+
+	// The spy logger must have captured the ResponseEvent publish failure
+	assert.True(t, sl.CalledWith("Error", "Failed to publish ResponseEvent; UI spinner may hang"),
+		"expected logger to capture ResponseEvent publish failure")
 }


### PR DESCRIPTION
Closes #829.

## Summary
Added test coverage for 15 MEDIUM-priority untested code paths in `internal/agent/executor/` and `internal/agent/orchestrator/`.

### Executor (12 tests)
- SetConcurrency noop short-circuit
- Empty extractFunctionCalls early return
- Tool suggestion "did you mean?"
- forwardHeartbeat successful send
- drainHeartbeats goroutine drain
- monitorLiveness timer-fire
- evaluateBatchOutcome parallel success
- suggestTool name-length thresholds
- resolveTimeout non-numeric type
- failRemainingTasks skip filled slots
- handleBatchResults sentinel nil error
- MaxTurns=0 first-turn-exceeds

### Orchestrator (3 tests)
- Tool reason extraction positive path
- InvokeModel ResponseEvent publish fail
- SessionProvider empty ActiveToolkits edge case

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| executor coverage | 99.2% |
| orchestrator coverage | 100.0% |
| go test -race (all agent packages) | PASS |
