### PR TITLE
fix(llm): add table-driven error handling tests for OpenAI, Anthropic, Gemini (#873)

### DIFF
--- a/internal/infrastructure/llm/ERROR_TEST_PATTERN.md
+++ b/internal/infrastructure/llm/ERROR_TEST_PATTERN.md
@@ -1,0 +1,131 @@
+# LLM Provider Error Testing Pattern
+
+Canonical table-driven pattern for testing error handling across LLM provider clients.
+Established in Issue #873. To be reused in follow-up distributed error-handling work.
+
+## Pattern Overview
+
+Every LLM provider client has a single entry point (`SendChat`) that can fail in
+three layers:
+
+1. **Transport layer** — network errors, DNS failures, connection refused, timeouts
+2. **HTTP layer** — non-200 status codes with structured/unstructured response bodies
+3. **Application layer** — malformed JSON, empty responses, tool-call parse failures
+
+Each layer requires a specific testing technique.
+
+## Canonical Test Structure
+
+```go
+func Test<Provider>_ErrorHandling(t *testing.T) {
+    tests := []struct {
+        name              string
+        statusCode        int
+        response          string
+        wantErrContains   string
+        wantAPIError      bool
+        wantAPIErrStatus  int
+        wantSentinel      error
+    }{
+        // Dimension 1: HTTP Status Codes
+        // ... 400, 401, 403, 408, 429, 499, 500, 502, 503 ...
+        // Dimension 2: Provider-Specific Error Shapes
+        // ... overloaded_error, permission_error, etc ...
+        // Dimension 3: Malformed Response Bodies
+        // ... malformed JSON, empty body, non-JSON body ...
+        // Dimension 4: Application-Layer Errors
+        // ... empty choices, invalid tool args ...
+    }
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            // Arrange: httptest server + client
+            // Act: SendChat
+            // Assert: error type + Classify chain
+        })
+    }
+}
+```
+
+## Assertion Template (Status Code Rows)
+
+Every status-code row must verify **three** assertions:
+
+```go
+// 1. Error wraps *llmerr.APIError with correct status
+var apiErr *llmerr.APIError
+require.True(t, errors.As(err, &apiErr), "expected *llmerr.APIError")
+require.Equal(t, tt.wantAPIErrStatus, apiErr.Status)
+
+// 2. Body is captured
+require.Contains(t, apiErr.Body, tt.wantBodyContains)
+
+// 3. llmerr.Classify maps to correct domain sentinel
+classified := llmerr.Classify(apiErr)
+require.True(t, errors.Is(classified, tt.wantSentinel),
+    "Classify: got %v, want %v", classified, tt.wantSentinel)
+```
+
+## Provider-Specific Adaptations
+
+### OpenAI / Anthropic (Raw HTTP)
+
+Use `httptest.NewServer` with a handler that writes the desired status code and
+response body, then construct the client pointing at the test server URL.
+
+```go
+server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+    w.WriteHeader(tt.statusCode)
+    _, _ = w.Write([]byte(tt.response))
+}))
+defer server.Close()
+client := NewClient(server.URL, "model", authenticator)
+```
+
+### Gemini (GenAI SDK)
+
+Two approaches:
+
+1. **HTTP-level** (`TestSendChat_ClassifyError_Integration`): Same `httptest` pattern
+   as OpenAI/Anthropic. The SDK translates HTTP errors into `genai.APIError` strings,
+   which `classifyError` → `llmerr.Classify` matches via `classifyString` regex/keyword.
+
+2. **SDK-level** (`TestSendChat_SDKError_Direct`): Inject a `newGenaiClient` factory
+   that returns a client wired to fail. This tests the `initSDK` → `classifyError`
+   pipeline without the HTTP layer.
+
+## Status Code → Domain Sentinel Mapping
+
+| HTTP Status | Domain Sentinel | Classification |
+|-------------|----------------|----------------|
+| 401 | `llm.ErrAuth` | Authentication failure |
+| 403 | `llm.ErrTerminal` | Permission denied |
+| 400 | `llm.ErrTerminal` | Invalid request |
+| 408 | `llm.ErrTransient` | Request timeout |
+| 429 | `llm.ErrRateLimit` | Rate limited |
+| 499 | `llm.ErrTransient` | Client closed request |
+| 500 | `llm.ErrTransient` | Internal server error |
+| 502 | `llm.ErrTransient` | Bad gateway |
+| 503 | `llm.ErrTransient` | Service unavailable |
+| 529 | `llm.ErrTransient` | Overloaded (Anthropic-specific) |
+
+## Test Coverage Checklist
+
+When adding a new provider or extending an existing one:
+
+- [ ] All 9 HTTP status codes (400–503) tested
+- [ ] Empty response body variant for at least one 5xx code
+- [ ] Non-JSON response body variant for at least one 5xx code
+- [ ] Provider-specific error shapes (overloaded_error, permission_error, etc.)
+- [ ] Malformed JSON on 200 response
+- [ ] Transport-layer errors (timeout, connection refused, pre-cancelled context)
+- [ ] Double-failure path (non-200 + body read failure)
+- [ ] `llmerr.Classify` verified on every status-code row
+- [ ] SDK-level error injection (for SDK-based providers)
+
+## Related Files
+
+- `internal/infrastructure/llm/llmerr/errors.go` — Classify, APIError, regex patterns
+- `internal/infrastructure/llm/llmerr/errors_test.go` — Classify unit tests (classifier in isolation)
+- `internal/infrastructure/llm/openai/client_chat_test.go` — `TestSendChat_ErrorHandling`
+- `internal/infrastructure/llm/anthropic/client_test.go` — `TestSendChat_ErrorHandling`
+- `internal/infrastructure/llm/gemini/gemini_test.go` — `TestSendChat_ClassifyError_Integration`, `TestClassifyError`, `TestSendChat_SDKError_Direct`

--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -153,54 +153,205 @@ func testHistoryProcessing(t *testing.T) {
 	}
 }
 
-func TestSendChat_Errors(t *testing.T) {
+func TestSendChat_ErrorHandling(t *testing.T) {
 	tests := []struct {
-		name          string
-		status        int
-		response      string
-		expectedError string
-		isAPIError    bool
+		name               string
+		status             int
+		responseBody       string
+		wantAPIErrorStatus int
+		wantSentinel       error
+		wantErrContains    string
+		isAPIError         bool
+		useReadFailure     bool
 	}{
+		// ── Dimension 1: Status Codes ──────────────────────────────────
 		{
-			name:          "400 Bad Request",
-			status:        http.StatusBadRequest,
-			response:      `{"error": {"type": "invalid_request_error", "message": "Missing required parameter"}}`,
-			expectedError: "api error (status 400)",
-			isAPIError:    true,
+			name:               "400_bad_request",
+			status:             400,
+			responseBody:       `{"type":"error","error":{"type":"invalid_request_error","message":"Missing required parameter: model"}}`,
+			wantAPIErrorStatus: 400,
+			wantSentinel:       llm.ErrTerminal,
+			isAPIError:         true,
 		},
 		{
-			name:          "Malformed JSON",
-			status:        http.StatusOK,
-			response:      `{ "id": "msg_123", "content...`,
-			expectedError: "failed to decode response",
+			name:               "401_unauthorized",
+			status:             401,
+			responseBody:       `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`,
+			wantAPIErrorStatus: 401,
+			wantSentinel:       llm.ErrAuth,
+			isAPIError:         true,
+		},
+		{
+			name:               "403_forbidden",
+			status:             403,
+			responseBody:       `{"type":"error","error":{"type":"permission_error","message":"Your API key does not have permission"}}`,
+			wantAPIErrorStatus: 403,
+			wantSentinel:       llm.ErrTerminal,
+			isAPIError:         true,
+		},
+		{
+			name:               "408_timeout",
+			status:             408,
+			responseBody:       `{"type":"error","error":{"type":"timeout_error","message":"Request timed out"}}`,
+			wantAPIErrorStatus: 408,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "429_rate_limit",
+			status:             429,
+			responseBody:       `{"type":"error","error":{"type":"rate_limit_error","message":"Rate limit exceeded"}}`,
+			wantAPIErrorStatus: 429,
+			wantSentinel:       llm.ErrRateLimit,
+			isAPIError:         true,
+		},
+		{
+			name:               "499_client_closed",
+			status:             499,
+			responseBody:       `{"type":"error","error":{"type":"cancelled_error","message":"Client closed request"}}`,
+			wantAPIErrorStatus: 499,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "500_internal",
+			status:             500,
+			responseBody:       `{"type":"error","error":{"type":"server_error","message":"Internal server error"}}`,
+			wantAPIErrorStatus: 500,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "502_bad_gateway",
+			status:             502,
+			responseBody:       `{"type":"error","error":{"type":"server_error","message":"Bad gateway"}}`,
+			wantAPIErrorStatus: 502,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "503_unavailable",
+			status:             503,
+			responseBody:       `{"type":"error","error":{"type":"overloaded_error","message":"Overloaded"}}`,
+			wantAPIErrorStatus: 503,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+
+		// ── Dimension 2: Anthropic-Specific Error Types ────────────────
+		{
+			name:               "overloaded_error",
+			status:             529,
+			responseBody:       `{"type":"error","error":{"type":"overloaded_error","message":"Anthropic's servers are temporarily overloaded"}}`,
+			wantAPIErrorStatus: 529,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "permission_error",
+			status:             403,
+			responseBody:       `{"type":"error","error":{"type":"permission_error","message":"Your API key does not have permission to use this resource"}}`,
+			wantAPIErrorStatus: 403,
+			wantSentinel:       llm.ErrTerminal,
+			isAPIError:         true,
+		},
+		{
+			name:               "invalid_request_error_empty_max_tokens",
+			status:             400,
+			responseBody:       `{"type":"error","error":{"type":"invalid_request_error","message":"max_tokens: must be greater than thinking budget"}}`,
+			wantAPIErrorStatus: 400,
+			wantSentinel:       llm.ErrTerminal,
+			isAPIError:         true,
+		},
+
+		// ── Dimension 3: Malformed Response + Edge ────────────────────
+		{
+			name:            "malformed_json",
+			status:          200,
+			responseBody:    `{"id":"msg_123","content...`,
+			wantErrContains: "failed to decode response",
+			isAPIError:      false,
+		},
+		{
+			name:            "500_read_failure",
+			status:          500,
+			wantErrContains: "simulated read failure",
+			isAPIError:      false,
+			useReadFailure:  true,
+		},
+
+		// ── Dimension 4: Response Body Variants for 500 ───────────────
+		{
+			name:               "500_empty_body",
+			status:             500,
+			responseBody:       "",
+			wantAPIErrorStatus: 500,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
+		},
+		{
+			name:               "500_non_json_body",
+			status:             500,
+			responseBody:       "<html>500 Internal Server Error</html>",
+			wantAPIErrorStatus: 500,
+			wantSentinel:       llm.ErrTransient,
+			isAPIError:         true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.status)
-				_, _ = w.Write([]byte(tt.response))
-			}))
-			defer server.Close()
+			var c *client
 
-			client := NewClient(server.URL, "claude-3", &auth.AnthropicAuth{APIKey: "key"})
-			_, _, err := client.SendChat(context.Background(), nil, nil, nil)
+			if tt.useReadFailure {
+				c = NewClient("", "claude-3", &auth.AnthropicAuth{APIKey: "key"})
+				c.httpClient.Transport = &readFailureRoundTripper{}
+			} else {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(tt.status)
+					if tt.responseBody != "" {
+						_, _ = w.Write([]byte(tt.responseBody))
+					}
+				}))
+				defer server.Close()
+				c = NewClient(server.URL, "claude-3", &auth.AnthropicAuth{APIKey: "key"})
+			}
 
+			_, _, err := c.SendChat(context.Background(), nil, nil, nil)
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
 
-			if !strings.Contains(err.Error(), tt.expectedError) {
-				t.Errorf("expected error containing %q, got %q", tt.expectedError, err.Error())
+			if tt.wantErrContains != "" {
+				if !strings.Contains(err.Error(), tt.wantErrContains) {
+					t.Errorf("expected error containing %q, got %q", tt.wantErrContains, err.Error())
+				}
 			}
 
+			var apiErr *llmerr.APIError
 			if tt.isAPIError {
-				var apiErr *llmerr.APIError
 				if !errors.As(err, &apiErr) {
-					t.Errorf("expected llmerr.APIError, got %T", err)
-				} else if apiErr.Status != tt.status {
-					t.Errorf("expected status %d, got %d", tt.status, apiErr.Status)
+					t.Fatalf("expected *llmerr.APIError, got %T", err)
+				}
+				if apiErr.Status != tt.wantAPIErrorStatus {
+					t.Errorf("status: got %d, want %d", apiErr.Status, tt.wantAPIErrorStatus)
+				}
+				if tt.wantSentinel != nil {
+					classified := llmerr.Classify(apiErr)
+					if !errors.Is(classified, tt.wantSentinel) {
+						t.Errorf("Classify: got %v, want %v", classified, tt.wantSentinel)
+					}
+				}
+			} else {
+				if errors.As(err, &apiErr) {
+					t.Errorf("expected non-APIError, got %T: %v", apiErr, apiErr)
+				}
+
+				// 500_read_failure: additionally verify the full error chain
+				if tt.useReadFailure {
+					if !strings.Contains(err.Error(), "additionally, failed to read response body") {
+						t.Errorf("expected error containing %q, got %q", "additionally, failed to read response body", err.Error())
+					}
 				}
 			}
 		})

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -573,39 +573,40 @@ func TestToSDKSchema(t *testing.T) {
 }
 
 func TestClassifyError(t *testing.T) {
-
 	client := &Client{}
 
 	tests := []struct {
-		name     string
-		err      error
-		expected error
+		name   string
+		err    error
+		wantIs error
 	}{
-		{
-			name:     "NilError",
-			err:      nil,
-			expected: nil,
-		},
-		{
-			name:     "GenericError",
-			err:      fmt.Errorf("some error"),
-			expected: fmt.Errorf("%w: some error", llm.ErrTerminal),
-		},
-		{
-			name:     "RateLimitError",
-			err:      fmt.Errorf("Error 429, Message: Resource exhausted."),
-			expected: fmt.Errorf("%w: Error 429, Message: Resource exhausted.", llm.ErrRateLimit),
-		},
+		{"nil_error", nil, nil},
+		{"domain_auth", llm.ErrAuth, llm.ErrAuth},
+		{"domain_rate_limit", llm.ErrRateLimit, llm.ErrRateLimit},
+		{"domain_transient", llm.ErrTransient, llm.ErrTransient},
+		{"domain_terminal", llm.ErrTerminal, llm.ErrTerminal},
+		{"sdk_format_429", fmt.Errorf("Error 429: Resource exhausted"), llm.ErrRateLimit},
+		{"sdk_format_503", fmt.Errorf("Error 503: Unavailable"), llm.ErrTransient},
+		{"sdk_format_500", fmt.Errorf("Error 500, Message: Internal"), llm.ErrTransient},
+		{"sdk_format_unauthenticated", fmt.Errorf("Error 401, Message: unauthenticated"), llm.ErrAuth},
+		{"sdk_format_permission_denied", fmt.Errorf("Error 403, Message: Permission denied"), llm.ErrTerminal},
+		{"rate_limit_keyword", fmt.Errorf("RATE LIMIT exceeded"), llm.ErrRateLimit},
+		{"quota_keyword", fmt.Errorf("QUOTA exceeded"), llm.ErrRateLimit},
+		{"unavailable_keyword", fmt.Errorf("SERVICE UNAVAILABLE"), llm.ErrTransient},
+		{"unknown_error", fmt.Errorf("something completely unexpected"), llm.ErrTerminal},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := client.classifyError(tt.err)
-			if (got == nil) != (tt.expected == nil) {
-				t.Fatalf("expected error %v, got %v", tt.expected, got)
+			if tt.wantIs == nil {
+				if got != nil {
+					t.Errorf("expected nil, got %v", got)
+				}
+				return
 			}
-			if got != nil && !errors.Is(got, tt.expected) && got.Error() != tt.expected.Error() {
-				t.Errorf("expected error message %q, got %q", tt.expected.Error(), got.Error())
+			if !errors.Is(got, tt.wantIs) {
+				t.Errorf("expected errors.Is(%v, %v), got %v", got, tt.wantIs, got)
 			}
 		})
 	}
@@ -627,6 +628,10 @@ func TestSendChat_ClassifyError_Integration(t *testing.T) {
 		{"HTTP 429 → ErrRateLimit", http.StatusTooManyRequests, `{"error":{"code":429,"message":"Resource exhausted"}}`, llm.ErrRateLimit},
 		{"HTTP 503 → ErrTransient", http.StatusServiceUnavailable, `{"error":{"code":503,"message":"Unavailable"}}`, llm.ErrTransient},
 		{"HTTP 400 → ErrTerminal", http.StatusBadRequest, `{"error":{"code":400,"message":"Bad request"}}`, llm.ErrTerminal},
+		{"HTTP 500 → ErrTransient", http.StatusInternalServerError, `{"error":{"code":500,"message":"Internal"}}`, llm.ErrTransient},
+		{"HTTP 502 → ErrTransient", http.StatusBadGateway, `{"error":{"code":502,"message":"Bad Gateway"}}`, llm.ErrTransient},
+		{"HTTP 408 → ErrTransient", http.StatusRequestTimeout, `{"error":{"code":408,"message":"Timeout"}}`, llm.ErrTransient},
+		{"HTTP 403 → ErrTerminal", http.StatusForbidden, `{"error":{"code":403,"message":"Forbidden"}}`, llm.ErrTerminal},
 	}
 
 	for _, tt := range tests {
@@ -1361,5 +1366,58 @@ func TestNewClient_Options(t *testing.T) {
 	}
 	if _, ok := c.logger.(*ports.NoOpLogger); !ok {
 		t.Error("expected logger to be NoOpLogger")
+	}
+}
+
+func TestSendChat_SDKError_Direct(t *testing.T) {
+	tests := []struct {
+		name         string
+		sdkInitErr   error
+		wantSentinel error
+	}{
+		{
+			name:         "sdk init auth error",
+			sdkInitErr:   fmt.Errorf("Error 401, Message: unauthenticated"),
+			wantSentinel: llm.ErrAuth,
+		},
+		{
+			name:         "sdk init rate limit",
+			sdkInitErr:   fmt.Errorf("Error 429, Message: Resource exhausted."),
+			wantSentinel: llm.ErrRateLimit,
+		},
+		{
+			name:         "sdk init unavailable",
+			sdkInitErr:   fmt.Errorf("Error 503, Message: The server encountered a temporary error."),
+			wantSentinel: llm.ErrTransient,
+		},
+		{
+			name:         "sdk init bad request",
+			sdkInitErr:   fmt.Errorf("Error 400, Message: Invalid request."),
+			wantSentinel: llm.ErrTerminal,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Client{
+				apiURL:        "https://us-central1-aiplatform.googleapis.com/v1/projects/p/locations/l/publishers/google/models",
+				model:         "test-model",
+				authenticator: &stubAuthenticator{token: "test"},
+				logger:        &ports.NoOpLogger{},
+				timeout:       5 * time.Second,
+				newGenaiClient: func(ctx context.Context, cfg *genai.ClientConfig) (*genai.Client, error) {
+					return nil, tt.sdkInitErr
+				},
+			}
+
+			err := c.initSDK(5 * time.Second)
+			if err == nil {
+				t.Fatal("expected initSDK error, got nil")
+			}
+			classified := c.classifyError(err)
+			if !errors.Is(classified, tt.wantSentinel) {
+				t.Errorf("expected error wrapping %v, got: %v", tt.wantSentinel, classified)
+			}
+		})
 	}
 }

--- a/internal/infrastructure/llm/openai/client_chat_test.go
+++ b/internal/infrastructure/llm/openai/client_chat_test.go
@@ -403,53 +403,123 @@ func TestDeepSeekHistoryWithToolCalls(t *testing.T) {
 	}
 }
 
-func TestSendChat_Errors(t *testing.T) {
-	tests := []struct {
-		name          string
-		status        int
-		response      string
-		expectedError string
-		isAPIError    bool
-	}{
+func TestSendChat_ErrorHandling(t *testing.T) {
+	type testCase struct {
+		name               string
+		statusCode         int
+		responseBody       string
+		wantAPIErrorStatus int   // 0 means error is NOT an *llmerr.APIError
+		wantSentinel       error // nil means skip Classify assertion
+		wantErrContains    string
+	}
+
+	tests := []testCase{
+		// ── Dimension 1: HTTP status codes ──────────────────────────
 		{
-			name:          "401 Unauthorized",
-			status:        http.StatusUnauthorized,
-			response:      `{"error": {"message": "Invalid API key", "type": "invalid_request_error"}}`,
-			expectedError: "api error (status 401)",
-			isAPIError:    true,
+			name:               "400_bad_request",
+			statusCode:         400,
+			responseBody:       `{"error":{"message":"Invalid request","type":"invalid_request_error"}}`,
+			wantAPIErrorStatus: 400,
+			wantSentinel:       llm.ErrTerminal,
+			wantErrContains:    "api error (status 400)",
 		},
 		{
-			name:          "429 Rate Limit",
-			status:        http.StatusTooManyRequests,
-			response:      `{"error": {"message": "Rate limit reached", "type": "requests"}}`,
-			expectedError: "api error (status 429)",
-			isAPIError:    true,
+			name:               "401_unauthorized",
+			statusCode:         401,
+			responseBody:       `{"error":{"message":"Invalid API key","type":"invalid_request_error"}}`,
+			wantAPIErrorStatus: 401,
+			wantSentinel:       llm.ErrAuth,
+			wantErrContains:    "api error (status 401)",
 		},
 		{
-			name:          "Malformed JSON",
-			status:        http.StatusOK,
-			response:      `{ "choices": [ { "mess...`,
-			expectedError: "failed to decode response",
+			name:               "403_forbidden",
+			statusCode:         403,
+			responseBody:       `{"error":{"message":"Access denied","type":"permission_error"}}`,
+			wantAPIErrorStatus: 403,
+			wantSentinel:       llm.ErrTerminal,
+			wantErrContains:    "api error (status 403)",
 		},
 		{
-			name:          "Empty Choices",
-			status:        http.StatusOK,
-			response:      `{"choices": [], "usage": {"total_tokens": 0}}`,
-			expectedError: "no choices returned from api",
+			name:               "408_timeout",
+			statusCode:         408,
+			responseBody:       `{"error":{"message":"Request timeout","type":"timeout_error"}}`,
+			wantAPIErrorStatus: 408,
+			wantSentinel:       llm.ErrTransient,
+			wantErrContains:    "api error (status 408)",
 		},
 		{
-			name:          "Tool Call with Invalid Arguments JSON",
-			status:        http.StatusOK,
-			response:      `{"choices": [{"message": {"role": "assistant", "tool_calls": [{"id": "call_1", "type": "function", "function": {"name": "test_tool", "arguments": "{broken json"}}]}, "content": "ok"}], "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}}`,
-			expectedError: "failed to unmarshal tool arguments",
+			name:               "429_rate_limit",
+			statusCode:         429,
+			responseBody:       `{"error":{"message":"Rate limit reached","type":"rate_limit_error"}}`,
+			wantAPIErrorStatus: 429,
+			wantSentinel:       llm.ErrRateLimit,
+			wantErrContains:    "api error (status 429)",
+		},
+		{
+			name:               "499_client_closed",
+			statusCode:         499,
+			responseBody:       `{"error":{"message":"Client closed request","type":"cancelled"}}`,
+			wantAPIErrorStatus: 499,
+			wantSentinel:       llm.ErrTransient,
+			wantErrContains:    "api error (status 499)",
+		},
+		{
+			name:               "500_internal",
+			statusCode:         500,
+			responseBody:       `{"error":{"message":"Internal server error","type":"server_error"}}`,
+			wantAPIErrorStatus: 500,
+			wantSentinel:       llm.ErrTransient,
+			wantErrContains:    "api error (status 500)",
+		},
+		{
+			name:               "502_bad_gateway",
+			statusCode:         502,
+			responseBody:       `{"error":{"message":"Bad gateway","type":"server_error"}}`,
+			wantAPIErrorStatus: 502,
+			wantSentinel:       llm.ErrTransient,
+			wantErrContains:    "api error (status 502)",
+		},
+		{
+			name:               "503_unavailable",
+			statusCode:         503,
+			responseBody:       `{"error":{"message":"Service unavailable","type":"server_error"}}`,
+			wantAPIErrorStatus: 503,
+			wantSentinel:       llm.ErrTransient,
+			wantErrContains:    "api error (status 503)",
+		},
+
+		// ── Dimension 2: Malformed / edge response bodies ──────────
+		{
+			name:            "malformed_json",
+			statusCode:      200,
+			responseBody:    `{"choices": [{"mess...`,
+			wantErrContains: "failed to decode response",
+			// not an APIError (200 with broken body → decode failure)
+		},
+		{
+			name:            "empty_choices",
+			statusCode:      200,
+			responseBody:    `{"choices":[],"usage":{"total_tokens":0}}`,
+			wantErrContains: "no choices returned from api",
+			// not an APIError (valid 200 but empty choices)
+		},
+
+		// ── Dimension 3: Tool call error path ──────────────────────
+		{
+			name:            "tool_call_invalid_args",
+			statusCode:      200,
+			responseBody:    `{"choices":[{"message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"test_tool","arguments":"{broken json"}}]},"content":"ok"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`,
+			wantErrContains: "failed to unmarshal tool arguments",
+			// not an APIError (valid 200 but broken tool args)
 		},
 	}
 
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tt.status)
-				_, _ = w.Write([]byte(tt.response))
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.responseBody))
 			}))
 			defer server.Close()
 
@@ -460,20 +530,77 @@ func TestSendChat_Errors(t *testing.T) {
 				t.Fatal("expected error, got nil")
 			}
 
-			if !strings.Contains(err.Error(), tt.expectedError) {
-				t.Errorf("expected error containing %q, got %q", tt.expectedError, err.Error())
+			// Assertion A: error message contains expected substring
+			if !strings.Contains(err.Error(), tt.wantErrContains) {
+				t.Errorf("expected error containing %q, got %q", tt.wantErrContains, err.Error())
 			}
 
-			if tt.isAPIError {
+			// Assertion B: APIError type + status (only for status-code rows)
+			if tt.wantAPIErrorStatus != 0 {
 				var apiErr *llmerr.APIError
 				if !errors.As(err, &apiErr) {
-					t.Errorf("expected llmerr.APIError, got %T", err)
-				} else if apiErr.Status != tt.status {
-					t.Errorf("expected status %d, got %d", tt.status, apiErr.Status)
+					t.Fatalf("expected *llmerr.APIError, got %T", err)
+				}
+				if apiErr.Status != tt.wantAPIErrorStatus {
+					t.Errorf("status: got %d, want %d", apiErr.Status, tt.wantAPIErrorStatus)
+				}
+
+				// Assertion C: Classify maps to the correct domain sentinel
+				if tt.wantSentinel != nil {
+					classified := llmerr.Classify(apiErr)
+					if !errors.Is(classified, tt.wantSentinel) {
+						t.Errorf("Classify: got %v, want %v", classified, tt.wantSentinel)
+					}
 				}
 			}
 		})
 	}
+
+	// ── Response body variants for HTTP 500 ───────────────────────
+	t.Run("500_responseBodyVariant", func(t *testing.T) {
+		variants := []struct {
+			name string
+			body string
+		}{
+			{"empty_body", ""},
+			{"non_json_body", "<html>Internal Server Error</html>"},
+		}
+
+		for _, v := range variants {
+			v := v
+			t.Run(v.name, func(t *testing.T) {
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(http.StatusInternalServerError)
+					if v.body != "" {
+						_, _ = w.Write([]byte(v.body))
+					}
+				}))
+				defer server.Close()
+
+				client := NewClient(server.URL, "gpt-4", &auth.BearerAuth{Token: "key"})
+				_, _, err := client.SendChat(context.Background(), nil, nil, nil)
+
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+
+				// Must still be an APIError
+				var apiErr *llmerr.APIError
+				if !errors.As(err, &apiErr) {
+					t.Fatalf("expected *llmerr.APIError, got %T", err)
+				}
+				if apiErr.Status != 500 {
+					t.Errorf("status: got %d, want 500", apiErr.Status)
+				}
+
+				// Classify must map to ErrTransient
+				classified := llmerr.Classify(apiErr)
+				if !errors.Is(classified, llm.ErrTransient) {
+					t.Errorf("Classify: got %v, want %v", classified, llm.ErrTransient)
+				}
+			})
+		}
+	})
 }
 
 func TestSendChat_EmptyToolResponseID(t *testing.T) {


### PR DESCRIPTION
Closes #873.

## Summary
Establishes comprehensive table-driven error-handling test coverage across all three LLM provider clients (~30 gaps covered):

| Provider | Test Function | Cases |
|----------|--------------|-------|
| **OpenAI** | `TestSendChat_ErrorHandling` | 14 scenarios across 4 dimensions |
| **Anthropic** | `TestSendChat_ErrorHandling` | 16 scenarios across 4 dimensions |
| **Gemini** | `TestSendChat_ClassifyError_Integration` + `TestClassifyError` + `TestSendChat_SDKError_Direct` | 26 cases total |

Every status-code row verifies the full `SendChat → APIError → llmerr.Classify → domain sentinel` chain.

Canonical pattern documented in `internal/infrastructure/llm/ERROR_TEST_PATTERN.md` for reuse in follow-up distributed error-handling work.

## Verification
| Check | Status |
|-------|--------|
| go fmt ./... | PASS |
| go mod tidy | PASS |
| go build ./... | PASS |
| golangci-lint | 0 issues |
| go test ./internal/infrastructure/llm/... | PASS (5 packages) |
| go test -race ./internal/infrastructure/llm/... | PASS |
| govulncheck | No vulnerabilities |