### PR TITLE
fix(cli): close error-handling coverage gaps in buildCapturer (#888)

### DIFF
--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -249,15 +249,13 @@ func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Confi
 		capturerInterface := c.newCapturer(c.Stdin, c.Stdout, c.Stderr, c.SM, clock.RealClock{}, c.MockPrompt, c.MockAnswer, false)
 		baseCapturer, ok := capturerInterface.(tui.BaseCapturer)
 		if !ok {
-			// Defensive: untestable without DI for NewCapturer.
-			// The concrete type returned by ui.NewCapturer always implements
-			// both BaseCapturer and CapturerInteractor in practice.
-			// Fallback: use the base capturer directly if it's an interactor
-			if ci, ok := capturerInterface.(agent.CapturerInteractor); ok {
-				return ci, func(ctx stdctx.Context) error {
-					return ci.Close(ctx)
-				}, nil
-			}
+			// Coverage gap accepted by architect: structurally unreachable.
+			// tui.BaseCapturer and agent.CapturerInteractor are structurally
+			// identical interfaces (both compose ports.Capturer +
+			// domain_security.UserInteractor). Any type that fails the
+			// BaseCapturer assertion necessarily also fails the
+			// CapturerInteractor assertion — and vice versa. The dual-failure
+			// path is covered by the error return below. See Issue #888.
 			return nil, nil, fmt.Errorf("ui.NewCapturer did not return a tui.BaseCapturer or agent.CapturerInteractor")
 		}
 

--- a/internal/cli/chat_command_test.go
+++ b/internal/cli/chat_command_test.go
@@ -1178,4 +1178,122 @@ func TestChatCommand_BuildCapturer_TUI_Fallback(t *testing.T) {
 		require.Nil(t, capturer)
 		require.Nil(t, cleanup)
 	})
+
+	t.Run("history_manager_non_nil_empty_last_message", func(t *testing.T) {
+		t.Parallel()
+
+		mb := &clitest.MockBootstrapper{
+			GetHistoryManagerFunc: func(ctx stdctx.Context, cfg *config.Config) (ports.HistoryManager, error) {
+				return &stubHistoryManager{}, nil
+			},
+			GetSuggestionServiceFunc: func(ctx stdctx.Context, recentHistory []string) (ports.SuggestionService, error) {
+				return &mockSuggestionService{}, nil
+			},
+		}
+		ms := &clitest.MockChatService{
+			GetLastUserMessageFunc: func(ctx stdctx.Context, hManager ports.HistoryManager) (string, int, error) {
+				return "", 0, nil // empty lastMsg — exercises hManager != nil but NOT lastMsg != ""
+			},
+		}
+
+		mockCap := &mockCapturerInteractor{}
+
+		c := &chatCommand{
+			Stdin:  strings.NewReader(""),
+			Stdout: new(strings.Builder),
+			Stderr: new(strings.Builder),
+			SM:     &mockSM{},
+			capturerFactory: func(stdin io.Reader, stdout, stderr io.Writer,
+				sm domain_security.Manager, clk clock.Clock,
+				mockPrompt, mockAnswer string, disableEscapeSequences bool,
+			) domain_security.UserInteractor {
+				return mockCap
+			},
+			Bootstrapper: mb,
+			ChatService:  ms,
+		}
+
+		opts := &cliOptions{tuiPrompt: true}
+		capturer, cleanup, err := c.buildCapturer(
+			stdctx.Background(), &config.Config{}, opts)
+
+		require.NoError(t, err)
+		require.NotNil(t, capturer)
+		require.NotNil(t, cleanup)
+
+		// Verify cleanup delegates to the capturer's Close
+		err = cleanup(stdctx.Background())
+		require.NoError(t, err)
+
+		// Verify bootstrapper call tracking
+		snap := mb.Snapshot()
+		if snap.GetHistoryManager != 1 {
+			t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
+		}
+		if snap.GetSuggestionService != 1 {
+			t.Errorf("GetSuggestionService: expected 1, got %d", snap.GetSuggestionService)
+		}
+	})
+
+	t.Run("history_manager_with_last_message_populates_recent_history", func(t *testing.T) {
+		t.Parallel()
+
+		const expectedLastMsg = "previous user message"
+
+		mb := &clitest.MockBootstrapper{
+			GetHistoryManagerFunc: func(ctx stdctx.Context, cfg *config.Config) (ports.HistoryManager, error) {
+				return &stubHistoryManager{}, nil
+			},
+			GetSuggestionServiceFunc: func(ctx stdctx.Context, recentHistory []string) (ports.SuggestionService, error) {
+				// Verify recentHistory contains the last message from GetLastUserMessage
+				if len(recentHistory) == 0 {
+					t.Error("expected non-empty recentHistory when lastMsg is populated")
+				} else if recentHistory[0] != expectedLastMsg {
+					t.Errorf("recentHistory[0] = %q, want %q", recentHistory[0], expectedLastMsg)
+				}
+				return &mockSuggestionService{}, nil
+			},
+		}
+		ms := &clitest.MockChatService{
+			GetLastUserMessageFunc: func(ctx stdctx.Context, hManager ports.HistoryManager) (string, int, error) {
+				return expectedLastMsg, 1, nil
+			},
+		}
+
+		mockCap := &mockCapturerInteractor{}
+
+		c := &chatCommand{
+			Stdin:  strings.NewReader(""),
+			Stdout: new(strings.Builder),
+			Stderr: new(strings.Builder),
+			SM:     &mockSM{},
+			capturerFactory: func(stdin io.Reader, stdout, stderr io.Writer,
+				sm domain_security.Manager, clk clock.Clock,
+				mockPrompt, mockAnswer string, disableEscapeSequences bool,
+			) domain_security.UserInteractor {
+				return mockCap
+			},
+			Bootstrapper: mb,
+			ChatService:  ms,
+		}
+
+		opts := &cliOptions{tuiPrompt: true}
+		capturer, cleanup, err := c.buildCapturer(
+			stdctx.Background(), &config.Config{}, opts)
+
+		require.NoError(t, err)
+		require.NotNil(t, capturer)
+		require.NotNil(t, cleanup)
+		err = cleanup(stdctx.Background())
+		require.NoError(t, err)
+
+		// Verify bootstrapper call tracking
+		snap := mb.Snapshot()
+		if snap.GetHistoryManager != 1 {
+			t.Errorf("GetHistoryManager: expected 1, got %d", snap.GetHistoryManager)
+		}
+		if snap.GetSuggestionService != 1 {
+			t.Errorf("GetSuggestionService: expected 1, got %d", snap.GetSuggestionService)
+		}
+	})
 }


### PR DESCRIPTION
Closes #888.

## Summary
- Identified that executor/decorators.go was already at **100% coverage** — issue data was stale
- Removed structurally unreachable dead code in `buildCapturer` (identical interfaces `tui.BaseCapturer` and `agent.CapturerInteractor`) — replaced with architect-accepted exclusion comment
- Added 2 table-driven subtests covering `hManager != nil` and `lastMsg != ""` paths in `buildCapturer`
- `buildCapturer` coverage: **88.6% → 100.0%**; CLI package: **98.5% → 100.0%**

## Verification
| Check | Status |
|-------|--------|
| make check-full (all 10 steps) | PASS |
| CLI coverage | 100.0% |
| Executor coverage | 100.0% |
| Race detection | clean |
| Linter | 0 issues |