### PR TITLE
fix(history): add architect coverage-gap annotations (#894)

### DIFF
--- a/internal/infrastructure/history/global_prompt_tracker.go
+++ b/internal/infrastructure/history/global_prompt_tracker.go
@@ -126,6 +126,7 @@ func (t *globalPromptTracker) Append(ctx context.Context, prompt string) error {
 
 	// json.Marshal cannot fail for promptEntry (all fields are string).
 	// The error path exists for interface contract compliance.
+	// Coverage gap accepted by architect — structurally unreachable.
 	data, err := json.Marshal(entry)
 	if err != nil {
 		return fmt.Errorf("failed to marshal prompt entry: %w", err)
@@ -373,6 +374,7 @@ func (t *globalPromptTracker) writeCompactedData(w io.Writer, entries []promptEn
 	for _, entry := range entries {
 		// json.Marshal cannot fail for promptEntry (all fields are string).
 		// Returning false ensures callers handle this defensive path.
+		// Coverage gap accepted by architect — structurally unreachable.
 		data, err := json.Marshal(entry)
 		if err != nil {
 			return false // abort compaction; do not silently drop entries


### PR DESCRIPTION
Closes #894.

## Summary
Added architect coverage-gap annotation sign-off lines above two structurally unreachable `json.Marshal(entry)` calls in `internal/infrastructure/history/global_prompt_tracker.go`:
- `Append()` — line 129
- `writeCompactedData()` — line 377

Both annotations follow the established project convention (`// Coverage gap accepted by architect — structurally unreachable.`) matching existing patterns in `internal/cli/chat_command.go`, `internal/infrastructure/llm/openai/responses.go`, and `internal/infrastructure/persistence/sqlite_store.go`.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage (history) | 99.3% (unchanged) |
| Annotation grep | 2/2 matches confirmed |
