### PR TITLE
fix(analysis): decompose getSymbolIdentity to reduce complexity (#880)

### DIFF
--- a/internal/tools/analysis/utils.go
+++ b/internal/tools/analysis/utils.go
@@ -18,6 +18,73 @@ func sanitize(name string) string {
 	}, name)
 }
 
+// isMethod reports whether obj is a *types.Func with a signature that has a receiver.
+func isMethod(obj types.Object) bool {
+	fn, ok := obj.(*types.Func)
+	if !ok {
+		return false
+	}
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return false
+	}
+	return sig.Recv() != nil
+}
+
+// derefPointer unwraps a *types.Pointer to its element type.
+// If t is not a pointer, it returns t unchanged.
+// If t is nil, it returns nil.
+func derefPointer(t types.Type) types.Type {
+	if ptr, ok := t.(*types.Pointer); ok {
+		return ptr.Elem()
+	}
+	return t
+}
+
+// extractTypeName resolves a receiver type to a human-readable name.
+// It handles *types.Named, *types.TypeParam, and a fallback that
+// strips the package path prefix from the type's string representation.
+func extractTypeName(recvType types.Type, pkgPath string) string {
+	if named, ok := recvType.(*types.Named); ok {
+		return named.Obj().Name()
+	}
+	if tp, ok := recvType.(*types.TypeParam); ok {
+		return tp.Obj().Name()
+	}
+	// Handle other types if necessary, but named is most common for methods
+	return strings.TrimPrefix(recvType.String(), pkgPath+".")
+}
+
+// stripGenerics removes generic type parameters like [T] from a type name.
+// For example, "MyType[T]" becomes "MyType".
+// If no bracket is found, the name is returned unchanged.
+func stripGenerics(name string) string {
+	if idx := strings.Index(name, "["); idx != -1 {
+		return name[:idx]
+	}
+	return name
+}
+
+// formatMethodIdentity builds the canonical identity string for a method:
+//
+//	pkgPath.TypeName.MethodName
+//
+// It dereferences the receiver, extracts the type name, and strips
+// generic parameters for stability. If fn.Type() is not a *types.Signature,
+// it falls back to pkgPath.FuncName (defensive — should not happen when
+// called from getSymbolIdentity after isMethod returns true).
+func formatMethodIdentity(pkgPath string, fn *types.Func) string {
+	sig, ok := fn.Type().(*types.Signature)
+	if !ok {
+		return fmt.Sprintf("%s.%s", pkgPath, fn.Name())
+	}
+	recvType := sig.Recv().Type()
+	recvType = derefPointer(recvType)
+	typeName := extractTypeName(recvType, pkgPath)
+	typeName = stripGenerics(typeName)
+	return fmt.Sprintf("%s.%s.%s", pkgPath, typeName, fn.Name())
+}
+
 // getSymbolIdentity creates a stable string representation for a Go symbol.
 func getSymbolIdentity(obj types.Object) string {
 	if obj == nil {
@@ -27,35 +94,8 @@ func getSymbolIdentity(obj types.Object) string {
 		return obj.Name()
 	}
 	pkgPath := getBasePkgPath(obj.Pkg().Path())
-
-	if fn, ok := obj.(*types.Func); ok {
-		sig, ok := fn.Type().(*types.Signature)
-		if !ok {
-			return fmt.Sprintf("%s.%s", pkgPath, obj.Name())
-		}
-		if sig.Recv() != nil {
-			recvType := sig.Recv().Type()
-			if ptr, ok := recvType.(*types.Pointer); ok {
-				recvType = ptr.Elem()
-			}
-
-			var typeName string
-			if named, ok := recvType.(*types.Named); ok {
-				typeName = named.Obj().Name()
-			} else if tp, ok := recvType.(*types.TypeParam); ok {
-				typeName = tp.Obj().Name()
-			} else {
-				// Handle other types if necessary, but named is most common for methods
-				typeName = strings.TrimPrefix(recvType.String(), pkgPath+".")
-			}
-
-			// Strip generic type parameters like [T] from the identity for stability
-			if idx := strings.Index(typeName, "["); idx != -1 {
-				typeName = typeName[:idx]
-			}
-
-			return fmt.Sprintf("%s.%s.%s", pkgPath, typeName, obj.Name())
-		}
+	if isMethod(obj) {
+		return formatMethodIdentity(pkgPath, obj.(*types.Func))
 	}
 	return fmt.Sprintf("%s.%s", pkgPath, obj.Name())
 }

--- a/internal/tools/analysis/utils_test.go
+++ b/internal/tools/analysis/utils_test.go
@@ -141,3 +141,221 @@ func TestGetBasePkgPath(t *testing.T) {
 		}
 	}
 }
+
+func TestIsMethod_NilObj(t *testing.T) {
+	if isMethod(nil) {
+		t.Error("isMethod(nil) = true, want false")
+	}
+}
+
+func TestIsMethod_VarNotFunc(t *testing.T) {
+	obj := types.NewVar(token.NoPos, nil, "x", types.Typ[types.Int])
+	if isMethod(obj) {
+		t.Error("isMethod(var) = true, want false")
+	}
+}
+
+func TestIsMethod_FuncNoReceiver(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "PlainFunc", sig)
+	if isMethod(fn) {
+		t.Error("isMethod(func without receiver) = true, want false")
+	}
+}
+
+func TestIsMethod_FuncWithReceiver(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	typeName := types.NewTypeName(token.NoPos, pkg, "MyType", nil)
+	named := types.NewNamed(typeName, types.NewStruct(nil, nil), nil)
+	ptr := types.NewPointer(named)
+	recv := types.NewVar(token.NoPos, nil, "", ptr)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "Method", sig)
+	if !isMethod(fn) {
+		t.Error("isMethod(func with receiver) = false, want true")
+	}
+}
+
+func TestIsMethod_NonSignatureFunc(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	fn := types.NewFunc(token.NoPos, pkg, "BadFunc", nil) // nil type means !ok on signature assertion
+	if isMethod(fn) {
+		t.Error("isMethod(func with nil type) = true, want false")
+	}
+}
+
+func TestDerefPointer_Nil(t *testing.T) {
+	got := derefPointer(nil)
+	if got != nil {
+		t.Errorf("derefPointer(nil) = %v, want nil", got)
+	}
+}
+
+func TestDerefPointer_UnwrapsPointer(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	typeName := types.NewTypeName(token.NoPos, pkg, "MyType", nil)
+	named := types.NewNamed(typeName, types.NewStruct(nil, nil), nil)
+	ptr := types.NewPointer(named)
+
+	got := derefPointer(ptr)
+	if got != named {
+		t.Errorf("derefPointer(*MyType) = %v, want MyType", got)
+	}
+}
+
+func TestDerefPointer_NonPointerPassesThrough(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	typeName := types.NewTypeName(token.NoPos, pkg, "MyType", nil)
+	named := types.NewNamed(typeName, types.NewStruct(nil, nil), nil)
+
+	got := derefPointer(named)
+	if got != named {
+		t.Errorf("derefPointer(MyType) = %v, want MyType unchanged", got)
+	}
+}
+
+func TestDerefPointer_BasicTypePassesThrough(t *testing.T) {
+	intType := types.Typ[types.Int]
+	got := derefPointer(intType)
+	if got != intType {
+		t.Errorf("derefPointer(int) = %v, want int unchanged", got)
+	}
+}
+
+func TestExtractTypeName_NamedType(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	typeName := types.NewTypeName(token.NoPos, pkg, "MyType", nil)
+	named := types.NewNamed(typeName, types.NewStruct(nil, nil), nil)
+
+	got := extractTypeName(named, "example.com/mypkg")
+	if got != "MyType" {
+		t.Errorf("extractTypeName(MyType) = %q, want %q", got, "MyType")
+	}
+}
+
+func TestExtractTypeName_TypeParam(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	tParamName := types.NewTypeName(token.NoPos, pkg, "T", nil)
+	tParam := types.NewTypeParam(tParamName, nil)
+
+	got := extractTypeName(tParam, "example.com/mypkg")
+	if got != "T" {
+		t.Errorf("extractTypeName(T) = %q, want %q", got, "T")
+	}
+}
+
+func TestExtractTypeName_BasicTypeFallback(t *testing.T) {
+	// A basic type like int — not valid Go for a method receiver but
+	// type-system legal. Should fall through to the TrimPrefix path.
+	intType := types.Typ[types.Int]
+	got := extractTypeName(intType, "example.com/mypkg")
+	// TrimPrefix("int", "example.com/mypkg.") → "int" (no change)
+	if got != "int" {
+		t.Errorf("extractTypeName(int) = %q, want %q", got, "int")
+	}
+}
+
+func TestExtractTypeName_ArrayTypeFallback(t *testing.T) {
+	// Array type [3]int — String() is "[3]int".
+	// TrimPrefix("[3]int", "example.com/mypkg.") → "[3]int" (no change)
+	// (Bracket stripping is handled separately by the caller.)
+	arrType := types.NewArray(types.Typ[types.Int], 3)
+	got := extractTypeName(arrType, "example.com/mypkg")
+	if got != "[3]int" {
+		t.Errorf("extractTypeName([3]int) = %q, want %q", got, "[3]int")
+	}
+}
+
+func TestStripGenerics(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"MyType[T]", "MyType"},
+		{"MyType[T, U]", "MyType"},
+		{"MyType", "MyType"},
+		{"", ""},
+		{"[3]int", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := stripGenerics(tt.input)
+			if got != tt.want {
+				t.Errorf("stripGenerics(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatMethodIdentity_NamedReceiver(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	typeName := types.NewTypeName(token.NoPos, pkg, "MyType", nil)
+	named := types.NewNamed(typeName, types.NewStruct(nil, nil), nil)
+	ptr := types.NewPointer(named)
+	recv := types.NewVar(token.NoPos, nil, "", ptr)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "Method", sig)
+
+	got := formatMethodIdentity("example.com/mypkg", fn)
+	want := "example.com/mypkg.MyType.Method"
+	if got != want {
+		t.Errorf("formatMethodIdentity = %q, want %q", got, want)
+	}
+}
+
+func TestFormatMethodIdentity_TypeParamReceiver(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	tParamName := types.NewTypeName(token.NoPos, pkg, "T", nil)
+	tParam := types.NewTypeParam(tParamName, nil)
+	recv := types.NewVar(token.NoPos, nil, "", tParam)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "Method", sig)
+
+	got := formatMethodIdentity("example.com/mypkg", fn)
+	want := "example.com/mypkg.T.Method"
+	if got != want {
+		t.Errorf("formatMethodIdentity = %q, want %q", got, want)
+	}
+}
+
+func TestFormatMethodIdentity_NonSignatureFallback(t *testing.T) {
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	fn := types.NewFunc(token.NoPos, pkg, "BadFunc", nil)
+
+	got := formatMethodIdentity("example.com/mypkg", fn)
+	want := "example.com/mypkg.BadFunc"
+	if got != want {
+		t.Errorf("formatMethodIdentity = %q, want %q", got, want)
+	}
+}
+
+func TestFormatMethodIdentity_NonNamedReceiver(t *testing.T) {
+	// Basic type receiver (int) — not valid Go but type-system legal
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	recv := types.NewVar(token.NoPos, nil, "", types.Typ[types.Int])
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "Method", sig)
+
+	got := formatMethodIdentity("example.com/mypkg", fn)
+	want := "example.com/mypkg.int.Method"
+	if got != want {
+		t.Errorf("formatMethodIdentity = %q, want %q", got, want)
+	}
+}
+
+func TestFormatMethodIdentity_ArrayTypeReceiver(t *testing.T) {
+	// Array type [3]int — String() is "[3]int", bracket at index 0
+	// extractTypeName returns "[3]int", stripGenerics returns ""
+	pkg := types.NewPackage("example.com/mypkg", "mypkg")
+	arrType := types.NewArray(types.Typ[types.Int], 3)
+	recv := types.NewVar(token.NoPos, nil, "", arrType)
+	sig := types.NewSignatureType(recv, nil, nil, nil, nil, false)
+	fn := types.NewFunc(token.NoPos, pkg, "Method", sig)
+
+	got := formatMethodIdentity("example.com/mypkg", fn)
+	want := "example.com/mypkg..Method"
+	if got != want {
+		t.Errorf("formatMethodIdentity = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Closes #880.

## Summary
Decomposed the monolithic `getSymbolIdentity` function (complexity 10 → 4) by extracting five single-responsibility helpers:

| Helper | Purpose | Complexity |
|--------|---------|------------|
| `isMethod` | Predicate: is obj a method with receiver? | 3 |
| `derefPointer` | Unwrap `*types.Pointer` | 2 |
| `extractTypeName` | Resolve type name (Named/TypeParam/fallback) | 3 |
| `stripGenerics` | Strip `[T]` suffix for identity stability | 2 |
| `formatMethodIdentity` | Compose `pkg.Type.Method` string | 3 |

Added 23 new table-driven tests. All 9 existing `TestGetSymbolIdentity_*` tests pass unchanged — pure refactor, zero behavior change.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Complexity (getSymbolIdentity) | 4 (was 10) |
| Production complexity alerts | 0 |
| Coverage (analysis) | 97.9% |