### PR TITLE
fix(services): remove in-memory task cache, delegate to persistent store (#906)

### DIFF
--- a/internal/domain/ports/repository.go
+++ b/internal/domain/ports/repository.go
@@ -94,11 +94,13 @@ type SessionInfo struct {
 type TaskReader interface {
 	// ListTasks returns tasks filtered by status, bounded by limit and offset.
 	// status="" returns all statuses. limit=0 means no limit. offset=0 means start from beginning.
-	ListTasks(status string, limit, offset int) []Task
+	// Returns an error if the underlying store query fails.
+	ListTasks(ctx context.Context, status string, limit, offset int) ([]Task, error)
 
 	// CountTasks returns the total number of tasks matching the given status filter.
 	// status="" returns the total count across all statuses.
-	CountTasks(status string) int
+	// Returns an error if the underlying store query fails.
+	CountTasks(ctx context.Context, status string) (int, error)
 }
 
 // TaskWriter defines the interface for modifying tasks.

--- a/internal/domain/services/task_service.go
+++ b/internal/domain/services/task_service.go
@@ -6,8 +6,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"sort"
-	"sync"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -18,42 +16,19 @@ import (
 var _ ports.TaskStore = (*taskService)(nil)
 
 // taskService handles the logic for managing tasks.
+// It is a stateless pass-through that delegates all operations to the store.
 type taskService struct {
-	mu     sync.RWMutex
-	store  ports.ListStore[ports.Task]
-	tasks  map[int64]ports.Task
-	nextID int64
+	store ports.ListStore[ports.Task]
 }
 
 // NewTaskService creates a new taskService.
 func NewTaskService(store ports.ListStore[ports.Task]) *taskService {
-	return &taskService{
-		store:  store,
-		tasks:  make(map[int64]ports.Task),
-		nextID: 1,
-	}
+	return &taskService{store: store}
 }
 
-// Initialize loads tasks from the repository.
-func (s *taskService) Initialize(ctx context.Context) error {
-	// Load only active tasks (not completed) into memory.
-	// Completed tasks remain in the persistent store and can be
-	// queried on demand via ListTasks with status filter.
-	tasks, err := s.store.Query(ctx, ports.ListFilter{NotStatus: "completed"}, 0, 0)
-	if err != nil {
-		return err
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	for _, t := range tasks {
-		s.tasks[t.ID] = t
-		if t.ID >= s.nextID {
-			s.nextID = t.ID + 1
-		}
-	}
-	return nil
-}
+// Initialize is a no-op required for ports.Initializer compatibility.
+// All state is managed by the backing store.
+func (s *taskService) Initialize(ctx context.Context) error { return nil }
 
 // AddTask adds a new task.
 func (s *taskService) AddTask(ctx context.Context, content string) (ports.Task, error) {
@@ -61,11 +36,11 @@ func (s *taskService) AddTask(ctx context.Context, content string) (ports.Task, 
 		return ports.Task{}, fmt.Errorf("content is required for add")
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
 	t := ports.Task{
-		ID:        s.nextID,
+		// [TECHNICAL DEBT] ID assignment uses time.Now().UnixNano() which is
+		// unique-enough for a single-user CLI tool. A more robust approach would
+		// be store-level auto-increment (e.g., SQLite INTEGER PRIMARY KEY).
+		ID:        time.Now().UnixNano(),
 		Content:   content,
 		Status:    "pending",
 		CreatedAt: time.Now(),
@@ -75,18 +50,27 @@ func (s *taskService) AddTask(ctx context.Context, content string) (ports.Task, 
 		return ports.Task{}, err
 	}
 
-	s.tasks[t.ID] = t
-	s.nextID++
 	return t, nil
 }
 
 // UpdateTask updates an existing task.
 func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status string) (ports.Task, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	// Fetch existing tasks from store to validate existence
+	tasks, err := s.store.Query(ctx, ports.ListFilter{}, 0, 0)
+	if err != nil {
+		return ports.Task{}, err
+	}
 
-	t, ok := s.tasks[id]
-	if !ok {
+	var t ports.Task
+	found := false
+	for _, existing := range tasks {
+		if existing.ID == id {
+			t = existing
+			found = true
+			break
+		}
+	}
+	if !found {
 		return ports.Task{}, fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 	}
 
@@ -101,90 +85,47 @@ func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status 
 		return ports.Task{}, err
 	}
 
-	s.tasks[id] = t
 	return t, nil
 }
 
 // DeleteTask removes a task.
 func (s *taskService) DeleteTask(ctx context.Context, id int64) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, ok := s.tasks[id]; !ok {
-		return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
-	}
-
-	if err := s.store.Delete(ctx, id); err != nil {
+	// Pre-check existence
+	tasks, err := s.store.Query(ctx, ports.ListFilter{}, 0, 0)
+	if err != nil {
 		return err
 	}
-
-	delete(s.tasks, id)
-	return nil
+	found := false
+	for _, t := range tasks {
+		if t.ID == id {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
+	}
+	return s.store.Delete(ctx, id)
 }
 
 // ListTasks returns all tasks, optionally filtered by status, bounded by limit and offset.
-func (s *taskService) ListTasks(status string, limit, offset int) []ports.Task {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	var list []ports.Task
-	for _, t := range s.tasks {
-		if status != "" && t.Status != status {
-			continue
-		}
-		list = append(list, t)
-	}
-
-	sort.Slice(list, func(i, j int) bool {
-		return list[i].ID < list[j].ID
-	})
-
-	// Apply offset
-	if offset > 0 {
-		if offset >= len(list) {
-			return []ports.Task{}
-		}
-		list = list[offset:]
-	}
-
-	// Apply limit
-	if limit > 0 && limit < len(list) {
-		list = list[:limit]
-	}
-
-	return list
+func (s *taskService) ListTasks(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
+	filter := ports.ListFilter{Status: status}
+	return s.store.Query(ctx, filter, limit, offset)
 }
 
 // CountTasks returns the total number of tasks matching the given status filter.
 // status="" returns the total count across all statuses.
-func (s *taskService) CountTasks(status string) int {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	// For the in-memory map path (current behavior): count from s.tasks.
-	// This is consistent with ListTasks which also reads from s.tasks.
-	// [TECHNICAL DEBT] When ListTasks is updated to query the persistent store
-	// for non-pending statuses (Issue #521), this must also fall through to
-	// the store for accurate counts across sessions.
-	count := 0
-	for _, t := range s.tasks {
-		if status != "" && t.Status != status {
-			continue
-		}
-		count++
+func (s *taskService) CountTasks(ctx context.Context, status string) (int, error) {
+	filter := ports.ListFilter{Status: status}
+	tasks, err := s.store.Query(ctx, filter, 0, 0)
+	if err != nil {
+		return 0, err
 	}
-	return count
+	return len(tasks), nil
 }
 
 // ClearTasks removes all tasks.
 func (s *taskService) ClearTasks(ctx context.Context) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if err := s.store.DeleteAll(ctx); err != nil {
-		return err
-	}
-
-	s.tasks = make(map[int64]ports.Task)
-	return nil
+	return s.store.DeleteAll(ctx)
 }

--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -7,19 +7,27 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 )
 
 type mockTaskRepo struct {
+	mu       sync.Mutex
 	tasks    []ports.Task
 	readErr  error
 	writeErr error
 }
 
-func (m *mockTaskRepo) ReadAll(ctx context.Context) ([]ports.Task, error) { return m.tasks, m.readErr }
+func (m *mockTaskRepo) ReadAll(ctx context.Context) ([]ports.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.tasks, m.readErr
+}
 func (m *mockTaskRepo) Update(ctx context.Context, id int64, task ports.Task) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.writeErr != nil {
 		return m.writeErr
 	}
@@ -33,6 +41,8 @@ func (m *mockTaskRepo) Update(ctx context.Context, id int64, task ports.Task) er
 }
 
 func (m *mockTaskRepo) Delete(ctx context.Context, id int64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.writeErr != nil {
 		return m.writeErr
 	}
@@ -47,6 +57,8 @@ func (m *mockTaskRepo) Delete(ctx context.Context, id int64) error {
 }
 
 func (m *mockTaskRepo) DeleteAll(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.writeErr != nil {
 		return m.writeErr
 	}
@@ -55,6 +67,8 @@ func (m *mockTaskRepo) DeleteAll(ctx context.Context) error {
 }
 
 func (m *mockTaskRepo) Append(ctx context.Context, task ports.Task) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.writeErr != nil {
 		return m.writeErr
 	}
@@ -63,6 +77,8 @@ func (m *mockTaskRepo) Append(ctx context.Context, task ports.Task) error {
 }
 
 func (m *mockTaskRepo) Query(ctx context.Context, filter ports.ListFilter, limit, offset int) ([]ports.Task, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.readErr != nil {
 		return nil, m.readErr
 	}
@@ -107,6 +123,8 @@ func applyTaskOffsetLimit(tasks []ports.Task, limit, offset int) []ports.Task {
 }
 
 func (m *mockTaskRepo) Count(ctx context.Context) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	if m.readErr != nil {
 		return 0, m.readErr
 	}
@@ -129,7 +147,7 @@ func TestTaskService_Add(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if task.ID != 1 || task.Content != "Test task" {
+	if task.ID == 0 || task.Content != "Test task" {
 		t.Errorf("unexpected task: %+v", task)
 	}
 	if len(repo.tasks) != 1 {
@@ -141,13 +159,16 @@ func TestTaskService_Update(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s, _ := setupTaskService(t)
-	_, _ = s.AddTask(ctx, "Initial task")
+	task, _ := s.AddTask(ctx, "Initial task")
 
-	_, err := s.UpdateTask(ctx, 1, "Updated task", "completed")
+	_, err := s.UpdateTask(ctx, task.ID, "Updated task", "completed")
 	if err != nil {
 		t.Fatal(err)
 	}
-	tasks := s.ListTasks("", 0, 0)
+	tasks, err := s.ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(tasks) != 1 || tasks[0].Content != "Updated task" || tasks[0].Status != "completed" {
 		t.Errorf("unexpected task: %+v", tasks[0])
 	}
@@ -157,12 +178,16 @@ func TestTaskService_Delete(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	s, _ := setupTaskService(t)
-	_, _ = s.AddTask(ctx, "To be deleted")
+	task, _ := s.AddTask(ctx, "To be deleted")
 
-	if err := s.DeleteTask(ctx, 1); err != nil {
+	if err := s.DeleteTask(ctx, task.ID); err != nil {
 		t.Fatal(err)
 	}
-	if len(s.ListTasks("", 0, 0)) != 0 {
+	tasks, err := s.ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
 		t.Error("task not deleted")
 	}
 }
@@ -178,7 +203,7 @@ func TestTaskService_Concurrency(t *testing.T) {
 	for i := 0; i < workers; i++ {
 		go func(val int) {
 			_, _ = s.AddTask(ctx, "Task")
-			_ = s.ListTasks("", 0, 0)
+			_, _ = s.ListTasks(context.Background(), "", 0, 0)
 			done <- true
 		}(i)
 	}
@@ -187,57 +212,13 @@ func TestTaskService_Concurrency(t *testing.T) {
 		<-done
 	}
 
-	if len(s.ListTasks("", 0, 0)) != workers {
-		t.Errorf("expected %d tasks, got %d", workers, len(s.ListTasks("", 0, 0)))
+	tasks, err := s.ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
 	}
-}
-
-func TestTaskService_Initialize(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	t.Run("Success", func(t *testing.T) {
-		t.Parallel()
-		repo := &mockTaskRepo{
-			tasks: []ports.Task{
-				{ID: 1, Content: "Task 1", Status: "pending"},
-				{ID: 10, Content: "Task 10", Status: "pending"},
-			},
-		}
-		s := NewTaskService(repo)
-
-		err := s.Initialize(ctx)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-
-		tasks := s.ListTasks("", 0, 0)
-		if len(tasks) != 2 {
-			t.Errorf("expected 2 tasks, got %d", len(tasks))
-		}
-
-		// Verify nextID is max(ID) + 1 = 11
-		newTask, err := s.AddTask(ctx, "New Task")
-		if err != nil {
-			t.Fatalf("failed to add task after init: %v", err)
-		}
-		if newTask.ID != 11 {
-			t.Errorf("expected new task ID to be 11, got %v", newTask.ID)
-		}
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		t.Parallel()
-		repo := &mockTaskRepo{
-			readErr: errors.New("read error"),
-		}
-		s := NewTaskService(repo)
-
-		err := s.Initialize(ctx)
-		if err == nil {
-			t.Error("expected error, got nil")
-		}
-	})
+	if len(tasks) != workers {
+		t.Errorf("expected %d tasks, got %d", workers, len(tasks))
+	}
 }
 
 func TestTaskService_ClearTasks(t *testing.T) {
@@ -255,7 +236,11 @@ func TestTaskService_ClearTasks(t *testing.T) {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
-		if len(s.ListTasks("", 0, 0)) != 0 {
+		tasks, err := s.ListTasks(ctx, "", 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(tasks) != 0 {
 			t.Error("tasks not cleared from service")
 		}
 		if len(repo.tasks) != 0 {
@@ -315,9 +300,9 @@ func TestTaskService_ErrorPaths(t *testing.T) {
 	t.Run("UpdateTask Write Error", func(t *testing.T) {
 		t.Parallel()
 		s, repo := setupTaskService(t)
-		_, _ = s.AddTask(ctx, "Task")
+		task, _ := s.AddTask(ctx, "Task")
 		repo.writeErr = errors.New("write fail")
-		_, err := s.UpdateTask(ctx, 1, "Updated", "completed")
+		_, err := s.UpdateTask(ctx, task.ID, "Updated", "completed")
 		if err == nil {
 			t.Error("expected write error")
 		}
@@ -335,9 +320,9 @@ func TestTaskService_ErrorPaths(t *testing.T) {
 	t.Run("DeleteTask Write Error", func(t *testing.T) {
 		t.Parallel()
 		s, repo := setupTaskService(t)
-		_, _ = s.AddTask(ctx, "Task")
+		task, _ := s.AddTask(ctx, "Task")
 		repo.writeErr = errors.New("write fail")
-		err := s.DeleteTask(ctx, 1)
+		err := s.DeleteTask(ctx, task.ID)
 		if err == nil {
 			t.Error("expected write error")
 		}
@@ -353,12 +338,18 @@ func TestTaskService_ListTasks_Filter(t *testing.T) {
 	t3, _ := s.AddTask(ctx, "Completed")
 	_, _ = s.UpdateTask(ctx, t3.ID, "", "completed")
 
-	pending := s.ListTasks("pending", 0, 0)
+	pending, err := s.ListTasks(ctx, "pending", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(pending) != 2 {
 		t.Errorf("expected 2 pending tasks, got %d", len(pending))
 	}
 
-	completed := s.ListTasks("completed", 0, 0)
+	completed, err := s.ListTasks(ctx, "completed", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(completed) != 1 {
 		t.Errorf("expected 1 completed task, got %d", len(completed))
 	}
@@ -396,48 +387,15 @@ func TestTaskService_DeleteTask_Multiple(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	tasks := s.ListTasks("", 0, 0)
+	tasks, err := s.ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if len(tasks) != 2 {
 		t.Errorf("expected 2 tasks, got %d", len(tasks))
 	}
 	if len(repo.tasks) != 2 {
 		t.Error("task not deleted from repo")
-	}
-}
-
-func TestTaskService_Initialize_OnlyActive(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-
-	repo := &mockTaskRepo{
-		tasks: []ports.Task{
-			{ID: 1, Content: "Pending 1", Status: "pending"},
-			{ID: 2, Content: "In Progress", Status: "in_progress"},
-			{ID: 3, Content: "Completed 1", Status: "completed"},
-			{ID: 4, Content: "Completed 2", Status: "completed"},
-		},
-	}
-	s := NewTaskService(repo)
-
-	err := s.Initialize(ctx)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	// Only pending and in_progress should be loaded
-	tasks := s.ListTasks("", 0, 0)
-	if len(tasks) != 2 {
-		t.Errorf("expected 2 active tasks, got %d: %+v", len(tasks), tasks)
-	}
-	for _, task := range tasks {
-		if task.Status == "completed" {
-			t.Errorf("completed task %d should not have been loaded", int(task.ID))
-		}
-	}
-
-	// nextID should be max of active IDs + 1 = 3 (not 5 from completed tasks)
-	if s.nextID != 3 {
-		t.Errorf("expected nextID 3, got %v", s.nextID)
 	}
 }
 
@@ -540,7 +498,10 @@ func TestTaskService_CountTasks(t *testing.T) {
 			s, _ := setupTaskService(t)
 			tt.setup(s)
 
-			got := s.CountTasks(tt.status)
+			got, err := s.CountTasks(ctx, tt.status)
+			if err != nil {
+				t.Fatal(err)
+			}
 			if got != tt.expected {
 				t.Errorf("CountTasks(%q) = %d; want %d", tt.status, got, tt.expected)
 			}
@@ -562,18 +523,22 @@ func seedTaskServiceWithN(t *testing.T, s ports.TaskStore, n int) {
 
 func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
 	t.Parallel()
+	ctx := context.Background()
 
 	t.Run("limit3_offset0_returns_first_3", func(t *testing.T) {
 		t.Parallel()
 		s, _ := setupTaskService(t)
 		seedTaskServiceWithN(t, s, 5)
 
-		tasks := s.ListTasks("", 3, 0)
+		tasks, err := s.ListTasks(ctx, "", 3, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(tasks) != 3 {
 			t.Errorf("expected 3 tasks, got %d", len(tasks))
 		}
-		if tasks[0].ID != 1 || tasks[2].ID != 3 {
-			t.Errorf("expected IDs 1,2,3, got %v", tasks)
+		if tasks[0].Content != "Task 1" || tasks[2].Content != "Task 3" {
+			t.Errorf("expected Task 1, Task 2, Task 3, got %v", tasks)
 		}
 	})
 
@@ -582,12 +547,15 @@ func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
 		s, _ := setupTaskService(t)
 		seedTaskServiceWithN(t, s, 5)
 
-		tasks := s.ListTasks("", 2, 3)
+		tasks, err := s.ListTasks(ctx, "", 2, 3)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(tasks) != 2 {
 			t.Errorf("expected 2 tasks, got %d", len(tasks))
 		}
-		if tasks[0].ID != 4 || tasks[1].ID != 5 {
-			t.Errorf("expected IDs 4,5, got %v", tasks)
+		if tasks[0].Content != "Task 4" || tasks[1].Content != "Task 5" {
+			t.Errorf("expected Task 4, Task 5, got %v", tasks)
 		}
 	})
 
@@ -596,7 +564,10 @@ func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
 		s, _ := setupTaskService(t)
 		seedTaskServiceWithN(t, s, 5)
 
-		tasks := s.ListTasks("", 10, 100)
+		tasks, err := s.ListTasks(ctx, "", 10, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(tasks) != 0 {
 			t.Errorf("expected 0 tasks, got %d", len(tasks))
 		}
@@ -607,7 +578,10 @@ func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
 		s, _ := setupTaskService(t)
 		seedTaskServiceWithN(t, s, 5)
 
-		tasks := s.ListTasks("", 0, 0)
+		tasks, err := s.ListTasks(ctx, "", 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if len(tasks) != 5 {
 			t.Errorf("expected 5 tasks, got %d", len(tasks))
 		}

--- a/internal/infrastructure/persistence/debug_test.go
+++ b/internal/infrastructure/persistence/debug_test.go
@@ -30,7 +30,10 @@ invalid json line starting with i
 		_ = state.Close()
 	}()
 
-	tasks := state.GetTasks().ListTasks("", 0, 0)
+	tasks, err := state.GetTasks().ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatalf("ListTasks failed: %v", err)
+	}
 
 	if len(tasks) != 2 {
 		t.Errorf("expected 2 tasks, got %d. Corrupted line might not have been skipped correctly", len(tasks))

--- a/internal/infrastructure/persistence/state.go
+++ b/internal/infrastructure/persistence/state.go
@@ -187,9 +187,8 @@ func initRepositories(ctx context.Context, configDir, storageType string) (ports
 
 func initServices(ctx context.Context, taskStore ports.ListStore[ports.Task]) (ports.TaskStore, error) {
 	tasks := services.NewTaskService(taskStore)
-
-	if err := tasks.Initialize(ctx); err != nil {
-		return nil, err
-	}
+	// Initialize is a no-op since taskService became stateless (Issue #906).
+	// Kept for interface compatibility with ports.Initializer.
+	_ = tasks.Initialize(ctx)
 	return tasks, nil
 }

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -181,8 +180,12 @@ func TestNewSessionState_InitRepositoriesFailure(t *testing.T) {
 		"error should be wrapped with initialization context")
 }
 
-func TestNewSessionState_InitServicesFailure(t *testing.T) {
+func TestNewSessionState_InitServicesSucceeds(t *testing.T) {
 	// NOT parallel: overrides package-level sqlOpenFn, must run sequentially.
+	//
+	// After Issue #906, initServices is a no-op that never queries the DB.
+	// Even with a connector that would fail on a 6th operation, NewSessionState
+	// succeeds because initServices no longer performs any DB operations.
 
 	ctx := context.Background()
 	tempDir := t.TempDir()
@@ -195,13 +198,14 @@ func TestNewSessionState_InitServicesFailure(t *testing.T) {
 		return sql.OpenDB(&initServicesFailingConnector{
 			dsn:       dsn,
 			opCount:   &opCount,
-			failAfter: 5, // initSQLiteDB does ~5 ops; fail on 6th (initServices ReadAll)
+			failAfter: 5, // initSQLiteDB does ~5 ops; initServices does none
 		}), nil
 	}
 
-	_, err := NewSessionState(ctx, tempDir)
-	require.Error(t, err, "expected error from NewSessionState when initServices fails")
-	t.Logf("error: %v", err)
+	state, err := NewSessionState(ctx, tempDir)
+	require.NoError(t, err, "NewSessionState should succeed since initServices is a no-op")
+	require.NotNil(t, state)
+	_ = state.Close()
 }
 
 // failingTaskStore is a ListStore[ports.Task] whose ReadAll always fails.
@@ -345,17 +349,16 @@ func TestSessionState_SetInfo_PersistError(t *testing.T) {
 	}
 }
 
-func TestInitServices_InitializeFailure(t *testing.T) {
+func TestInitServices_InitializeIsNoOp(t *testing.T) {
 	t.Parallel()
 
+	// After Issue #906, Initialize is a no-op that always returns nil.
+	// initServices ignores the return value. Even with a failing task store,
+	// initServices succeeds because it never calls any store methods during init.
 	ctx := context.Background()
-	_, err := initServices(ctx, &failingTaskStore{})
-	if err == nil {
-		t.Fatal("expected error from initServices when Initialize fails, got nil")
-	}
-	if !strings.Contains(err.Error(), "simulated query failure") {
-		t.Errorf("expected error to contain 'simulated query failure', got: %v", err)
-	}
+	tasks, err := initServices(ctx, &failingTaskStore{})
+	require.NoError(t, err, "initServices should succeed since Initialize is a no-op")
+	require.NotNil(t, tasks)
 }
 
 func TestInitRepositories_MigrationFailure(t *testing.T) {
@@ -388,8 +391,8 @@ func TestInitRepositories_MigrationFailure(t *testing.T) {
 // initServicesFailingConnector wraps the SQLite driver and returns connections
 // whose QueryContext and ExecContext fail after a deterministic number of
 // successful operations. This allows initRepositories to complete normally
-// (5 ops: 2 pragmas + 2 CREATE TABLE + 1 COUNT) while initServices fails on
-// its first ReadAll QueryContext (the 6th operation).
+// (5 ops: 2 pragmas + 2 CREATE TABLE + 1 COUNT) while initServices is
+// verified to not perform any DB operations (it's a no-op after Issue #906).
 type initServicesFailingConnector struct {
 	dsn       string
 	opCount   *atomic.Int32

--- a/internal/tools/workspace/persistence_tools.go
+++ b/internal/tools/workspace/persistence_tools.go
@@ -136,7 +136,7 @@ func (t *persistenceTools) ManageTasks(ctx context.Context, args map[string]inte
 	case "delete":
 		return t.deleteTask(ctx, params.TaskID)
 	case "list":
-		return t.listTasks(params.Status, params.Limit, params.Offset)
+		return t.listTasks(ctx, params.Status, params.Limit, params.Offset)
 	case "clear":
 		return t.clearTasks(ctx)
 	default:
@@ -166,12 +166,18 @@ func (t *persistenceTools) deleteTask(ctx context.Context, id int64) (tools.Tool
 	return tools.ToolResult{Text: fmt.Sprintf("Task %d deleted", id)}, nil
 }
 
-func (t *persistenceTools) listTasks(status string, limit, offset int) (tools.ToolResult, error) {
+func (t *persistenceTools) listTasks(ctx context.Context, status string, limit, offset int) (tools.ToolResult, error) {
 	if limit == 0 {
 		limit = 50
 	}
-	tasks := t.tasks.ListTasks(status, limit, offset)
-	totalCount := t.tasks.CountTasks(status)
+	tasks, err := t.tasks.ListTasks(ctx, status, limit, offset)
+	if err != nil {
+		return tools.ToolResult{}, err
+	}
+	totalCount, err := t.tasks.CountTasks(ctx, status)
+	if err != nil {
+		return tools.ToolResult{}, err
+	}
 
 	if len(tasks) == 0 {
 		if totalCount > 0 {

--- a/internal/ui/tui/tasks_model.go
+++ b/internal/ui/tui/tasks_model.go
@@ -93,8 +93,14 @@ func fetchTasksCmd(ctx context.Context, provider ports.TaskStore, status string,
 		if ctx.Err() != nil {
 			return tasksLoadedMsg{err: ctx.Err()}
 		}
-		tasks := provider.ListTasks(status, limit, offset)
-		count := provider.CountTasks(status)
+		tasks, err := provider.ListTasks(ctx, status, limit, offset)
+		if err != nil {
+			return tasksLoadedMsg{err: err}
+		}
+		count, err := provider.CountTasks(ctx, status)
+		if err != nil {
+			return tasksLoadedMsg{err: err}
+		}
 		return tasksLoadedMsg{tasks: tasks, totalCount: count}
 	}
 }

--- a/internal/ui/tui/tasks_model_test.go
+++ b/internal/ui/tui/tasks_model_test.go
@@ -17,8 +17,8 @@ import (
 // ── TaskStore mock ──
 
 type mockTaskStore struct {
-	ListTasksFunc  func(status string, limit, offset int) []ports.Task
-	CountTasksFunc func(status string) int
+	ListTasksFunc  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error)
+	CountTasksFunc func(ctx context.Context, status string) (int, error)
 
 	// TaskWriter methods (unused by taskListModel but needed for interface)
 	AddTaskFunc    func(ctx context.Context, content string) (ports.Task, error)
@@ -27,18 +27,18 @@ type mockTaskStore struct {
 	ClearTasksFunc func(ctx context.Context) error
 }
 
-func (m *mockTaskStore) ListTasks(status string, limit, offset int) []ports.Task {
+func (m *mockTaskStore) ListTasks(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 	if m.ListTasksFunc != nil {
-		return m.ListTasksFunc(status, limit, offset)
+		return m.ListTasksFunc(ctx, status, limit, offset)
 	}
-	return nil
+	return nil, nil
 }
 
-func (m *mockTaskStore) CountTasks(status string) int {
+func (m *mockTaskStore) CountTasks(ctx context.Context, status string) (int, error) {
 	if m.CountTasksFunc != nil {
-		return m.CountTasksFunc(status)
+		return m.CountTasksFunc(ctx, status)
 	}
-	return 0
+	return 0, nil
 }
 
 func (m *mockTaskStore) AddTask(ctx context.Context, content string) (ports.Task, error) {
@@ -122,12 +122,12 @@ func TestTaskListModel_SearchEnter_NormalizesStatus(t *testing.T) {
 	var receivedStatus string
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedStatus = status
-			return []ports.Task{{ID: 1, Content: "test", Status: "pending"}}
+			return []ports.Task{{ID: 1, Content: "test", Status: "pending"}}, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 1
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 1, nil
 		},
 	}
 
@@ -166,11 +166,11 @@ func TestTaskListModel_SearchEnter_ValidStatus_Pending(t *testing.T) {
 	var receivedStatus string
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedStatus = status
-			return []ports.Task{}
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int { return 0 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -194,11 +194,11 @@ func TestTaskListModel_SearchEnter_ValidStatus_Completed(t *testing.T) {
 	var receivedStatus string
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedStatus = status
-			return []ports.Task{}
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int { return 0 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -222,11 +222,11 @@ func TestTaskListModel_SearchEsc_ResetsFilter(t *testing.T) {
 	var receivedStatus string
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedStatus = status
-			return []ports.Task{}
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int { return 0 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -254,8 +254,8 @@ func TestTaskListModel_SearchEsc_ResetsFilter(t *testing.T) {
 
 func TestTaskListModel_SearchEnter_BlurAndReset(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -279,8 +279,8 @@ func TestTaskListModel_SearchEnter_BlurAndReset(t *testing.T) {
 
 func TestTaskListModel_SearchBar_FocusAndUnfocus(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -301,8 +301,8 @@ func TestTaskListModel_SearchBar_FocusAndUnfocus(t *testing.T) {
 
 func TestTaskListModel_FooterText(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -475,8 +475,8 @@ func TestTaskListModel_View_NotReady(t *testing.T) {
 
 func TestTaskListModel_View_WithSearchFocused(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -539,8 +539,8 @@ func TestTaskListModel_UpdateViewportHeight_NotReady(t *testing.T) {
 
 func TestTaskListModel_Init(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 	m := newTaskListModel(context.Background(), store)
 	cmd := m.Init()
@@ -587,8 +587,8 @@ func TestTaskListModel_HandleTasksLoadedMsg_Success(t *testing.T) {
 
 func TestTaskListModel_QuitKeys(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	tests := []struct {
@@ -612,16 +612,16 @@ func TestTaskListModel_QuitKeys(t *testing.T) {
 
 func TestTaskListModel_FetchTasksCmd(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			return []ports.Task{
 				{ID: 1, Content: "test", Status: status},
-			}
+			}, nil
 		},
-		CountTasksFunc: func(status string) int {
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
 			if status == "pending" {
-				return 5
+				return 5, nil
 			}
-			return 10
+			return 10, nil
 		},
 	}
 
@@ -696,15 +696,15 @@ func assertPageNav(t *testing.T, m *taskListModel, key tea.KeyMsg, wantPendingOf
 func TestTaskListModel_PageNav_NextPage_IncrementsOffset(t *testing.T) {
 	var receivedOffset int
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedOffset = offset
 			tasks := make([]ports.Task, 50)
 			for i := range tasks {
 				tasks[i] = ports.Task{ID: int64(offset + i + 1), Content: "task", Status: "pending"}
 			}
-			return tasks
+			return tasks, nil
 		},
-		CountTasksFunc: func(status string) int { return 100 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 100, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -725,15 +725,15 @@ func TestTaskListModel_PageNav_NextPage_IncrementsOffset(t *testing.T) {
 func TestTaskListModel_PageNav_PrevPage_DecrementsOffset(t *testing.T) {
 	var receivedOffset int
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedOffset = offset
 			tasks := make([]ports.Task, 50)
 			for i := range tasks {
 				tasks[i] = ports.Task{ID: int64(offset + i + 1), Content: "task", Status: "pending"}
 			}
-			return tasks
+			return tasks, nil
 		},
-		CountTasksFunc: func(status string) int { return 100 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 100, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -755,12 +755,12 @@ func TestTaskListModel_PageNav_PrevPage_AtZero_Clamped(t *testing.T) {
 	var receivedOffset int
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedOffset = offset
-			return []ports.Task{}
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 10
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 10, nil
 		},
 	}
 
@@ -799,12 +799,12 @@ func TestTaskListModel_PageNav_NextPage_AtLastPage_Clamped(t *testing.T) {
 	var receivedOffset int
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedOffset = offset
-			return []ports.Task{}
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 100
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 100, nil
 		},
 	}
 
@@ -841,8 +841,8 @@ func TestTaskListModel_PageNav_NextPage_AtLastPage_Clamped(t *testing.T) {
 
 func TestTaskListModel_Footer_ShowsCorrectRange(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -864,8 +864,8 @@ func TestTaskListModel_Footer_ShowsCorrectRange(t *testing.T) {
 
 func TestTaskListModel_Footer_AtPageZero(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -887,13 +887,13 @@ func TestTaskListModel_PageNav_PreservesStatusFilter(t *testing.T) {
 	var receivedOffset int
 
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			receivedStatus = status
 			receivedOffset = offset
-			return []ports.Task{{ID: 1, Content: "test", Status: "pending"}}
+			return []ports.Task{{ID: 1, Content: "test", Status: "pending"}}, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 100
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 100, nil
 		},
 	}
 
@@ -933,13 +933,13 @@ func TestTaskListModel_PageNav_PreservesStatusFilter(t *testing.T) {
 
 func TestTaskListModel_PageNav_OffsetAppliedOnlyOnSuccess(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			return []ports.Task{
 				{ID: int64(offset + 1), Content: "task", Status: "pending"},
-			}
+			}, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 100
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 100, nil
 		},
 	}
 
@@ -985,11 +985,11 @@ func TestTaskListModel_PageNav_OffsetAppliedOnlyOnSuccess(t *testing.T) {
 
 func TestTaskListModel_PageNav_ErrorDoesNotAdvanceOffset(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
-			return nil
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
+			return nil, nil
 		},
-		CountTasksFunc: func(status string) int {
-			return 100
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
+			return 100, nil
 		},
 	}
 
@@ -1026,10 +1026,10 @@ func TestTaskListModel_PageNav_ErrorDoesNotAdvanceOffset(t *testing.T) {
 
 func TestTaskListModel_PageNav_PrevClamped_ErrorNoAdvance(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
-			return []ports.Task{}
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
+			return []ports.Task{}, nil
 		},
-		CountTasksFunc: func(status string) int { return 100 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 100, nil },
 	}
 
 	m := newTaskListModel(context.Background(), store)
@@ -1123,10 +1123,10 @@ func TestTaskListModel_PrevPage(t *testing.T) {
 
 func TestTaskListModel_ErrorRecovery_RetryOnAnyKey(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
-			return []ports.Task{{ID: 1, Content: "recovered", Status: "pending"}}
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
+			return []ports.Task{{ID: 1, Content: "recovered", Status: "pending"}}, nil
 		},
-		CountTasksFunc: func(status string) int { return 1 },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 1, nil },
 	}
 
 	m := &taskListModel{
@@ -1228,8 +1228,8 @@ func TestTaskListModel_HandleViewportUpdate_NotReady(t *testing.T) {
 
 func TestTaskListModel_HandleViewportUpdate_Ready(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 	m := newTaskListModel(context.Background(), store)
 	m.handleWindowSizeMsg(tea.WindowSizeMsg{Width: 80, Height: 40})
@@ -1277,13 +1277,13 @@ func TestFetchTasksCmd_CancelledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	store := &mockTaskStore{
-		ListTasksFunc: func(status string, limit, offset int) []ports.Task {
+		ListTasksFunc: func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) {
 			t.Error("ListTasks should not be called")
-			return nil
+			return nil, nil
 		},
-		CountTasksFunc: func(status string) int {
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) {
 			t.Error("CountTasks should not be called")
-			return 0
+			return 0, nil
 		},
 	}
 	cmd := fetchTasksCmd(ctx, store, "", 0, 50)
@@ -1298,8 +1298,8 @@ func TestFetchTasksCmd_CancelledContext(t *testing.T) {
 
 func TestTaskListModel_Update_UnknownMessageNotReady(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 	m := newTaskListModel(context.Background(), store)
 	_, cmd := m.Update(tea.BatchMsg{})
@@ -1310,8 +1310,8 @@ func TestTaskListModel_Update_UnknownMessageNotReady(t *testing.T) {
 
 func TestTaskListModel_Update_UnknownMessageReady(t *testing.T) {
 	store := &mockTaskStore{
-		ListTasksFunc:  func(status string, limit, offset int) []ports.Task { return nil },
-		CountTasksFunc: func(status string) int { return 0 },
+		ListTasksFunc:  func(ctx context.Context, status string, limit, offset int) ([]ports.Task, error) { return nil, nil },
+		CountTasksFunc: func(ctx context.Context, status string) (int, error) { return 0, nil },
 	}
 	m := newTaskListModel(context.Background(), store)
 	m.ready = true


### PR DESCRIPTION
Closes #906.

## Summary

Removed the in-memory task cache (`s.tasks`) from `taskService`, making it a stateless service that delegates all read/write operations to `s.store` (`ports.ListStore`). This fixes cross-session data loss where completed tasks from prior sessions were invisible to `ListTasks`/`CountTasks`.

### Changes

| File | Change |
|------|--------|
| `internal/domain/ports/repository.go` | Added `context.Context` + `error` to `TaskReader` interface |
| `internal/domain/services/task_service.go` | Stateless rewrite — removed cache, delegates to store |
| `internal/domain/services/task_service_test.go` | Updated 12 tests, removed 2 obsolete Initialize tests |
| `internal/ui/tui/tasks_model.go` | `fetchTasksCmd` passes ctx, handles errors |
| `internal/ui/tui/tasks_model_test.go` | Updated mock signatures + ~50 closures |
| `internal/tools/workspace/persistence_tools.go` | `listTasks` passes ctx, handles errors |
| `internal/infrastructure/persistence/state.go` | `initServices` — Initialize is now no-op |
| `internal/infrastructure/persistence/debug_test.go` | Fixed `ListTasks` call site |
| `internal/infrastructure/persistence/state_test.go` | Adapted Initialize error-path tests |

## Verification

| Check | Status |
|-------|--------|
| `make check-full` | ✅ PASS (all 10 steps) |
| `go test ./... -race` | ✅ 68 packages, 0 failures |
| `go vet ./...` | ✅ No issues |
| `golangci-lint run ./...` | ✅ 0 issues |
| Coverage (`internal/domain/services`) | 91.3% |
