### PR TITLE
fix(executor): close 3 high-priority coverage gaps from v1.6.2 (#846)

### DIFF
--- a/internal/agent/executor/decorators.go
+++ b/internal/agent/executor/decorators.go
@@ -86,13 +86,18 @@ func (d *safetyDecorator) Execute(parentCtx context.Context, tool *tools.ToolDec
 		return d.handleTimeout(parentCtx, ctx.Err(), call.Name, activeTimeout, outCh), nil
 
 	case out := <-outCh:
-		// In case of a select race where both the context cancels and the tool returns simultaneously,
-		// and the tool returned an error, we prefer the friendly context cancellation message.
-		if out.Err != nil && ctx.Err() != nil && (errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
-			return d.formatContextError(ctx.Err(), activeTimeout), nil
-		}
-		return out.Result, out.Err
+		return d.handleToolOutput(out, ctx, activeTimeout)
 	}
+}
+
+// handleToolOutput resolves the tool output against the current context state.
+// When both the tool returned an error and the context is cancelled/deadline-exceeded,
+// the friendly context message takes priority over the raw tool error.
+func (d *safetyDecorator) handleToolOutput(out tools.ToolOutput, ctx context.Context, activeTimeout time.Duration) (tools.ToolResult, error) {
+	if out.Err != nil && ctx.Err() != nil && (errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded)) {
+		return d.formatContextError(ctx.Err(), activeTimeout), nil
+	}
+	return out.Result, out.Err
 }
 
 func (d *safetyDecorator) formatContextError(errCtx error, activeTimeout time.Duration) tools.ToolResult {

--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -244,6 +244,201 @@ func TestSafetyDecorator_PrecedenceLogic(t *testing.T) {
 	})
 }
 
+// TestSafetyDecorator_ContextCancellationPrecedence exercises the precedence-check
+// logic in decorators.go:91-93 directly, without going through the goroutine-based
+// select statement. This ensures deterministic coverage of the branch where both
+// the tool returned an error AND the context is cancelled/deadline-exceeded.
+func TestSafetyDecorator_ContextCancellationPrecedence(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	d := newSafetyDecorator(
+		&mockExecutor{},
+		registry,
+		logger,
+		bus,
+		zombie,
+		5*time.Second,
+		5*time.Second,
+		10*time.Millisecond,
+	).(*safetyDecorator)
+
+	tests := []struct {
+		name             string
+		toolErr          error
+		ctxErr           error
+		activeTimeout    time.Duration
+		wantNilError     bool
+		wantTextContains string
+		wantErrorWraps   error
+	}{
+		{
+			name:             "context_canceled_tool_errored",
+			toolErr:          errors.New("raw tool crash"),
+			ctxErr:           context.Canceled,
+			activeTimeout:    5 * time.Second,
+			wantNilError:     true,
+			wantTextContains: "interrupted or cancelled",
+			wantErrorWraps:   context.Canceled,
+		},
+		{
+			name:             "context_deadline_exceeded_tool_errored",
+			toolErr:          errors.New("tool timed out internally"),
+			ctxErr:           context.DeadlineExceeded,
+			activeTimeout:    2 * time.Second,
+			wantNilError:     true,
+			wantTextContains: "timed out after 2s",
+			wantErrorWraps:   llm.ErrTransient,
+		},
+		{
+			name:             "context_canceled_tool_succeeded",
+			toolErr:          nil,
+			ctxErr:           context.Canceled,
+			activeTimeout:    5 * time.Second,
+			wantNilError:     false,
+			wantTextContains: "",
+			wantErrorWraps:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			out := tools.ToolOutput{
+				Result: tools.ToolResult{Text: "raw tool output"},
+				Err:    tt.toolErr,
+			}
+
+			var ctx context.Context
+			var cancel context.CancelFunc
+			switch {
+			case errors.Is(tt.ctxErr, context.Canceled):
+				ctx, cancel = context.WithCancel(context.Background())
+				cancel()
+			case errors.Is(tt.ctxErr, context.DeadlineExceeded):
+				ctx, cancel = context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+				defer cancel()
+			default:
+				ctx = context.Background()
+			}
+
+			var result tools.ToolResult
+			var execErr error
+
+			result, execErr = d.handleToolOutput(out, ctx, tt.activeTimeout)
+
+			if tt.wantNilError {
+				require.NoError(t, execErr, "second return value must be nil")
+			} else {
+				require.Equal(t, tt.toolErr, execErr, "second return value must be the tool error")
+			}
+
+			if tt.wantTextContains != "" {
+				require.Contains(t, result.Text, tt.wantTextContains)
+			}
+
+			if tt.wantErrorWraps != nil {
+				require.Error(t, result.Error, "result.Error must be non-nil")
+				require.True(t, errors.Is(result.Error, tt.wantErrorWraps),
+					"result.Error must wrap %v, got: %v", tt.wantErrorWraps, result.Error)
+			} else if tt.toolErr == nil {
+				require.NoError(t, result.Error, "result.Error must be nil when tool succeeded")
+				require.Equal(t, "raw tool output", result.Text)
+			}
+		})
+	}
+}
+
+// TestSafetyDecorator_Execute_RacePrecedence hits the race-condition path at
+// decorators.go:91-93 where the outCh case wins the select when the context
+// is also cancelled/deadline-exceeded and the tool returned an error. Because
+// Go's select is non-deterministic when multiple cases are ready, this test
+// retries up to 200 times to guarantee coverage. The expected behavior is
+// identical for both select branches: formatContextError is returned with a
+// nil second return value.
+func TestSafetyDecorator_Execute_RacePrecedence(t *testing.T) {
+	t.Parallel()
+
+	logger := &ports.NoOpLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	t.Run("cancelled_context_outCh_wins", func(t *testing.T) {
+		t.Parallel()
+		next := &mockExecutor{
+			Result: tools.ToolResult{Text: "raw output"},
+			Err:    errors.New("raw tool crash"),
+		}
+		decorator := newSafetyDecorator(
+			next, registry, logger, bus, zombie,
+			5*time.Second, 5*time.Second, 10*time.Millisecond,
+		)
+
+		// Retry until the select picks outCh over ctx.Done().
+		// Both branches produce formatContextError output, so we verify
+		// the outcome matches regardless of which path was taken.
+		for i := 0; i < 200; i++ {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // pre-cancelled per ADR-036 §2
+
+			res, err := decorator.Execute(
+				ctx,
+				&tools.ToolDeclaration{Name: "test"},
+				&llm.FunctionCall{Name: "test"},
+				nil,
+			)
+
+			// Both branches return (friendly result, nil).
+			require.NoError(t, err)
+			require.Error(t, res.Error)
+			require.Contains(t, res.Text, "interrupted or cancelled")
+			require.True(t, errors.Is(res.Error, context.Canceled),
+				"error must wrap context.Canceled")
+		}
+	})
+
+	t.Run("deadlined_context_outCh_wins", func(t *testing.T) {
+		t.Parallel()
+		next := &mockExecutor{
+			Result: tools.ToolResult{Text: "raw output"},
+			Err:    errors.New("tool failed"),
+		}
+		decorator := newSafetyDecorator(
+			next, registry, logger, bus, zombie,
+			1*time.Nanosecond, 1*time.Nanosecond, 10*time.Millisecond,
+		)
+
+		for i := 0; i < 200; i++ {
+			// Pre-deadlined context: ensures child context inherits a past deadline.
+			ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+
+			res, err := decorator.Execute(
+				ctx,
+				&tools.ToolDeclaration{Name: "test"},
+				&llm.FunctionCall{Name: "test"},
+				nil,
+			)
+
+			cancel() // clean up immediately, not deferred
+
+			require.NoError(t, err)
+			require.Error(t, res.Error)
+			require.Contains(t, res.Text, "timed out")
+			require.True(t, errors.Is(res.Error, llm.ErrTransient),
+				"error must wrap llm.ErrTransient")
+		}
+	})
+}
+
 func TestTracingDecorator(t *testing.T) {
 	t.Parallel()
 	registry := &panicRegistry{}

--- a/internal/agent/executor/dispatcher_unit_test.go
+++ b/internal/agent/executor/dispatcher_unit_test.go
@@ -368,7 +368,7 @@ func TestDispatcher_RunExecutionPlan_ContextCancelledAfterEmptyBatches(t *testin
 	cancel()
 
 	// No tool calls → empty batches → for-loop skipped → hits post-loop ctx.Err() check.
-	err = dispatcher.runExecutionPlan(ctx, nil, nil, nil)
+	err = dispatcher.runExecutionPlan(ctx, nil, nil, nil, nil)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, context.Canceled)
 }
@@ -392,7 +392,7 @@ func TestRunExecutionPlan_PostLoopContextCancellation(t *testing.T) {
 	dispatcher, err := NewPipelineDispatcher(reg, &mockSecurityManager{AllowAll: true}, bus, logger, observer)
 	require.NoError(t, err)
 
-	err = dispatcher.runExecutionPlan(context.Background(), nil, nil, nil)
+	err = dispatcher.runExecutionPlan(context.Background(), nil, nil, nil, nil)
 	require.NoError(t, err)
 }
 
@@ -424,7 +424,7 @@ func TestRunExecutionPlan_PostLoopContextCancellation_WithBatches(t *testing.T) 
 	calls := []*llm.FunctionCall{{Name: "p1"}}
 	results := make([]tools.ToolResult, 1)
 
-	err = dispatcher.runExecutionPlan(context.Background(), calls, nil, results)
+	err = dispatcher.runExecutionPlan(context.Background(), calls, nil, results, nil)
 	require.NoError(t, err)
 
 	// Verify the successful tool result
@@ -643,7 +643,7 @@ func TestRunExecutionPlan_HappyPath_SuccessfulBatchesReturnNil(t *testing.T) {
 
 	// context.Background() is never cancelled — this is the critical ingredient
 	// that distinguishes this test from the existing PostLoopContextCancellation tests.
-	err = dispatcher.runExecutionPlan(context.Background(), calls, nil, results)
+	err = dispatcher.runExecutionPlan(context.Background(), calls, nil, results, nil)
 
 	// The coverage target: ctx.Err() returns nil on the happy path.
 	require.NoError(t, err)

--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -264,6 +264,12 @@ func (e *Dispatcher) emitEvent(ctx context.Context, bus events.EventBus, evt eve
 }
 
 func (e *Dispatcher) Execute(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+	return e.executeInternal(ctx, respContent, turn, maxToolTurns, nil)
+}
+
+// executeInternal is Execute with a test-only fanIn injection seam.
+// When fanIn is nil, the default wg.Wait() fan-in is used (production path).
+func (e *Dispatcher) executeInternal(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int, fanIn fanInFunc) (*llm.Content, error) {
 	calls := e.extractFunctionCalls(respContent)
 	if len(calls) == 0 {
 		return nil, nil
@@ -295,7 +301,7 @@ func (e *Dispatcher) Execute(ctx context.Context, respContent *llm.Content, turn
 	startTime := time.Now()
 
 	results := make([]tools.ToolResult, len(calls))
-	waitErr := e.runExecutionPlan(ctx, calls, declinedMap, results)
+	waitErr := e.runExecutionPlan(ctx, calls, declinedMap, results, fanIn)
 
 	duration := time.Since(startTime)
 
@@ -361,7 +367,7 @@ type taskBatch struct {
 	tasks    []int
 }
 
-func (e *Dispatcher) runExecutionPlan(ctx context.Context, calls []*llm.FunctionCall, declinedMap map[int]bool, results []tools.ToolResult) error {
+func (e *Dispatcher) runExecutionPlan(ctx context.Context, calls []*llm.FunctionCall, declinedMap map[int]bool, results []tools.ToolResult, fanIn fanInFunc) error {
 	batches := e.buildExecutionBatches(calls, declinedMap, results)
 	state := e.state.Load()
 
@@ -377,7 +383,7 @@ func (e *Dispatcher) runExecutionPlan(ctx context.Context, calls []*llm.Function
 		resultsCh := make(chan toolExecResult, len(batch.tasks))
 
 		// 1. Fan-out
-		e.executeBatch(ctx, batch, calls, state.config.MaxConcurrentTools, resultsCh)
+		e.executeBatch(ctx, batch, calls, state.config.MaxConcurrentTools, resultsCh, fanIn)
 
 		// 2. Fan-in Aggregator Loop (lock-free mutation of failures)
 		planErrors = e.handleBatchResults(ctx, resultsCh, results, planErrors)
@@ -418,11 +424,11 @@ func (e *Dispatcher) checkPreconditions(ctx context.Context, batchIdx int, batch
 	return nil
 }
 
-func (e *Dispatcher) executeBatch(ctx context.Context, batch taskBatch, calls []*llm.FunctionCall, maxWorkers int, resultsCh chan<- toolExecResult) {
+func (e *Dispatcher) executeBatch(ctx context.Context, batch taskBatch, calls []*llm.FunctionCall, maxWorkers int, resultsCh chan<- toolExecResult, fanIn fanInFunc) {
 	if batch.isSerial {
 		e.executeSerialBatch(ctx, batch, calls, resultsCh)
 	} else {
-		e.executeParallelBatch(ctx, batch, calls, maxWorkers, resultsCh)
+		e.executeParallelBatchWithFanIn(ctx, batch, calls, maxWorkers, resultsCh, fanIn)
 	}
 }
 
@@ -446,7 +452,12 @@ func (e *Dispatcher) executeSerialBatch(ctx context.Context, batch taskBatch, ca
 	close(resultsCh)
 }
 
-func (e *Dispatcher) executeParallelBatch(ctx context.Context, batch taskBatch, calls []*llm.FunctionCall, maxWorkers int, resultsCh chan<- toolExecResult) {
+// fanInFunc is a test-only seam that replaces the wg.Wait() call in the
+// fan-in goroutine of executeParallelBatchWithFanIn. When nil, the default wg.Wait()
+// is used. Injected only by tests to trigger the panic-recovery path.
+type fanInFunc func(wg *sync.WaitGroup, resultsCh chan<- toolExecResult)
+
+func (e *Dispatcher) executeParallelBatchWithFanIn(ctx context.Context, batch taskBatch, calls []*llm.FunctionCall, maxWorkers int, resultsCh chan<- toolExecResult, fanIn fanInFunc) {
 	jobsCh := make(chan int, len(batch.tasks))
 	for _, taskIdx := range batch.tasks {
 		jobsCh <- taskIdx
@@ -481,7 +492,11 @@ func (e *Dispatcher) executeParallelBatch(ctx context.Context, batch taskBatch, 
 			}
 			close(resultsCh)
 		}()
-		wg.Wait()
+		if fanIn != nil {
+			fanIn(&wg, resultsCh)
+		} else {
+			wg.Wait()
+		}
 	}()
 }
 

--- a/internal/agent/executor/executor_chaos_test.go
+++ b/internal/agent/executor/executor_chaos_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -145,7 +146,7 @@ func assertTimeoutScenario(t *testing.T, o *Dispatcher, ctx context.Context, cal
 	t.Helper()
 	errChan := make(chan error, 1)
 	go func() {
-		errChan <- o.runExecutionPlan(ctx, calls, declinedMap, results)
+		errChan <- o.runExecutionPlan(ctx, calls, declinedMap, results, nil)
 	}()
 
 	<-syncChan
@@ -159,7 +160,7 @@ func assertTimeoutScenario(t *testing.T, o *Dispatcher, ctx context.Context, cal
 
 func assertPanicScenario(t *testing.T, o *Dispatcher, ctx context.Context, calls []*llm.FunctionCall, declinedMap map[int]bool, results []tools.ToolResult, wantPanicText string) {
 	t.Helper()
-	err := o.runExecutionPlan(ctx, calls, declinedMap, results)
+	err := o.runExecutionPlan(ctx, calls, declinedMap, results, nil)
 
 	// With the new contract, tool-result errors (including panics recovered inside
 	// the tool pipeline) are delivered to the LLM via AssembleResponse and are NOT
@@ -312,7 +313,7 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 		declinedMap := make(map[int]bool)
 		results := make([]tools.ToolResult, len(calls))
 
-		err := o.runExecutionPlan(ctx, calls, declinedMap, results)
+		err := o.runExecutionPlan(ctx, calls, declinedMap, results, nil)
 
 		// With the new contract, tool-result errors stay in results[] — they are
 		// NOT promoted to plan-level Go errors. runExecutionPlan returns nil.
@@ -372,7 +373,7 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 		}
 		results := make([]tools.ToolResult, 3)
 
-		err := d.runExecutionPlan(ctx, calls, nil, results)
+		err := d.runExecutionPlan(ctx, calls, nil, results, nil)
 
 		require.NoError(t, err, "runExecutionPlan must return nil on normal completion")
 
@@ -384,5 +385,105 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 			assert.NotContains(t, res.Text, "fan_in_panic",
 				"tool %s result must not contain sentinel text 'fan_in_panic'", calls[i].Name)
 		}
+	})
+
+	t.Run("fan_in_goroutine_panic_inside_executeParallelBatch", func(t *testing.T) {
+		t.Parallel()
+		// This subtest exercises the actual panic-recovery block inside the
+		// fan-in goroutine of executeParallelBatch by injecting a panicking
+		// fanInFunc through the test-only seam executeParallelBatchWithFanIn.
+		//
+		// The injected fanIn panics before workers complete, triggering the
+		// defer/recover block which propagates a sentinel (index:-1, name:fan_in_panic)
+		// through resultsCh. Without this recovery path, a panic in wg.Wait()
+		// would deadlock the agent loop (resultsCh never closed).
+
+		log := &capturingLogger{}
+
+		mock := &mockToolPipeline{
+			IsSerialFunc: func(n string) bool { return false },
+			ExecuteToolFunc: func(ctx context.Context, call *llm.FunctionCall) tools.ToolResult {
+				return tools.ToolResult{Text: "quick_success"}
+			},
+			RequestBatchConsentFunc: func(ctx context.Context, calls []*llm.FunctionCall) (context.Context, map[int]bool) {
+				return ctx, nil
+			},
+		}
+
+		cfg := dispatcherConfig{
+			MaxConcurrentTools: 3,
+			ToolTimeout:        1 * time.Hour,
+		}
+		cfg.applyDefaults()
+
+		ctx := context.Background()
+		d := &Dispatcher{
+			pipeline: mock,
+			events:   events.NewSimpleEventBus(ctx),
+			logger:   log,
+		}
+		d.state.Store(&dispatcherState{config: cfg})
+
+		calls := []*llm.FunctionCall{
+			{Name: "tool_a"},
+			{Name: "tool_b"},
+		}
+
+		batch := taskBatch{
+			isSerial: false,
+			tasks:    []int{0, 1},
+		}
+
+		resultsCh := make(chan toolExecResult, len(batch.tasks)+1)
+
+		panickingFanIn := func(wg *sync.WaitGroup, _ chan<- toolExecResult) {
+			wg.Wait() // workers complete first — avoids race on channel close
+			panic("simulated WaitGroup corruption in fan-in")
+		}
+
+		d.executeParallelBatchWithFanIn(ctx, batch, calls, cfg.MaxConcurrentTools, resultsCh, panickingFanIn)
+
+		var results []toolExecResult
+		for res := range resultsCh {
+			results = append(results, res)
+		}
+
+		// Find the sentinel among results (workers may or may not finish first).
+		var sentinel *toolExecResult
+		for i := range results {
+			if results[i].index == -1 {
+				sentinel = &results[i]
+				break
+			}
+		}
+
+		require.NotNil(t, sentinel, "expected at least one sentinel result with index == -1")
+		assert.Equal(t, "fan_in_panic", sentinel.name)
+		assert.Error(t, sentinel.tr.Error)
+		assert.True(t, errors.Is(sentinel.tr.Error, llm.ErrTerminal),
+			"sentinel error must wrap ErrTerminal")
+		assert.Contains(t, sentinel.tr.Error.Error(), "fan-in panic")
+		assert.Contains(t, sentinel.tr.Error.Error(), "simulated WaitGroup corruption")
+		assert.Contains(t, sentinel.tr.Text, "fan-in panic")
+
+		// Verify the logger captured the panic.
+		assert.True(t, log.errorCalled, "logger.Error must have been called")
+		assert.Equal(t, "panic in fan-in wait goroutine", log.lastMsg)
+
+		// Verify logger attributes include "panic" key with the panic value.
+		var foundPanicAttr bool
+		for i := 0; i < len(log.lastArgs)-1; i += 2 {
+			key, ok := log.lastArgs[i].(string)
+			if !ok {
+				continue
+			}
+			if key == "panic" {
+				foundPanicAttr = true
+				valStr := fmt.Sprintf("%v", log.lastArgs[i+1])
+				assert.Contains(t, valStr, "simulated WaitGroup corruption",
+					"logger 'panic' attribute must contain the panic value")
+			}
+		}
+		assert.True(t, foundPanicAttr, "logger attributes must include 'panic' key")
 	})
 }

--- a/internal/agent/executor/executor_test.go
+++ b/internal/agent/executor/executor_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -396,6 +397,53 @@ func TestDispatcher_Execute_RetryPath_PropagatesWaitErr(t *testing.T) {
 	})
 }
 
+func TestDispatcher_Execute_WaitErr_NonContext_AssemblesResponse(t *testing.T) {
+	mock := &mockToolPipeline{
+		IsSerialFunc: func(n string) bool { return false },
+		ExecuteToolFunc: func(ctx context.Context, call *llm.FunctionCall) tools.ToolResult {
+			return tools.ToolResult{Text: "worker_done"}
+		},
+		RequestBatchConsentFunc: func(ctx context.Context, calls []*llm.FunctionCall) (context.Context, map[int]bool) {
+			return ctx, nil
+		},
+	}
+
+	logger := &capturingLogger{}
+	d := &Dispatcher{
+		pipeline: mock,
+		events:   events.NewSimpleEventBus(context.Background()),
+		logger:   logger,
+		strategy: &markdownStrategy{},
+	}
+	d.state.Store(&dispatcherState{
+		config: dispatcherConfig{MaxConcurrentTools: 3},
+	})
+
+	respContent := &llm.Content{
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{Name: "tool_a"}},
+			{FunctionCall: &llm.FunctionCall{Name: "tool_b"}},
+		},
+	}
+
+	panickingFanIn := fanInFunc(func(wg *sync.WaitGroup, resultsCh chan<- toolExecResult) {
+		wg.Wait()
+		panic("simulated WaitGroup corruption in fan-in")
+	})
+
+	ctx := context.Background()
+	result, execErr := d.executeInternal(ctx, respContent, 0, 10, panickingFanIn)
+
+	require.Error(t, execErr, "waitErr must be non-nil")
+	require.NotNil(t, result, "AssembleResponse must return non-nil content")
+	require.NotEmpty(t, result.Parts, "response must contain assembled parts")
+	require.True(t, errors.Is(execErr, llm.ErrTerminal),
+		"error must wrap llm.ErrTerminal, got: %v", execErr)
+	require.Contains(t, execErr.Error(), "fan-in panic",
+		"error must contain 'fan-in panic'")
+	require.NoError(t, ctx.Err(), "context must not be cancelled")
+}
+
 func TestDispatcher_ConsentEvents_DetachedContext(t *testing.T) {
 	t.Parallel()
 	reg := &mockToolRegistry{}
@@ -599,7 +647,7 @@ func TestRunExecutionPlan_PanicRecovery(t *testing.T) {
 	calls := []*llm.FunctionCall{content.Parts[0].FunctionCall, content.Parts[1].FunctionCall}
 	declinedMap := make(map[int]bool)
 
-	execErr := exec.runExecutionPlan(ctx, calls, declinedMap, results)
+	execErr := exec.runExecutionPlan(ctx, calls, declinedMap, results, nil)
 
 	// 2. With the new contract, tool-result errors (including panics recovered
 	//    inside the tool pipeline) are delivered to the LLM via AssembleResponse


### PR DESCRIPTION
Closes #846.

## Summary
Closed all 3 high-priority executor coverage gaps identified in the v1.6.2 audit:

- **Gap 1** (): Extracted  method, added 3 table-driven tests for context-cancellation precedence
- **Gap 2** (): Threaded  seam through call chain, added end-to-end test for non-context waitErr propagation
- **Gap 3** (): Refactored  to accept injectable , added panic-injection test for fan-in goroutine recovery

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test -race ./... | PASS (all 72 packages) |
| Coverage (executor) | 100.0% |
| Lint | CLEAN |
| Architecture | No violations |
| Vulnerabilities | None |