### PR TITLE
fix(cli): decompose sanitizeArgs and buildCapturer to reduce complexity (#925)

### DIFF
--- a/internal/cli/chat_command.go
+++ b/internal/cli/chat_command.go
@@ -230,58 +230,66 @@ func (c *chatCommand) captureInput(ctx stdctx.Context, capturer agent.CapturerIn
 	return prompt, nil
 }
 
+// buildTUICapturer constructs a TUI-based prompt capturer with suggestion support.
+// It seeds the suggestion trie from the last user message (best-effort), initializes
+// the suggestion service, and wraps the base capturer. Falls back to a bare capturer
+// if suggestion initialization fails.
+func (c *chatCommand) buildTUICapturer(ctx stdctx.Context, cfg *domain_config.Config) (agent.CapturerInteractor, func(stdctx.Context) error, error) {
+	// Try to get at least the last user message for the trie
+	hManager, _ := c.Bootstrapper.GetHistoryManager(ctx, cfg)
+	var lastMsg string
+	if hManager != nil {
+		lastMsg, _, _ = c.ChatService.GetLastUserMessage(ctx, hManager)
+	}
+
+	var recentHistory []string
+	if lastMsg != "" {
+		recentHistory = append(recentHistory, lastMsg)
+	}
+
+	svc, err := c.Bootstrapper.GetSuggestionService(ctx, recentHistory)
+
+	capturerInterface := c.newCapturer(c.Stdin, c.Stdout, c.Stderr, c.SM, clock.RealClock{}, c.MockPrompt, c.MockAnswer, false)
+	baseCapturer, ok := capturerInterface.(tui.BaseCapturer)
+	if !ok {
+		// Coverage gap accepted by architect: structurally unreachable.
+		// tui.BaseCapturer and agent.CapturerInteractor are structurally
+		// identical interfaces (both compose ports.Capturer +
+		// domain_security.UserInteractor). Any type that fails the
+		// BaseCapturer assertion necessarily also fails the
+		// CapturerInteractor assertion — and vice versa. The dual-failure
+		// path is covered by the error return below. See Issue #888.
+		return nil, nil, fmt.Errorf("ui.NewCapturer did not return a tui.BaseCapturer or agent.CapturerInteractor")
+	}
+
+	var capturer agent.CapturerInteractor
+	var cleanup func(stdctx.Context) error
+
+	if err != nil {
+		// Log warning and fall back to the base capturer (no suggestions)
+		c.warnf("Warning: failed to initialize suggestions: %v\n", err)
+		capturer = baseCapturer
+		cleanup = func(ctx stdctx.Context) error {
+			return capturer.Close(ctx)
+		}
+	} else {
+		capturer = tui.NewPromptCapturer(baseCapturer, svc)
+		cleanup = func(ctx stdctx.Context) error {
+			if err := capturer.Close(ctx); err != nil {
+				c.warnf("Warning: failed to close capturer: %v\n", err)
+				return err
+			}
+			return nil
+		}
+	}
+
+	c.Interactor.set(capturer)
+	return capturer, cleanup, nil
+}
+
 func (c *chatCommand) buildCapturer(ctx stdctx.Context, cfg *domain_config.Config, opts *cliOptions) (agent.CapturerInteractor, func(stdctx.Context) error, error) {
 	if opts.tuiPrompt {
-		// Try to get at least the last user message for the trie
-		hManager, _ := c.Bootstrapper.GetHistoryManager(ctx, cfg)
-		var lastMsg string
-		if hManager != nil {
-			lastMsg, _, _ = c.ChatService.GetLastUserMessage(ctx, hManager)
-		}
-
-		var recentHistory []string
-		if lastMsg != "" {
-			recentHistory = append(recentHistory, lastMsg)
-		}
-
-		svc, err := c.Bootstrapper.GetSuggestionService(ctx, recentHistory)
-
-		capturerInterface := c.newCapturer(c.Stdin, c.Stdout, c.Stderr, c.SM, clock.RealClock{}, c.MockPrompt, c.MockAnswer, false)
-		baseCapturer, ok := capturerInterface.(tui.BaseCapturer)
-		if !ok {
-			// Coverage gap accepted by architect: structurally unreachable.
-			// tui.BaseCapturer and agent.CapturerInteractor are structurally
-			// identical interfaces (both compose ports.Capturer +
-			// domain_security.UserInteractor). Any type that fails the
-			// BaseCapturer assertion necessarily also fails the
-			// CapturerInteractor assertion — and vice versa. The dual-failure
-			// path is covered by the error return below. See Issue #888.
-			return nil, nil, fmt.Errorf("ui.NewCapturer did not return a tui.BaseCapturer or agent.CapturerInteractor")
-		}
-
-		var capturer agent.CapturerInteractor
-		var cleanup func(stdctx.Context) error
-
-		if err != nil {
-			// Log warning and fall back to the base capturer (no suggestions)
-			c.warnf("Warning: failed to initialize suggestions: %v\n", err)
-			capturer = baseCapturer
-			cleanup = func(ctx stdctx.Context) error {
-				return capturer.Close(ctx)
-			}
-		} else {
-			capturer = tui.NewPromptCapturer(baseCapturer, svc)
-			cleanup = func(ctx stdctx.Context) error {
-				if err := capturer.Close(ctx); err != nil {
-					c.warnf("Warning: failed to close capturer: %v\n", err)
-					return err
-				}
-				return nil
-			}
-		}
-
-		c.Interactor.set(capturer)
-		return capturer, cleanup, nil
+		return c.buildTUICapturer(ctx, cfg)
 	}
 	capturer, cleanup, err := c.setupCapturer()
 	if err != nil {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -176,6 +176,26 @@ func (a *App) Run(ctx stdctx.Context, args []string) error {
 	return nil
 }
 
+// consumeOptionalIntFlag checks if args[index] is an optional-int flag (-l, --last, -b, --back).
+// If the next argument is a valid integer, it is consumed as the flag value.
+// Returns the normalized "flag=value" string and the number of arguments consumed (1 or 2).
+// Returns ("", 0) if args[index] is not an optional-int flag.
+func consumeOptionalIntFlag(args []string, index int) (string, int) {
+	arg := args[index]
+	if arg != "-l" && arg != "--last" && arg != "-b" && arg != "--back" {
+		return "", 0
+	}
+	val := "1"
+	consumed := 1
+	if index+1 < len(args) {
+		if _, err := strconv.Atoi(args[index+1]); err == nil {
+			val = args[index+1]
+			consumed = 2
+		}
+	}
+	return fmt.Sprintf("%s=%s", arg, val), consumed
+}
+
 // sanitizeArgs preprocessing allows integer flags like -l and -b to behave like boolean flags
 // defaulting to 1 when no argument is explicitly provided, preventing positional arguments
 // (like the prompt string) from being mistakenly parsed as their values.
@@ -183,28 +203,15 @@ func sanitizeArgs(args []string) []string {
 	if len(args) < 2 {
 		return args
 	}
-
 	result := make([]string, 0, len(args))
 	result = append(result, args[0])
-
 	for i := 1; i < len(args); i++ {
-		arg := args[i]
-
-		// Check if the current argument is one of our optional-int flags
-		if arg == "-l" || arg == "--last" || arg == "-b" || arg == "--back" {
-			val := "1"
-			if i+1 < len(args) {
-				if _, err := strconv.Atoi(args[i+1]); err == nil {
-					val = args[i+1]
-					i++ // consume the next arg as the flag value
-				}
-			}
-			// Re-inject as a single joint argument to force pflag to consume it
-			result = append(result, fmt.Sprintf("%s=%s", arg, val))
+		if normalized, consumed := consumeOptionalIntFlag(args, i); consumed > 0 {
+			result = append(result, normalized)
+			i += consumed - 1
 			continue
 		}
-
-		result = append(result, arg)
+		result = append(result, args[i])
 	}
 	return result
 }


### PR DESCRIPTION
Closes #925.

## Summary
Refactored two high-complexity functions in `internal/cli` via pure Extract Method:

1. **`sanitizeArgs`** (complexity 9 → 4): Extracted `consumeOptionalIntFlag` helper for optional-integer flag detection and value consumption.
2. **`buildCapturer`** (complexity 8 → 3): Extracted `buildTUICapturer` method for TUI capturer construction, leaving `buildCapturer` as a clean 2-branch router.

Zero behavioral changes — all existing tests pass identically.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint (golangci-lint) | 0 issues |
| govulncheck | No vulnerabilities |
| test-race | PASS (all packages) |
| target coverage (internal/cli) | 100.0% |
| dead-code | None found |
