### PR TITLE
fix(workspace): add fuzz test and fix UTF-8 sanitization in stream processor (#851)

### DIFF
--- a/internal/tools/workspace/fuzz_test.go
+++ b/internal/tools/workspace/fuzz_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package workspace
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"unicode/utf8"
+)
+
+// verifyStreamProcessorInvariants checks the correctness properties that must
+// hold after every call to processLine or appendErr.
+func verifyStreamProcessorInvariants(t *testing.T, sp *streamProcessor, sb *strings.Builder, rawLine []byte) {
+	t.Helper()
+
+	// (b) Capture must never exceed maxCapture.
+	if sb.Len() > sp.maxCapture {
+		t.Errorf("sb.Len() = %d exceeds maxCapture = %d", sb.Len(), sp.maxCapture)
+	}
+
+	// (c) totalCaptured must equal sb.Len() — they track the same data.
+	if *sp.totalCaptured != sb.Len() {
+		t.Errorf("*sp.totalCaptured = %d, sb.Len() = %d; want equal", *sp.totalCaptured, sb.Len())
+	}
+
+	// (d) Truncation invariant: if we are exactly at maxCapture, the
+	// truncated flag must be set. A line that fits precisely without
+	// exceeding remaining capacity will not trigger truncation in the
+	// current implementation, so the fuzzer may discover counter-
+	// examples to this property.
+	if sb.Len() > 0 && sb.Len() == sp.maxCapture && !sp.truncated.Load() {
+		t.Errorf("sb.Len() == maxCapture (%d) but truncated is false", sp.maxCapture)
+	}
+
+	// (e) Output must be valid UTF-8.
+	if !utf8.ValidString(sb.String()) {
+		t.Errorf("sb.String() is not valid UTF-8: %q", sb.String())
+	}
+}
+
+// FuzzStreamProcessor explores the behaviour of streamProcessor.processLine
+// and streamProcessor.appendErr with arbitrary byte slices.
+func FuzzStreamProcessor(f *testing.F) {
+	// Seed corpus — register every []byte seed described in the spec.
+	f.Add([]byte("hello world"))
+	f.Add([]byte(""))
+	f.Add([]byte{0xff, 0xfe, 0xfd})                               // invalid UTF-8
+	f.Add([]byte{0x80, 0x80, 0x80})                               // continuation bytes without starter
+	f.Add([]byte("before\x00after"))                              // NUL mid-string
+	f.Add([]byte("\x00\x00\x00"))                                 // all NULs
+	f.Add([]byte("\x1b[31mRED\x1b[0m"))                           // ANSI escape
+	f.Add([]byte("😀😀😀😀😀😀😀😀"))                                     // 4-byte emoji (8 × 4 = 32 bytes)
+	f.Add([]byte("世世世世世世世世"))                                     // 3-byte CJK (8 × 3 = 24 bytes)
+	f.Add([]byte{0x00, 0x01, 0x02, 0x03, 0x04})                   // binary garbage
+	f.Add(bytes.Repeat([]byte("A"), 500))                         // long line (exercises truncation)
+	f.Add([]byte("progress\r"))                                   // carriage return
+	f.Add([]byte("col1\tcol2\tcol3"))                             // tabs
+	f.Add([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}) // control chars
+	f.Add([]byte("\xef\xbf\xbd"))                                 // Unicode replacement char U+FFFD
+
+	f.Fuzz(func(t *testing.T, rawLine []byte) {
+		// 1. Construct streamProcessor per spec.
+		sp := &streamProcessor{
+			mu:            &sync.Mutex{},
+			truncated:     &atomic.Bool{},
+			totalCaptured: new(int),
+			maxCapture:    256,
+			file:          nil,
+			feedback:      nil,
+			wt:            nil,
+			// stdoutStr and stderrStr left as zero-value (nil)
+		}
+
+		var sb strings.Builder
+
+		// 2. Process the fuzzer-provided line with empty prefix.
+		sp.processLine(&sb, rawLine, "", nil)
+
+		// 3. Verify invariants after processLine.
+		verifyStreamProcessorInvariants(t, sp, &sb, rawLine)
+
+		// 4. nil error — must be a true no-op.
+		sbLenBefore := sb.Len()
+		truncatedBefore := sp.truncated.Load()
+		sp.appendErr(&sb, nil)
+		if sb.Len() != sbLenBefore {
+			t.Errorf("appendErr(nil): sb.Len() changed from %d to %d", sbLenBefore, sb.Len())
+		}
+		if sp.truncated.Load() != truncatedBefore {
+			t.Errorf("appendErr(nil): truncated changed from %v to %v", truncatedBefore, sp.truncated.Load())
+		}
+
+		// 5. bufio.ErrTooLong — warning must appear when there is room.
+		sbLenBeforeAppend := sb.Len()
+		sp.appendErr(&sb, bufio.ErrTooLong)
+		if sbLenBeforeAppend < sp.maxCapture {
+			// Warning should appear only when remaining > 0
+			if !strings.Contains(sb.String(), "[Warning] Output line too long") {
+				t.Errorf("appendErr(ErrTooLong): expected warning in sb when remaining > 0, got %q", sb.String())
+			}
+		}
+		// When sb was already at maxCapture, the truncated flag is re-set
+		// (no-op) but no new content appears — that's acceptable.
+
+		// 6. Invariants must still hold after appendErr.
+		verifyStreamProcessorInvariants(t, sp, &sb, rawLine)
+	})
+}

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -203,7 +203,7 @@ func (e *processExecutor) handleCaptureError(err error, sb *strings.Builder, mu 
 		if len(fullMsg) > remaining {
 			truncated.Store(true)
 		}
-		content := truncateToValidUTF8(fullMsg, remaining)
+		content := sanitizeAndTruncateUTF8(fullMsg, remaining)
 		sb.WriteString(content)
 	} else {
 		truncated.Store(true)
@@ -395,9 +395,11 @@ func (wt *writeTracker) Write(w io.Writer, p []byte) {
 	}
 }
 
-// truncateToValidUTF8 ensures that a string is truncated to a maximum number of bytes
-// without breaking a multi-byte UTF-8 character.
-func truncateToValidUTF8(s string, maxBytes int) string {
+// sanitizeAndTruncateUTF8 strips invalid UTF-8 sequences from s, then
+// ensures the result does not exceed maxBytes without breaking a
+// multi-byte UTF-8 character at the boundary.
+func sanitizeAndTruncateUTF8(s string, maxBytes int) string {
+	s = strings.ToValidUTF8(s, "")
 	if len(s) <= maxBytes {
 		return s
 	}

--- a/internal/tools/workspace/process_executor_unit_test.go
+++ b/internal/tools/workspace/process_executor_unit_test.go
@@ -49,7 +49,7 @@ func TestStderrPrefixConsistency(t *testing.T) {
 // UTF-8 truncation
 // ---------------------------------------------------------------------------
 
-func TestTruncateToValidUTF8(t *testing.T) {
+func TestSanitizeAndTruncateUTF8(t *testing.T) {
 	tests := []struct {
 		input    string
 		max      int
@@ -58,18 +58,18 @@ func TestTruncateToValidUTF8(t *testing.T) {
 		{"hello", 3, "hel"},
 		{"hello", 5, "hello"},
 		{"hello", 10, "hello"},
-		{"世界", 3, "世"},                             // "世" is 3 bytes, "界" starts at index 3
-		{"世界", 4, "世"},                             // "界" is 3 bytes, cannot take only 1 byte of "界"
-		{"世界", 6, "世界"},                            // exactly 6 bytes
-		{"😀", 2, ""},                               // Emoji is 4 bytes
-		{"😀", 4, "😀"},                              // Emoji is 4 bytes
-		{string([]byte{0xff, 0xff}), 1, ""},        // Invalid UTF-8
-		{"A" + string([]byte{0xff}) + "B", 2, "A"}, // Invalid UTF-8 after 'A'
+		{"世界", 3, "世"},                              // "世" is 3 bytes, "界" starts at index 3
+		{"世界", 4, "世"},                              // "界" is 3 bytes, cannot take only 1 byte of "界"
+		{"世界", 6, "世界"},                             // exactly 6 bytes
+		{"😀", 2, ""},                                // Emoji is 4 bytes
+		{"😀", 4, "😀"},                               // Emoji is 4 bytes
+		{string([]byte{0xff, 0xff}), 1, ""},         // Invalid UTF-8 → stripped by ToValidUTF8 → ""
+		{"A" + string([]byte{0xff}) + "B", 2, "AB"}, // Invalid byte stripped → "AB" (fits in 2 bytes)
 	}
 	for _, tt := range tests {
-		got := truncateToValidUTF8(tt.input, tt.max)
+		got := sanitizeAndTruncateUTF8(tt.input, tt.max)
 		if got != tt.expected {
-			t.Errorf("truncate(%q, %d) = %q; want %q", tt.input, tt.max, got, tt.expected)
+			t.Errorf("sanitizeAndTruncateUTF8(%q, %d) = %q; want %q", tt.input, tt.max, got, tt.expected)
 		}
 	}
 }

--- a/internal/tools/workspace/stream_processor.go
+++ b/internal/tools/workspace/stream_processor.go
@@ -61,7 +61,7 @@ func (sp *streamProcessor) processLine(sb *strings.Builder, rawLine []byte, pref
 		if len(content) > remaining {
 			sp.truncated.Store(true)
 		}
-		content = truncateToValidUTF8(content, remaining)
+		content = sanitizeAndTruncateUTF8(content, remaining)
 		sb.WriteString(content)
 		*sp.totalCaptured += len(content)
 	} else {
@@ -94,7 +94,7 @@ func (sp *streamProcessor) appendErr(sb *strings.Builder, err error) {
 		if len(fullMsg) > remaining {
 			sp.truncated.Store(true)
 		}
-		content := truncateToValidUTF8(fullMsg, remaining)
+		content := sanitizeAndTruncateUTF8(fullMsg, remaining)
 		sb.WriteString(content)
 		*sp.totalCaptured += len(content)
 	} else {


### PR DESCRIPTION
Closes #851.

## Summary
- **Add `FuzzStreamProcessor`** fuzz test with 15 seeds exercising `processLine` and `appendErr` in `internal/tools/workspace/`
- **Fix architectural blocker**: Rename `truncateToValidUTF8` → `sanitizeAndTruncateUTF8` and add unconditional `strings.ToValidUTF8()` to strip invalid byte sequences before truncation
- Previously, invalid UTF-8 from subprocess output passed through unchanged when content fit within `maxCapture`, causing potential JSON marshaling failures
- Update all 3 call sites and rename `TestSanitizeAndTruncateUTF8`

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage | 98.0% (workspace package) |
| Fuzz seeds | 15/15 PASS |
| Race detector | PASS |
| vulncheck | No vulnerabilities |