### PR TITLE
fix(agenttest): fill 20 BUSINESS_LOGIC coverage gaps (#904)

### DIFF
--- a/internal/agent/agenttest/helpers_test.go
+++ b/internal/agent/agenttest/helpers_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -62,68 +64,100 @@ func TestStubUIRenderer_NoOpMethods(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("RenderResponse", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.RenderResponse(ctx, &llm.Content{Role: "assistant"}, true, true)
-		s.RenderResponse(ctx, nil, false, false)
-	})
+	tests := []struct {
+		name string
+		fn   func()
+	}{
+		// RenderResponse
+		{"RenderResponse_normal", func() {
+			s := &stubUIRenderer{}
+			s.RenderResponse(ctx, &llm.Content{Role: "assistant"}, true, true)
+		}},
+		{"RenderResponse_nil_content", func() {
+			s := &stubUIRenderer{}
+			s.RenderResponse(ctx, nil, false, false)
+		}},
+		// LogTurnStatus
+		{"LogTurnStatus_with_turns", func() {
+			s := &stubUIRenderer{}
+			s.LogTurnStatus(ctx, events.TurnStatus{CurrentTurns: 1})
+		}},
+		{"LogTurnStatus_empty", func() {
+			s := &stubUIRenderer{}
+			s.LogTurnStatus(ctx, events.TurnStatus{})
+		}},
+		// LogSystemMessage
+		{"LogSystemMessage_normal", func() {
+			s := &stubUIRenderer{}
+			s.LogSystemMessage(ctx, "hello", "info")
+		}},
+		{"LogSystemMessage_empty", func() {
+			s := &stubUIRenderer{}
+			s.LogSystemMessage(ctx, "", "")
+		}},
+		// LogUsage
+		{"LogUsage_with_metrics", func() {
+			s := &stubUIRenderer{}
+			s.LogUsage(ctx, &llm.Metrics{}, "log.json", time.Now())
+		}},
+		{"LogUsage_nil_metrics", func() {
+			s := &stubUIRenderer{}
+			s.LogUsage(ctx, nil, "", time.Time{})
+		}},
+		// LogToolCall
+		{"LogToolCall_with_calls", func() {
+			s := &stubUIRenderer{}
+			s.LogToolCall(ctx, []*llm.FunctionCall{{Name: "test"}}, 1, 10, true)
+		}},
+		{"LogToolCall_nil_calls", func() {
+			s := &stubUIRenderer{}
+			s.LogToolCall(ctx, nil, 0, 0, false)
+		}},
+		// LogToolResult
+		{"LogToolResult_with_result", func() {
+			s := &stubUIRenderer{}
+			s.LogToolResult(ctx, "tool", tools.ToolResult{Text: "ok"}, true)
+		}},
+		{"LogToolResult_empty", func() {
+			s := &stubUIRenderer{}
+			s.LogToolResult(ctx, "", tools.ToolResult{}, false)
+		}},
+		// RenderHealthReport
+		{"RenderHealthReport_with_report", func() {
+			s := &stubUIRenderer{}
+			s.RenderHealthReport(ctx, &ports.HealthReport{})
+		}},
+		{"RenderHealthReport_nil_report", func() {
+			s := &stubUIRenderer{}
+			s.RenderHealthReport(ctx, nil)
+		}},
+		// SetUseColor
+		{"SetUseColor_true", func() {
+			s := &stubUIRenderer{}
+			s.SetUseColor(true)
+		}},
+		{"SetUseColor_false", func() {
+			s := &stubUIRenderer{}
+			s.SetUseColor(false)
+		}},
+		// SetForceSpinner
+		{"SetForceSpinner_true", func() {
+			s := &stubUIRenderer{}
+			s.SetForceSpinner(true)
+		}},
+		{"SetForceSpinner_false", func() {
+			s := &stubUIRenderer{}
+			s.SetForceSpinner(false)
+		}},
+	}
 
-	t.Run("LogTurnStatus", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.LogTurnStatus(ctx, events.TurnStatus{CurrentTurns: 1})
-		s.LogTurnStatus(ctx, events.TurnStatus{})
-	})
-
-	t.Run("LogSystemMessage", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.LogSystemMessage(ctx, "hello", "info")
-		s.LogSystemMessage(ctx, "", "")
-	})
-
-	t.Run("LogUsage", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.LogUsage(ctx, &llm.Metrics{}, "log.json", time.Now())
-		s.LogUsage(ctx, nil, "", time.Time{})
-	})
-
-	t.Run("LogToolCall", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.LogToolCall(ctx, []*llm.FunctionCall{{Name: "test"}}, 1, 10, true)
-		s.LogToolCall(ctx, nil, 0, 0, false)
-	})
-
-	t.Run("LogToolResult", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.LogToolResult(ctx, "tool", tools.ToolResult{Text: "ok"}, true)
-		s.LogToolResult(ctx, "", tools.ToolResult{}, false)
-	})
-
-	t.Run("RenderHealthReport", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.RenderHealthReport(ctx, &ports.HealthReport{})
-		s.RenderHealthReport(ctx, nil)
-	})
-
-	t.Run("SetUseColor", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.SetUseColor(true)
-		s.SetUseColor(false)
-	})
-
-	t.Run("SetForceSpinner", func(t *testing.T) {
-		t.Parallel()
-		s := &stubUIRenderer{}
-		s.SetForceSpinner(true)
-		s.SetForceSpinner(false)
-	})
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			require.NotPanics(t, tt.fn, "stubUIRenderer no-op method must not panic")
+		})
+	}
 }
 
 func TestStubUIRenderer_IsTerminalContext(t *testing.T) {

--- a/internal/agent/agenttest/mock_capturer_test.go
+++ b/internal/agent/agenttest/mock_capturer_test.go
@@ -243,3 +243,90 @@ func TestMockCapturer_RaceDetection(t *testing.T) {
 			total, it, cp, cf, cl, wc, pc, rsk, rl, wantTotal)
 	}
 }
+
+func TestMockCapturer_NilFuncs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func(m *MockCapturer)
+	}{
+		{
+			name: "IsTTY_nil_func",
+			call: func(m *MockCapturer) {
+				got := m.IsTTY("any")
+				if got {
+					t.Error("nil IsTTYFn: got true; want false")
+				}
+			},
+		},
+		{
+			name: "CapturePrompt_nil_func",
+			call: func(m *MockCapturer) {
+				got, err := m.CapturePrompt(ctx, nil)
+				if got != "" {
+					t.Errorf("nil CapturePromptFn: got %q; want empty", got)
+				}
+				if err != nil {
+					t.Errorf("nil CapturePromptFn: unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "Confirm_nil_func",
+			call: func(m *MockCapturer) {
+				got, err := m.Confirm(ctx, "proceed?")
+				if got {
+					t.Error("nil ConfirmFn: got true; want false")
+				}
+				if err != nil {
+					t.Errorf("nil ConfirmFn: unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "Close_nil_func",
+			call: func(m *MockCapturer) {
+				err := m.Close(ctx)
+				if err != nil {
+					t.Errorf("nil CloseFn: unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "ReadSingleKey_nil_func",
+			call: func(m *MockCapturer) {
+				got, err := m.ReadSingleKey(ctx)
+				if got != "" {
+					t.Errorf("nil ReadSingleKeyFn: got %q; want empty", got)
+				}
+				if err != nil {
+					t.Errorf("nil ReadSingleKeyFn: unexpected error: %v", err)
+				}
+			},
+		},
+		{
+			name: "ReadLine_nil_func",
+			call: func(m *MockCapturer) {
+				got, err := m.ReadLine(ctx)
+				if got != "" {
+					t.Errorf("nil ReadLineFn: got %q; want empty", got)
+				}
+				if err != nil {
+					t.Errorf("nil ReadLineFn: unexpected error: %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MockCapturer{} // zero value — no Fn fields set
+			tt.call(m)
+		})
+	}
+}

--- a/internal/agent/agenttest/mock_entropy_source_test.go
+++ b/internal/agent/agenttest/mock_entropy_source_test.go
@@ -120,3 +120,19 @@ func TestMockEntropySource_RaceDetection(t *testing.T) {
 		t.Errorf("Read calls: got %d, want %d", called.Load(), goroutines*iterations)
 	}
 }
+
+func TestMockEntropySource_Read_TrueNilFunc(t *testing.T) {
+	t.Parallel()
+
+	m := &MockEntropySource{} // zero value — ReadFunc is nil
+
+	buf := make([]byte, 8)
+	n, err := m.Read(buf)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("got n %d; want 0 (nil ReadFunc default)", n)
+	}
+}

--- a/internal/agent/agenttest/mock_gateway_test.go
+++ b/internal/agent/agenttest/mock_gateway_test.go
@@ -263,3 +263,66 @@ func TestMockGateway_RaceDetection(t *testing.T) {
 		t.Errorf("SendChat calls: got %d, want %d", chat, goroutines*iterations)
 	}
 }
+
+func TestMockGateway_NilFuncs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		call func(m *MockGateway)
+	}{
+		{
+			name: "Generate_nil_func",
+			call: func(m *MockGateway) {
+				content, metrics, err := m.Generate(ctx, nil, nil, nil)
+				if err != nil {
+					t.Fatalf("nil GenerateFunc: unexpected error: %v", err)
+				}
+				if content == nil {
+					t.Fatal("nil GenerateFunc: got nil content")
+				}
+				if content.Role != "model" {
+					t.Errorf("nil GenerateFunc: got role %q; want %q", content.Role, "model")
+				}
+				if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
+					t.Errorf("nil GenerateFunc: got parts %+v; want [Text:generated]", content.Parts)
+				}
+				if metrics == nil {
+					t.Error("nil GenerateFunc: got nil metrics")
+				}
+			},
+		},
+		{
+			name: "SendChat_nil_func",
+			call: func(m *MockGateway) {
+				content, metrics, err := m.SendChat(ctx, nil, nil, nil)
+				if err != nil {
+					t.Fatalf("nil SendChatFn: unexpected error: %v", err)
+				}
+				if content == nil {
+					t.Fatal("nil SendChatFn: got nil content")
+				}
+				if content.Role != "model" {
+					t.Errorf("nil SendChatFn: got role %q; want %q", content.Role, "model")
+				}
+				if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
+					t.Errorf("nil SendChatFn: got parts %+v; want [Text:generated]", content.Parts)
+				}
+				if metrics == nil {
+					t.Error("nil SendChatFn: got nil metrics")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MockGateway{} // zero value — no func fields set
+			tt.call(m)
+		})
+	}
+}

--- a/internal/agent/orchestrator/orchestratortest/helpers_test.go
+++ b/internal/agent/orchestrator/orchestratortest/helpers_test.go
@@ -567,3 +567,33 @@ func TestSetupTransitionTurn_ExecuteFunc_Success(t *testing.T) {
 		t.Errorf("FunctionResponse.Name = %q, want %q", fr.Name, "test")
 	}
 }
+
+// TestSetupTurnEngineTest_CleanupExecutes verifies that the cleanup function
+// registered by SetupTurnEngineTest (bus.Shutdown) executes without panicking.
+// This closes coverage gap #10: the cleanup runs during test teardown, outside
+// Go's coverage window.
+func TestSetupTurnEngineTest_CleanupExecutes(t *testing.T) {
+	t.Parallel()
+
+	rt := &cleanupRecordingT{}
+	env := SetupTurnEngineTest(rt)
+
+	if env == nil {
+		t.Fatal("SetupTurnEngineTest returned nil")
+	}
+	if len(rt.cleanupFuncs) < 1 {
+		t.Fatal("expected at least one cleanup function to be registered")
+	}
+
+	for i, fn := range rt.cleanupFuncs {
+		// Each cleanup must not panic when executed explicitly.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("cleanup[%d] panicked: %v", i, r)
+				}
+			}()
+			fn()
+		}()
+	}
+}


### PR DESCRIPTION
Closes #904.

## Summary
Added 5 new test functions across 4 test files to fill 20 BUSINESS_LOGIC coverage gaps identified by `get_detailed_coverage`:

| Group | Gaps | File | Test |
|-------|------|------|------|
| A | 1–6 | `mock_capturer_test.go` | `TestMockCapturer_NilFuncs` — table-driven, 6 subtests |
| A | 7 | `mock_entropy_source_test.go` | `TestMockEntropySource_Read_TrueNilFunc` |
| A | 8–9 | `mock_gateway_test.go` | `TestMockGateway_NilFuncs` — table-driven, 2 subtests |
| A | 10 | `orchestratortest/helpers_test.go` | `TestSetupTurnEngineTest_CleanupExecutes` |
| B | 11–19 | `helpers_test.go` | Restructured `TestStubUIRenderer_NoOpMethods` — 18 subtests with `require.NotPanics` |
| C | 20 | N/A | Pre-existing coverage in `agent_hook_test.go` |

All tests follow established patterns: table-driven where appropriate, `t.Parallel()`, zero-value mock construction for nil-fn branches.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| `go test -race ./internal/agent/...` | PASS (10/10 packages) |
| mock_capturer.go coverage | 100% (was ~75%) |
| mock_entropy_source.go Read | 100% |
| mock_gateway.go Generate/SendChat | 100% |
| agenttest package coverage | 98.0% |