### PR TITLE
fix(test): refactor top-5 cyclomatic-complexity test functions (#934)

### DIFF
--- a/internal/agent/agenttest/mock_gateway_test.go
+++ b/internal/agent/agenttest/mock_gateway_test.go
@@ -183,6 +183,52 @@ func checkSendChatWithOverride(t *testing.T, m *MockGateway) {
 	}
 }
 
+// assertNilGenerateReturnsDefault verifies that calling Generate on a
+// MockGateway with a nil GenerateFunc returns the default "model"/"generated"
+// response with non-nil Metrics.
+func assertNilGenerateReturnsDefault(t *testing.T, m *MockGateway) {
+	t.Helper()
+	content, metrics, err := m.Generate(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("nil GenerateFunc: unexpected error: %v", err)
+	}
+	if content == nil {
+		t.Fatal("nil GenerateFunc: got nil content")
+	}
+	if content.Role != "model" {
+		t.Errorf("nil GenerateFunc: got role %q; want %q", content.Role, "model")
+	}
+	if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
+		t.Errorf("nil GenerateFunc: got parts %+v; want [Text:generated]", content.Parts)
+	}
+	if metrics == nil {
+		t.Error("nil GenerateFunc: got nil metrics")
+	}
+}
+
+// assertNilSendChatReturnsDefault verifies that calling SendChat on a
+// MockGateway with a nil SendChatFn returns the default "model"/"generated"
+// response with non-nil Metrics.
+func assertNilSendChatReturnsDefault(t *testing.T, m *MockGateway) {
+	t.Helper()
+	content, metrics, err := m.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("nil SendChatFn: unexpected error: %v", err)
+	}
+	if content == nil {
+		t.Fatal("nil SendChatFn: got nil content")
+	}
+	if content.Role != "model" {
+		t.Errorf("nil SendChatFn: got role %q; want %q", content.Role, "model")
+	}
+	if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
+		t.Errorf("nil SendChatFn: got parts %+v; want [Text:generated]", content.Parts)
+	}
+	if metrics == nil {
+		t.Error("nil SendChatFn: got nil metrics")
+	}
+}
+
 func TestMockGateway(t *testing.T) {
 	t.Parallel()
 
@@ -267,53 +313,17 @@ func TestMockGateway_RaceDetection(t *testing.T) {
 func TestMockGateway_NilFuncs(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
 	tests := []struct {
 		name string
-		call func(m *MockGateway)
+		call func(t *testing.T, m *MockGateway)
 	}{
 		{
 			name: "Generate_nil_func",
-			call: func(m *MockGateway) {
-				content, metrics, err := m.Generate(ctx, nil, nil, nil)
-				if err != nil {
-					t.Fatalf("nil GenerateFunc: unexpected error: %v", err)
-				}
-				if content == nil {
-					t.Fatal("nil GenerateFunc: got nil content")
-				}
-				if content.Role != "model" {
-					t.Errorf("nil GenerateFunc: got role %q; want %q", content.Role, "model")
-				}
-				if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
-					t.Errorf("nil GenerateFunc: got parts %+v; want [Text:generated]", content.Parts)
-				}
-				if metrics == nil {
-					t.Error("nil GenerateFunc: got nil metrics")
-				}
-			},
+			call: assertNilGenerateReturnsDefault,
 		},
 		{
 			name: "SendChat_nil_func",
-			call: func(m *MockGateway) {
-				content, metrics, err := m.SendChat(ctx, nil, nil, nil)
-				if err != nil {
-					t.Fatalf("nil SendChatFn: unexpected error: %v", err)
-				}
-				if content == nil {
-					t.Fatal("nil SendChatFn: got nil content")
-				}
-				if content.Role != "model" {
-					t.Errorf("nil SendChatFn: got role %q; want %q", content.Role, "model")
-				}
-				if len(content.Parts) != 1 || content.Parts[0].Text != "generated" {
-					t.Errorf("nil SendChatFn: got parts %+v; want [Text:generated]", content.Parts)
-				}
-				if metrics == nil {
-					t.Error("nil SendChatFn: got nil metrics")
-				}
-			},
+			call: assertNilSendChatReturnsDefault,
 		},
 	}
 
@@ -322,7 +332,7 @@ func TestMockGateway_NilFuncs(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			m := &MockGateway{} // zero value — no func fields set
-			tt.call(m)
+			tt.call(t, m)
 		})
 	}
 }

--- a/internal/domain/events/fuzz_test.go
+++ b/internal/domain/events/fuzz_test.go
@@ -74,6 +74,79 @@ func (s *funcSubscriberWithErr) Handle(ctx context.Context, e Event) error {
 	return s.f(ctx, e)
 }
 
+// verifyPanickingSubscriber asserts that a panicking subscriber produces
+// an error containing "subscriber panicked" and logs an ERROR entry.
+func verifyPanickingSubscriber(t *testing.T, bus *SimpleEventBus, event Event, panicValue string, logBuf *bytes.Buffer) {
+	t.Helper()
+
+	panicSub := &panickingSubscriber{v: panicValue}
+	err := bus.notifySubscriber(context.Background(), panicSub, event)
+
+	if err == nil {
+		t.Error("panicking subscriber: expected error, got nil")
+	} else if !strings.Contains(err.Error(), "subscriber panicked") {
+		t.Errorf("panicking subscriber: error %q does not contain 'subscriber panicked'", err.Error())
+	}
+	if !strings.Contains(logBuf.String(), `"level":"ERROR"`) {
+		t.Error("panicking subscriber: expected ERROR log")
+	}
+	if !strings.Contains(logBuf.String(), "Subscriber panicked") {
+		t.Error("panicking subscriber: expected 'Subscriber panicked' in log")
+	}
+}
+
+// verifyErrorSubscriber asserts that an error-returning subscriber
+// correctly propagates or suppresses errors based on errMsg.
+func verifyErrorSubscriber(t *testing.T, bus *SimpleEventBus, event Event, errMsg string, logBuf *bytes.Buffer) {
+	t.Helper()
+
+	errSub := &funcSubscriberWithErr{f: func(ctx context.Context, e Event) error {
+		if errMsg == "" {
+			return nil
+		}
+		return errors.New(errMsg)
+	}}
+	err := bus.notifySubscriber(context.Background(), errSub, event)
+
+	if errMsg == "" {
+		if err != nil {
+			t.Errorf("error subscriber (nil case): expected nil, got %v", err)
+		}
+	} else {
+		if err == nil {
+			t.Error("error subscriber: expected error, got nil")
+		} else if !strings.Contains(err.Error(), errMsg) {
+			t.Errorf("error subscriber: error %q does not contain %q", err.Error(), errMsg)
+		}
+	}
+}
+
+// verifyEventPassthrough asserts that an event reaches the subscriber
+// intact with the correct Type() and StatusUpdate fields.
+func verifyEventPassthrough(t *testing.T, bus *SimpleEventBus, event Event, eventMessage string, logBuf *bytes.Buffer) {
+	t.Helper()
+
+	var capturedEvent Event
+	captureSub := &funcSubscriberWithErr{f: func(ctx context.Context, e Event) error {
+		capturedEvent = e
+		return nil
+	}}
+	_ = bus.notifySubscriber(context.Background(), captureSub, event)
+
+	if capturedEvent == nil {
+		t.Error("capture subscriber: event was nil")
+	} else if capturedEvent.Type() != "StatusUpdate" {
+		t.Errorf("capture subscriber: expected Type()='StatusUpdate', got %q", capturedEvent.Type())
+	}
+	if su, ok := capturedEvent.(StatusUpdate); ok {
+		if su.Message != eventMessage {
+			t.Errorf("capture subscriber: Message=%q, want %q", su.Message, eventMessage)
+		}
+	} else {
+		t.Errorf("capture subscriber: expected StatusUpdate, got %T", capturedEvent)
+	}
+}
+
 func FuzzNotifySubscriber(f *testing.F) {
 	// Seed corpus: diverse panic values, error messages, and event messages.
 	f.Add("boom", "sub err", "fuzz")                                     // baseline
@@ -90,63 +163,10 @@ func FuzzNotifySubscriber(f *testing.F) {
 
 		event := StatusUpdate{Message: eventMessage}
 
-		// 1. Test panicking subscriber with fuzzed panic value.
-		panicSub := &panickingSubscriber{v: panicValue}
-		err := bus.notifySubscriber(context.Background(), panicSub, event)
-
-		if err == nil {
-			t.Error("panicking subscriber: expected error, got nil")
-		} else if !strings.Contains(err.Error(), "subscriber panicked") {
-			t.Errorf("panicking subscriber: error %q does not contain 'subscriber panicked'", err.Error())
-		}
-		if !strings.Contains(logBuf.String(), `"level":"ERROR"`) {
-			t.Error("panicking subscriber: expected ERROR log")
-		}
-		if !strings.Contains(logBuf.String(), "Subscriber panicked") {
-			t.Error("panicking subscriber: expected 'Subscriber panicked' in log")
-		}
-
-		// 2. Test error-returning subscriber with fuzzed error message.
+		verifyPanickingSubscriber(t, bus, event, panicValue, &logBuf)
 		logBuf.Reset()
-		errSub := &funcSubscriberWithErr{f: func(ctx context.Context, e Event) error {
-			if errMsg == "" {
-				return nil
-			}
-			return errors.New(errMsg)
-		}}
-		err = bus.notifySubscriber(context.Background(), errSub, event)
-
-		if errMsg == "" {
-			if err != nil {
-				t.Errorf("error subscriber (nil case): expected nil, got %v", err)
-			}
-		} else {
-			if err == nil {
-				t.Error("error subscriber: expected error, got nil")
-			} else if !strings.Contains(err.Error(), errMsg) {
-				t.Errorf("error subscriber: error %q does not contain %q", err.Error(), errMsg)
-			}
-		}
-
-		// 3. Test event passthrough: event reaches subscriber intact.
+		verifyErrorSubscriber(t, bus, event, errMsg, &logBuf)
 		logBuf.Reset()
-		var capturedEvent Event
-		captureSub := &funcSubscriberWithErr{f: func(ctx context.Context, e Event) error {
-			capturedEvent = e
-			return nil
-		}}
-		_ = bus.notifySubscriber(context.Background(), captureSub, event)
-		if capturedEvent == nil {
-			t.Error("capture subscriber: event was nil")
-		} else if capturedEvent.Type() != "StatusUpdate" {
-			t.Errorf("capture subscriber: expected Type()='StatusUpdate', got %q", capturedEvent.Type())
-		}
-		if su, ok := capturedEvent.(StatusUpdate); ok {
-			if su.Message != eventMessage {
-				t.Errorf("capture subscriber: Message=%q, want %q", su.Message, eventMessage)
-			}
-		} else {
-			t.Errorf("capture subscriber: expected StatusUpdate, got %T", capturedEvent)
-		}
+		verifyEventPassthrough(t, bus, event, eventMessage, &logBuf)
 	})
 }

--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -265,155 +265,164 @@ func TestTaskService_ClearTasks(t *testing.T) {
 	})
 }
 
-func TestTaskService_ErrorPaths(t *testing.T) {
+// setupTaskServiceWithError creates a TaskService backed by a mockTaskRepo
+// with pre-configured error injection. Use readErr=nil / writeErr=nil for
+// happy-path setup; set non-nil errors to test error propagation.
+func setupTaskServiceWithError(t *testing.T, readErr, writeErr error) (ports.TaskStore, *mockTaskRepo) {
+	t.Helper()
+	repo := &mockTaskRepo{readErr: readErr, writeErr: writeErr}
+	return NewTaskService(repo), repo
+}
+
+func TestTaskService_AddTask_EmptyContent(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	_, err := s.AddTask(ctx, "")
+	if err == nil {
+		t.Error("expected error for empty content")
+	}
+}
 
-	t.Run("AddTask Empty Content", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		_, err := s.AddTask(ctx, "")
-		if err == nil {
-			t.Error("expected error for empty content")
-		}
-	})
+func TestTaskService_AddTask_WriteError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskServiceWithError(t, nil, errors.New("write fail"))
+	_, err := s.AddTask(ctx, "Test")
+	if err == nil {
+		t.Error("expected write error")
+	}
+}
 
-	t.Run("AddTask Write Error", func(t *testing.T) {
-		t.Parallel()
-		repo := &mockTaskRepo{writeErr: errors.New("write fail")}
-		s := NewTaskService(repo)
-		_, err := s.AddTask(ctx, "Test")
-		if err == nil {
-			t.Error("expected write error")
-		}
-	})
+func TestTaskService_CountTasks_QueryError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sentinel := errors.New("store query failed")
+	s, _ := setupTaskServiceWithError(t, sentinel, nil)
+	count, err := s.CountTasks(ctx, "")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if count != 0 {
+		t.Errorf("expected count 0, got %d", count)
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+}
 
-	t.Run("CountTasks Query Error", func(t *testing.T) {
-		t.Parallel()
-		sentinel := errors.New("store query failed")
-		repo := &mockTaskRepo{readErr: sentinel}
-		s := NewTaskService(repo)
-		count, err := s.CountTasks(ctx, "")
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		if count != 0 {
-			t.Errorf("expected count 0, got %d", count)
-		}
-		if !errors.Is(err, sentinel) {
-			t.Errorf("expected sentinel error, got %v", err)
-		}
-	})
+func TestTaskService_UpdateTask_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	_, err := s.UpdateTask(ctx, 999, "content", "status")
+	if err == nil {
+		t.Error("expected not found error")
+	}
+}
 
-	t.Run("UpdateTask Not Found", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		_, err := s.UpdateTask(ctx, 999, "content", "status")
-		if err == nil {
-			t.Error("expected not found error")
-		}
-	})
+func TestTaskService_UpdateTask_QueryError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sentinel := errors.New("store query failed")
+	s, repo := setupTaskService(t)
 
-	t.Run("UpdateTask Query Error", func(t *testing.T) {
-		t.Parallel()
-		sentinel := errors.New("store query failed")
-		repo := &mockTaskRepo{}
-		s := NewTaskService(repo)
+	// Add a task first (no read error)
+	task, err := s.AddTask(ctx, "task to update")
+	if err != nil {
+		t.Fatalf("setup AddTask failed: %v", err)
+	}
 
-		// Add a task first (no read error)
-		task, err := s.AddTask(ctx, "task to update")
-		if err != nil {
-			t.Fatalf("setup AddTask failed: %v", err)
-		}
+	// Now inject the read error
+	repo.readErr = sentinel
 
-		// Now inject the read error
-		repo.readErr = sentinel
+	// Attempt update — should fail at Query, never reach iteration or Update
+	_, err = s.UpdateTask(ctx, task.ID, "new content", "completed")
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
 
-		// Attempt update — should fail at Query, never reach iteration or Update
-		_, err = s.UpdateTask(ctx, task.ID, "new content", "completed")
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		if !errors.Is(err, sentinel) {
-			t.Errorf("expected sentinel error, got %v", err)
-		}
+	// Verify no side effects: task should be unchanged
+	if repo.tasks[0].Content != "task to update" || repo.tasks[0].Status != "pending" {
+		t.Errorf("task was mutated despite query error: content=%q status=%q",
+			repo.tasks[0].Content, repo.tasks[0].Status)
+	}
+}
 
-		// Verify no side effects: task should be unchanged
-		if repo.tasks[0].Content != "task to update" || repo.tasks[0].Status != "pending" {
-			t.Errorf("task was mutated despite query error: content=%q status=%q",
-				repo.tasks[0].Content, repo.tasks[0].Status)
-		}
-	})
+func TestTaskService_UpdateTask_WriteError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, repo := setupTaskService(t)
+	task, _ := s.AddTask(ctx, "Task")
+	repo.writeErr = errors.New("write fail")
+	_, err := s.UpdateTask(ctx, task.ID, "Updated", "completed")
+	if err == nil {
+		t.Error("expected write error")
+	}
+}
 
-	t.Run("UpdateTask Write Error", func(t *testing.T) {
-		t.Parallel()
-		s, repo := setupTaskService(t)
-		task, _ := s.AddTask(ctx, "Task")
-		repo.writeErr = errors.New("write fail")
-		_, err := s.UpdateTask(ctx, task.ID, "Updated", "completed")
-		if err == nil {
-			t.Error("expected write error")
-		}
-	})
+func TestTaskService_DeleteTask_NotFound(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	err := s.DeleteTask(ctx, 999)
+	if err == nil {
+		t.Error("expected not found error")
+	}
+}
 
-	t.Run("DeleteTask Not Found", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		err := s.DeleteTask(ctx, 999)
-		if err == nil {
-			t.Error("expected not found error")
-		}
-	})
+func TestTaskService_DeleteTask_QueryError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	sentinel := errors.New("store query failed")
+	s, repo := setupTaskServiceWithError(t, nil, nil)
 
-	t.Run("DeleteTask Query Error", func(t *testing.T) {
-		t.Parallel()
-		sentinel := errors.New("store query failed")
-		repo := &mockTaskRepo{readErr: sentinel}
-		s := NewTaskService(repo)
+	// Add a task so it exists in the store (no read error yet)
+	task, err := s.AddTask(ctx, "task to delete")
+	if err != nil {
+		t.Fatalf("setup AddTask failed: %v", err)
+	}
 
-		// Add a task so it exists in the store (no read error yet)
-		repo.readErr = nil
-		task, err := s.AddTask(ctx, "task to delete")
-		if err != nil {
-			t.Fatalf("setup AddTask failed: %v", err)
-		}
+	// Now inject the read error
+	repo.readErr = sentinel
 
-		// Now inject the read error
-		repo.readErr = sentinel
+	// Attempt delete — should fail at Query, not reach the not-found or delete logic
+	err = s.DeleteTask(ctx, task.ID)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
 
-		// Attempt delete — should fail at Query, not reach the not-found or delete logic
-		err = s.DeleteTask(ctx, task.ID)
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		if !errors.Is(err, sentinel) {
-			t.Errorf("expected sentinel error, got %v", err)
-		}
+	// Verify the task still exists (delete didn't happen)
+	if len(repo.tasks) != 1 {
+		t.Errorf("expected task to still exist, got %d tasks", len(repo.tasks))
+	}
+}
 
-		// Verify the task still exists (delete didn't happen)
-		if len(repo.tasks) != 1 {
-			t.Errorf("expected task to still exist, got %d tasks", len(repo.tasks))
-		}
-	})
+func TestTaskService_DeleteTask_WriteError(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, repo := setupTaskService(t)
+	task, _ := s.AddTask(ctx, "Task")
+	repo.writeErr = errors.New("write fail")
+	err := s.DeleteTask(ctx, task.ID)
+	if err == nil {
+		t.Error("expected write error")
+	}
+}
 
-	t.Run("DeleteTask Write Error", func(t *testing.T) {
-		t.Parallel()
-		s, repo := setupTaskService(t)
-		task, _ := s.AddTask(ctx, "Task")
-		repo.writeErr = errors.New("write fail")
-		err := s.DeleteTask(ctx, task.ID)
-		if err == nil {
-			t.Error("expected write error")
-		}
-	})
-
-	t.Run("Initialize", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		if err := s.(ports.Initializer).Initialize(ctx); err != nil {
-			t.Fatalf("Initialize returned unexpected error: %v", err)
-		}
-	})
+func TestTaskService_Initialize(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	if err := s.(ports.Initializer).Initialize(ctx); err != nil {
+		t.Fatalf("Initialize returned unexpected error: %v", err)
+	}
 }
 
 func TestTaskService_ListTasks_Filter(t *testing.T) {

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -883,83 +883,89 @@ func TestNewVertexAuth_DefaultTokenCmdFunc_ExecError(t *testing.T) {
 // readCacheFile / writeCacheFile unit tests
 // ---------------------------------------------------------------------------
 
-func TestVertexAuth_ReadCacheFile(t *testing.T) {
-	t.Run("cache hit", func(t *testing.T) {
-		dir := t.TempDir()
-		auth := &VertexAuth{CacheDir: dir}
-		cachePath := auth.getCachePath()
-		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
-			t.Fatalf("MkdirAll: %v", err)
-		}
-		if err := os.WriteFile(cachePath, []byte("  cached-token\n"), 0600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
-		}
+func TestVertexAuth_ReadCacheFile_Hit(t *testing.T) {
+	t.Parallel()
 
-		token, ok := auth.readCacheFile()
-		if !ok {
-			t.Fatal("expected cache hit")
-		}
-		if token != "cached-token" {
-			t.Errorf("got %q, want cached-token", token)
-		}
-	})
+	dir := t.TempDir()
+	auth := &VertexAuth{CacheDir: dir}
+	cachePath := auth.getCachePath()
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("  cached-token\n"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
-	t.Run("missing file", func(t *testing.T) {
-		auth := &VertexAuth{CacheDir: t.TempDir()}
-		token, ok := auth.readCacheFile()
-		if ok {
-			t.Errorf("expected cache miss, got token=%q", token)
-		}
-		if token != "" {
-			t.Errorf("expected empty token on miss, got %q", token)
-		}
-	})
+	token, ok := auth.readCacheFile()
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if token != "cached-token" {
+		t.Errorf("got %q, want cached-token", token)
+	}
+}
 
-	t.Run("expired cache", func(t *testing.T) {
-		dir := t.TempDir()
-		auth := &VertexAuth{CacheDir: dir}
-		cachePath := auth.getCachePath()
-		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
-			t.Fatalf("MkdirAll: %v", err)
-		}
-		if err := os.WriteFile(cachePath, []byte("expired-token"), 0600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
-		}
-		// Set mod time to 2 hours ago → older than 55 minutes
-		past := time.Now().Add(-2 * time.Hour)
-		if err := os.Chtimes(cachePath, past, past); err != nil {
-			t.Fatalf("Chtimes: %v", err)
-		}
+func TestVertexAuth_ReadCacheFile_Missing(t *testing.T) {
+	t.Parallel()
 
-		token, ok := auth.readCacheFile()
-		if ok {
-			t.Errorf("expected cache miss for expired token, got %q", token)
-		}
-	})
+	auth := &VertexAuth{CacheDir: t.TempDir()}
+	token, ok := auth.readCacheFile()
+	if ok {
+		t.Errorf("expected cache miss, got token=%q", token)
+	}
+	if token != "" {
+		t.Errorf("expected empty token on miss, got %q", token)
+	}
+}
 
-	t.Run("unreadable cache", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Chmod 0000 not reliable on Windows")
-		}
-		dir := t.TempDir()
-		auth := &VertexAuth{CacheDir: dir}
-		cachePath := auth.getCachePath()
-		if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
-			t.Fatalf("MkdirAll: %v", err)
-		}
-		if err := os.WriteFile(cachePath, []byte("unreadable-token"), 0600); err != nil {
-			t.Fatalf("WriteFile: %v", err)
-		}
-		if err := os.Chmod(cachePath, 0000); err != nil {
-			t.Fatalf("Chmod: %v", err)
-		}
-		t.Cleanup(func() { _ = os.Chmod(cachePath, 0600) })
+func TestVertexAuth_ReadCacheFile_Expired(t *testing.T) {
+	t.Parallel()
 
-		token, ok := auth.readCacheFile()
-		if ok {
-			t.Errorf("expected cache miss for unreadable file, got %q", token)
-		}
-	})
+	dir := t.TempDir()
+	auth := &VertexAuth{CacheDir: dir}
+	cachePath := auth.getCachePath()
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("expired-token"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	// Set mod time to 2 hours ago → older than 55 minutes
+	past := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(cachePath, past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+
+	token, ok := auth.readCacheFile()
+	if ok {
+		t.Errorf("expected cache miss for expired token, got %q", token)
+	}
+}
+
+func TestVertexAuth_ReadCacheFile_Unreadable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Chmod 0000 not reliable on Windows")
+	}
+	t.Parallel()
+
+	dir := t.TempDir()
+	auth := &VertexAuth{CacheDir: dir}
+	cachePath := auth.getCachePath()
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("unreadable-token"), 0600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if err := os.Chmod(cachePath, 0000); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(cachePath, 0600) })
+
+	token, ok := auth.readCacheFile()
+	if ok {
+		t.Errorf("expected cache miss for unreadable file, got %q", token)
+	}
 }
 
 func TestVertexAuth_WriteCacheFile(t *testing.T) {

--- a/internal/tools/integrations/network_test.go
+++ b/internal/tools/integrations/network_test.go
@@ -295,7 +295,116 @@ func TestHttpRequest_RequestCreationError(t *testing.T) {
 	}
 }
 
-func TestExecuteRequest(t *testing.T) {
+func TestExecuteRequest_ValidGET(t *testing.T) {
+	t.Parallel()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	wantResp := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("OK")),
+	}
+	mock := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Method != "GET" {
+				t.Errorf("expected GET, got %s", req.Method)
+			}
+			if req.URL.String() != "https://example.com" {
+				t.Errorf("expected https://example.com, got %s", req.URL.String())
+			}
+			return wantResp, nil
+		},
+	}
+	tool := newnetworkTool(sm, mock)
+	resp, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != wantResp {
+		t.Error("response mismatch")
+	}
+	if stopHB != nil {
+		t.Error("stopHB should be nil when hb channel is nil")
+	}
+}
+
+func TestExecuteRequest_InvalidURL(t *testing.T) {
+	t.Parallel()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	tool := newnetworkTool(sm, &mockHTTPClient{})
+	_, stopHB, err := tool.executeRequest(context.Background(), "GET", "://invalid-url", "", nil, nil)
+	if err == nil {
+		t.Error("expected error for invalid URL")
+	}
+	if !strings.Contains(err.Error(), "failed to create request") {
+		t.Errorf("expected 'failed to create request', got: %v", err)
+	}
+	if stopHB != nil {
+		t.Error("stopHB should be nil on error")
+	}
+}
+
+func TestExecuteRequest_ClientError(t *testing.T) {
+	t.Parallel()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	mock := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("connection refused")
+		},
+	}
+	tool := newnetworkTool(sm, mock)
+	_, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, nil)
+	if err == nil {
+		t.Error("expected error from client")
+	}
+	if !strings.Contains(err.Error(), "request failed") {
+		t.Errorf("expected 'request failed', got: %v", err)
+	}
+	if stopHB != nil {
+		t.Error("stopHB should be nil on client error")
+	}
+}
+
+func TestExecuteRequest_POSTWithBodyAndHeaders(t *testing.T) {
+	t.Parallel()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	wantResp := &http.Response{
+		Status:     "201 Created",
+		StatusCode: 201,
+		Body:       io.NopCloser(strings.NewReader("Created")),
+	}
+	mock := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			if req.Method != "POST" {
+				t.Errorf("expected POST, got %s", req.Method)
+			}
+			if req.Header.Get("X-Custom") != "value" {
+				t.Errorf("expected X-Custom: value, got %s", req.Header.Get("X-Custom"))
+			}
+			body, _ := io.ReadAll(req.Body)
+			if string(body) != "request body" {
+				t.Errorf("expected body 'request body', got %q", string(body))
+			}
+			return wantResp, nil
+		},
+	}
+	tool := newnetworkTool(sm, mock)
+	resp, stopHB, err := tool.executeRequest(context.Background(), "POST", "https://example.com", "request body", map[string]string{"X-Custom": "value"}, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp != wantResp {
+		t.Error("response mismatch")
+	}
+	if stopHB != nil {
+		t.Error("stopHB should be nil when hb channel is nil")
+	}
+}
+
+func TestExecuteRequest_WithHeartbeat(t *testing.T) {
 	defer goleak.VerifyNone(t,
 		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).readLoop"),
 		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).writeLoop"),
@@ -303,134 +412,35 @@ func TestExecuteRequest(t *testing.T) {
 	)
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 
-	t.Run("valid GET", func(t *testing.T) {
-		wantResp := &http.Response{
-			Status:     "200 OK",
-			StatusCode: 200,
-			Body:       io.NopCloser(strings.NewReader("OK")),
-		}
-		mock := &mockHTTPClient{
-			DoFunc: func(req *http.Request) (*http.Response, error) {
-				if req.Method != "GET" {
-					t.Errorf("expected GET, got %s", req.Method)
-				}
-				if req.URL.String() != "https://example.com" {
-					t.Errorf("expected https://example.com, got %s", req.URL.String())
-				}
-				return wantResp, nil
-			},
-		}
-		tool := newnetworkTool(sm, mock)
-		resp, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp != wantResp {
-			t.Error("response mismatch")
-		}
-		if stopHB != nil {
-			t.Error("stopHB should be nil when hb channel is nil")
-		}
-	})
-
-	t.Run("invalid URL", func(t *testing.T) {
-		tool := newnetworkTool(sm, &mockHTTPClient{})
-		_, stopHB, err := tool.executeRequest(context.Background(), "GET", "://invalid-url", "", nil, nil)
-		if err == nil {
-			t.Error("expected error for invalid URL")
-		}
-		if !strings.Contains(err.Error(), "failed to create request") {
-			t.Errorf("expected 'failed to create request', got: %v", err)
-		}
-		if stopHB != nil {
-			t.Error("stopHB should be nil on error")
-		}
-	})
-
-	t.Run("client error propagates", func(t *testing.T) {
-		mock := &mockHTTPClient{
-			DoFunc: func(req *http.Request) (*http.Response, error) {
-				return nil, errors.New("connection refused")
-			},
-		}
-		tool := newnetworkTool(sm, mock)
-		_, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, nil)
-		if err == nil {
-			t.Error("expected error from client")
-		}
-		if !strings.Contains(err.Error(), "request failed") {
-			t.Errorf("expected 'request failed', got: %v", err)
-		}
-		if stopHB != nil {
-			t.Error("stopHB should be nil on client error")
-		}
-	})
-
-	t.Run("POST with body and headers", func(t *testing.T) {
-		wantResp := &http.Response{
-			Status:     "201 Created",
-			StatusCode: 201,
-			Body:       io.NopCloser(strings.NewReader("Created")),
-		}
-		mock := &mockHTTPClient{
-			DoFunc: func(req *http.Request) (*http.Response, error) {
-				if req.Method != "POST" {
-					t.Errorf("expected POST, got %s", req.Method)
-				}
-				if req.Header.Get("X-Custom") != "value" {
-					t.Errorf("expected X-Custom: value, got %s", req.Header.Get("X-Custom"))
-				}
-				body, _ := io.ReadAll(req.Body)
-				if string(body) != "request body" {
-					t.Errorf("expected body 'request body', got %q", string(body))
-				}
-				return wantResp, nil
-			},
-		}
-		tool := newnetworkTool(sm, mock)
-		resp, stopHB, err := tool.executeRequest(context.Background(), "POST", "https://example.com", "request body", map[string]string{"X-Custom": "value"}, nil)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if resp != wantResp {
-			t.Error("response mismatch")
-		}
-		if stopHB != nil {
-			t.Error("stopHB should be nil when hb channel is nil")
-		}
-	})
-
-	t.Run("with heartbeat channel", func(t *testing.T) {
-		wantResp := &http.Response{
-			Status:     "200 OK",
-			StatusCode: 200,
-			Body:       io.NopCloser(strings.NewReader("OK")),
-		}
-		mock := &mockHTTPClient{
-			DoFunc: func(req *http.Request) (*http.Response, error) {
-				return wantResp, nil
-			},
-		}
-		tool := newnetworkTool(sm, mock)
-		tool.heartbeatInterval = 10 * time.Millisecond
-		hb := make(chan struct{}, 1)
-		resp, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, hb)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if stopHB == nil {
-			t.Error("stopHB should not be nil when hb channel is provided")
-		}
-		stopHB()
-		// Drain heartbeat
-		select {
-		case <-hb:
-		default:
-		}
-		if resp != wantResp {
-			t.Error("response mismatch")
-		}
-	})
+	wantResp := &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body:       io.NopCloser(strings.NewReader("OK")),
+	}
+	mock := &mockHTTPClient{
+		DoFunc: func(req *http.Request) (*http.Response, error) {
+			return wantResp, nil
+		},
+	}
+	tool := newnetworkTool(sm, mock)
+	tool.heartbeatInterval = 10 * time.Millisecond
+	hb := make(chan struct{}, 1)
+	resp, stopHB, err := tool.executeRequest(context.Background(), "GET", "https://example.com", "", nil, hb)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stopHB == nil {
+		t.Error("stopHB should not be nil when hb channel is provided")
+	}
+	stopHB()
+	// Drain heartbeat
+	select {
+	case <-hb:
+	default:
+	}
+	if resp != wantResp {
+		t.Error("response mismatch")
+	}
 }
 
 func TestReadExternalDocs_RequestCreationError(t *testing.T) {


### PR DESCRIPTION
Closes #934.

## Summary
Split and refactored the top 5 highest cyclomatic-complexity test functions to reduce cognitive load and enable function-level parallelism:

| # | Original Function | Complexity Before | After |
|---|---|---|---|
| 1 | `TestMockGateway_NilFuncs` | 14 | 2 (+ two helpers at 7,7) |
| 2 | `TestVertexAuth_ReadCacheFile` | 16 | 4 standalone functions (max 6) |
| 3 | `TestExecuteRequest` | 23 | 5 standalone functions (max 7) |
| 4 | `TestTaskService_ErrorPaths` | 20 | 10 standalone functions (max 6) |
| 5 | `FuzzNotifySubscriber` | 14 | 1 (+ three helpers at 5,6,5) |

**Result**: Complexity alerts >10 dropped from 13 → 8 (target ≤9 met). All 5 eliminated from the top tier.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test -race -count=1 ./... | PASS |
| golangci-lint | 0 issues |
| Complexity alerts (>10) | 13 → 8 |
| Dead code | None |