### PR TITLE
fix(integrations): decompose 5 complexity-9 functions into focused helpers (#916)

### DIFF
--- a/internal/tools/integrations/ado/azure_devops_pr_test.go
+++ b/internal/tools/integrations/ado/azure_devops_pr_test.go
@@ -15,6 +15,53 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestThreadFilter(t *testing.T) {
+	// Helper to build a thread inline
+	makeThread := func(deleted bool, commentTypes ...string) adoThread {
+		var comments []struct {
+			Author struct {
+				DisplayName string `json:"displayName"`
+			} `json:"author"`
+			Content       string `json:"content"`
+			PublishedDate string `json:"publishedDate"`
+			CommentType   string `json:"commentType"`
+		}
+		for _, ct := range commentTypes {
+			comments = append(comments, struct {
+				Author struct {
+					DisplayName string `json:"displayName"`
+				} `json:"author"`
+				Content       string `json:"content"`
+				PublishedDate string `json:"publishedDate"`
+				CommentType   string `json:"commentType"`
+			}{CommentType: ct, Content: "test", Author: struct {
+				DisplayName string `json:"displayName"`
+			}{DisplayName: "User"}, PublishedDate: "2023-01-01"})
+		}
+		return adoThread{Comments: comments, IsDeleted: deleted}
+	}
+
+	tests := []struct {
+		name   string
+		thread adoThread
+		want   bool
+	}{
+		{"user comments only", makeThread(false, "text", "text"), true},
+		{"mixed system and user", makeThread(false, "system", "text"), true},
+		{"single user comment", makeThread(false, "text"), true},
+		{"deleted thread", makeThread(true, "text"), false},
+		{"all system comments", makeThread(false, "system", "system"), false},
+		{"single system comment", makeThread(false, "system"), false},
+		{"no comments", makeThread(false), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, threadFilter(tt.thread))
+		})
+	}
+}
+
 func TestAdoGetPullRequest(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 
@@ -421,17 +468,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		t.Parallel()
 		m := &AdoManager{}
 		threadData := adoThreadResponse{
-			Value: []struct {
-				Comments []struct {
-					Author struct {
-						DisplayName string `json:"displayName"`
-					} `json:"author"`
-					Content       string `json:"content"`
-					PublishedDate string `json:"publishedDate"`
-					CommentType   string `json:"commentType"`
-				} `json:"comments"`
-				IsDeleted bool `json:"isDeleted"`
-			}{
+			Value: []adoThread{
 				{
 					IsDeleted: false,
 					Comments: []struct {
@@ -461,17 +498,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 		t.Parallel()
 		m := &AdoManager{}
 		threadData := adoThreadResponse{
-			Value: []struct {
-				Comments []struct {
-					Author struct {
-						DisplayName string `json:"displayName"`
-					} `json:"author"`
-					Content       string `json:"content"`
-					PublishedDate string `json:"publishedDate"`
-					CommentType   string `json:"commentType"`
-				} `json:"comments"`
-				IsDeleted bool `json:"isDeleted"`
-			}{
+			Value: []adoThread{
 				{
 					IsDeleted: false,
 					Comments: []struct {

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -255,34 +255,54 @@ func (m *AdoManager) ListPipelineLogs(ctx context.Context, args map[string]inter
 	return params.RunId, logsData.Value, nil
 }
 
+// pipelineLogParams holds the parsed arguments for fetching pipeline log content.
+type pipelineLogParams struct {
+	Organization string `json:"organization"`
+	Project      string `json:"project"`
+	PipelineId   int    `json:"pipeline_id"`
+	RunId        int    `json:"run_id"`
+	LogId        int    `json:"log_id"`
+	TailLines    int    `json:"tail_lines"`
+	HeadLines    int    `json:"head_lines"`
+	FilterQuery  string `json:"filter_query"`
+	ContextLines int    `json:"context_lines"`
+	StartLine    int    `json:"start_line"`
+	MaxLines     int    `json:"max_lines"`
+}
+
+// parsePipelineLogParams unmarshals and validates the arguments for
+// getPipelineLogContent. Returns an error if required fields are missing.
+func parsePipelineLogParams(args map[string]interface{}) (pipelineLogParams, error) {
+	var params pipelineLogParams
+	if err := tools.UnmarshalArgs(args, &params); err != nil {
+		return pipelineLogParams{}, fmt.Errorf("parsing get pipeline log content args: %w", err)
+	}
+
+	if params.Organization == "" || params.Project == "" || params.PipelineId == 0 || params.RunId == 0 || params.LogId == 0 {
+		return pipelineLogParams{}, fmt.Errorf("organization, project, pipeline_id, run_id, and log_id are required")
+	}
+
+	return params, nil
+}
+
+// buildPipelineLogURL constructs the Azure DevOps API URL for fetching
+// the content of a single pipeline run log.
+func (m *AdoManager) buildPipelineLogURL(p pipelineLogParams) string {
+	return fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs/%d?api-version=7.1",
+		m.BaseURL, url.PathEscape(p.Organization), url.PathEscape(p.Project),
+		p.PipelineId, p.RunId, p.LogId)
+}
+
 // getPipelineLogContent is the infrastructure-layer entry point for fetching the
 // content of a single pipeline log. Returns logContent describing the body and
 // whether it was truncated.
 func (m *AdoManager) getPipelineLogContent(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (logContent, error) {
-	var params struct {
-		Organization string `json:"organization"`
-		Project      string `json:"project"`
-		PipelineId   int    `json:"pipeline_id"`
-		RunId        int    `json:"run_id"`
-		LogId        int    `json:"log_id"`
-		TailLines    int    `json:"tail_lines"`
-		HeadLines    int    `json:"head_lines"`
-		FilterQuery  string `json:"filter_query"`
-		ContextLines int    `json:"context_lines"`
-		StartLine    int    `json:"start_line"`
-		MaxLines     int    `json:"max_lines"`
+	params, err := parsePipelineLogParams(args)
+	if err != nil {
+		return logContent{}, err
 	}
 
-	if err := tools.UnmarshalArgs(args, &params); err != nil {
-		return logContent{}, fmt.Errorf("parsing get pipeline log content args: %w", err)
-	}
-
-	if params.Organization == "" || params.Project == "" || params.PipelineId == 0 || params.RunId == 0 || params.LogId == 0 {
-		return logContent{}, fmt.Errorf("organization, project, pipeline_id, run_id, and log_id are required")
-	}
-
-	u := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs/%d?api-version=7.1",
-		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId, params.RunId, params.LogId)
+	u := m.buildPipelineLogURL(params)
 
 	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, map[string]string{"Accept": "*/*"})
 	if err != nil {

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -235,18 +235,46 @@ func formatPrDiffChanges(pullRequestID int, changeEntries []prChangeEntry) strin
 	return resultText.String()
 }
 
+type adoThread struct {
+	Comments []struct {
+		Author struct {
+			DisplayName string `json:"displayName"`
+		} `json:"author"`
+		Content       string `json:"content"`
+		PublishedDate string `json:"publishedDate"`
+		CommentType   string `json:"commentType"`
+	} `json:"comments"`
+	IsDeleted bool `json:"isDeleted"`
+}
+
 type adoThreadResponse struct {
-	Value []struct {
-		Comments []struct {
-			Author struct {
-				DisplayName string `json:"displayName"`
-			} `json:"author"`
-			Content       string `json:"content"`
-			PublishedDate string `json:"publishedDate"`
-			CommentType   string `json:"commentType"`
-		} `json:"comments"`
-		IsDeleted bool `json:"isDeleted"`
-	} `json:"value"`
+	Value []adoThread `json:"value"`
+}
+
+// threadFilter decides whether a thread should be rendered in output.
+// It filters out deleted threads and threads that contain only system comments.
+func threadFilter(thread adoThread) bool {
+	if thread.IsDeleted {
+		return false
+	}
+	for _, c := range thread.Comments {
+		if c.CommentType != "system" {
+			return true // has at least one user comment
+		}
+	}
+	return false
+}
+
+// formatSingleThread renders one thread's comments into the builder.
+func formatSingleThread(sb *strings.Builder, index int, thread adoThread) {
+	fmt.Fprintf(sb, "--- Thread %d ---\n", index)
+	for _, c := range thread.Comments {
+		if c.Content == "" {
+			continue
+		}
+		fmt.Fprintf(sb, "[%s] %s: %s\n", c.PublishedDate, c.Author.DisplayName, c.Content)
+	}
+	sb.WriteString("\n")
 }
 
 func (m *AdoManager) AdoGetPrThreads(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -284,39 +312,18 @@ func (m *AdoManager) AdoGetPrThreads(ctx context.Context, args map[string]interf
 
 func (m *AdoManager) formatPrThreads(pullRequestId int, threadData adoThreadResponse) string {
 	var resultText strings.Builder
-	_, _ = fmt.Fprintf(&resultText, "Pull Request #%d Discussion Threads:\n\n", pullRequestId)
+	fmt.Fprintf(&resultText, "Pull Request #%d Discussion Threads:\n\n", pullRequestId)
 
-	threadCount := 0
+	idx := 0
 	for _, thread := range threadData.Value {
-		if thread.IsDeleted {
+		if !threadFilter(thread) {
 			continue
 		}
-
-		// Check if it's a system thread (often has only system comments)
-		isSystem := true
-		for _, comment := range thread.Comments {
-			if comment.CommentType != "system" {
-				isSystem = false
-				break
-			}
-		}
-
-		if isSystem {
-			continue
-		}
-
-		threadCount++
-		_, _ = fmt.Fprintf(&resultText, "--- Thread %d ---\n", threadCount)
-		for _, comment := range thread.Comments {
-			if comment.Content == "" {
-				continue
-			}
-			_, _ = fmt.Fprintf(&resultText, "[%s] %s: %s\n", comment.PublishedDate, comment.Author.DisplayName, comment.Content)
-		}
-		resultText.WriteString("\n")
+		idx++
+		formatSingleThread(&resultText, idx, thread)
 	}
 
-	if threadCount == 0 {
+	if idx == 0 {
 		return "No discussion threads found in this pull request."
 	}
 

--- a/internal/tools/integrations/atlassian/confluence_format.go
+++ b/internal/tools/integrations/atlassian/confluence_format.go
@@ -33,6 +33,27 @@ var (
 	reItalic2 = regexp.MustCompile(`_(.*?)_`)
 )
 
+// headingTags maps Markdown heading prefixes to their XHTML tag names.
+var headingTags = map[string]string{
+	"# ":      "h1",
+	"## ":     "h2",
+	"### ":    "h3",
+	"#### ":   "h4",
+	"##### ":  "h5",
+	"###### ": "h6",
+}
+
+// convertHeading detects a Markdown ATX heading line and returns the XHTML tag,
+// escaped content, and true. Returns zero values and false for non-heading lines.
+func convertHeading(line string) (tag string, content string, ok bool) {
+	for prefix, tag := range headingTags {
+		if strings.HasPrefix(line, prefix) {
+			return tag, html.EscapeString(strings.TrimPrefix(line, prefix)), true
+		}
+	}
+	return "", "", false
+}
+
 func (m *ConfluenceManager) xhtmlToMarkdown(xhtml string) string {
 	// 1. Normalize whitespace - replace all newlines and tabs with spaces
 	content := strings.ReplaceAll(xhtml, "\r", "")
@@ -88,24 +109,8 @@ func (m *ConfluenceManager) markdownToXhtml(markdown string) string {
 			continue
 		}
 
-		if strings.HasPrefix(line, "# ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "# "))
-			result.WriteString("<h1>" + content + "</h1>")
-		} else if strings.HasPrefix(line, "## ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "## "))
-			result.WriteString("<h2>" + content + "</h2>")
-		} else if strings.HasPrefix(line, "### ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "### "))
-			result.WriteString("<h3>" + content + "</h3>")
-		} else if strings.HasPrefix(line, "#### ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "#### "))
-			result.WriteString("<h4>" + content + "</h4>")
-		} else if strings.HasPrefix(line, "##### ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "##### "))
-			result.WriteString("<h5>" + content + "</h5>")
-		} else if strings.HasPrefix(line, "###### ") {
-			content := html.EscapeString(strings.TrimPrefix(line, "###### "))
-			result.WriteString("<h6>" + content + "</h6>")
+		if tag, content, ok := convertHeading(line); ok {
+			result.WriteString("<" + tag + ">" + content + "</" + tag + ">")
 		} else {
 			// Escape first to avoid escaping generated tags
 			line = html.EscapeString(line)

--- a/internal/tools/integrations/atlassian/confluence_format_test.go
+++ b/internal/tools/integrations/atlassian/confluence_format_test.go
@@ -10,6 +10,42 @@ import (
 )
 
 // ---------------------------------------------------------------------------
+// convertHeading tests
+// ---------------------------------------------------------------------------
+
+func TestConvertHeading(t *testing.T) {
+	tests := []struct {
+		name        string
+		line        string
+		wantTag     string
+		wantContent string
+		wantOk      bool
+	}{
+		{"h1", "# Title", "h1", "Title", true},
+		{"h2", "## Subtitle", "h2", "Subtitle", true},
+		{"h3", "### Section", "h3", "Section", true},
+		{"h4", "#### Subsection", "h4", "Subsection", true},
+		{"h5", "##### Minor", "h5", "Minor", true},
+		{"h6", "###### Small", "h6", "Small", true},
+		{"seven hashes not a heading", "####### Not heading", "", "", false},
+		{"no space after hash", "#NoSpace", "", "", false},
+		{"plain text", "Just a paragraph", "", "", false},
+		{"empty string", "", "", "", false},
+		{"bold text not heading", "**bold**", "", "", false},
+		{"hash mid-line", "text # not heading", "", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tag, content, ok := convertHeading(tt.line)
+			assert.Equal(t, tt.wantTag, tag)
+			assert.Equal(t, tt.wantContent, content)
+			assert.Equal(t, tt.wantOk, ok)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // xhtmlToMarkdown / markdownToXhtml tests
 // ---------------------------------------------------------------------------
 

--- a/internal/tools/integrations/atlassian/confluence_search.go
+++ b/internal/tools/integrations/atlassian/confluence_search.go
@@ -16,27 +16,16 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
-type searchResponse struct {
-	Results []struct {
-		ID    string `json:"id"`
-		Title string `json:"title"`
-	} `json:"results"`
-	Links struct {
-		Next string `json:"next"`
-	} `json:"_links"`
+// isNumeric reports whether s is a positive integer, used to detect
+// numeric space IDs that bypass the key-resolution HTTP call.
+func isNumeric(s string) bool {
+	n, err := strconv.Atoi(s)
+	return err == nil && n >= 0
 }
 
-type searchMatch struct {
-	ID    string
-	Title string
-}
-
-func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string) (string, error) {
-	// If it's already numeric, return it
-	if _, err := strconv.Atoi(spaceKey); err == nil {
-		return spaceKey, nil
-	}
-
+// fetchSpaceByKey resolves a Confluence space key (e.g., "PROJ") to its
+// numeric ID via the /wiki/api/v2/spaces endpoint.
+func (m *ConfluenceManager) fetchSpaceByKey(ctx context.Context, spaceKey string) (string, error) {
 	u, err := url.Parse(m.provider.baseURL)
 	if err != nil {
 		return "", fmt.Errorf("invalid base url: %w", err)
@@ -57,7 +46,7 @@ func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string)
 		return "", err
 	}
 	defer func() {
-		_, _ = io.Copy(io.Discard, resp.Body) // drain to enable connection reuse
+		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
 
@@ -83,6 +72,30 @@ func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string)
 	}
 
 	return responseData.Results[0].ID, nil
+}
+
+type searchResponse struct {
+	Results []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	} `json:"results"`
+	Links struct {
+		Next string `json:"next"`
+	} `json:"_links"`
+}
+
+type searchMatch struct {
+	ID    string
+	Title string
+}
+
+func (m *ConfluenceManager) resolveSpaceID(ctx context.Context, spaceKey string) (string, error) {
+	// If it's already numeric, return it
+	if isNumeric(spaceKey) {
+		return spaceKey, nil
+	}
+
+	return m.fetchSpaceByKey(ctx, spaceKey)
 }
 
 func (m *ConfluenceManager) FetchSearchPage(ctx context.Context, url string) (*searchResponse, error) {
@@ -149,6 +162,31 @@ func (m *ConfluenceManager) resolveNextURL(baseURL, nextPath string) string {
 	return parsedBase.ResolveReference(parsedNext).String()
 }
 
+// fetchAllPages performs a paginated search, following next links until
+// maxPages is reached or no more pages exist. It returns accumulated
+// matches and the total number of API results processed.
+func (m *ConfluenceManager) fetchAllPages(ctx context.Context, startURL string, maxPages int, keyword string) ([]searchMatch, int, error) {
+	maxIterations := (maxPages + 49) / 50
+	nextURL := startURL
+	var matches []searchMatch
+	pagesProcessed := 0
+
+	for i := 0; i < maxIterations && nextURL != ""; i++ {
+		responseData, err := m.FetchSearchPage(ctx, nextURL)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		pageMatches := m.processSearchResults(responseData.Results, keyword)
+		matches = append(matches, pageMatches...)
+		pagesProcessed += len(responseData.Results)
+
+		nextURL = m.resolveNextURL(m.provider.baseURL, responseData.Links.Next)
+	}
+
+	return matches, pagesProcessed, nil
+}
+
 func (m *ConfluenceManager) confluenceSearch(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Title   string `json:"title"`
@@ -174,22 +212,10 @@ func (m *ConfluenceManager) confluenceSearch(ctx context.Context, args map[strin
 	}
 
 	maxPages, warning := m.getSearchLimit(params.Limit)
-	nextURL := u.String()
-	var matches []searchMatch
-	maxIterations := (maxPages + 49) / 50
-	pagesProcessed := 0
 
-	for i := 0; i < maxIterations && nextURL != ""; i++ {
-		responseData, err := m.FetchSearchPage(ctx, nextURL)
-		if err != nil {
-			return tools.ToolResult{}, err
-		}
-
-		pageMatches := m.processSearchResults(responseData.Results, params.Title)
-		matches = append(matches, pageMatches...)
-		pagesProcessed += len(responseData.Results)
-
-		nextURL = m.resolveNextURL(m.provider.baseURL, responseData.Links.Next)
+	matches, pagesProcessed, err := m.fetchAllPages(ctx, u.String(), maxPages, params.Title)
+	if err != nil {
+		return tools.ToolResult{}, err
 	}
 
 	return m.formatSearchResults(matches, warning, pagesProcessed, params.SpaceID, params.Title), nil

--- a/internal/tools/integrations/atlassian/confluence_test.go
+++ b/internal/tools/integrations/atlassian/confluence_test.go
@@ -17,6 +17,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestIsNumeric(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{"positive integer", "123", true},
+		{"zero", "0", true},
+		{"large number", "999999", true},
+		{"alphabetic", "abc", false},
+		{"empty string", "", false},
+		{"negative number", "-1", false},
+		{"alphanumeric", "abc123", false},
+		{"float", "12.5", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isNumeric(tt.input))
+		})
+	}
+}
+
 func TestConfluenceManager_GetAuthHeader(t *testing.T) {
 	t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
 	t.Run("Missing Email", func(t *testing.T) {


### PR DESCRIPTION
Closes #916.

## Summary
Decomposed 5 complexity-9 functions in the integrations layer (ADO + Atlassian) by extracting focused helpers. All functions reduced from complexity 9 to ≤7, with extracted helpers independently unit-testable.

### ADO Integration (2 functions)
- **`formatPrThreads`** → extracted `threadFilter` predicate + `formatSingleThread` formatter + named `adoThread` type
- **`getPipelineLogContent`** → extracted `pipelineLogParams` struct + `parsePipelineLogParams` + `buildPipelineLogURL`

### Atlassian Integration (3 functions)
- **`markdownToXhtml`** → extracted `convertHeading` pure function with table-driven `headingTags` map
- **`resolveSpaceID`** → extracted `isNumeric` + `fetchSpaceByKey` HTTP method
- **`confluenceSearch`** → extracted `fetchAllPages` pagination loop

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| fmt | PASS |
| tidy | PASS |
| build | PASS |
| lint | PASS (0 issues) |
| verify-architecture | PASS |
| vulncheck | PASS (0 vulns) |
| test | PASS |
| test-race | PASS |
| test-coverage | ≥99% (ado 99.5%, atlassian 99.2%) |
| dead-code | PASS (none) |