### PR TITLE
fix(testing): close 3 edge-case coverage gaps in executor, session, and LLM adapter (#923)

### DIFF
--- a/internal/agent/executor/decorators_test.go
+++ b/internal/agent/executor/decorators_test.go
@@ -1022,3 +1022,78 @@ func TestMonitorLiveness_TimerFires_CancelsContext(t *testing.T) {
 	}
 	assert.Equal(t, "zombie_tool", attrs["tool_name"])
 }
+
+// TestMonitorLiveness_TimerChannelFires covers the <-timer.channel() branch
+// at decorators.go:271. Unlike TestMonitorLiveness_TimerFires_CancelsContext
+// (which tests via go d.monitorLiveness(...) and may not register in Go's
+// coverage tooling), this test calls monitorLiveness DIRECTLY — the timer
+// fires synchronously within the test goroutine, guaranteeing coverage
+// instrumentation sees the branch.
+func TestMonitorLiveness_TimerChannelFires(t *testing.T) {
+	t.Parallel()
+
+	logger := &capturingLogger{}
+	bus := &mockEventBus{}
+	observer := &mockLogger{}
+	zombie, _ := tools.NewZombieTool(observer)
+	registry := &panicRegistry{}
+
+	decorator := newSafetyDecorator(
+		&mockExecutor{},
+		registry,
+		logger,
+		bus,
+		zombie,
+		5*time.Second,
+		5*time.Second,
+		10*time.Millisecond,
+	).(*safetyDecorator)
+
+	// Create a context whose cancel func we can observe
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cleanup in case monitorLiveness doesn't call it
+
+	// hbCh with no sender — the <-hbCh case blocks forever
+	hbCh := make(chan struct{})
+
+	// heartbeat channel — irrelevant for this test, can be nil
+	var heartbeat chan struct{}
+
+	// Liveness threshold: 1ms — timer fires almost immediately
+	opts := tools.ToolOptions{LivenessThreshold: 1 * time.Millisecond}
+
+	// DIRECT CALL (no goroutine) — this is the key difference from
+	// TestMonitorLiveness_TimerFires_CancelsContext
+	MonitorLiveness(decorator, ctx, "test_tool", opts, hbCh, heartbeat, cancel)
+
+	// After MonitorLiveness returns, the cancel func MUST have been called
+	// by handleLivenessTimeout
+	select {
+	case <-ctx.Done():
+		// context cancelled — success
+	default:
+		t.Fatal("expected context to be cancelled after liveness timer fires")
+	}
+
+	// Verify the logger captured the liveness timeout
+	if !logger.errorCalled {
+		t.Fatal("expected Error to be called for tool_liveness_timeout")
+	}
+	if logger.lastMsg != "tool_liveness_timeout" {
+		t.Errorf("expected lastMsg 'tool_liveness_timeout', got %q", logger.lastMsg)
+	}
+
+	// Verify tool name in log attrs
+	attrs := make(map[string]any)
+	for i := 0; i < len(logger.lastArgs); i += 2 {
+		if i+1 < len(logger.lastArgs) {
+			key, ok := logger.lastArgs[i].(string)
+			if ok {
+				attrs[key] = logger.lastArgs[i+1]
+			}
+		}
+	}
+	if attrs["tool_name"] != "test_tool" {
+		t.Errorf("expected tool_name 'test_tool', got %v", attrs["tool_name"])
+	}
+}

--- a/internal/agent/executor/export_test.go
+++ b/internal/agent/executor/export_test.go
@@ -10,3 +10,6 @@ var HandleTimeout = (*safetyDecorator).handleTimeout
 
 // NewLivenessTimer exposes the private newLivenessTimer constructor.
 var NewLivenessTimer = newLivenessTimer
+
+// MonitorLiveness exposes the private (*safetyDecorator).monitorLiveness method.
+var MonitorLiveness = (*safetyDecorator).monitorLiveness

--- a/internal/agent/session/context/token_counter_test.go
+++ b/internal/agent/session/context/token_counter_test.go
@@ -317,3 +317,50 @@ func TestEstimatePartChars_AllPartTypes(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Deep recursion guard tests
+// ---------------------------------------------------------------------------
+
+// buildDeepMap constructs a deeply nested map[string]interface{}.
+// buildDeepMap(0) returns {"k": "v"} (1 level).
+// buildDeepMap(n) returns a map with n+1 levels of nesting.
+func buildDeepMap(depth int) map[string]interface{} {
+	if depth <= 0 {
+		return map[string]interface{}{"k": "v"}
+	}
+	inner := buildDeepMap(depth - 1)
+	return map[string]interface{}{"k": inner}
+}
+
+// TestEstimateMapSizeInternal_DeepRecursionGuard verifies the recursion
+// breaker at token_counter.go:111-113. When a map exceeds maxEstimateDepth
+// (100), estimateMapSizeInternal must return 0 instead of continuing to
+// recurse. The "at boundary" subtest proves normal estimation works at
+// exactly 100 levels; the "exceeds boundary" subtest proves the guard
+// triggers at 101 levels, preventing a stack overflow panic.
+func TestEstimateMapSizeInternal_DeepRecursionGuard(t *testing.T) {
+	t.Parallel()
+
+	t.Run("at_max_depth_returns_normal_estimate", func(t *testing.T) {
+		// 100 levels deep = exactly at maxEstimateDepth
+		m := buildDeepMap(maxEstimateDepth - 1)
+		result := estimateMapSizeInternal(m, 0)
+
+		require.Greater(t, result, 0,
+			"at exactly maxEstimateDepth, estimate must be > 0")
+	})
+
+	t.Run("exceeds_max_depth_returns_zero", func(t *testing.T) {
+		// Call estimateMapSizeInternal directly with depth > maxEstimateDepth.
+		// Through normal recursion the estimateValueSizeInternal guard (at
+		// odd depths) fires before estimateMapSizeInternal's guard (at even
+		// depths), so a direct call with excessive depth is needed to cover
+		// token_counter.go:111-113.
+		m := map[string]interface{}{"key": "value"}
+		result := estimateMapSizeInternal(m, maxEstimateDepth+1)
+
+		require.Equal(t, 0, result,
+			"when depth exceeds maxEstimateDepth, must return 0")
+	})
+}

--- a/internal/infrastructure/llm/export_test.go
+++ b/internal/infrastructure/llm/export_test.go
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package llm
+
+import "net/http"
+
+// GetHTTPClient exposes the private httpClient field for tests.
+var GetHTTPClient = func(c *llmProviderHealthChecker) *http.Client {
+	return c.httpClient
+}

--- a/internal/infrastructure/llm/provider_health_test.go
+++ b/internal/infrastructure/llm/provider_health_test.go
@@ -5,6 +5,7 @@ package llm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -494,4 +495,68 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestLLMProviderHealthChecker_DefaultTransportFallback verifies the
+// defensive fallback at provider_health.go:52. When http.DefaultTransport
+// is not a *http.Transport (e.g., replaced by middleware), the constructor
+// must gracefully fall back to using http.DefaultTransport directly instead
+// of panicking on a failed type assertion.
+//
+// This test temporarily replaces http.DefaultTransport with a custom
+// RoundTripper that is NOT a *http.Transport, which forces the else branch
+// of the IIFE. The global is restored via t.Cleanup.
+//
+// IMPORTANT: This test is NOT parallel-safe because it mutates a global.
+// Do NOT add t.Parallel().
+func TestLLMProviderHealthChecker_DefaultTransportFallback(t *testing.T) {
+	// NOTE: no t.Parallel() — mutates http.DefaultTransport
+
+	// 1. Save and replace http.DefaultTransport with a non-*http.Transport
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() { http.DefaultTransport = originalTransport })
+
+	customTransport := &customRoundTripper{}
+	http.DefaultTransport = customTransport
+
+	// 2. Construct the checker — the IIFE should hit the else branch
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+
+	// 3. Verify the transport is our custom one (not a clone)
+	client := GetHTTPClient(checker)
+	if client.Transport != customTransport {
+		t.Errorf("expected Transport to be customRoundTripper (fallback path), got %T", client.Transport)
+	}
+}
+
+// TestLLMProviderHealthChecker_TransportClone verifies the happy path:
+// when http.DefaultTransport is a *http.Transport (normal case), the
+// constructor clones it instead of reusing the pointer.
+func TestLLMProviderHealthChecker_TransportClone(t *testing.T) {
+	t.Parallel()
+
+	authMock := &auth.BearerAuth{Token: "test-key"}
+	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+
+	client := GetHTTPClient(checker)
+
+	// Transport must be non-nil
+	if client.Transport == nil {
+		t.Fatal("expected Transport to be non-nil")
+	}
+
+	// Transport must NOT be the same pointer as http.DefaultTransport
+	// (proves Clone() was called, not direct assignment)
+	if client.Transport == http.DefaultTransport {
+		t.Error("Transport must be a clone of DefaultTransport, not the same pointer")
+	}
+}
+
+// customRoundTripper is a non-*http.Transport implementation used to
+// force the fallback branch in NewLLMProviderHealthChecker's IIFE.
+type customRoundTripper struct{}
+
+func (c *customRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return nil, errors.New("customRoundTripper: not a real transport")
 }


### PR DESCRIPTION
Closes #923.

## Summary
Added tests to close three medium-priority edge-case coverage gaps identified by detailed coverage analysis:

1. **Executor Timeout Timer** (`decorators.go:271`) — Added `TestMonitorLiveness_TimerChannelFires` with direct-call coverage of the `case <-timer.channel()` branch via exported `MonitorLiveness` in `export_test.go`. The existing integration test exercised this path but through a goroutine that Go's coverage tooling could not track.

2. **Token Counter Recursion Breaker** (`token_counter.go:111-113`) — Added `TestEstimateMapSizeInternal_DeepRecursionGuard` with two sub-tests: at max depth (100 levels, returns > 0) and exceeding max depth (direct call with depth 101, returns 0). Includes a `buildDeepMap` helper.

3. **LLM Provider Health Transport Fallback** (`provider_health.go:52`) — Added `TestLLMProviderHealthChecker_DefaultTransportFallback` (forces the fallback branch by temporarily replacing `http.DefaultTransport`) and `TestLLMProviderHealthChecker_TransportClone` (verifies the normal clone path). Created `export_test.go` with `GetHTTPClient` accessor.

## Changed Files
| File | Change |
|------|--------|
| `internal/agent/executor/export_test.go` | +3: `MonitorLiveness` export |
| `internal/agent/executor/decorators_test.go` | +75: `TestMonitorLiveness_TimerChannelFires` |
| `internal/agent/session/context/token_counter_test.go` | +47: `TestEstimateMapSizeInternal_DeepRecursionGuard` + helper |
| `internal/infrastructure/llm/export_test.go` | +12 (NEW): `GetHTTPClient` accessor |
| `internal/infrastructure/llm/provider_health_test.go` | +65: 2 tests + `customRoundTripper` |

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (all 10 steps) | ✅ PASS |
| Lint | ✅ 0 issues |
| Race detector | ✅ No data races |
| Coverage (target packages) | ✅ executor: 100%, session/context: 100%, llm: 100% |
| Overall coverage | ✅ >98.5% maintained |
| Detailed coverage gaps | ✅ All three gaps closed |