### PR TITLE
fix(services): close 5 uncovered error-handling paths in domain services and event bus (#913)

### DIFF
--- a/internal/domain/events/event_bus_lifecycle_whitebox_test.go
+++ b/internal/domain/events/event_bus_lifecycle_whitebox_test.go
@@ -142,6 +142,77 @@ func TestFlush_BusShutdownDuringFlush(t *testing.T) {
 	}
 }
 
+// TestShutdown_ContextCancellationDuringSelect exercises the <-ctx.Done()
+// branch in Shutdown's select (event_bus_lifecycle.go:74-75). Unlike the
+// pre-cancelled path (ctx.Err() guard at line 68-70, covered by
+// TestSimpleEventBus_Shutdown_FlushTimeout), this test verifies that a context
+// which is alive when Shutdown enters but expires while waiting for workers
+// correctly returns the context error.
+func TestShutdown_ContextCancellationDuringSelect(t *testing.T) {
+	t.Parallel()
+
+	bus := NewSimpleEventBus(context.Background(), WithAsync(true), WithQueueSize(2))
+
+	// Start Listen with a cancellable context so we can clean up later.
+	listenCtx, listenCancel := context.WithCancel(context.Background())
+	listenDone := make(chan struct{})
+	go func() {
+		defer close(listenDone)
+		_ = bus.Listen(listenCtx)
+	}()
+	bus.WaitStarted()
+
+	// Subscribe a blocking subscriber that signals when its Handle method is
+	// entered and then blocks until we release it. This keeps a worker
+	// goroutine busy so waitWorkers never returns and done never closes.
+	block := make(chan struct{})
+	started := make(chan struct{}, 1)
+	bus.SubscribeGlobal(&funcSubscriber{f: func(ctx context.Context, e Event) {
+		started <- struct{}{}
+		<-block
+	}})
+
+	// Publish an event so a worker goroutine dequeues it, enters Handle,
+	// and blocks on <-block.
+	if err := bus.Publish(context.Background(), StatusUpdate{Message: "keep worker busy"}); err != nil {
+		close(block)
+		listenCancel()
+		<-listenDone
+		t.Fatalf("Publish failed: %v", err)
+	}
+
+	// Confirm the worker is blocked inside Handle.
+	select {
+	case <-started:
+	case <-time.After(1 * time.Second):
+		close(block)
+		listenCancel()
+		<-listenDone
+		t.Fatal("worker did not start processing")
+	}
+
+	// Call Shutdown with a context that has a short timeout. Inside Shutdown:
+	//   - b.cancel() cancels the bus's internal context
+	//   - waitWorkers goroutine starts but b.workerWG.Wait() won't return
+	//     (worker is blocked on <-block)
+	//   - done channel never closes
+	//   - The early ctx.Err() check passes (context is not yet expired)
+	//   - The select enters, <-done doesn't fire
+	//   - After 50ms, <-ctx.Done() fires → the uncovered path
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer shutdownCancel()
+	err := bus.Shutdown(shutdownCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected context.DeadlineExceeded from ctx.Done() select branch, got %v", err)
+	}
+
+	// Cleanup: unblock the subscriber so the worker drains, then cancel the
+	// listen context and wait for Listen to return.
+	close(block)
+	listenCancel()
+	<-listenDone
+}
+
 // TestWaitStarted_NilBus exercises the nil-receiver early-return guard
 // in WaitStarted. A nil SimpleEventBus must return immediately without
 // panicking or blocking.

--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -288,12 +288,60 @@ func TestTaskService_ErrorPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("CountTasks Query Error", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("store query failed")
+		repo := &mockTaskRepo{readErr: sentinel}
+		s := NewTaskService(repo)
+		count, err := s.CountTasks(ctx, "")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if count != 0 {
+			t.Errorf("expected count 0, got %d", count)
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected sentinel error, got %v", err)
+		}
+	})
+
 	t.Run("UpdateTask Not Found", func(t *testing.T) {
 		t.Parallel()
 		s, _ := setupTaskService(t)
 		_, err := s.UpdateTask(ctx, 999, "content", "status")
 		if err == nil {
 			t.Error("expected not found error")
+		}
+	})
+
+	t.Run("UpdateTask Query Error", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("store query failed")
+		repo := &mockTaskRepo{}
+		s := NewTaskService(repo)
+
+		// Add a task first (no read error)
+		task, err := s.AddTask(ctx, "task to update")
+		if err != nil {
+			t.Fatalf("setup AddTask failed: %v", err)
+		}
+
+		// Now inject the read error
+		repo.readErr = sentinel
+
+		// Attempt update — should fail at Query, never reach iteration or Update
+		_, err = s.UpdateTask(ctx, task.ID, "new content", "completed")
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected sentinel error, got %v", err)
+		}
+
+		// Verify no side effects: task should be unchanged
+		if repo.tasks[0].Content != "task to update" || repo.tasks[0].Status != "pending" {
+			t.Errorf("task was mutated despite query error: content=%q status=%q",
+				repo.tasks[0].Content, repo.tasks[0].Status)
 		}
 	})
 
@@ -317,6 +365,37 @@ func TestTaskService_ErrorPaths(t *testing.T) {
 		}
 	})
 
+	t.Run("DeleteTask Query Error", func(t *testing.T) {
+		t.Parallel()
+		sentinel := errors.New("store query failed")
+		repo := &mockTaskRepo{readErr: sentinel}
+		s := NewTaskService(repo)
+
+		// Add a task so it exists in the store (no read error yet)
+		repo.readErr = nil
+		task, err := s.AddTask(ctx, "task to delete")
+		if err != nil {
+			t.Fatalf("setup AddTask failed: %v", err)
+		}
+
+		// Now inject the read error
+		repo.readErr = sentinel
+
+		// Attempt delete — should fail at Query, not reach the not-found or delete logic
+		err = s.DeleteTask(ctx, task.ID)
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !errors.Is(err, sentinel) {
+			t.Errorf("expected sentinel error, got %v", err)
+		}
+
+		// Verify the task still exists (delete didn't happen)
+		if len(repo.tasks) != 1 {
+			t.Errorf("expected task to still exist, got %d tasks", len(repo.tasks))
+		}
+	})
+
 	t.Run("DeleteTask Write Error", func(t *testing.T) {
 		t.Parallel()
 		s, repo := setupTaskService(t)
@@ -325,6 +404,14 @@ func TestTaskService_ErrorPaths(t *testing.T) {
 		err := s.DeleteTask(ctx, task.ID)
 		if err == nil {
 			t.Error("expected write error")
+		}
+	})
+
+	t.Run("Initialize", func(t *testing.T) {
+		t.Parallel()
+		s, _ := setupTaskService(t)
+		if err := s.(ports.Initializer).Initialize(ctx); err != nil {
+			t.Fatalf("Initialize returned unexpected error: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes #913.

## Summary
Added 5 table-driven test cases covering previously uncovered error-handling paths:

| # | Location | Test | Approach |
|---|----------|------|----------|
| 1 | `Initialize` no-op | `TestTaskService_ErrorPaths/Initialize` | Assert `err == nil` |
| 2 | `UpdateTask` Query error | `TestTaskService_ErrorPaths/UpdateTask Query Error` | Sentinel error + `errors.Is` + verify no mutation |
| 3 | `DeleteTask` Query error | `TestTaskService_ErrorPaths/DeleteTask Query Error` | Sentinel error + `errors.Is` + verify task preserved |
| 4 | `CountTasks` Query error | `TestTaskService_ErrorPaths/CountTasks Query Error` | Sentinel error + `errors.Is` + verify count=0 |
| 5 | `Shutdown` `<-ctx.Done()` branch | `TestShutdown_ContextCancellationDuringSelect` | 50ms timeout context + blocked worker |

## Verification
| Check | Status |
|-------|--------|
| Build + Vet | PASS |
| Lint (golangci-lint) | PASS (0 issues) |
| Tests (services + events) | PASS |
| Race detector | PASS |
| Coverage (services) | 100.0% |
| Coverage (events) | 100.0% |