### PR TITLE
fix(ui): close 5 graceful degradation coverage gaps in markdown rendering and metrics (#926)

### DIFF
--- a/internal/domain/ports/renderer.go
+++ b/internal/domain/ports/renderer.go
@@ -111,6 +111,10 @@ type HistoryRenderOptions struct {
 	ShowThoughts bool
 	// UseColor enables ANSI color escape sequences in the output.
 	UseColor bool
+	// CustomRenderer, if non-nil, is used instead of creating a glamour
+	// TermRenderer. The value must have a Render(string)(string,error) method.
+	// Intended for testing. Ignored when Raw is true.
+	CustomRenderer interface{ Render(string) (string, error) }
 }
 
 // SystemMetricsProvider defines the interface for collecting host resource usage.

--- a/internal/ui/export_test.go
+++ b/internal/ui/export_test.go
@@ -8,7 +8,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/charmbracelet/glamour"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 )
 
@@ -93,7 +92,7 @@ func (ui *UIState) C(s string) string {
 	return ui.c(s)
 }
 
-func (r *stdUIRenderer) SetGlamourRenderer(tr *glamour.TermRenderer) {
+func (r *stdUIRenderer) SetGlamourRenderer(tr markdownRenderer) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.renderer = tr

--- a/internal/ui/history.go
+++ b/internal/ui/history.go
@@ -48,10 +48,14 @@ func renderHistory(w io.Writer, h ports.HistoryReader, n int, options ports.Hist
 		useColor:     options.UseColor,
 	}
 	if !options.Raw {
-		hr.renderer, _ = glamour.NewTermRenderer(
-			glamour.WithAutoStyle(),
-			glamour.WithEmoji(),
-		)
+		if options.CustomRenderer != nil {
+			hr.renderer = options.CustomRenderer
+		} else {
+			hr.renderer, _ = glamour.NewTermRenderer(
+				glamour.WithAutoStyle(),
+				glamour.WithEmoji(),
+			)
+		}
 	}
 
 	for _, content := range contents {
@@ -67,7 +71,7 @@ func renderHistory(w io.Writer, h ports.HistoryReader, n int, options ports.Hist
 }
 
 type historyRenderer struct {
-	renderer     *glamour.TermRenderer
+	renderer     markdownRenderer
 	writer       io.Writer
 	raw          bool
 	showThoughts bool

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -280,4 +280,31 @@ func TestHistory_RenderTextError(t *testing.T) {
 			t.Errorf("expected fallback text 'hello world', got: %q", output)
 		}
 	})
+
+	t.Run("renderer error prints [render error:] prefix and raw text", func(t *testing.T) {
+		// Use a fresh history with one entry
+		ctx := context.Background()
+		tmp := t.TempDir()
+		historyPath := filepath.Join(tmp, "history.json")
+		h := history.NewManager(infrapersistence.NewOSFileSystem(), historyPath, historyPath+".archive")
+		if err := h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello world"}}}); err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		ui.RenderHistory(&buf, h, 10, ports.HistoryRenderOptions{
+			Raw:            false,
+			CustomRenderer: &failingRenderer{err: errors.New("history render failure")},
+		})
+
+		output := buf.String()
+		// Must contain the [render error: ...] prefix from the degradation path
+		if !strings.Contains(output, "[render error: history render failure]") {
+			t.Errorf("expected [render error: history render failure] in output, got: %q", output)
+		}
+		// Must still contain the raw text after the error line
+		if !strings.Contains(output, "hello world") {
+			t.Errorf("expected raw text 'hello world' after error, got: %q", output)
+		}
+	})
 }

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -22,13 +22,36 @@ import (
 	"golang.org/x/term"
 )
 
+// markdownRenderer abstracts glamour for testability. *glamour.TermRenderer
+// satisfies this interface implicitly via its Render(string)(string,error) method.
+type markdownRenderer interface {
+	Render(text string) (string, error)
+}
+
+// rendererConfig holds optional configuration for NewRenderer.
+type rendererConfig struct {
+	glamourOpts []glamour.TermRendererOption
+}
+
+// RendererOption is a functional option for NewRenderer.
+type RendererOption func(*rendererConfig)
+
+// WithGlamourOption appends a glamour TermRendererOption to be passed to
+// glamour.NewTermRenderer during initialization. Use this in tests to inject
+// a failing option that forces the degradation path.
+func WithGlamourOption(opt glamour.TermRendererOption) RendererOption {
+	return func(c *rendererConfig) {
+		c.glamourOpts = append(c.glamourOpts, opt)
+	}
+}
+
 // stdUIRenderer implements ports.UIRenderer using standard output/error and Glamour.
 type stdUIRenderer struct {
 	locker          domain_security.Manager
 	stdout          io.Writer
 	stderr          io.Writer
 	clock           clock.Clock
-	renderer        *glamour.TermRenderer
+	renderer        markdownRenderer
 	mu              sync.RWMutex
 	ioMu            sync.Mutex
 	useColor        bool
@@ -140,17 +163,25 @@ func (bdr *binaryDependencyRenderer) renderBinaries(ui uiState, stderr io.Writer
 }
 
 // NewRenderer creates a new ports.UIRenderer.
-func NewRenderer(locker domain_security.Manager, stdout, stderr io.Writer, clk clock.Clock, metricsProvider ports.SystemMetricsProvider) ports.UIRenderer {
+func NewRenderer(locker domain_security.Manager, stdout, stderr io.Writer, clk clock.Clock, metricsProvider ports.SystemMetricsProvider, opts ...RendererOption) ports.UIRenderer {
 	if clk == nil {
 		clk = clock.RealClock{}
 	}
 	if metricsProvider == nil {
 		metricsProvider = &defaultMetricsProvider{}
 	}
-	tr, err := glamour.NewTermRenderer(
-		glamour.WithAutoStyle(),
-		glamour.WithEmoji(),
-	)
+
+	cfg := &rendererConfig{
+		glamourOpts: []glamour.TermRendererOption{
+			glamour.WithAutoStyle(),
+			glamour.WithEmoji(),
+		},
+	}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+
+	tr, err := glamour.NewTermRenderer(cfg.glamourOpts...)
 	r := &stdUIRenderer{
 		locker:          locker,
 		stdout:          stdout,

--- a/internal/ui/renderer_test.go
+++ b/internal/ui/renderer_test.go
@@ -6,6 +6,7 @@ package ui_test
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/glamour"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
@@ -1010,6 +1012,30 @@ func TestStdUIRenderer_IsTerminalContext(t *testing.T) {
 			t.Error("expected IsTerminalContext to return false for nil stderr")
 		}
 	})
+
+	t.Run("non-TTY spinner produces no output without forceSpinner", func(t *testing.T) {
+		var stdout, stderr bytes.Buffer
+		lock := ui.NewMockLocker()
+		mc := ui.NewMockClock(time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC))
+		r := ui.NewRenderer(lock, &stdout, &stderr, mc, nil).(*ui.StdUIRenderer)
+
+		// stderr is bytes.Buffer — IsTerminalContext() returns false
+		if r.IsTerminalContext() {
+			t.Fatal("prerequisite: expected non-TTY context for bytes.Buffer")
+		}
+
+		// Do NOT call SetForceSpinner — we want to test the default behavior
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		stop := r.StartSpinner(ctx)
+		stop()
+
+		// In non-TTY mode without forceSpinner, the spinner should be a no-op:
+		// no spinner frames, no output written to stderr.
+		if stderr.Len() > 0 {
+			t.Errorf("expected no spinner output in non-TTY mode, got: %q", stderr.String())
+		}
+	})
 }
 
 func TestStdUIRenderer_MarkdownRenderingFallback(t *testing.T) {
@@ -1107,7 +1133,31 @@ func TestStdUIRenderer_LogUsage_NilAndEmpty(t *testing.T) {
 	})
 }
 
+// TestStdUIRenderer_LogUsage_MarshalFailure documents the json.Marshal error
+// branch in LogUsage (renderer_metrics.go:244). This branch is defensive dead
+// code: llm.Metrics contains only basic JSON-marshalable types (string, int32,
+// int, float64, bool). json.Marshal cannot fail on this struct.
+//
+// If Metrics ever gains an interface{}, map, or any field that can hold an
+// unmarshalable Go value, replace t.Skip with an actual test:
+//  1. Construct a Metrics with an unmarshalable value via reflection/unsafe
+//  2. Call LogUsage with that Metrics
+//  3. Assert stderr contains "failed to marshal usage metrics" (warn level)
+func TestStdUIRenderer_LogUsage_MarshalFailure(t *testing.T) {
+	t.Skip("Defensive dead code: json.Marshal on llm.Metrics cannot fail with current field types (all basic). " +
+		"See renderer_metrics.go:244. If Metrics gains an interface{} field, implement the test described above.")
+}
+
 // ── Markdown render error logging tests (G4+G5) ──
+
+// failingRenderer is a mock markdownRenderer that always returns an error.
+type failingRenderer struct {
+	err error
+}
+
+func (f *failingRenderer) Render(text string) (string, error) {
+	return "", f.err
+}
 
 func TestStdUIRenderer_MarkdownRenderError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
@@ -1122,6 +1172,23 @@ func TestStdUIRenderer_MarkdownRenderError(t *testing.T) {
 		output := stdout.String()
 		if !strings.Contains(output, "**bold**") {
 			t.Errorf("expected raw markdown text, got: %q", output)
+		}
+	})
+
+	t.Run("renderer error falls back to raw text with warning", func(t *testing.T) {
+		// sync.Once on markdownErrOnce requires a fresh renderer
+		var outBuf, errBuf bytes.Buffer
+		r2 := ui.NewRenderer(locker, &outBuf, &errBuf, nil, nil).(*ui.StdUIRenderer)
+		r2.SetGlamourRenderer(&failingRenderer{err: errors.New("render engine exploded")})
+		r2.RenderMarkdown("**bold** and *italic*")
+
+		// stdout must contain the raw markdown text (fallback)
+		if !strings.Contains(outBuf.String(), "**bold**") {
+			t.Errorf("expected stdout to contain raw markdown '**bold**', got: %q", outBuf.String())
+		}
+		// stderr must contain the degradation warning
+		if !strings.Contains(errBuf.String(), "[WARN] markdown rendering degraded") {
+			t.Errorf("expected stderr to contain '[WARN] markdown rendering degraded', got: %q", errBuf.String())
 		}
 	})
 }
@@ -1157,6 +1224,52 @@ func TestNewRenderer_GlamourFailure(t *testing.T) {
 		output := buf.String()
 		if !strings.Contains(output, "**bold**") {
 			t.Errorf("expected raw markdown fallback, got: %q", output)
+		}
+	})
+}
+
+// ── G3b: Glamour initialization failure path (Issue #383) ──
+
+func TestNewRenderer_GlamourInitFailure(t *testing.T) {
+	t.Run("init-failure degrades and logs", func(t *testing.T) {
+		var buf bytes.Buffer
+		locker := ui.NewMockLocker()
+
+		failingOpt := glamour.TermRendererOption(func(tr *glamour.TermRenderer) error {
+			return errors.New("injected glamour init failure")
+		})
+
+		r := ui.NewRenderer(locker, &buf, &buf, nil, nil, ui.WithGlamourOption(failingOpt)).(*ui.StdUIRenderer)
+
+		// Verify degradation flag
+		if !r.IsRendererDegraded() {
+			t.Error("expected IsRendererDegraded() = true after glamour init failure")
+		}
+
+		// Verify error logged to stderr
+		stderrOutput := buf.String()
+		if !strings.Contains(stderrOutput, "failed to initialize glamour renderer") {
+			t.Errorf("expected stderr to contain 'failed to initialize glamour renderer', got: %q", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, "injected glamour init failure") {
+			t.Errorf("expected stderr to contain 'injected glamour init failure', got: %q", stderrOutput)
+		}
+
+		// Verify raw text fallback via RenderMarkdown
+		buf.Reset()
+		r.RenderMarkdown("**bold**")
+		stdoutOutput := buf.String()
+		if !strings.Contains(stdoutOutput, "**bold**") {
+			t.Errorf("expected raw markdown fallback '**bold**', got: %q", stdoutOutput)
+		}
+	})
+
+	t.Run("normal renderer is not degraded", func(t *testing.T) {
+		var buf bytes.Buffer
+		locker := ui.NewMockLocker()
+		r := ui.NewRenderer(locker, &buf, &buf, nil, nil).(*ui.StdUIRenderer)
+		if r.IsRendererDegraded() {
+			t.Error("expected IsRendererDegraded() = false for normal renderer")
 		}
 	})
 }


### PR DESCRIPTION
Closes #926.

## Summary

Added test coverage for 5 graceful degradation branches in the `internal/ui` package:

| Gap | Description | Implementation |
|-----|-------------|----------------|
| 1 | Glamour Init Failure (`renderer.go:163`) | `TestNewRenderer_GlamourInitFailure` — injects failing option via `WithGlamourOption` |
| 2 | Markdown Render Failure (`renderer.go:251`) | Sub-test in `TestStdUIRenderer_MarkdownRenderError` — injects `failingRenderer` mock |
| 3 | History Render Failure (`history.go:98`) | Sub-test in `TestHistory_RenderTextError` — injects via new `CustomRenderer` option |
| 4 | JSON Marshal Failure (`renderer_metrics.go:244`) | Documented skip test — branch is defensive dead code on current `Metrics` struct |
| 5 | isTerminal + Spinner (`renderer.go:313`) | Sub-test in `TestStdUIRenderer_IsTerminalContext` — verifies non-TTY no-op |

**Structural changes:**
- Extracted `markdownRenderer` interface from concrete `*glamour.TermRenderer`
- Added `RendererOption` / `WithGlamourOption` functional options to `NewRenderer`
- Added `CustomRenderer` field to `ports.HistoryRenderOptions`

## Verification

| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go test ./...` | PASS |
| `go test -race ./...` | PASS (UI package) |
| `golangci-lint run` | 0 issues |
| `make check-full` | All steps pass\* |
| Coverage (`internal/ui`) | 96.4% |

\*Only pre-existing flaky `TestDependencyAnalyzer_StartHeartbeat` in `internal/tools/analysis` — unrelated.