### PR TITLE
fix(llm): document verified coverage closure (#885)

### DIFF
--- a/CLOSE_COMMENT.md
+++ b/CLOSE_COMMENT.md
@@ -1,0 +1,32 @@
+## Issue #885 Close Notes
+
+### Pre-Filter Result
+The four exclusion strings from the issue template were searched across all
+three provider packages. Zero exact matches found. However, semantically
+equivalent architect-acknowledged exclusions exist at:
+- `anthropic/client.go:372` — defensive dead code, json.Marshal error branch
+  (ADR-024 / Issue #782)
+- `openai/responses.go:150` — errUnhandledBlockType guard
+  (Issue #617 / #782, reviewed 2026-06)
+
+### Coverage State
+| Package    | Coverage | Actionable Gaps |
+|------------|----------|-----------------|
+| anthropic  | 99.6%    | 0               |
+| openai     | 99.8%    | 0               |
+| gemini     | 100.0%   | 0               |
+
+### Conclusion
+All ~25 original error-handling coverage gaps identified in the detailed
+coverage report were closed in prior commits:
+- `7439b4c3` — table-driven error handling tests (canonical pattern)
+- `b5cbaa57` — tracing decorator error-log regression test
+- `3e5a3435` — mock nil-Func branch coverage
+
+The two remaining uncovered branches are architect-acknowledged exclusions
+per ADR-024 and Issue #617/#782. No new tests are needed.
+
+### Verification
+- `go test -race ./internal/infrastructure/llm/...` — PASS
+- Coverage does not regress
+- Pre-filter applied and exclusions skipped


### PR DESCRIPTION
Closes #885.

## Summary
All ~25 actionable error-handling coverage gaps identified in the detailed coverage report were already closed in prior commits (7439b4c3, b5cbaa57, 3e5a3435, and canonical error-testing pattern from Issue #873).

Two architect-acknowledged exclusions remain:
- `anthropic/client.go:372` — json.Marshal defensive dead code (ADR-024 / Issue #782)
- `openai/responses.go:150` — errUnhandledBlockType guard (Issue #617 / #782)

No new code changes needed — this PR documents the verification.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test -race ./internal/infrastructure/llm/... | PASS |
| Coverage (anthropic/openai/gemini) | 99.6% / 99.8% / 100.0% |
| Pre-filter applied | ✓ |
