### PR TITLE
fix(llm): use DefaultTransport.Clone() instead of zero-value http.Transport (#909)

### DIFF
--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -44,8 +44,13 @@ func NewLLMProviderHealthChecker(providerName string, authenticator auth.Authent
 		authenticator: authenticator,
 		baseURL:       strings.TrimSuffix(baseURL, "/"),
 		httpClient: &http.Client{
-			Timeout:   5 * time.Second,
-			Transport: &http.Transport{},
+			Timeout: 5 * time.Second,
+			Transport: func() http.RoundTripper {
+				if dt, ok := http.DefaultTransport.(*http.Transport); ok {
+					return dt.Clone()
+				}
+				return http.DefaultTransport
+			}(),
 		},
 		gateway: gateway,
 	}


### PR DESCRIPTION
Closes #909.

## Summary
Replaces the zero-value `&http.Transport{}` in `internal/infrastructure/llm/provider_health.go` with the codebase-standard `http.DefaultTransport.(*http.Transport).Clone()` pattern (with fallback to `http.DefaultTransport`). This matches the established pattern used in `openai/client.go`, `anthropic/client.go`, and `gemini/backend.go`.

A zero-value `http.Transport` lacks TCP dial timeouts, TLS handshake timeouts, idle connection timeouts, and connection pooling limits — risking goroutine leaks, file-descriptor exhaustion, and memory leaks under degraded network conditions.

## Verification
| Check | Status |
|-------|--------|
| make check-full (all 10 steps) | PASS |
| Tests (with -race) | PASS |
| Lint | 0 issues |
| Vulncheck | No vulnerabilities |
| Dead code | None found |
| Coverage (llm package) | 99.6% |