### PR TITLE
fix(persistence): simplify rows.Close defer, remove unreachable branches (#924)

### DIFF
--- a/internal/infrastructure/persistence/sqlite_store.go
+++ b/internal/infrastructure/persistence/sqlite_store.go
@@ -136,19 +136,13 @@ func (s *sqliteTaskStore) queryOrdered(ctx context.Context, filter ports.ListFil
 	if err != nil {
 		return nil, fmt.Errorf("querying tasks ordered %s: %w", order, err)
 	}
-	// NOTE: The rows.Close() defer error-shadowing and rows.Err() check below
-	// are defensive branches that cannot be triggered by modernc.org/sqlite
-	// (which eagerly buffers all results during QueryContext). These branches
-	// exist for correctness if the SQLite driver is swapped.
-	// Coverage gap accepted by architect — verified by code review only;
-	// no test coverage is possible.
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil {
-			if err == nil {
-				err = closeErr
-			}
-		}
-	}()
+	// NOTE: The rows.Err() check below catches driver Close errors when
+	// iteration completes normally — database/sql internally closes
+	// driver.Rows when Next() returns io.EOF and stores any close error
+	// in lasterr, which rows.Err() surfaces. The deferred rows.Close()
+	// handles cleanup on early returns (scan/parse errors). Both paths
+	// are covered in sqlite_store_error_test.go.
+	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var t ports.Task
 		var createdAtStr string
@@ -251,19 +245,13 @@ func (s *sqliteKVStore) GetAll(ctx context.Context) (res map[string]string, err 
 	if err != nil {
 		return nil, fmt.Errorf("querying all settings: %w", err)
 	}
-	// NOTE: The rows.Close() defer error-shadowing and rows.Err() check below
-	// are defensive branches that cannot be triggered by modernc.org/sqlite
-	// (which eagerly buffers all results during QueryContext). These branches
-	// exist for correctness if the SQLite driver is swapped.
-	// Coverage gap accepted by architect — verified by code review only;
-	// no test coverage is possible.
-	defer func() {
-		if closeErr := rows.Close(); closeErr != nil {
-			if err == nil {
-				err = closeErr
-			}
-		}
-	}()
+	// NOTE: The rows.Err() check below catches driver Close errors when
+	// iteration completes normally — database/sql internally closes
+	// driver.Rows when Next() returns io.EOF and stores any close error
+	// in lasterr, which rows.Err() surfaces. The deferred rows.Close()
+	// handles cleanup on early returns (scan/parse errors). Both paths
+	// are covered in sqlite_store_error_test.go.
+	defer func() { _ = rows.Close() }()
 
 	res = make(map[string]string)
 	for rows.Next() {


### PR DESCRIPTION
Closes #924.

## Summary

Removed two provably unreachable `err = closeErr` branches in `queryOrdered` and `GetAll` defer blocks in `sqlite_store.go`. Go's `database/sql` eagerly closes `driver.Rows` when `Next()` returns `io.EOF`, making deferred `rows.Close()` always return nil on normal loop exhaustion. The correct error-surfacing path (`rows.Err()`) was already tested via `closeFailingConnector` in `sqlite_store_error_test.go`.

**Changes:**
- Replaced two error-shadowing `defer func(){...}()` blocks with idiomatic `defer func() { _ = rows.Close() }()`
- Updated stale architect notes documenting the actual error-surfacing mechanism

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| queryOrdered coverage | 91.3% → 100.0% |
| GetAll coverage | 87.5% → 100.0% |
| Overall coverage | 48.4% → 48.5% |
| Existing CloseError/RowsErr tests | 5/5 PASS |
