### PR TITLE
fix(analysis): decompose 9 complexity-9 functions to <=5 (#920)

### DIFF
--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -89,6 +89,41 @@ func (a *VertexAuth) getCachePath() string {
 	return filepath.Join(dir, "token.txt")
 }
 
+// readCacheFile attempts to read a valid cached token from disk.
+// Returns ("", false) when the cache file is missing, expired
+// (older than 55 minutes), or unreadable.
+func (a *VertexAuth) readCacheFile() (string, bool) {
+	cacheFile := a.getCachePath()
+	info, err := os.Stat(cacheFile)
+	if err != nil {
+		return "", false
+	}
+	// Tokens are valid for 1 hour. We use 55 minutes (3300s) as a safe buffer.
+	if time.Since(info.ModTime()) >= 55*time.Minute {
+		return "", false
+	}
+	content, err := os.ReadFile(cacheFile)
+	if err != nil {
+		log.Printf("failed to read auth cache file %s: %v", cacheFile, err)
+		return "", false
+	}
+	return strings.TrimSpace(string(content)), true
+}
+
+// writeCacheFile persists the token to the local cache directory.
+// Failures are logged but not returned — cache writes are best-effort.
+func (a *VertexAuth) writeCacheFile(ctx context.Context, token string) {
+	cacheFile := a.getCachePath()
+	cacheDir := filepath.Dir(cacheFile)
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		log.Printf("failed to create auth cache directory: %v", err)
+		return
+	}
+	if err := persistence.AtomicWrite(ctx, &persistence.OSFileSystem{}, cacheFile, []byte(token), 0600); err != nil {
+		log.Printf("failed to write auth cache: %v", err)
+	}
+}
+
 // getToken retrieves the OAuth2 access token with local caching.
 func (a *VertexAuth) getToken(ctx context.Context) (string, error) {
 	a.mu.Lock()
@@ -99,17 +134,9 @@ func (a *VertexAuth) getToken(ctx context.Context) (string, error) {
 	}
 
 	// 1. Try local cache
-	cacheFile := a.getCachePath()
-	if info, err := os.Stat(cacheFile); err == nil {
-		// Tokens are valid for 1 hour. We use 55 minutes (3300s) as a safe buffer.
-		if time.Since(info.ModTime()) < 55*time.Minute {
-			content, err := os.ReadFile(cacheFile)
-			if err == nil {
-				a.Token = strings.TrimSpace(string(content))
-				return a.Token, nil
-			}
-			log.Printf("failed to read auth cache file %s: %v", cacheFile, err)
-		}
+	if token, ok := a.readCacheFile(); ok {
+		a.Token = token
+		return a.Token, nil
 	}
 
 	// 2. Fallback to gcloud
@@ -121,14 +148,7 @@ func (a *VertexAuth) getToken(ctx context.Context) (string, error) {
 	token := strings.TrimSpace(string(out))
 
 	// 3. Save to cache
-	cacheDir := filepath.Dir(cacheFile)
-	if err := os.MkdirAll(cacheDir, 0700); err == nil {
-		if writeErr := persistence.AtomicWrite(ctx, &persistence.OSFileSystem{}, cacheFile, []byte(token), 0600); writeErr != nil {
-			log.Printf("failed to write auth cache: %v", writeErr)
-		}
-	} else {
-		log.Printf("failed to create auth cache directory: %v", err)
-	}
+	a.writeCacheFile(ctx, token)
 
 	a.Token = token
 	return a.Token, nil

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -878,3 +878,140 @@ func TestNewVertexAuth_DefaultTokenCmdFunc_ExecError(t *testing.T) {
 		t.Error("expected error from default tokenCmdFunc when execCommand fails")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// readCacheFile / writeCacheFile unit tests
+// ---------------------------------------------------------------------------
+
+func TestVertexAuth_ReadCacheFile(t *testing.T) {
+	t.Run("cache hit", func(t *testing.T) {
+		dir := t.TempDir()
+		auth := &VertexAuth{CacheDir: dir}
+		cachePath := auth.getCachePath()
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(cachePath, []byte("  cached-token\n"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+
+		token, ok := auth.readCacheFile()
+		if !ok {
+			t.Fatal("expected cache hit")
+		}
+		if token != "cached-token" {
+			t.Errorf("got %q, want cached-token", token)
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		auth := &VertexAuth{CacheDir: t.TempDir()}
+		token, ok := auth.readCacheFile()
+		if ok {
+			t.Errorf("expected cache miss, got token=%q", token)
+		}
+		if token != "" {
+			t.Errorf("expected empty token on miss, got %q", token)
+		}
+	})
+
+	t.Run("expired cache", func(t *testing.T) {
+		dir := t.TempDir()
+		auth := &VertexAuth{CacheDir: dir}
+		cachePath := auth.getCachePath()
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(cachePath, []byte("expired-token"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		// Set mod time to 2 hours ago → older than 55 minutes
+		past := time.Now().Add(-2 * time.Hour)
+		if err := os.Chtimes(cachePath, past, past); err != nil {
+			t.Fatalf("Chtimes: %v", err)
+		}
+
+		token, ok := auth.readCacheFile()
+		if ok {
+			t.Errorf("expected cache miss for expired token, got %q", token)
+		}
+	})
+
+	t.Run("unreadable cache", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Chmod 0000 not reliable on Windows")
+		}
+		dir := t.TempDir()
+		auth := &VertexAuth{CacheDir: dir}
+		cachePath := auth.getCachePath()
+		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		if err := os.WriteFile(cachePath, []byte("unreadable-token"), 0600); err != nil {
+			t.Fatalf("WriteFile: %v", err)
+		}
+		if err := os.Chmod(cachePath, 0000); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(cachePath, 0600) })
+
+		token, ok := auth.readCacheFile()
+		if ok {
+			t.Errorf("expected cache miss for unreadable file, got %q", token)
+		}
+	})
+}
+
+func TestVertexAuth_WriteCacheFile(t *testing.T) {
+	t.Run("successful write", func(t *testing.T) {
+		dir := t.TempDir()
+		auth := &VertexAuth{CacheDir: dir}
+		auth.writeCacheFile(context.Background(), "my-token")
+
+		cachePath := auth.getCachePath()
+		content, err := os.ReadFile(cachePath)
+		if err != nil {
+			t.Fatalf("ReadFile after writeCacheFile: %v", err)
+		}
+		if string(content) != "my-token" {
+			t.Errorf("got %q, want my-token", string(content))
+		}
+	})
+
+	t.Run("mkdir failure does not panic", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Chmod 0555 not reliable on Windows")
+		}
+		dir := t.TempDir()
+		// Create a read-only parent so MkdirAll fails
+		if err := os.Chmod(dir, 0555); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(dir, 0700) })
+
+		auth := &VertexAuth{CacheDir: filepath.Join(dir, "sub", "deep")}
+		// Must not panic
+		auth.writeCacheFile(context.Background(), "should-not-panic")
+	})
+
+	t.Run("write failure does not panic", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("Chmod 0555 not reliable on Windows")
+		}
+		dir := t.TempDir()
+		auth := &VertexAuth{CacheDir: dir}
+		cachePath := auth.getCachePath()
+		cacheDir := filepath.Dir(cachePath)
+		if err := os.MkdirAll(cacheDir, 0700); err != nil {
+			t.Fatalf("MkdirAll: %v", err)
+		}
+		// Make directory read-only so AtomicWrite cannot create temp file
+		if err := os.Chmod(cacheDir, 0555); err != nil {
+			t.Fatalf("Chmod: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chmod(cacheDir, 0700) })
+
+		// Must not panic
+		auth.writeCacheFile(context.Background(), "should-not-panic")
+	})
+}

--- a/internal/infrastructure/logging/async_turns_logger.go
+++ b/internal/infrastructure/logging/async_turns_logger.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
@@ -244,6 +245,41 @@ func (l *asyncTurnsLogger) renderTurnHeader(sb *strings.Builder, status events.T
 	fmt.Fprintf(sb, "[%s] Payload: %s%d/%d tokens%s\n", timestamp, prefix, status.Tokens, status.MaxHistoryTokens, modeStr)
 }
 
+// formatDisplayName returns the human-readable model identifier for log output.
+// Provider takes precedence over Model. ON_DEMAND_PRIORITY traffic appends
+// a "-priority" suffix. Returns empty string when both Provider and Model are empty.
+func formatDisplayName(m *llm.Metrics) string {
+	if m == nil {
+		return ""
+	}
+	displayName := m.Provider
+	if displayName == "" {
+		displayName = m.Model
+	}
+	if strings.EqualFold(m.TrafficType, "ON_DEMAND_PRIORITY") {
+		displayName = fmt.Sprintf("%s-priority", displayName)
+	}
+	return displayName
+}
+
+// formatTiming returns the formatted latency string for log output.
+// It includes total turn latency, cumulative tool duration, and optionally
+// session duration with per-turn throughput when StartTime is populated.
+func formatTiming(m *llm.Metrics, startTime time.Time, currentTurns int, now time.Time) string {
+	totalTurnLatency := m.Duration + m.ToolDuration
+	timingRaw := fmt.Sprintf("%.2fs (ΣT: %.2fs)", totalTurnLatency, m.CumulativeToolDuration)
+	if startTime.IsZero() {
+		return timingRaw
+	}
+	totalSessionDuration := now.Sub(startTime).Seconds()
+	if currentTurns+1 > 0 {
+		timingRaw = fmt.Sprintf("%s / %.2fs (%.2f)", timingRaw, totalSessionDuration, totalSessionDuration/float64(currentTurns+1))
+	} else {
+		timingRaw = fmt.Sprintf("%s / %.2fs", timingRaw, totalSessionDuration)
+	}
+	return timingRaw
+}
+
 func (l *asyncTurnsLogger) renderTurnMetrics(sb *strings.Builder, status events.TurnStatus, now time.Time, timestamp string) {
 	m := status.Metrics
 	// Token line (actual)
@@ -255,28 +291,13 @@ func (l *asyncTurnsLogger) renderTurnMetrics(sb *strings.Builder, status events.
 
 	// Metrics line
 	miss := m.PromptTokens - m.CachedTokens
+	displayName := formatDisplayName(m)
 	modelStr := ""
-	displayName := m.Provider
-	if displayName == "" {
-		displayName = m.Model
-	}
-	if strings.EqualFold(m.TrafficType, "ON_DEMAND_PRIORITY") {
-		displayName = fmt.Sprintf("%s-priority", displayName)
-	}
 	if displayName != "" {
 		modelStr = fmt.Sprintf(" [%s]", displayName)
 	}
 
-	totalTurnLatency := m.Duration + m.ToolDuration
-	timingRaw := fmt.Sprintf("%.2fs (ΣT: %.2fs)", totalTurnLatency, m.CumulativeToolDuration)
-	if !status.StartTime.IsZero() {
-		totalSessionDuration := now.Sub(status.StartTime).Seconds()
-		if status.CurrentTurns+1 > 0 {
-			timingRaw = fmt.Sprintf("%s / %.2fs (%.2f)", timingRaw, totalSessionDuration, totalSessionDuration/float64(status.CurrentTurns+1))
-		} else {
-			timingRaw = fmt.Sprintf("%s / %.2fs", timingRaw, totalSessionDuration)
-		}
-	}
+	timingRaw := formatTiming(m, status.StartTime, status.CurrentTurns, now)
 
 	// Prepare thinking-tokens segment. Suppressed when zero — kept in
 	// lockstep with the on-screen renderer (see internal/ui/renderer.go

--- a/internal/infrastructure/logging/async_turns_logger_test.go
+++ b/internal/infrastructure/logging/async_turns_logger_test.go
@@ -809,6 +809,119 @@ func TestFormatTurnStatusForLog(t *testing.T) {
 }
 
 // countingErrorFile is a mock that fails Write/Sync for the first N calls, then succeeds.
+
+func TestFormatDisplayName(t *testing.T) {
+	tests := []struct {
+		name string
+		m    *llm.Metrics
+		want string
+	}{
+		{
+			name: "nil metrics",
+			m:    nil,
+			want: "",
+		},
+		{
+			name: "provider takes precedence",
+			m:    &llm.Metrics{Provider: "openai", Model: "gpt-4o"},
+			want: "openai",
+		},
+		{
+			name: "model fallback when provider empty",
+			m:    &llm.Metrics{Provider: "", Model: "gpt-4o"},
+			want: "gpt-4o",
+		},
+		{
+			name: "priority suffix appended",
+			m:    &llm.Metrics{Provider: "openai", TrafficType: "ON_DEMAND_PRIORITY"},
+			want: "openai-priority",
+		},
+		{
+			name: "priority suffix with model fallback",
+			m:    &llm.Metrics{Model: "gpt-4o", TrafficType: "ON_DEMAND_PRIORITY"},
+			want: "gpt-4o-priority",
+		},
+		{
+			name: "both empty returns empty",
+			m:    &llm.Metrics{},
+			want: "",
+		},
+		{
+			name: "case insensitive traffic type",
+			m:    &llm.Metrics{Provider: "openai", TrafficType: "on_demand_priority"},
+			want: "openai-priority",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatDisplayName(tt.m)
+			if got != tt.want {
+				t.Errorf("formatDisplayName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatTiming(t *testing.T) {
+	now := time.Date(2026, 1, 1, 12, 0, 10, 0, time.UTC)
+	startTime := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name         string
+		m            *llm.Metrics
+		startTime    time.Time
+		currentTurns int
+		wantContains []string
+	}{
+		{
+			name: "basic timing without start time",
+			m: &llm.Metrics{
+				Duration:               5.5,
+				ToolDuration:           2.5,
+				CumulativeToolDuration: 1.23,
+			},
+			startTime:    time.Time{},
+			currentTurns: 0,
+			wantContains: []string{"8.00s (ΣT: 1.23s)"},
+		},
+		{
+			name: "timing with start time and multi-turn throughput",
+			m: &llm.Metrics{
+				Duration:               5.5,
+				ToolDuration:           2.5,
+				CumulativeToolDuration: 1.23,
+			},
+			startTime:    startTime,
+			currentTurns: 1,
+			wantContains: []string{"8.00s (ΣT: 1.23s) / 10.00s (5.00)"},
+		},
+		{
+			name: "timing with start time and zero current turns",
+			m: &llm.Metrics{
+				Duration:               5.5,
+				ToolDuration:           2.5,
+				CumulativeToolDuration: 1.23,
+			},
+			startTime:    startTime,
+			currentTurns: -1,
+			wantContains: []string{"8.00s (ΣT: 1.23s) / 10.00s"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatTiming(tt.m, tt.startTime, tt.currentTurns, now)
+			for _, want := range tt.wantContains {
+				if !strings.Contains(got, want) {
+					t.Errorf("formatTiming() = %q, want to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// countingErrorFile is a mock that fails Write/Sync for the first N calls, then succeeds.
 type countingErrorFile struct {
 	infra_persistence.File
 	mu            sync.Mutex

--- a/internal/infrastructure/telemetry/ledger.go
+++ b/internal/infrastructure/telemetry/ledger.go
@@ -139,6 +139,36 @@ func (ls *ledgerStore) getPricingWithOverrides(ctx context.Context, globalDir st
 	return pricing
 }
 
+// tryProcessLogFile attempts to process a single log file into a
+// sessionCostRecord. It returns nil when the file has already been
+// seen, is inaccessible, or cannot be parsed. Non-fatal errors are
+// logged and result in nil.
+func (ls *ledgerStore) tryProcessLogFile(ctx context.Context, path string, globalDir string, seen map[string]bool, pricing domain_pricing.PricingData) *sessionCostRecord {
+	sessionID, err := ls.getSessionID(path, globalDir)
+	if err != nil {
+		log.Printf("Recovery: skipping %s: %v\n", path, err)
+		return nil
+	}
+	if seen[sessionID] {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+
+	record, err := ls.processLogFile(path, info, globalDir, pricing)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Printf("Recovery: failed to parse %s: %v\n", path, err)
+		}
+		return nil
+	}
+
+	return record
+}
+
 // discoverNewRecords scans the list of log files for new sessions not yet in the ledger.
 func (ls *ledgerStore) discoverNewRecords(ctx context.Context, files []string, globalDir string, seen map[string]bool, pricing domain_pricing.PricingData) []sessionCostRecord {
 	var discovered []sessionCostRecord
@@ -147,29 +177,7 @@ func (ls *ledgerStore) discoverNewRecords(ctx context.Context, files []string, g
 			break
 		}
 
-		// Prevent redundant parsing by checking sessionID first
-		sessionID, err := ls.getSessionID(path, globalDir)
-		if err != nil {
-			log.Printf("Recovery: skipping %s: %v\n", path, err)
-			continue
-		}
-		if seen[sessionID] {
-			continue
-		}
-
-		info, err := os.Stat(path)
-		if err != nil {
-			continue
-		}
-
-		record, err := ls.processLogFile(path, info, globalDir, pricing)
-		if err != nil {
-			if !os.IsNotExist(err) {
-				log.Printf("Recovery: failed to parse %s: %v\n", path, err)
-			}
-			continue
-		}
-
+		record := ls.tryProcessLogFile(ctx, path, globalDir, seen, pricing)
 		if record != nil {
 			discovered = append(discovered, *record)
 			seen[record.Session] = true

--- a/internal/infrastructure/telemetry/try_process_log_file_test.go
+++ b/internal/infrastructure/telemetry/try_process_log_file_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package telemetry
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTryProcessLogFile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("valid file", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		sessionDir := filepath.Join(tempDir, "session")
+		require.NoError(t, os.MkdirAll(sessionDir, 0755))
+		logFile := filepath.Join(sessionDir, "tokens.log")
+		require.NoError(t, os.WriteFile(logFile,
+			[]byte(`{"cost": 1.5, "timestamp": "2023-10-27T10:00:00Z"}`), 0644))
+
+		sm := security.NewSecurityManager(nil)
+		sm.RegisterSafePath(tempDir)
+		ls := newLedgerStore(sm, "test-model", nil)
+		seen := make(map[string]bool)
+		pricing := GetPricing(context.Background(), sm, tempDir)
+
+		record := ls.tryProcessLogFile(context.Background(), logFile, tempDir, seen, pricing)
+
+		require.NotNil(t, record, "expected a record for a valid log file")
+		assert.Contains(t, record.Session, "session/tokens.log")
+		assert.Equal(t, 1.5, record.TotalCost)
+	})
+
+	t.Run("already seen", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		sessionDir := filepath.Join(tempDir, "session")
+		require.NoError(t, os.MkdirAll(sessionDir, 0755))
+		logFile := filepath.Join(sessionDir, "tokens.log")
+		require.NoError(t, os.WriteFile(logFile,
+			[]byte(`{"cost": 1.0, "timestamp": "2023-10-27T10:00:00Z"}`), 0644))
+
+		sm := security.NewSecurityManager(nil)
+		sm.RegisterSafePath(tempDir)
+		ls := newLedgerStore(sm, "test-model", nil)
+
+		// Pre-populate seen with the expected session ID
+		seen := map[string]bool{"session/tokens.log": true}
+		pricing := GetPricing(context.Background(), sm, tempDir)
+
+		record := ls.tryProcessLogFile(context.Background(), logFile, tempDir, seen, pricing)
+
+		assert.Nil(t, record, "expected nil when session already seen")
+	})
+
+	t.Run("stat error", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		// Path to a file that does not exist
+		nonexistentLog := filepath.Join(tempDir, "gone", "tokens.log")
+
+		sm := security.NewSecurityManager(nil)
+		sm.RegisterSafePath(tempDir)
+		ls := newLedgerStore(sm, "test-model", nil)
+		seen := make(map[string]bool)
+		pricing := GetPricing(context.Background(), sm, tempDir)
+
+		record := ls.tryProcessLogFile(context.Background(), nonexistentLog, tempDir, seen, pricing)
+
+		assert.Nil(t, record, "expected nil when os.Stat fails")
+	})
+
+	t.Run("getSessionID error", func(t *testing.T) {
+		t.Parallel()
+		tempDir := t.TempDir()
+
+		sessionDir := filepath.Join(tempDir, "session")
+		require.NoError(t, os.MkdirAll(sessionDir, 0755))
+		logFile := filepath.Join(sessionDir, "tokens.log")
+		require.NoError(t, os.WriteFile(logFile,
+			[]byte(`{"cost": 1.0}`), 0644))
+
+		sm := security.NewSecurityManager(nil)
+		sm.RegisterSafePath(tempDir)
+		ls := newLedgerStore(sm, "test-model", nil)
+
+		// Override getSessionID to always return an error
+		ls.getSessionIDFunc = func(path, globalDir string) (string, error) {
+			return "", os.ErrPermission
+		}
+
+		seen := make(map[string]bool)
+		pricing := GetPricing(context.Background(), sm, tempDir)
+
+		record := ls.tryProcessLogFile(context.Background(), logFile, tempDir, seen, pricing)
+
+		assert.Nil(t, record, "expected nil when getSessionID returns an error")
+	})
+}

--- a/internal/tools/analysis/architecture.go
+++ b/internal/tools/analysis/architecture.go
@@ -16,6 +16,7 @@ import (
 
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"golang.org/x/tools/go/packages"
 )
 
 const (
@@ -57,6 +58,35 @@ type indexedPackageProvider struct {
 	idx symbolIndex
 }
 
+// detectModuleFromPackages sets p.m.ModulePath from the first package
+// with a non-nil Module. The sync.Once ensures ModulePath is set at most
+// once across all calls.
+func (p *indexedPackageProvider) detectModuleFromPackages(pkgs []*packages.Package) {
+	for _, pkg := range pkgs {
+		if pkg.Module != nil {
+			p.m.once.Do(func() {
+				p.m.ModulePath = pkg.Module.Path
+			})
+			break
+		}
+	}
+}
+
+// collectTrackedImports returns the module-internal imports for pkg
+// when it is a tracked package. Returns nil when pkg is not tracked.
+func (p *indexedPackageProvider) collectTrackedImports(pkg *packages.Package) []string {
+	if !p.m.isTrackedPackage(pkg.PkgPath) {
+		return nil
+	}
+	trackedImports := make([]string, 0)
+	for impPath := range pkg.Imports {
+		if strings.HasPrefix(impPath, p.m.ModulePath) {
+			trackedImports = append(trackedImports, impPath)
+		}
+	}
+	return trackedImports
+}
+
 func (p *indexedPackageProvider) LoadPackages(ctx context.Context) (map[string][]string, error) {
 	pkgs, err := p.idx.Packages(ctx, nil)
 	if err != nil {
@@ -67,25 +97,12 @@ func (p *indexedPackageProvider) LoadPackages(ctx context.Context) (map[string][
 		return nil, fmt.Errorf("no packages found in index")
 	}
 
-	for _, pkg := range pkgs {
-		if pkg.Module != nil {
-			p.m.once.Do(func() {
-				p.m.ModulePath = pkg.Module.Path
-			})
-			break
-		}
-	}
+	p.detectModuleFromPackages(pkgs)
 
 	res := make(map[string][]string)
 	for _, pkg := range pkgs {
-		if p.m.isTrackedPackage(pkg.PkgPath) {
-			var trackedImports []string
-			for impPath := range pkg.Imports {
-				if strings.HasPrefix(impPath, p.m.ModulePath) {
-					trackedImports = append(trackedImports, impPath)
-				}
-			}
-			res[pkg.PkgPath] = trackedImports
+		if imports := p.collectTrackedImports(pkg); imports != nil {
+			res[pkg.PkgPath] = imports
 		}
 	}
 	return res, nil

--- a/internal/tools/analysis/architecture_indexed_test.go
+++ b/internal/tools/analysis/architecture_indexed_test.go
@@ -64,3 +64,180 @@ func TestIndexedPackageProvider_LoadPackages(t *testing.T) {
 		}
 	})
 }
+
+func TestCollectTrackedImports(t *testing.T) {
+	t.Parallel()
+
+	m := &architectureManager{
+		ModulePath: "github.com/gosharplite/tell-me-go",
+	}
+	p := &indexedPackageProvider{m: m}
+
+	t.Run("tracked package with mixed imports", func(t *testing.T) {
+		t.Parallel()
+		pkg := &packages.Package{
+			PkgPath: "github.com/gosharplite/tell-me-go/internal/domain",
+			Imports: map[string]*packages.Package{
+				"github.com/gosharplite/tell-me-go/internal/agent":  {},
+				"github.com/gosharplite/tell-me-go/internal/domain": {},
+				"fmt":                            {},
+				"golang.org/x/tools/go/packages": {},
+			},
+		}
+		got := p.collectTrackedImports(pkg)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 imports, got %d: %v", len(got), got)
+		}
+	})
+
+	t.Run("non-tracked package returns nil", func(t *testing.T) {
+		t.Parallel()
+		pkg := &packages.Package{
+			PkgPath: "fmt",
+			Imports: map[string]*packages.Package{
+				"errors": {},
+			},
+		}
+		got := p.collectTrackedImports(pkg)
+		if got != nil {
+			t.Fatalf("expected nil for non-tracked package, got %v", got)
+		}
+	})
+
+	t.Run("tracked package with no internal imports", func(t *testing.T) {
+		t.Parallel()
+		pkg := &packages.Package{
+			PkgPath: "github.com/gosharplite/tell-me-go/internal/domain",
+			Imports: map[string]*packages.Package{
+				"fmt":     {},
+				"strings": {},
+			},
+		}
+		got := p.collectTrackedImports(pkg)
+		if got == nil {
+			t.Fatal("expected non-nil slice for tracked package")
+		}
+		if len(got) != 0 {
+			t.Fatalf("expected 0 imports, got %d: %v", len(got), got)
+		}
+	})
+}
+
+func TestIndexedPackageProvider_DetectModuleFromPackages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("sets ModulePath from first package with Module", func(t *testing.T) {
+		t.Parallel()
+		m := &architectureManager{
+			ModulePath: "",
+		}
+		p := &indexedPackageProvider{
+			m: m,
+		}
+		pkgs := []*packages.Package{
+			{
+				PkgPath: "example.com/project/internal/foo",
+				Module:  &packages.Module{Path: "example.com/project"},
+			},
+		}
+		p.detectModuleFromPackages(pkgs)
+		if m.ModulePath != "example.com/project" {
+			t.Errorf("expected ModulePath 'example.com/project', got %q", m.ModulePath)
+		}
+	})
+
+	t.Run("picks first package when multiple have Module", func(t *testing.T) {
+		t.Parallel()
+		m := &architectureManager{
+			ModulePath: "",
+		}
+		p := &indexedPackageProvider{
+			m: m,
+		}
+		pkgs := []*packages.Package{
+			{
+				PkgPath: "example.com/first/internal/foo",
+				Module:  &packages.Module{Path: "example.com/first"},
+			},
+			{
+				PkgPath: "example.com/second/internal/bar",
+				Module:  &packages.Module{Path: "example.com/second"},
+			},
+		}
+		p.detectModuleFromPackages(pkgs)
+		if m.ModulePath != "example.com/first" {
+			t.Errorf("expected ModulePath from first package, got %q", m.ModulePath)
+		}
+	})
+
+	t.Run("skips packages with nil Module", func(t *testing.T) {
+		t.Parallel()
+		m := &architectureManager{
+			ModulePath: "",
+		}
+		p := &indexedPackageProvider{
+			m: m,
+		}
+		pkgs := []*packages.Package{
+			{
+				PkgPath: "example.com/project/internal/foo",
+				Module:  nil,
+			},
+			{
+				PkgPath: "example.com/project/internal/bar",
+				Module:  &packages.Module{Path: "example.com/project"},
+			},
+		}
+		p.detectModuleFromPackages(pkgs)
+		if m.ModulePath != "example.com/project" {
+			t.Errorf("expected ModulePath from second package, got %q", m.ModulePath)
+		}
+	})
+
+	t.Run("no packages with Module leaves ModulePath unchanged", func(t *testing.T) {
+		t.Parallel()
+		m := &architectureManager{
+			ModulePath: "",
+		}
+		p := &indexedPackageProvider{
+			m: m,
+		}
+		pkgs := []*packages.Package{
+			{
+				PkgPath: "example.com/project/internal/foo",
+				Module:  nil,
+			},
+		}
+		p.detectModuleFromPackages(pkgs)
+		if m.ModulePath != "" {
+			t.Errorf("expected ModulePath to remain empty, got %q", m.ModulePath)
+		}
+	})
+
+	t.Run("sync.Once prevents overwrite on second call", func(t *testing.T) {
+		t.Parallel()
+		m := &architectureManager{
+			ModulePath: "",
+		}
+		p := &indexedPackageProvider{
+			m: m,
+		}
+		pkgs1 := []*packages.Package{
+			{
+				PkgPath: "example.com/first/internal/foo",
+				Module:  &packages.Module{Path: "example.com/first"},
+			},
+		}
+		pkgs2 := []*packages.Package{
+			{
+				PkgPath: "example.com/second/internal/bar",
+				Module:  &packages.Module{Path: "example.com/second"},
+			},
+		}
+		p.detectModuleFromPackages(pkgs1)
+		p.detectModuleFromPackages(pkgs2) // should be no-op due to sync.Once
+		if m.ModulePath != "example.com/first" {
+			t.Errorf("sync.Once should prevent overwrite, got %q", m.ModulePath)
+		}
+	})
+}

--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -454,6 +454,38 @@ func (a *defaultDeadCodeAnalyzer) propagateInterfaceUsages(ctx context.Context, 
 // declaring package. Skips packages with nil TypesInfo. Returns early
 // on first confirmed match.
 
+// findMethodUsageInFile walks the AST of a single file looking for a
+// method identifier that type-resolves to targetId. Returns true on
+// first confirmed match. The found flag enables early exit from
+// ast.Inspect.
+func (a *defaultDeadCodeAnalyzer) findMethodUsageInFile(
+	file *ast.File,
+	pkg *packages.Package,
+	methodName string,
+	targetId string,
+) bool {
+	found := false
+	ast.Inspect(file, func(n ast.Node) bool {
+		if found {
+			return false
+		}
+		ident, ok := n.(*ast.Ident)
+		if !ok || ident.Name != methodName {
+			return true
+		}
+		obj, ok := pkg.TypesInfo.Uses[ident]
+		if !ok || obj == nil {
+			return true
+		}
+		if getSymbolIdentity(obj) == targetId {
+			found = true
+			return false
+		}
+		return true
+	})
+	return found
+}
+
 // resolveInPackage walks the AST of a single package looking for a
 // method identifier that type-resolves to targetId. Returns true on
 // first confirmed match.
@@ -466,26 +498,7 @@ func (a *defaultDeadCodeAnalyzer) resolveInPackage(
 	targetId string,
 ) bool {
 	for _, file := range pkg.Syntax {
-		found := false
-		ast.Inspect(file, func(n ast.Node) bool {
-			if found {
-				return false
-			}
-			ident, ok := n.(*ast.Ident)
-			if !ok || ident.Name != methodName {
-				return true
-			}
-			obj, ok := pkg.TypesInfo.Uses[ident]
-			if !ok || obj == nil {
-				return true
-			}
-			if getSymbolIdentity(obj) == targetId {
-				found = true
-				return false
-			}
-			return true
-		})
-		if found {
+		if a.findMethodUsageInFile(file, pkg, methodName, targetId) {
 			return true
 		}
 	}

--- a/internal/tools/analysis/dead_code_deep_test.go
+++ b/internal/tools/analysis/dead_code_deep_test.go
@@ -283,3 +283,62 @@ func TestResolveInPackage_IdentityResolution(t *testing.T) {
 		"resolveInPackage must NOT match Bar — "+
 			"no such method is called in pkgB.")
 }
+
+// TestFindMethodUsageInFile is a unit test of the extracted
+// findMethodUsageInFile method. It verifies the AST walk correctly
+// resolves identifiers within a single file.
+func TestFindMethodUsageInFile(t *testing.T) {
+	t.Parallel()
+	tmpDir, err := filepath.EvalSymlinks(t.TempDir())
+	require.NoError(t, err)
+
+	writeFixture(t, tmpDir, deepIdentFixture())
+
+	idx, err := newIndexer(tmpDir)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, idx.Refresh(ctx, nil))
+
+	pkgs, err := idx.Packages(ctx, nil)
+	require.NoError(t, err)
+
+	// Find pkgB — it contains the cross-package call `a.Foo()` where
+	// `a` is pkgA.TypeA.
+	var pkgB *packages.Package
+	for _, pkg := range pkgs {
+		if strings.Contains(pkg.PkgPath, "pkgB") {
+			pkgB = pkg
+			break
+		}
+	}
+	require.NotNil(t, pkgB, "must find pkgB package")
+	require.NotNil(t, pkgB.TypesInfo, "pkgB must be type-checked")
+	require.NotEmpty(t, pkgB.Syntax, "pkgB must have syntax trees")
+
+	analyzer := newDeadCodeAnalyzer(&deadCodeSecurityProvider{tempDir: tmpDir}, idx)
+
+	// Test each file in pkgB — at least one should contain the Foo call.
+	targetId := "example.com/deepident/pkgA.TypeA.Foo"
+	foundInAnyFile := false
+	for _, file := range pkgB.Syntax {
+		if analyzer.findMethodUsageInFile(file, pkgB, "Foo", targetId) {
+			foundInAnyFile = true
+			break
+		}
+	}
+	assert.True(t, foundInAnyFile,
+		"findMethodUsageInFile must find TypeA.Foo in at least one file of pkgB")
+
+	// Confirm that wrong identity is NOT found.
+	for _, file := range pkgB.Syntax {
+		assert.False(t, analyzer.findMethodUsageInFile(file, pkgB, "Foo",
+			"example.com/deepident/pkgA.OtherType.Foo"),
+			"findMethodUsageInFile must NOT match OtherType.Foo")
+	}
+
+	// Confirm that wrong method name is NOT found.
+	for _, file := range pkgB.Syntax {
+		assert.False(t, analyzer.findMethodUsageInFile(file, pkgB, "Bar", targetId),
+			"findMethodUsageInFile must NOT match method name 'Bar'")
+	}
+}

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -1815,6 +1815,113 @@ func TestHarvestPackageSymbols_AbsError(t *testing.T) {
 	analyzer.harvestPackageSymbols(pkg, state)
 }
 
+// TestIsInTargetScope verifies the extracted isInTargetScope predicate
+// independently across all guard-clause branches.
+func TestIsInTargetScope(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil module returns false", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		pkg := &packages.Package{
+			PkgPath: "example.com/project/internal/foo",
+			Module:  nil,
+		}
+		state := &scanState{targetModule: "example.com/project"}
+		if a.isInTargetScope(pkg, state) {
+			t.Error("nil Module should return false")
+		}
+	})
+
+	t.Run("wrong module prefix returns false", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		pkg := &packages.Package{
+			PkgPath: "other.com/lib/internal/foo",
+			Module:  &packages.Module{Path: "other.com/lib"},
+		}
+		state := &scanState{targetModule: "example.com/project"}
+		if a.isInTargetScope(pkg, state) {
+			t.Error("wrong module prefix should return false")
+		}
+	})
+
+	t.Run("target path mismatch returns false", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		tmpDir := t.TempDir()
+		goFile := filepath.Join(tmpDir, "subdir", "file.go")
+		require.NoError(t, os.MkdirAll(filepath.Dir(goFile), 0755))
+		require.NoError(t, os.WriteFile(goFile, []byte("package foo"), 0644))
+
+		pkg := &packages.Package{
+			PkgPath: "example.com/project/internal/foo",
+			Module:  &packages.Module{Path: "example.com/project"},
+			GoFiles: []string{goFile},
+		}
+		state := &scanState{
+			targetModule: "example.com/project",
+			targetPath:   "/completely/different/path",
+		}
+		if a.isInTargetScope(pkg, state) {
+			t.Error("target path mismatch should return false")
+		}
+	})
+
+	t.Run("excluded package returns false", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		pkg := &packages.Package{
+			PkgPath: "example.com/project/internal/vendor/foo",
+			Module:  &packages.Module{Path: "example.com/project"},
+		}
+		state := &scanState{
+			targetModule:     "example.com/project",
+			excludedPackages: []string{"vendor"},
+		}
+		if a.isInTargetScope(pkg, state) {
+			t.Error("excluded package should return false")
+		}
+	})
+
+	t.Run("valid package returns true", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		tmpDir := t.TempDir()
+		goFile := filepath.Join(tmpDir, "file.go")
+		require.NoError(t, os.WriteFile(goFile, []byte("package foo"), 0644))
+
+		pkg := &packages.Package{
+			PkgPath: "example.com/project/internal/foo",
+			Module:  &packages.Module{Path: "example.com/project"},
+			GoFiles: []string{goFile},
+		}
+		state := &scanState{
+			targetModule: "example.com/project",
+			targetPath:   tmpDir,
+		}
+		if !a.isInTargetScope(pkg, state) {
+			t.Error("valid package should return true")
+		}
+	})
+
+	t.Run("empty target path skips path check", func(t *testing.T) {
+		t.Parallel()
+		a := &defaultDeadCodeAnalyzer{}
+		pkg := &packages.Package{
+			PkgPath: "example.com/project/internal/foo",
+			Module:  &packages.Module{Path: "example.com/project"},
+		}
+		state := &scanState{
+			targetModule: "example.com/project",
+			targetPath:   "",
+		}
+		if !a.isInTargetScope(pkg, state) {
+			t.Error("empty target path should skip path check and return true")
+		}
+	})
+}
+
 // =============================================================================
 // Gap: harvestNamedMethods isExportTestFile guard (L186-187).
 // Covered by creating a named struct type with a method whose position

--- a/internal/tools/analysis/harvest.go
+++ b/internal/tools/analysis/harvest.go
@@ -91,12 +91,12 @@ func (a *defaultDeadCodeAnalyzer) harvestExportedSymbols(state *scanState) {
 	}
 }
 
-// harvestPackageSymbols collects exported symbols from a single package
-// that belongs to the target module and is within the target path.
-func (a *defaultDeadCodeAnalyzer) harvestPackageSymbols(pkg *packages.Package, state *scanState) {
-	// Ensure the package belongs to our module for declaration tracking
+// isInTargetScope reports whether pkg belongs to the target module,
+// resides within the target path (when specified), and is not excluded
+// by user-provided exclusion patterns.
+func (a *defaultDeadCodeAnalyzer) isInTargetScope(pkg *packages.Package, state *scanState) bool {
 	if pkg.Module == nil || !strings.HasPrefix(pkg.PkgPath, state.targetModule) {
-		return
+		return false
 	}
 
 	if state.targetPath != "" && len(pkg.GoFiles) > 0 {
@@ -105,11 +105,17 @@ func (a *defaultDeadCodeAnalyzer) harvestPackageSymbols(pkg *packages.Package, s
 			absPkg = filepath.Dir(pkg.GoFiles[0]) // fallback to raw dir path
 		}
 		if !strings.HasPrefix(absPkg, state.targetPath) {
-			return
+			return false
 		}
 	}
 
-	if a.shouldExclude(pkg.PkgPath, state.excludedPackages) {
+	return !a.shouldExclude(pkg.PkgPath, state.excludedPackages)
+}
+
+// harvestPackageSymbols collects exported symbols from a single package
+// that belongs to the target module and is within the target path.
+func (a *defaultDeadCodeAnalyzer) harvestPackageSymbols(pkg *packages.Package, state *scanState) {
+	if !a.isInTargetScope(pkg, state) {
 		return
 	}
 

--- a/internal/tools/analysis/imports.go
+++ b/internal/tools/analysis/imports.go
@@ -32,24 +32,22 @@ func newImportCleanupTransform(path string) *importCleanupTransform {
 	return &importCleanupTransform{Path: path}
 }
 
-func (t *importCleanupTransform) Apply(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
-	file, ok := files[t.Path]
-	if !ok {
-		// If it's not loaded, we don't need to clean it up in this transaction
-		return nil
-	}
-
-	// Clean up imports using imports.Process
-	// We need to format the file to a buffer first because imports.Process works on bytes
+// formatAndReprocess runs the three-step import cleanup pipeline:
+// 1. Format the AST to a buffer
+// 2. Run imports.Process on the formatted bytes
+// 3. Re-parse the result back into an AST
+func (t *importCleanupTransform) formatAndReprocess(fset *token.FileSet, file *ast.File) (*ast.File, error) {
+	// Step 1: Format to buffer
 	var buf bytes.Buffer
 	if t.testFormatNode != nil {
 		if err := t.testFormatNode(&buf, fset, file); err != nil {
-			return err
+			return nil, err
 		}
 	} else if err := format.Node(&buf, fset, file); err != nil {
-		return fmt.Errorf("formatting %s: %w", t.Path, err)
+		return nil, fmt.Errorf("formatting %s: %w", t.Path, err)
 	}
 
+	// Step 2: Process imports
 	var res []byte
 	var err error
 	if t.testProcessFunc != nil {
@@ -58,10 +56,10 @@ func (t *importCleanupTransform) Apply(ctx context.Context, fset *token.FileSet,
 		res, err = imports.Process(t.Path, buf.Bytes(), nil)
 	}
 	if err != nil {
-		return fmt.Errorf("processing imports for %s: %w", t.Path, err)
+		return nil, fmt.Errorf("processing imports for %s: %w", t.Path, err)
 	}
 
-	// Re-parse the result back into the AST
+	// Step 3: Re-parse
 	var newFile *ast.File
 	if t.testParseFileFunc != nil {
 		newFile, err = t.testParseFileFunc(fset, t.Path, res, parser.ParseComments)
@@ -69,7 +67,22 @@ func (t *importCleanupTransform) Apply(ctx context.Context, fset *token.FileSet,
 		newFile, err = parser.ParseFile(fset, t.Path, res, parser.ParseComments)
 	}
 	if err != nil {
-		return fmt.Errorf("parsing formatted file %s: %w", t.Path, err)
+		return nil, fmt.Errorf("parsing formatted file %s: %w", t.Path, err)
+	}
+
+	return newFile, nil
+}
+
+func (t *importCleanupTransform) Apply(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
+	file, ok := files[t.Path]
+	if !ok {
+		// If it's not loaded, we don't need to clean it up in this transaction
+		return nil
+	}
+
+	newFile, err := t.formatAndReprocess(fset, file)
+	if err != nil {
+		return err
 	}
 
 	files[t.Path] = newFile

--- a/internal/tools/analysis/imports_test.go
+++ b/internal/tools/analysis/imports_test.go
@@ -111,3 +111,85 @@ func TestImportCleanupTransform_Apply_ParseError(t *testing.T) {
 		t.Errorf("expected wrapping message, got: %v", err)
 	}
 }
+
+func TestFormatAndReprocess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "test.go",
+			"package p\n\nimport \"fmt\"\n\nfunc main() { fmt.Println() }",
+			parser.ParseComments)
+		require.NoError(t, err)
+
+		tx := &importCleanupTransform{Path: "test.go"}
+		newFile, err := tx.formatAndReprocess(fset, file)
+		require.NoError(t, err)
+		require.NotNil(t, newFile)
+	})
+
+	t.Run("format error via test hook", func(t *testing.T) {
+		t.Parallel()
+		formatErr := errors.New("format.Node failed: simulated write error")
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "test.go",
+			"package p\n\nimport \"fmt\"\n\nfunc main() { fmt.Println() }",
+			parser.ParseComments)
+		require.NoError(t, err)
+
+		tx := &importCleanupTransform{
+			Path: "test.go",
+			testFormatNode: func(buf *bytes.Buffer, fset *token.FileSet, file *ast.File) error {
+				return formatErr
+			},
+		}
+		_, err = tx.formatAndReprocess(fset, file)
+		require.Error(t, err)
+		require.ErrorIs(t, err, formatErr)
+	})
+
+	t.Run("process error via test hook", func(t *testing.T) {
+		t.Parallel()
+		processErr := errors.New("imports.Process failed")
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "test.go",
+			"package p\n\nimport \"fmt\"\n\nfunc main() { fmt.Println() }",
+			parser.ParseComments)
+		require.NoError(t, err)
+
+		tx := &importCleanupTransform{
+			Path: "test.go",
+			testProcessFunc: func(path string, src []byte, opts *imports.Options) ([]byte, error) {
+				return nil, processErr
+			},
+		}
+		_, err = tx.formatAndReprocess(fset, file)
+		require.Error(t, err)
+		if !strings.Contains(err.Error(), "processing imports for test.go") {
+			t.Errorf("expected wrapping message, got: %v", err)
+		}
+	})
+
+	t.Run("parse error via test hook", func(t *testing.T) {
+		t.Parallel()
+		parseErr := errors.New("parser.ParseFile failed")
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, "test.go",
+			"package p\n\nimport \"fmt\"\n\nfunc main() { fmt.Println() }",
+			parser.ParseComments)
+		require.NoError(t, err)
+
+		tx := &importCleanupTransform{
+			Path: "test.go",
+			testParseFileFunc: func(fset *token.FileSet, filename string, src interface{}, mode parser.Mode) (*ast.File, error) {
+				return nil, parseErr
+			},
+		}
+		_, err = tx.formatAndReprocess(fset, file)
+		require.Error(t, err)
+		if !strings.Contains(err.Error(), "parsing formatted file test.go") {
+			t.Errorf("expected wrapping message, got: %v", err)
+		}
+	})
+}

--- a/internal/tools/analysis/move.go
+++ b/internal/tools/analysis/move.go
@@ -79,22 +79,77 @@ func (t *moveTransform) matchesTypeName(expr ast.Expr, typeName string) bool {
 	return false
 }
 
+// declMatcher is a function that reports whether a declaration matches
+// a symbol name. Used in table-driven dispatch for matchSymbol.
+type declMatcher func(ast.Decl, string) bool
+
+// matchFuncDecl matches *ast.FuncDecl by name.
+func matchFuncDecl(decl ast.Decl, symbol string) bool {
+	fd, ok := decl.(*ast.FuncDecl)
+	return ok && fd.Name.Name == symbol
+}
+
+// matchTypeSpec matches *ast.GenDecl containing a *ast.TypeSpec by name.
+func matchTypeSpec(decl ast.Decl, symbol string) bool {
+	gd, ok := decl.(*ast.GenDecl)
+	if !ok {
+		return false
+	}
+	for _, spec := range gd.Specs {
+		if typeSpecIs(spec, symbol) {
+			return true
+		}
+	}
+	return false
+}
+
+// typeSpecIs reports whether an ast.Spec is a *ast.TypeSpec with the given name.
+func typeSpecIs(spec ast.Spec, symbol string) bool {
+	ts, ok := spec.(*ast.TypeSpec)
+	return ok && ts.Name.Name == symbol
+}
+
+// matchValueSpec matches *ast.GenDecl containing a *ast.ValueSpec by name.
+func matchValueSpec(decl ast.Decl, symbol string) bool {
+	gd, ok := decl.(*ast.GenDecl)
+	if !ok {
+		return false
+	}
+	for _, spec := range gd.Specs {
+		if valueSpecHas(spec, symbol) {
+			return true
+		}
+	}
+	return false
+}
+
+// valueSpecHas reports whether an ast.Spec is a *ast.ValueSpec that
+// contains an identifier with the given name.
+func valueSpecHas(spec ast.Spec, symbol string) bool {
+	vs, ok := spec.(*ast.ValueSpec)
+	if !ok {
+		return false
+	}
+	for _, name := range vs.Names {
+		if name.Name == symbol {
+			return true
+		}
+	}
+	return false
+}
+
+// declMatchers is the ordered table of matcher functions for matchSymbol.
+// Order is significant only for performance (FuncDecl is most common).
+var declMatchers = []declMatcher{
+	matchFuncDecl,
+	matchTypeSpec,
+	matchValueSpec,
+}
+
 func (t *moveTransform) matchSymbol(decl ast.Decl) bool {
-	switch d := decl.(type) {
-	case *ast.FuncDecl:
-		return d.Name.Name == t.Plan.Symbol
-	case *ast.GenDecl:
-		for _, spec := range d.Specs {
-			if ts, ok := spec.(*ast.TypeSpec); ok && ts.Name.Name == t.Plan.Symbol {
-				return true
-			}
-			if vs, ok := spec.(*ast.ValueSpec); ok {
-				for _, name := range vs.Names {
-					if name.Name == t.Plan.Symbol {
-						return true
-					}
-				}
-			}
+	for _, m := range declMatchers {
+		if m(decl, t.Plan.Symbol) {
+			return true
 		}
 	}
 	return false

--- a/internal/tools/analysis/move_test.go
+++ b/internal/tools/analysis/move_test.go
@@ -237,6 +237,111 @@ func TestMatchesTypeName_StarExpr(t *testing.T) {
 	})
 }
 
+func TestDeclMatchers(t *testing.T) {
+	t.Parallel()
+
+	// ---- matchFuncDecl ----
+	t.Run("matchFuncDecl matches by name", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "Hello"}}
+		if !matchFuncDecl(decl, "Hello") {
+			t.Error("matchFuncDecl should match FuncDecl by name")
+		}
+	})
+
+	t.Run("matchFuncDecl returns false for non-FuncDecl", func(t *testing.T) {
+		t.Parallel()
+		if matchFuncDecl(&ast.BadDecl{}, "Hello") {
+			t.Error("matchFuncDecl should return false for BadDecl")
+		}
+	})
+
+	t.Run("matchFuncDecl returns false for BadDecl", func(t *testing.T) {
+		t.Parallel()
+		if matchFuncDecl(&ast.BadDecl{}, "Nope") {
+			t.Error("matchFuncDecl should return false for BadDecl")
+		}
+	})
+
+	// ---- matchTypeSpec ----
+	t.Run("matchTypeSpec matches type by name", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.GenDecl{
+			Specs: []ast.Spec{
+				&ast.TypeSpec{Name: &ast.Ident{Name: "MyType"}},
+			},
+		}
+		if !matchTypeSpec(decl, "MyType") {
+			t.Error("matchTypeSpec should match TypeSpec by name")
+		}
+	})
+
+	t.Run("matchTypeSpec returns false for FuncDecl", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "MyType"}}
+		if matchTypeSpec(decl, "MyType") {
+			t.Error("matchTypeSpec should return false for FuncDecl")
+		}
+	})
+
+	// ---- matchValueSpec ----
+	t.Run("matchValueSpec matches const by name", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.GenDecl{
+			Specs: []ast.Spec{
+				&ast.ValueSpec{Names: []*ast.Ident{{Name: "MyConst"}}},
+			},
+		}
+		if !matchValueSpec(decl, "MyConst") {
+			t.Error("matchValueSpec should match const by name")
+		}
+	})
+
+	t.Run("matchValueSpec matches var by name", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.GenDecl{
+			Specs: []ast.Spec{
+				&ast.ValueSpec{Names: []*ast.Ident{{Name: "MyVar"}}},
+			},
+		}
+		if !matchValueSpec(decl, "MyVar") {
+			t.Error("matchValueSpec should match var by name")
+		}
+	})
+
+	t.Run("matchValueSpec matches second name in multi-name ValueSpec", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.GenDecl{
+			Specs: []ast.Spec{
+				&ast.ValueSpec{Names: []*ast.Ident{{Name: "A"}, {Name: "B"}}},
+			},
+		}
+		if !matchValueSpec(decl, "B") {
+			t.Error("matchValueSpec should match second name in multi-name ValueSpec")
+		}
+	})
+
+	t.Run("matchValueSpec returns false for import GenDecl", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.GenDecl{
+			Specs: []ast.Spec{
+				&ast.ImportSpec{Name: &ast.Ident{Name: "fmt"}},
+			},
+		}
+		if matchValueSpec(decl, "fmt") {
+			t.Error("matchValueSpec should return false for ImportSpec (not ValueSpec)")
+		}
+	})
+
+	t.Run("matchValueSpec returns false for FuncDecl", func(t *testing.T) {
+		t.Parallel()
+		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "MyFunc"}}
+		if matchValueSpec(decl, "MyFunc") {
+			t.Error("matchValueSpec should return false for FuncDecl")
+		}
+	})
+}
+
 func TestMatchSymbol_GenDeclEdgeCases(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/analysis/orphan_evaluator_deep.go
+++ b/internal/tools/analysis/orphan_evaluator_deep.go
@@ -17,17 +17,24 @@ type deepVerificationEvaluator struct {
 	analyzer *defaultDeadCodeAnalyzer
 }
 
-func (e *deepVerificationEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+// shouldDeepVerify reports whether the context qualifies for deep
+// type-aware AST verification. It returns false when any required
+// field is nil, deep mode is off, or the symbol is not a method.
+func (e *deepVerificationEvaluator) shouldDeepVerify(ctx *orphanEvalContext) bool {
 	if ctx == nil || ctx.report == nil {
-		return ctx
+		return false
 	}
 	if ctx.meta == nil || ctx.state == nil {
-		return ctx
+		return false
 	}
 	if e.analyzer == nil {
-		return ctx
+		return false
 	}
-	if !ctx.deep || !ctx.meta.isMethod {
+	return ctx.deep && ctx.meta.isMethod
+}
+
+func (e *deepVerificationEvaluator) evaluate(ctx *orphanEvalContext) *orphanEvalContext {
+	if !e.shouldDeepVerify(ctx) {
 		return ctx
 	}
 

--- a/internal/tools/analysis/orphan_evaluator_test.go
+++ b/internal/tools/analysis/orphan_evaluator_test.go
@@ -245,6 +245,107 @@ func TestDeepVerificationEvaluator(t *testing.T) {
 		})
 	}
 }
+func TestDeepVerificationEvaluator_ShouldDeepVerify(t *testing.T) {
+	tests := []struct {
+		name string
+		e    *deepVerificationEvaluator
+		ctx  *orphanEvalContext
+		want bool
+	}{
+		{
+			name: "nil context",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx:  nil,
+			want: false,
+		},
+		{
+			name: "nil report",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: nil,
+				meta:   &symMeta{isMethod: true},
+				state:  &scanState{},
+				deep:   true,
+			},
+			want: false,
+		},
+		{
+			name: "nil meta",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   nil,
+				state:  &scanState{},
+				deep:   true,
+			},
+			want: false,
+		},
+		{
+			name: "nil state",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   &symMeta{isMethod: true},
+				state:  nil,
+				deep:   true,
+			},
+			want: false,
+		},
+		{
+			name: "nil analyzer",
+			e:    &deepVerificationEvaluator{analyzer: nil},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   &symMeta{isMethod: true},
+				state:  &scanState{},
+				deep:   true,
+			},
+			want: false,
+		},
+		{
+			name: "deep disabled",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   &symMeta{isMethod: true},
+				state:  &scanState{},
+				deep:   false,
+			},
+			want: false,
+		},
+		{
+			name: "not a method",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   &symMeta{isMethod: false},
+				state:  &scanState{},
+				deep:   true,
+			},
+			want: false,
+		},
+		{
+			name: "all conditions met",
+			e:    &deepVerificationEvaluator{analyzer: &defaultDeadCodeAnalyzer{}},
+			ctx: &orphanEvalContext{
+				report: &orphanReport{},
+				meta:   &symMeta{isMethod: true},
+				state:  &scanState{},
+				deep:   true,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.e.shouldDeepVerify(tt.ctx)
+			if got != tt.want {
+				t.Errorf("shouldDeepVerify() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 func TestAnonInterfaceWarningEvaluator(t *testing.T) {
 	validReport := &orphanReport{
 		Symbol:   "Symbol",


### PR DESCRIPTION
Closes #920.

## Summary
Decomposed all 9 complexity-9 functions across 4 packages into smaller, independently testable helpers using four decomposition patterns:

| # | Function | Package | Before | After | Pattern |
|---|----------|---------|--------|-------|---------|
| 1 | `evaluate` | analysis | 9 | 3 | Guard → Predicate |
| 2 | `harvestPackageSymbols` | analysis | 9 | 3 | Guard → Predicate |
| 3 | `resolveInPackage` | analysis | 9 | 3 | Closure → Method |
| 4 | `Apply` | analysis | 9 | 3 | Pipeline → Sequence |
| 5 | `LoadPackages` | analysis | 9 | 5 | Module+Import extraction |
| 6 | `matchSymbol` | analysis | 9 | 3 | Type-switch → Table-driven |
| 7 | `getToken` | auth | 8 | 4 | I/O → Helpers |
| 8 | `renderTurnMetrics` | logging | 9 | 5 | Formatting → Pure |
| 9 | `discoverNewRecords` | telemetry | 9 | 4 | Loop → Helper |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint (golangci-lint) | 0 issues |
| vulncheck | No vulnerabilities |
| dead-code | No dead code |
| test-race (all packages) | PASS |
| coverage | ≥99% on affected packages |