### PR TITLE
fix(persistence): add architect-exclusion annotation to coverage comments (#886)

### DIFF
--- a/internal/infrastructure/persistence/sqlite_store.go
+++ b/internal/infrastructure/persistence/sqlite_store.go
@@ -139,8 +139,9 @@ func (s *sqliteTaskStore) queryOrdered(ctx context.Context, filter ports.ListFil
 	// NOTE: The rows.Close() defer error-shadowing and rows.Err() check below
 	// are defensive branches that cannot be triggered by modernc.org/sqlite
 	// (which eagerly buffers all results during QueryContext). These branches
-	// exist for correctness if the SQLite driver is swapped. Verified by code
-	// review only; no test coverage is possible.
+	// exist for correctness if the SQLite driver is swapped.
+	// Coverage gap accepted by architect — verified by code review only;
+	// no test coverage is possible.
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
 			if err == nil {
@@ -253,8 +254,9 @@ func (s *sqliteKVStore) GetAll(ctx context.Context) (res map[string]string, err 
 	// NOTE: The rows.Close() defer error-shadowing and rows.Err() check below
 	// are defensive branches that cannot be triggered by modernc.org/sqlite
 	// (which eagerly buffers all results during QueryContext). These branches
-	// exist for correctness if the SQLite driver is swapped. Verified by code
-	// review only; no test coverage is possible.
+	// exist for correctness if the SQLite driver is swapped.
+	// Coverage gap accepted by architect — verified by code review only;
+	// no test coverage is possible.
 	defer func() {
 		if closeErr := rows.Close(); closeErr != nil {
 			if err == nil {


### PR DESCRIPTION
Closes #886.

## Summary
Added the literal string "Coverage gap accepted by architect" to the architect-acknowledged exclusion comments at both locations (`queryOrdered` defer at line 143 and `GetAll` defer at line 258) in `sqlite_store.go`. This ensures the pre-filter grep documented in Issue #886 works as intended — these two `rows.Close()` defer branches cannot be triggered with the `modernc.org/sqlite` driver (which eagerly buffers all results) and are intentionally excluded from test coverage.

All other actionable error-handling branches in the persistence layer are already at 100% coverage.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| go test -race ./internal/infrastructure/persistence/... | PASS |
| Coverage (sqlite_store.go) | 99.4% (excluded: 2 defer Close shadowing) |
| Pre-filter grep | 2 locations match in sqlite_store.go |