### PR TITLE
fix(test): decompose top-3 high-complexity test functions (#874)

### DIFF
--- a/internal/agent/executor/executor_chaos_test.go
+++ b/internal/agent/executor/executor_chaos_test.go
@@ -199,6 +199,26 @@ func assertNoErrorResult(t *testing.T, results []tools.ToolResult) {
 	}
 }
 
+// assertLogHasPanicAttr verifies that the capturingLogger recorded a "panic" key
+// with a value containing the expected substring (key-value pair convention).
+func assertLogHasPanicAttr(t *testing.T, log *capturingLogger, wantContain string) {
+	t.Helper()
+	var foundPanicAttr bool
+	for i := 0; i < len(log.lastArgs)-1; i += 2 {
+		key, ok := log.lastArgs[i].(string)
+		if !ok {
+			continue
+		}
+		if key == "panic" {
+			foundPanicAttr = true
+			valStr := fmt.Sprintf("%v", log.lastArgs[i+1])
+			assert.Contains(t, valStr, wantContain,
+				"logger 'panic' attribute must contain the panic value")
+		}
+	}
+	assert.True(t, foundPanicAttr, "logger attributes must include 'panic' key")
+}
+
 // TestExecuteParallelBatch_FanInPanic_Propagates verifies that a panic in the
 // fan-in wait goroutine (e.g. a corrupted sync.WaitGroup causing wg.Wait() to panic)
 // is propagated as an error through the results channel and surfaced to the caller
@@ -245,29 +265,15 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 			results = append(results, res)
 		}
 
-		if len(results) != 1 {
-			t.Fatalf("expected exactly 1 result from fan-in panic, got %d", len(results))
-		}
+		require.Len(t, results, 1, "expected exactly 1 result from fan-in panic")
 
 		res := results[0]
-		if res.index != -1 {
-			t.Errorf("expected index -1 sentinel, got %d", res.index)
-		}
-		if res.name != "fan_in_panic" {
-			t.Errorf("expected name 'fan_in_panic', got %q", res.name)
-		}
-		if res.tr.Error == nil {
-			t.Fatal("expected error in ToolResult, got nil")
-		}
-		if !errors.Is(res.tr.Error, llm.ErrTerminal) {
-			t.Errorf("expected error wrapped in ErrTerminal, got: %v", res.tr.Error)
-		}
-		if !strings.Contains(res.tr.Error.Error(), "simulated wg.Wait corruption") {
-			t.Errorf("expected error to contain panic text, got: %v", res.tr.Error)
-		}
-		if !strings.Contains(res.tr.Text, "fan-in panic") {
-			t.Errorf("expected Text to contain 'fan-in panic', got: %q", res.tr.Text)
-		}
+		assert.Equal(t, -1, res.index, "expected index -1 sentinel")
+		assert.Equal(t, "fan_in_panic", res.name)
+		require.Error(t, res.tr.Error, "expected error in ToolResult")
+		assert.True(t, errors.Is(res.tr.Error, llm.ErrTerminal), "expected error wrapped in ErrTerminal")
+		assert.Contains(t, res.tr.Error.Error(), "simulated wg.Wait corruption")
+		assert.Contains(t, res.tr.Text, "fan-in panic")
 	})
 
 	t.Run("parallel worker panic propagates through runExecutionPlan", func(t *testing.T) {
@@ -319,20 +325,11 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 		// NOT promoted to plan-level Go errors. runExecutionPlan returns nil.
 		require.NoError(t, err, "runExecutionPlan must return nil — panics are recovered and stored in results[]")
 
-		// Verify safe tools still completed.
-		if results[0].Text != "safe_result" {
-			t.Errorf("safe_tool result: got %q, want 'safe_result'", results[0].Text)
-		}
-		if results[2].Text != "safe_result" {
-			t.Errorf("another_safe_tool result: got %q, want 'safe_result'", results[2].Text)
-		}
+		assert.Equal(t, "safe_result", results[0].Text)
+		assert.Equal(t, "safe_result", results[2].Text)
 
-		// Verify crash_tool result has the panic error.
-		if results[1].Error == nil {
-			t.Error("crash_tool should have an error result")
-		} else if !strings.Contains(results[1].Error.Error(), "simulated nil pointer dereference") {
-			t.Errorf("crash_tool error: got %v, want panic text", results[1].Error)
-		}
+		require.Error(t, results[1].Error, "crash_tool should have an error result")
+		assert.Contains(t, results[1].Error.Error(), "simulated nil pointer dereference")
 	})
 
 	t.Run("fan_in_no_panic_resultsCh_closed_cleanly", func(t *testing.T) {
@@ -459,7 +456,7 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 
 		require.NotNil(t, sentinel, "expected at least one sentinel result with index == -1")
 		assert.Equal(t, "fan_in_panic", sentinel.name)
-		assert.Error(t, sentinel.tr.Error)
+		require.Error(t, sentinel.tr.Error)
 		assert.True(t, errors.Is(sentinel.tr.Error, llm.ErrTerminal),
 			"sentinel error must wrap ErrTerminal")
 		assert.Contains(t, sentinel.tr.Error.Error(), "fan-in panic")
@@ -469,21 +466,6 @@ func TestExecuteParallelBatch_FanInPanic_Propagates(t *testing.T) {
 		// Verify the logger captured the panic.
 		assert.True(t, log.errorCalled, "logger.Error must have been called")
 		assert.Equal(t, "panic in fan-in wait goroutine", log.lastMsg)
-
-		// Verify logger attributes include "panic" key with the panic value.
-		var foundPanicAttr bool
-		for i := 0; i < len(log.lastArgs)-1; i += 2 {
-			key, ok := log.lastArgs[i].(string)
-			if !ok {
-				continue
-			}
-			if key == "panic" {
-				foundPanicAttr = true
-				valStr := fmt.Sprintf("%v", log.lastArgs[i+1])
-				assert.Contains(t, valStr, "simulated WaitGroup corruption",
-					"logger 'panic' attribute must contain the panic value")
-			}
-		}
-		assert.True(t, foundPanicAttr, "logger attributes must include 'panic' key")
+		assertLogHasPanicAttr(t, log, "simulated WaitGroup corruption")
 	})
 }

--- a/internal/infrastructure/llm/anthropic/client_messages_test.go
+++ b/internal/infrastructure/llm/anthropic/client_messages_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
@@ -470,18 +473,12 @@ func TestConvertParts_ThinkingRole(t *testing.T) {
 			{Text: "visible"},
 		}
 		blocks, err := c.convertParts(parts, "user")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(blocks) != 2 {
-			t.Fatalf("expected 2 blocks (thought becomes text for non-assistant), got %d", len(blocks))
-		}
-		if blocks[0].Type != "text" || blocks[0].Text != "think" {
-			t.Errorf("expected first block to be text block 'think', got type=%q text=%q", blocks[0].Type, blocks[0].Text)
-		}
-		if blocks[1].Type != "text" || blocks[1].Text != "visible" {
-			t.Errorf("expected second block to be text block 'visible', got type=%q text=%q", blocks[1].Type, blocks[1].Text)
-		}
+		require.NoError(t, err)
+		require.Len(t, blocks, 2, "thought becomes text for non-assistant")
+		assert.Equal(t, "text", blocks[0].Type)
+		assert.Equal(t, "think", blocks[0].Text)
+		assert.Equal(t, "text", blocks[1].Type)
+		assert.Equal(t, "visible", blocks[1].Text)
 	})
 
 	t.Run("thinking parts kept for assistant role", func(t *testing.T) {
@@ -490,15 +487,9 @@ func TestConvertParts_ThinkingRole(t *testing.T) {
 			{Text: "visible"},
 		}
 		blocks, err := c.convertParts(parts, "assistant")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(blocks) != 2 {
-			t.Fatalf("expected 2 blocks, got %d", len(blocks))
-		}
-		if blocks[0].Type != "thinking" {
-			t.Errorf("expected first block type 'thinking', got %q", blocks[0].Type)
-		}
+		require.NoError(t, err)
+		require.Len(t, blocks, 2)
+		assert.Equal(t, "thinking", blocks[0].Type)
 	})
 
 	t.Run("unsigned thinking parts stripped for assistant role", func(t *testing.T) {
@@ -507,15 +498,10 @@ func TestConvertParts_ThinkingRole(t *testing.T) {
 			{Text: "visible"},
 		}
 		blocks, err := c.convertParts(parts, "assistant")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(blocks) != 1 {
-			t.Fatalf("expected 1 block (thought stripped), got %d", len(blocks))
-		}
-		if blocks[0].Type != "text" || blocks[0].Text != "visible" {
-			t.Errorf("expected only text block 'visible', got type=%q text=%q", blocks[0].Type, blocks[0].Text)
-		}
+		require.NoError(t, err)
+		require.Len(t, blocks, 1, "unsigned thought should be stripped")
+		assert.Equal(t, "text", blocks[0].Type)
+		assert.Equal(t, "visible", blocks[0].Text)
 	})
 
 	t.Run("empty-text thinking parts stripped for assistant role", func(t *testing.T) {
@@ -527,14 +513,9 @@ func TestConvertParts_ThinkingRole(t *testing.T) {
 			{Text: "visible"},
 		}
 		blocks, err := c.convertParts(parts, "assistant")
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if len(blocks) != 1 {
-			t.Fatalf("expected 1 block (empty thought stripped), got %d", len(blocks))
-		}
-		if blocks[0].Type != "text" || blocks[0].Text != "visible" {
-			t.Errorf("expected only text block 'visible', got type=%q text=%q", blocks[0].Type, blocks[0].Text)
-		}
+		require.NoError(t, err)
+		require.Len(t, blocks, 1, "empty thought should be stripped")
+		assert.Equal(t, "text", blocks[0].Type)
+		assert.Equal(t, "visible", blocks[0].Text)
 	})
 }

--- a/internal/tools/integrations/ado/policy_test.go
+++ b/internal/tools/integrations/ado/policy_test.go
@@ -18,256 +18,151 @@ import (
 func TestFormatBranchPolicies(t *testing.T) {
 	m := &AdoManager{}
 
-	tests := []struct {
-		name           string
-		branchName     string
-		repositoryName string
-		policyConfigs  []adoPolicyConfig
-		targetRepoId   string
-		assertFn       func(t *testing.T, result string)
-	}{
-		{
-			name:           "empty configs",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs:  []adoPolicyConfig{},
-			targetRepoId:   "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, "No active policies found") {
-					t.Errorf("expected 'No active policies found', got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "disabled config",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  false,
-					IsBlocking: true,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, "No active policies found") {
-					t.Errorf("expected 'No active policies found', got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "non-matching branch",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/develop"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, "No active policies found") {
-					t.Errorf("expected 'No active policies found', got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "single enabled matching",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, "- Type: Build") {
-					t.Errorf("expected '- Type: Build', got: %s", result)
-				}
-				if !strings.Contains(result, "Status: Enabled") {
-					t.Errorf("expected 'Status: Enabled', got: %s", result)
-				}
-				if !strings.Contains(result, "Branch Policies for main in myrepo") {
-					t.Errorf("expected header, got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "blocking policy",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: true,
-					Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, " [REQUIRED]") {
-					t.Errorf("expected ' [REQUIRED]' in output, got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "non-blocking policy",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if strings.Contains(result, "[REQUIRED]") {
-					t.Errorf("did NOT expect '[REQUIRED]' in output, got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "branch name normalization",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				// The function should internally normalize "main" to "refs/heads/main"
-				if !strings.Contains(result, "- Type: Build") {
-					t.Errorf("expected policy to match after branch normalization, got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "branch already has refs/heads prefix",
-			branchName:     "refs/heads/main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if !strings.Contains(result, "- Type: Build") {
-					t.Errorf("expected policy to match with full ref, got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "settings with scope key skipped",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings: map[string]interface{}{
-						"scope": []interface{}{
-							map[string]interface{}{"repositoryId": "repo-guid", "refName": "refs/heads/main"},
-						},
-						"minimumApproverCount": float64(2),
-						"buildDefinitionId":    float64(42),
-					},
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if strings.Contains(result, "scope:") || strings.Contains(result, "Scope:") {
-					t.Errorf("expected 'scope' to be skipped in settings output, got: %s", result)
-				}
-				if !strings.Contains(result, "Minimum Approver Count: 2") {
-					t.Errorf("expected 'Minimum Approver Count: 2', got: %s", result)
-				}
-				if !strings.Contains(result, "Build Definition ID: 42") {
-					t.Errorf("expected 'Build Definition ID: 42', got: %s", result)
-				}
-			},
-		},
-		{
-			name:           "multiple policies mixed",
-			branchName:     "main",
-			repositoryName: "myrepo",
-			policyConfigs: []adoPolicyConfig{
-				{
-					IsEnabled:  false, // disabled - should be skipped
-					IsBlocking: true,
-					Type:       adoPolicyType{DisplayName: "DisabledPolicy"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-				{
-					IsEnabled:  true,
-					IsBlocking: true,
-					Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "Build"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
-				},
-				{
-					IsEnabled:  true,
-					IsBlocking: false,
-					Type:       adoPolicyType{DisplayName: "WrongBranch"},
-					Settings:   newMatchingScope("repo-guid", "refs/heads/develop"),
-				},
-			},
-			targetRepoId: "repo-guid",
-			assertFn: func(t *testing.T, result string) {
-				if strings.Contains(result, "DisabledPolicy") {
-					t.Errorf("disabled policy should not appear, got: %s", result)
-				}
-				if strings.Contains(result, "WrongBranch") {
-					t.Errorf("non-matching branch policy should not appear, got: %s", result)
-				}
-				if !strings.Contains(result, "RequiredReviewer") {
-					t.Errorf("expected RequiredReviewer in output, got: %s", result)
-				}
-				if !strings.Contains(result, "Build") {
-					t.Errorf("expected Build in output, got: %s", result)
-				}
-				// Count policy blocks: each policy has "- Type:" line
-				count := strings.Count(result, "- Type:")
-				if count != 2 {
-					t.Errorf("expected 2 policy blocks, got %d: %s", count, result)
-				}
-			},
-		},
-	}
+	t.Run("empty configs", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{}, "repo-guid")
+		assert.Contains(t, result, "No active policies found")
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := m.formatBranchPolicies(tt.branchName, tt.repositoryName, tt.policyConfigs, tt.targetRepoId)
-			tt.assertFn(t, result)
-		})
-	}
+	t.Run("disabled config", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  false,
+				IsBlocking: true,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, "No active policies found")
+	})
+
+	t.Run("non-matching branch", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/develop"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, "No active policies found")
+	})
+
+	t.Run("single enabled matching", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, "- Type: Build")
+		assert.Contains(t, result, "Status: Enabled")
+		assert.Contains(t, result, "Branch Policies for main in myrepo")
+	})
+
+	t.Run("blocking policy", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: true,
+				Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, " [REQUIRED]")
+	})
+
+	t.Run("non-blocking policy", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.NotContains(t, result, "[REQUIRED]")
+	})
+
+	t.Run("branch name normalization", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, "- Type: Build")
+	})
+
+	t.Run("branch already has refs/heads prefix", func(t *testing.T) {
+		result := m.formatBranchPolicies("refs/heads/main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+		}, "repo-guid")
+		assert.Contains(t, result, "- Type: Build")
+	})
+
+	t.Run("settings with scope key skipped", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings: map[string]interface{}{
+					"scope": []interface{}{
+						map[string]interface{}{"repositoryId": "repo-guid", "refName": "refs/heads/main"},
+					},
+					"minimumApproverCount": float64(2),
+					"buildDefinitionId":    float64(42),
+				},
+			},
+		}, "repo-guid")
+		assert.NotContains(t, result, "scope:")
+		assert.NotContains(t, result, "Scope:")
+		assert.Contains(t, result, "Minimum Approver Count: 2")
+		assert.Contains(t, result, "Build Definition ID: 42")
+	})
+
+	t.Run("multiple policies mixed", func(t *testing.T) {
+		result := m.formatBranchPolicies("main", "myrepo", []adoPolicyConfig{
+			{
+				IsEnabled:  false,
+				IsBlocking: true,
+				Type:       adoPolicyType{DisplayName: "DisabledPolicy"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+			{
+				IsEnabled:  true,
+				IsBlocking: true,
+				Type:       adoPolicyType{DisplayName: "RequiredReviewer"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "Build"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/main"),
+			},
+			{
+				IsEnabled:  true,
+				IsBlocking: false,
+				Type:       adoPolicyType{DisplayName: "WrongBranch"},
+				Settings:   newMatchingScope("repo-guid", "refs/heads/develop"),
+			},
+		}, "repo-guid")
+		assert.NotContains(t, result, "DisabledPolicy")
+		assert.NotContains(t, result, "WrongBranch")
+		assert.Contains(t, result, "RequiredReviewer")
+		assert.Contains(t, result, "Build")
+		assert.Equal(t, 2, strings.Count(result, "- Type:"))
+	})
 }
 
 // newMatchingScope creates a Settings map with a scope entry matching the given repoId and refName.


### PR DESCRIPTION
Closes #874.

## Summary
Replaced manual if/else assertion branches in the three highest-complexity test functions with testify require/assert calls. Pure test refactor — zero production code changes.

| Function | Before | After |
|----------|--------|-------|
| `TestFormatBranchPolicies` | **21** | **1** |
| `TestConvertParts_ThinkingRole` | **18** | **1** |
| `TestExecuteParallelBatch_FanInPanic_Propagates` | **22** | **8** |

All assertions preserved 1:1. Subtest names unchanged.

## Verification
| Check | Status |
|-------|--------|
| make check-full (all 10 steps) | ✅ PASS |
| golangci-lint | ✅ CLEAN (0 issues) |
| Race detection | ✅ PASS |
| All existing assertions preserved | ✅ Yes |