### PR TITLE
fix(context): add fuzz test for HeuristicTokenCounter.Count (#853)

### DIFF
--- a/internal/agent/session/context/fuzz_test.go
+++ b/internal/agent/session/context/fuzz_test.go
@@ -1,0 +1,311 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+)
+
+// FuzzTokenCounter verifies that HeuristicTokenCounter.Count never panics
+// and always produces a non-negative result across all nil-variant scenarios,
+// randomized Part types, and nil Content pointers.
+func FuzzTokenCounter(f *testing.F) {
+	// Seed corpus: descriptive labels mapped to concrete structures in buildSeedContents.
+	f.Add("empty")
+	f.Add("nil_slice")
+	f.Add("one_nil_content")
+	f.Add("nil_parts_slices")
+	f.Add("nil_part_in_parts")
+	f.Add("nil_part_in_transient")
+	f.Add("text_only")
+	f.Add("function_call")
+	f.Add("function_response")
+	f.Add("inline_data")
+	f.Add("transient_only")
+	f.Add("mixed_all_types")
+	f.Add("nil_functioncall_args")
+	f.Add("nil_functionresponse_response")
+	f.Add("nested_maps")
+	f.Add("mixed_slice_types")
+	f.Add("multiple_contents")
+	f.Add("large_text")
+	f.Add("circular_map")
+	f.Add("overflow_many_contents")
+	f.Add("exotic_map_types")
+
+	f.Fuzz(func(t *testing.T, seedName string) {
+		contents := buildSeedContents(seedName)
+
+		// Test with nil registry
+		counterNoReg := NewHeuristicTokenCounter(nil)
+		resultNoReg := counterNoReg.Count(contents)
+		verifyInvariants(t, counterNoReg, contents, resultNoReg)
+
+		// Test with stub registry
+		reg := &stubRegistry{decls: makeToolDecls(5)}
+		counterWithReg := NewHeuristicTokenCounter(reg)
+		resultWithReg := counterWithReg.Count(contents)
+		verifyInvariants(t, counterWithReg, contents, resultWithReg)
+
+		// Registry must not decrease count
+		if resultWithReg < resultNoReg {
+			t.Errorf("registry decreased count: with=%d, without=%d", resultWithReg, resultNoReg)
+		}
+	})
+}
+
+// buildSeedContents maps a seed label to a concrete []*llm.Content structure.
+// The default branch handles fuzzer-generated mutations by using the seed
+// string directly as text content.
+func buildSeedContents(seed string) []*llm.Content {
+	switch seed {
+	case "empty":
+		return []*llm.Content{}
+	case "nil_slice":
+		return nil
+	case "one_nil_content":
+		return []*llm.Content{nil}
+	case "nil_parts_slices":
+		return []*llm.Content{{Role: "user"}}
+	case "nil_part_in_parts":
+		return []*llm.Content{{
+			Role:  "user",
+			Parts: []*llm.Part{nil, {Text: "hello"}},
+		}}
+	case "nil_part_in_transient":
+		return []*llm.Content{{
+			Role:           "user",
+			TransientParts: []*llm.Part{nil, {Text: "transient"}},
+		}}
+	case "text_only":
+		return []*llm.Content{{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: "hello world"}},
+		}}
+	case "function_call":
+		return []*llm.Content{{
+			Role: "model",
+			Parts: []*llm.Part{{
+				FunctionCall: &llm.FunctionCall{
+					Name: "search",
+					Args: map[string]interface{}{"q": "test", "n": float64(5)},
+				},
+			}},
+		}}
+	case "function_response":
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{
+					Name:     "search",
+					Response: map[string]interface{}{"ok": true, "count": float64(3)},
+				},
+			}},
+		}}
+	case "inline_data":
+		return []*llm.Content{{
+			Role: "user",
+			Parts: []*llm.Part{{
+				InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte("fake")},
+			}},
+		}}
+	case "transient_only":
+		return []*llm.Content{{
+			Role:           "user",
+			Parts:          []*llm.Part{},
+			TransientParts: []*llm.Part{{Text: "transient instruction"}},
+		}}
+	case "mixed_all_types":
+		return []*llm.Content{{
+			Role: "model",
+			Parts: []*llm.Part{{
+				Text: "mixed",
+				FunctionCall: &llm.FunctionCall{
+					Name: "multi",
+					Args: map[string]interface{}{"x": float64(1)},
+				},
+				FunctionResponse: &llm.FunctionResponse{
+					Name:     "multi",
+					Response: map[string]interface{}{"y": "z"},
+				},
+				InlineData: &llm.Blob{MIMEType: "text/plain", Data: []byte("data")},
+			}},
+			TransientParts: []*llm.Part{{Text: "transient"}},
+		}}
+	case "nil_functioncall_args":
+		return []*llm.Content{{
+			Role: "model",
+			Parts: []*llm.Part{{
+				FunctionCall: &llm.FunctionCall{Name: "f", Args: nil},
+			}},
+		}}
+	case "nil_functionresponse_response":
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{Name: "g", Response: nil},
+			}},
+		}}
+	case "nested_maps":
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "nest",
+					Response: map[string]interface{}{
+						"a": map[string]interface{}{
+							"b": map[string]interface{}{
+								"c": "d",
+							},
+						},
+					},
+				},
+			}},
+		}}
+	case "mixed_slice_types":
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "mix",
+					Response: map[string]interface{}{
+						"items": []interface{}{"str", float64(1), true, nil},
+					},
+				},
+			}},
+		}}
+	case "multiple_contents":
+		return []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+			{Role: "model", Parts: []*llm.Part{{
+				FunctionCall: &llm.FunctionCall{
+					Name: "f",
+					Args: map[string]interface{}{"x": "y"},
+				},
+			}}},
+			{Role: "user", Parts: []*llm.Part{{Text: "thanks"}}},
+		}
+	case "large_text":
+		large := make([]byte, 10000)
+		for i := range large {
+			large[i] = 'a'
+		}
+		return []*llm.Content{{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: string(large)}},
+		}}
+	case "circular_map":
+		// Self-referencing map: exercises unbounded recursion path (R2).
+		// This should NOT panic or stack-overflow; if it does, the fuzz
+		// framework will report the crash.
+		selfRef := map[string]interface{}{}
+		selfRef["self"] = selfRef
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{
+					Name:     "cycle",
+					Response: selfRef,
+				},
+			}},
+		}}
+	case "overflow_many_contents":
+		// 1000 contents each with a 1KB text + function call with args.
+		// Stresses totalTokens accumulation. On 64-bit systems this is
+		// harmless (~1000 * 350 ≈ 350K tokens); the seed validates no
+		// panic and non-negative result under bulk input.
+		n := 1000
+		contents := make([]*llm.Content, n)
+		for i := 0; i < n; i++ {
+			role := "user"
+			if i%2 == 1 {
+				role = "model"
+			}
+			// ~1KB text
+			text := make([]byte, 1024)
+			for j := range text {
+				text[j] = byte('a' + (i+j)%26)
+			}
+			contents[i] = &llm.Content{
+				Role: role,
+				Parts: []*llm.Part{
+					{Text: string(text)},
+					{
+						FunctionCall: &llm.FunctionCall{
+							Name: "f",
+							Args: map[string]interface{}{
+								"input":   string(text),
+								"count":   float64(i),
+								"enabled": i%2 == 0,
+								"nested": map[string]interface{}{
+									"key": "value",
+								},
+							},
+						},
+					},
+				},
+			}
+		}
+		return contents
+
+	case "exotic_map_types":
+		// Maps with types that fall through to the default branch (20 chars)
+		// of estimateValueSizeInternal. Confirms no type-assertion panic.
+		return []*llm.Content{{
+			Role: "tool",
+			Parts: []*llm.Part{{
+				FunctionResponse: &llm.FunctionResponse{
+					Name: "exotic",
+					Response: map[string]interface{}{
+						"int32_val":    int32(42),
+						"float32_val":  float32(3.14),
+						"uint_val":     uint(100),
+						"byte_slice":   []byte("raw bytes"),
+						"string_slice": []string{"a", "b", "c"}, // NOT []interface{}
+						"empty_slice":  []interface{}{},
+						"deep_nest": map[string]interface{}{
+							"l2": map[string]interface{}{
+								"l3": map[string]interface{}{
+									"l4": map[string]interface{}{
+										"l5": "deep",
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}}
+	default:
+		// Fuzzer-generated mutations: use seed as text to explore the string space.
+		return []*llm.Content{{
+			Role:  "user",
+			Parts: []*llm.Part{{Text: seed}},
+		}}
+	}
+}
+
+// verifyInvariants checks that Count results satisfy basic correctness properties.
+func verifyInvariants(t *testing.T, counter *HeuristicTokenCounter, contents []*llm.Content, result int) {
+	t.Helper()
+
+	// Invariant 1: non-negative
+	if result < 0 {
+		t.Errorf("Count returned negative: %d", result)
+	}
+
+	// Invariant 2: TokenCount cache side-effect
+	for i, c := range contents {
+		if c == nil {
+			continue // nil Content is skipped
+		}
+		if len(c.TransientParts) == 0 && len(c.Parts) > 0 {
+			if c.TokenCount < 0 {
+				t.Errorf("content[%d]: TokenCount not cached (got %d) when TransientParts empty and Parts non-empty", i, c.TokenCount)
+			}
+		}
+	}
+}

--- a/internal/agent/session/context/token_counter.go
+++ b/internal/agent/session/context/token_counter.go
@@ -8,6 +8,11 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
+// maxEstimateDepth limits recursion in estimateMapSizeInternal and
+// estimateValueSizeInternal to prevent stack overflow from circular
+// map references (e.g., m["self"] = m).
+const maxEstimateDepth = 100
+
 // HeuristicTokenCounter provides a rule-of-thumb token estimation.
 type HeuristicTokenCounter struct {
 	registry tools.Registry
@@ -33,6 +38,9 @@ func (c *HeuristicTokenCounter) Count(contents []*llm.Content) int {
 	}
 
 	for _, content := range contents {
+		if content == nil {
+			continue
+		}
 		charCount := 0
 		for _, p := range content.Parts {
 			charCount += c.estimatePartChars(p)
@@ -68,11 +76,11 @@ func (c *HeuristicTokenCounter) estimatePartChars(p *llm.Part) int {
 	}
 	if p.FunctionCall != nil {
 		charCount += len(p.FunctionCall.Name)
-		charCount += estimateMapSizeInternal(p.FunctionCall.Args)
+		charCount += estimateMapSizeInternal(p.FunctionCall.Args, 0)
 	}
 	if p.FunctionResponse != nil {
 		charCount += len(p.FunctionResponse.Name)
-		charCount += estimateMapSizeInternal(p.FunctionResponse.Response)
+		charCount += estimateMapSizeInternal(p.FunctionResponse.Response, 0)
 	}
 	if p.InlineData != nil {
 		charCount += 160 // Heuristic for blob (roughly 50 tokens)
@@ -80,19 +88,25 @@ func (c *HeuristicTokenCounter) estimatePartChars(p *llm.Part) int {
 	return charCount
 }
 
-func estimateMapSizeInternal(m map[string]interface{}) int {
+func estimateMapSizeInternal(m map[string]interface{}, depth int) int {
+	if depth > maxEstimateDepth {
+		return 0
+	}
 	if m == nil {
 		return 0
 	}
 	size := 0
 	for k, v := range m {
 		size += len(k)
-		size += estimateValueSizeInternal(v)
+		size += estimateValueSizeInternal(v, depth+1)
 	}
 	return size
 }
 
-func estimateValueSizeInternal(v interface{}) int {
+func estimateValueSizeInternal(v interface{}, depth int) int {
+	if depth > maxEstimateDepth {
+		return 0
+	}
 	if v == nil {
 		return 4
 	}
@@ -104,11 +118,11 @@ func estimateValueSizeInternal(v interface{}) int {
 	case bool:
 		return 5
 	case map[string]interface{}:
-		return estimateMapSizeInternal(val)
+		return estimateMapSizeInternal(val, depth+1)
 	case []interface{}:
 		size := 1
 		for _, item := range val {
-			size += estimateValueSizeInternal(item)
+			size += estimateValueSizeInternal(item, depth+1)
 		}
 		return size
 	default:

--- a/internal/agent/session/context/token_counter_test.go
+++ b/internal/agent/session/context/token_counter_test.go
@@ -165,7 +165,7 @@ func TestEstimatePartChars_InlineData(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestEstimateMapSizeInternal_NilMap(t *testing.T) {
-	size := estimateMapSizeInternal(nil)
+	size := estimateMapSizeInternal(nil, 0)
 
 	require.Equal(t, 0, size, "nil map must return 0")
 }
@@ -221,7 +221,7 @@ func TestEstimateValueSizeInternal_AllTypes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := estimateValueSizeInternal(tt.input)
+			got := estimateValueSizeInternal(tt.input, 0)
 			require.Equal(t, tt.expected, got,
 				"estimateValueSizeInternal(%v)", tt.input)
 		})


### PR DESCRIPTION
Closes #853.

## Summary
Add comprehensive fuzz test for `HeuristicTokenCounter.Count` in `internal/agent/session/context/` with 21 seed corpus entries covering nil variants, all Part types, circular maps, overflow stress, and exotic map types.

### Fixes included
- **R1**: Nil-content guard in `Count()` — prevents panic on `nil` `*llm.Content` pointer in slice
- **R2**: Recursion depth guard (`maxEstimateDepth=100`) in `estimateMapSizeInternal`/`estimateValueSizeInternal` — prevents stack overflow from circular map references

### Files changed
| File | Change |
|------|--------|
| `fuzz_test.go` | New — 21 fuzz seeds with invariant assertions |
| `token_counter.go` | Nil-guard + recursion depth guard |
| `token_counter_test.go` | Updated call sites for new depth parameter |

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| `context` coverage | 99.9% |
| Fuzz exploration | 14,769 executions, 0 panics |
| Race detection | ✅ Clean |