### PR TITLE
fix(security): document dead error-propagation path in ValidatePath (#896)

### DIFF
--- a/internal/infrastructure/security/paths.go
+++ b/internal/infrastructure/security/paths.go
@@ -152,6 +152,14 @@ func (p *pathPolicy) ValidatePath(path string, writable bool) (string, error) {
 	for _, rule := range rules {
 		ok, err := rule(absPath, writable)
 		if err != nil {
+			// NOTE: This error-propagation path is currently dead code because
+			// all three built-in rules (checkDefaultBoundaries, checkSafePaths,
+			// checkReadOnlyPaths) use log-and-continue semantics — they log
+			// checkBoundary errors via log.Printf and return nil. This ensures
+			// all boundaries are checked and all errors are logged before
+			// rejecting the path (fail-secure). The path exists as a safety
+			// net for custom pathRule implementations that may propagate errors.
+			// See ADR #830 for the architectural decision.
 			return "", err
 		}
 		if ok {


### PR DESCRIPTION
Closes #896.

## Summary
Added an architectural comment to `ValidatePath` in `internal/infrastructure/security/paths.go` documenting why the error-propagation path (line 155) is intentionally dead code. All three built-in path rules use log-and-continue semantics — they log `checkBoundary` errors and return nil to ensure all boundaries are checked before rejecting the path (fail-secure). The error-propagation path exists as a safety net for custom `pathRule` implementations. See ADR #830.

After full architectural analysis, the remaining uncovered error branches (lines 45, 60, 71, 78, 96, 117, 207) are either:
- Already conditionally covered by existing tests (`TestBoundaryChecks_ErrorLogging`, `TestIsExemptedDirectory_CaseInsensitive`)
- Already documented as `[SYSTEM-DEPENDENT]` in `TestSystemDependentBranches_Documented`
- Logically unreachable (defensive log statements on paths that cannot fail)

No security vulnerabilities found.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| Coverage (security package) | 97.4% |
| Lint | 0 issues |
| Vulncheck | No vulnerabilities |
| Race detection | All clear |