### PR TITLE
fix(test): reduce cyclomatic complexity of 4 test functions (#936)

### DIFF
--- a/internal/agent/agenttest/mock_capturer_test.go
+++ b/internal/agent/agenttest/mock_capturer_test.go
@@ -244,10 +244,85 @@ func TestMockCapturer_RaceDetection(t *testing.T) {
 	}
 }
 
+// assertIsTTYNilReturnsFalse asserts that a zero-value MockCapturer
+// returns false from IsTTY (the nil-func default).
+func assertIsTTYNilReturnsFalse(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	got := m.IsTTY("any")
+	if got {
+		t.Error("nil IsTTYFn: got true; want false")
+	}
+}
+
+// assertCapturePromptNilReturnsEmpty asserts that a zero-value MockCapturer
+// returns ("", nil) from CapturePrompt (the nil-func default).
+func assertCapturePromptNilReturnsEmpty(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	ctx := context.Background()
+	got, err := m.CapturePrompt(ctx, nil)
+	if got != "" {
+		t.Errorf("nil CapturePromptFn: got %q; want empty", got)
+	}
+	if err != nil {
+		t.Errorf("nil CapturePromptFn: unexpected error: %v", err)
+	}
+}
+
+// assertConfirmNilReturnsFalse asserts that a zero-value MockCapturer
+// returns (false, nil) from Confirm (the nil-func default).
+func assertConfirmNilReturnsFalse(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	ctx := context.Background()
+	got, err := m.Confirm(ctx, "proceed?")
+	if got {
+		t.Error("nil ConfirmFn: got true; want false")
+	}
+	if err != nil {
+		t.Errorf("nil ConfirmFn: unexpected error: %v", err)
+	}
+}
+
+// assertCloseNilReturnsNil asserts that a zero-value MockCapturer
+// returns nil from Close (the nil-func default).
+func assertCloseNilReturnsNil(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	ctx := context.Background()
+	err := m.Close(ctx)
+	if err != nil {
+		t.Errorf("nil CloseFn: unexpected error: %v", err)
+	}
+}
+
+// assertReadSingleKeyNilReturnsEmpty asserts that a zero-value MockCapturer
+// returns ("", nil) from ReadSingleKey (the nil-func default).
+func assertReadSingleKeyNilReturnsEmpty(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	ctx := context.Background()
+	got, err := m.ReadSingleKey(ctx)
+	if got != "" {
+		t.Errorf("nil ReadSingleKeyFn: got %q; want empty", got)
+	}
+	if err != nil {
+		t.Errorf("nil ReadSingleKeyFn: unexpected error: %v", err)
+	}
+}
+
+// assertReadLineNilReturnsEmpty asserts that a zero-value MockCapturer
+// returns ("", nil) from ReadLine (the nil-func default).
+func assertReadLineNilReturnsEmpty(t *testing.T, m *MockCapturer) {
+	t.Helper()
+	ctx := context.Background()
+	got, err := m.ReadLine(ctx)
+	if got != "" {
+		t.Errorf("nil ReadLineFn: got %q; want empty", got)
+	}
+	if err != nil {
+		t.Errorf("nil ReadLineFn: unexpected error: %v", err)
+	}
+}
+
 func TestMockCapturer_NilFuncs(t *testing.T) {
 	t.Parallel()
-
-	ctx := context.Background()
 
 	tests := []struct {
 		name string
@@ -256,67 +331,37 @@ func TestMockCapturer_NilFuncs(t *testing.T) {
 		{
 			name: "IsTTY_nil_func",
 			call: func(m *MockCapturer) {
-				got := m.IsTTY("any")
-				if got {
-					t.Error("nil IsTTYFn: got true; want false")
-				}
+				assertIsTTYNilReturnsFalse(t, m)
 			},
 		},
 		{
 			name: "CapturePrompt_nil_func",
 			call: func(m *MockCapturer) {
-				got, err := m.CapturePrompt(ctx, nil)
-				if got != "" {
-					t.Errorf("nil CapturePromptFn: got %q; want empty", got)
-				}
-				if err != nil {
-					t.Errorf("nil CapturePromptFn: unexpected error: %v", err)
-				}
+				assertCapturePromptNilReturnsEmpty(t, m)
 			},
 		},
 		{
 			name: "Confirm_nil_func",
 			call: func(m *MockCapturer) {
-				got, err := m.Confirm(ctx, "proceed?")
-				if got {
-					t.Error("nil ConfirmFn: got true; want false")
-				}
-				if err != nil {
-					t.Errorf("nil ConfirmFn: unexpected error: %v", err)
-				}
+				assertConfirmNilReturnsFalse(t, m)
 			},
 		},
 		{
 			name: "Close_nil_func",
 			call: func(m *MockCapturer) {
-				err := m.Close(ctx)
-				if err != nil {
-					t.Errorf("nil CloseFn: unexpected error: %v", err)
-				}
+				assertCloseNilReturnsNil(t, m)
 			},
 		},
 		{
 			name: "ReadSingleKey_nil_func",
 			call: func(m *MockCapturer) {
-				got, err := m.ReadSingleKey(ctx)
-				if got != "" {
-					t.Errorf("nil ReadSingleKeyFn: got %q; want empty", got)
-				}
-				if err != nil {
-					t.Errorf("nil ReadSingleKeyFn: unexpected error: %v", err)
-				}
+				assertReadSingleKeyNilReturnsEmpty(t, m)
 			},
 		},
 		{
 			name: "ReadLine_nil_func",
 			call: func(m *MockCapturer) {
-				got, err := m.ReadLine(ctx)
-				if got != "" {
-					t.Errorf("nil ReadLineFn: got %q; want empty", got)
-				}
-				if err != nil {
-					t.Errorf("nil ReadLineFn: unexpected error: %v", err)
-				}
+				assertReadLineNilReturnsEmpty(t, m)
 			},
 		},
 	}

--- a/internal/tools/analysis/move_test.go
+++ b/internal/tools/analysis/move_test.go
@@ -165,76 +165,77 @@ func TestMovePlanDescription(t *testing.T) {
 	}
 }
 
-func TestMatchesTypeName_StarExpr(t *testing.T) {
+func TestMatchesTypeName_StarExpr_PointerReceiver(t *testing.T) {
 	t.Parallel()
 
 	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}\nfunc (s *MyStruct) Method() {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	// Find the method decl
+	var methodDecl *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
+			methodDecl = fd
+			break
+		}
+	}
+	if methodDecl == nil {
+		t.Fatal("expected to find method declaration")
+	}
+	// matchesTypeName on *MyStruct receiver
+	if !tr.matchesTypeName(methodDecl.Recv.List[0].Type, "MyStruct") {
+		t.Error("matchesTypeName should match *MyStruct pointer receiver")
+	}
+}
 
-	t.Run("pointer receiver matches", func(t *testing.T) {
-		t.Parallel()
-		// *ast.StarExpr{X: *ast.Ident{Name: "MyStruct"}}
-		fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}\nfunc (s *MyStruct) Method() {}")
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = fset
-		// Find the method decl
-		var methodDecl *ast.FuncDecl
-		for _, d := range f.Decls {
-			if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
-				methodDecl = fd
-				break
-			}
-		}
-		if methodDecl == nil {
-			t.Fatal("expected to find method declaration")
-		}
-		// matchesTypeName on *MyStruct receiver
-		if !tr.matchesTypeName(methodDecl.Recv.List[0].Type, "MyStruct") {
-			t.Error("matchesTypeName should match *MyStruct pointer receiver")
-		}
-	})
+func TestMatchesTypeName_StarExpr_NonMatch(t *testing.T) {
+	t.Parallel()
 
-	t.Run("pointer receiver non-match", func(t *testing.T) {
-		t.Parallel()
-		fset, f, err := parseTestMoveFile("package a\ntype Other struct{}\nfunc (s *Other) Method() {}")
-		if err != nil {
-			t.Fatal(err)
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	fset, f, err := parseTestMoveFile("package a\ntype Other struct{}\nfunc (s *Other) Method() {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	var methodDecl *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
+			methodDecl = fd
+			break
 		}
-		_ = fset
-		var methodDecl *ast.FuncDecl
-		for _, d := range f.Decls {
-			if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
-				methodDecl = fd
-				break
-			}
-		}
-		if methodDecl == nil {
-			t.Fatal("expected to find method declaration")
-		}
-		if tr.matchesTypeName(methodDecl.Recv.List[0].Type, "MyStruct") {
-			t.Error("matchesTypeName should NOT match *Other as MyStruct")
-		}
-	})
+	}
+	if methodDecl == nil {
+		t.Fatal("expected to find method declaration")
+	}
+	if tr.matchesTypeName(methodDecl.Recv.List[0].Type, "MyStruct") {
+		t.Error("matchesTypeName should NOT match *Other as MyStruct")
+	}
+}
 
-	t.Run("double pointer handled by recursion", func(t *testing.T) {
-		t.Parallel()
-		// **MyStruct - StarExpr wrapping another StarExpr wrapping Ident
-		// matchesTypeName recurses through StarExpr, so this matches.
-		innerStar := &ast.StarExpr{X: &ast.Ident{Name: "MyStruct"}}
-		doubleStar := &ast.StarExpr{X: innerStar}
-		if !tr.matchesTypeName(doubleStar, "MyStruct") {
-			t.Error("matchesTypeName should match **MyStruct via recursion through StarExpr")
-		}
-	})
+func TestMatchesTypeName_StarExpr_DoublePointer(t *testing.T) {
+	t.Parallel()
 
-	t.Run("unhandled expr type returns false", func(t *testing.T) {
-		t.Parallel()
-		// ArrayType is not handled by the switch
-		if tr.matchesTypeName(&ast.ArrayType{}, "MyStruct") {
-			t.Error("matchesTypeName should return false for unhandled expr type")
-		}
-	})
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	// **MyStruct - StarExpr wrapping another StarExpr wrapping Ident
+	// matchesTypeName recurses through StarExpr, so this matches.
+	innerStar := &ast.StarExpr{X: &ast.Ident{Name: "MyStruct"}}
+	doubleStar := &ast.StarExpr{X: innerStar}
+	if !tr.matchesTypeName(doubleStar, "MyStruct") {
+		t.Error("matchesTypeName should match **MyStruct via recursion through StarExpr")
+	}
+}
+
+func TestMatchesTypeName_StarExpr_UnhandledExpr(t *testing.T) {
+	t.Parallel()
+
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	// ArrayType is not handled by the switch
+	if tr.matchesTypeName(&ast.ArrayType{}, "MyStruct") {
+		t.Error("matchesTypeName should return false for unhandled expr type")
+	}
 }
 
 func TestDeclMatchers(t *testing.T) {
@@ -342,96 +343,92 @@ func TestDeclMatchers(t *testing.T) {
 	})
 }
 
-func TestMatchSymbol_GenDeclEdgeCases(t *testing.T) {
+func TestMatchSymbol_GenDecl_ImportReturnsFalse(t *testing.T) {
 	t.Parallel()
-
-	t.Run("non-type non-value GenDecl returns false", func(t *testing.T) {
-		t.Parallel()
-		// GenDecl with an ImportSpec — not a TypeSpec or ValueSpec
-		tr := newMoveTransform(&movePlan{Symbol: "fmt"})
-		code := `package a
+	// GenDecl with an ImportSpec — not a TypeSpec or ValueSpec
+	tr := newMoveTransform(&movePlan{Symbol: "fmt"})
+	code := `package a
 import "fmt"`
-		fset, f, err := parseTestMoveFile(code)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = fset
-		// GenDecl with Tok==token.IMPORT and Specs containing ImportSpec
-		if tr.matchSymbol(f.Decls[0]) {
-			t.Error("matchSymbol should return false for import GenDecl (not TypeSpec or ValueSpec)")
-		}
-	})
+	fset, f, err := parseTestMoveFile(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	// GenDecl with Tok==token.IMPORT and Specs containing ImportSpec
+	if tr.matchSymbol(f.Decls[0]) {
+		t.Error("matchSymbol should return false for import GenDecl (not TypeSpec or ValueSpec)")
+	}
+}
 
-	t.Run("multiple ValueSpecs matches second", func(t *testing.T) {
-		t.Parallel()
-		tr := newMoveTransform(&movePlan{Symbol: "B"})
-		code := `package a
+func TestMatchSymbol_GenDecl_MultiValueSpec(t *testing.T) {
+	t.Parallel()
+	tr := newMoveTransform(&movePlan{Symbol: "B"})
+	code := `package a
 var A, B = 1, 2`
-		fset, f, err := parseTestMoveFile(code)
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = fset
-		if !tr.matchSymbol(f.Decls[0]) {
-			t.Error("matchSymbol should match B in multi-name ValueSpec")
-		}
-	})
+	fset, f, err := parseTestMoveFile(code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	if !tr.matchSymbol(f.Decls[0]) {
+		t.Error("matchSymbol should match B in multi-name ValueSpec")
+	}
+}
 
-	t.Run("isMethodOf with value receiver", func(t *testing.T) {
-		t.Parallel()
-		tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
-		fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}\nfunc (s MyStruct) ValueMethod() {}")
-		if err != nil {
-			t.Fatal(err)
+func TestMatchSymbol_IsMethodOf_ValueReceiver(t *testing.T) {
+	t.Parallel()
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}\nfunc (s MyStruct) ValueMethod() {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	// Find the method decl
+	var methodDecl ast.Decl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
+			methodDecl = d
+			break
 		}
-		_ = fset
-		// Find the method decl
-		var methodDecl ast.Decl
-		for _, d := range f.Decls {
-			if fd, ok := d.(*ast.FuncDecl); ok && fd.Recv != nil {
-				methodDecl = d
-				break
-			}
-		}
-		if !tr.isMethodOf(methodDecl, "MyStruct") {
-			t.Error("isMethodOf should match value receiver method of MyStruct")
-		}
-	})
+	}
+	if !tr.isMethodOf(methodDecl, "MyStruct") {
+		t.Error("isMethodOf should match value receiver method of MyStruct")
+	}
+}
 
-	t.Run("isMethodOf non-FuncDecl returns false", func(t *testing.T) {
-		t.Parallel()
-		tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
-		fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}")
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = fset
-		if tr.isMethodOf(f.Decls[0], "MyStruct") {
-			t.Error("isMethodOf should return false for GenDecl (not FuncDecl)")
-		}
-	})
+func TestMatchSymbol_IsMethodOf_NonFuncDecl(t *testing.T) {
+	t.Parallel()
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	fset, f, err := parseTestMoveFile("package a\ntype MyStruct struct{}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	if tr.isMethodOf(f.Decls[0], "MyStruct") {
+		t.Error("isMethodOf should return false for GenDecl (not FuncDecl)")
+	}
+}
 
-	t.Run("isMethodOf nil receiver returns false", func(t *testing.T) {
-		t.Parallel()
-		tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
-		fset, f, err := parseTestMoveFile("package a\nfunc PlainFunc() {}")
-		if err != nil {
-			t.Fatal(err)
-		}
-		_ = fset
-		if tr.isMethodOf(f.Decls[0], "MyStruct") {
-			t.Error("isMethodOf should return false for function without receiver")
-		}
-	})
+func TestMatchSymbol_IsMethodOf_NilReceiver(t *testing.T) {
+	t.Parallel()
+	tr := newMoveTransform(&movePlan{Symbol: "MyStruct"})
+	fset, f, err := parseTestMoveFile("package a\nfunc PlainFunc() {}")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = fset
+	if tr.isMethodOf(f.Decls[0], "MyStruct") {
+		t.Error("isMethodOf should return false for function without receiver")
+	}
+}
 
-	t.Run("matchSymbol non-FuncDecl non-GenDecl returns false", func(t *testing.T) {
-		t.Parallel()
-		tr := newMoveTransform(&movePlan{Symbol: "Anything"})
-		// BadDecl is not *ast.FuncDecl or *ast.GenDecl
-		if tr.matchSymbol(&ast.BadDecl{}) {
-			t.Error("matchSymbol should return false for BadDecl")
-		}
-	})
+func TestMatchSymbol_BadDeclReturnsFalse(t *testing.T) {
+	t.Parallel()
+	tr := newMoveTransform(&movePlan{Symbol: "Anything"})
+	// BadDecl is not *ast.FuncDecl or *ast.GenDecl
+	if tr.matchSymbol(&ast.BadDecl{}) {
+		t.Error("matchSymbol should return false for BadDecl")
+	}
 }
 
 func TestMoveTransform_ErrorContext(t *testing.T) {

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -963,82 +963,103 @@ func TestRenderTaskPage(t *testing.T) {
 	}
 }
 
-func TestFetchAndCount(t *testing.T) {
-	t.Run("success returns tasks and count", func(t *testing.T) {
-		pt, provider := setupPersistenceTools()
-		ctx := context.Background()
+// countErrorStore wraps a ports.TaskStore and overrides CountTasks to
+// return a configurable error, while delegating all other methods (including
+// ListTasks) to the inner store. This enables testing the CountTasks error
+// path independently from ListTasks.
+type countErrorStore struct {
+	ports.TaskStore
+	countErr error
+}
 
-		_, err := provider.tasks.AddTask(ctx, "task one")
-		if err != nil {
-			t.Fatal(err)
-		}
-		_, err = provider.tasks.AddTask(ctx, "task two")
-		if err != nil {
-			t.Fatal(err)
-		}
+func (s *countErrorStore) CountTasks(ctx context.Context, status string) (int, error) {
+	if s.countErr != nil {
+		return 0, s.countErr
+	}
+	return s.TaskStore.CountTasks(ctx, status)
+}
 
-		tasks, count, err := pt.fetchAndCount(ctx, "", 50, 0)
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if count != 2 {
-			t.Errorf("count = %d; want 2", count)
-		}
-		if len(tasks) != 2 {
-			t.Errorf("len(tasks) = %d; want 2", len(tasks))
-		}
-	})
+// TestFetchAndCount_Success verifies the happy path: tasks and count
+// are both returned correctly.
+func TestFetchAndCount_Success(t *testing.T) {
+	t.Parallel()
+	pt, provider := setupPersistenceTools()
+	ctx := context.Background()
 
-	t.Run("ListTasks error propagates", func(t *testing.T) {
-		pt, provider := setupPersistenceTools()
-		provider.listStore.err = errors.New("list failed")
+	_, err := provider.tasks.AddTask(ctx, "task one")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = provider.tasks.AddTask(ctx, "task two")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		tasks, count, err := pt.fetchAndCount(context.Background(), "", 50, 0)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "list failed") {
-			t.Errorf("error = %q; want containing 'list failed'", err.Error())
-		}
-		if tasks != nil {
-			t.Errorf("tasks = %v; want nil on error", tasks)
-		}
-		if count != 0 {
-			t.Errorf("count = %d; want 0 on error", count)
-		}
-	})
+	tasks, count, err := pt.fetchAndCount(ctx, "", 50, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("count = %d; want 2", count)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("len(tasks) = %d; want 2", len(tasks))
+	}
+}
 
-	t.Run("CountTasks error propagates", func(t *testing.T) {
-		pt, provider := setupPersistenceTools()
-		ctx := context.Background()
-		// Add a task so ListTasks succeeds
-		_, err := provider.tasks.AddTask(ctx, "task one")
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Now inject error — but CountTasks on the mock delegates to
-		// mockListStore.Count which uses m.err. We need ListTasks to
-		// succeed and CountTasks to fail. The mockListStore shares a
-		// single error field, so we set it after ListTasks would read it.
-		//
-		// Strategy: wrap the store to inject error only on Count.
-		// Simpler approach: verify that a direct store error propagates.
-		// Our mock shares m.err for both, so this test confirms the
-		// second I/O error path is reachable.
-		provider.listStore.err = errors.New("count failed")
+// TestFetchAndCount_ListTasksError verifies that a ListTasks error
+// propagates correctly, returning nil tasks and zero count.
+func TestFetchAndCount_ListTasksError(t *testing.T) {
+	t.Parallel()
+	pt, provider := setupPersistenceTools()
+	provider.listStore.err = errors.New("list failed")
 
-		tasks, count, err := pt.fetchAndCount(ctx, "", 50, 0)
-		if err == nil {
-			t.Fatal("expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "count failed") {
-			t.Errorf("error = %q; want containing 'count failed'", err.Error())
-		}
-		if tasks != nil {
-			t.Errorf("tasks = %v; want nil on error", tasks)
-		}
-		if count != 0 {
-			t.Errorf("count = %d; want 0 on error", count)
-		}
-	})
+	tasks, count, err := pt.fetchAndCount(context.Background(), "", 50, 0)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "list failed") {
+		t.Errorf("error = %q; want containing 'list failed'", err.Error())
+	}
+	if tasks != nil {
+		t.Errorf("tasks = %v; want nil on error", tasks)
+	}
+	if count != 0 {
+		t.Errorf("count = %d; want 0 on error", count)
+	}
+}
+
+// TestFetchAndCount_CountTasksError verifies that when ListTasks succeeds
+// but CountTasks fails, the error propagates correctly. Uses countErrorStore
+// to independently control the CountTasks error without affecting ListTasks.
+func TestFetchAndCount_CountTasksError(t *testing.T) {
+	t.Parallel()
+	pt, provider := setupPersistenceTools()
+	ctx := context.Background()
+
+	// Add a task so ListTasks succeeds
+	_, err := provider.tasks.AddTask(ctx, "task one")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wrap the real TaskStore so ListTasks works but CountTasks fails
+	pt.tasks = &countErrorStore{
+		TaskStore: provider.tasks,
+		countErr:  errors.New("count failed"),
+	}
+
+	tasks, count, err := pt.fetchAndCount(ctx, "", 50, 0)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "count failed") {
+		t.Errorf("error = %q; want containing 'count failed'", err.Error())
+	}
+	if tasks != nil {
+		t.Errorf("tasks = %v; want nil on error", tasks)
+	}
+	if count != 0 {
+		t.Errorf("count = %d; want 0 on error", count)
+	}
 }


### PR DESCRIPTION
Closes #936.

## Summary
Refactored 4 high-cyclomatic-complexity test functions (complexity 12-15) across 3 files:

| Function | Before | After | Approach |
|---|---|---|---|
| `TestMatchesTypeName_StarExpr` | 15 | 2-7 | Split into 4 standalone functions |
| `TestMatchSymbol_GenDeclEdgeCases` | 15 | 2-6 | Split into 6 standalone functions |
| `TestMockCapturer_NilFuncs` | 12 | 2 | Extracted 6 `t.Helper()` assertion helpers |
| `TestFetchAndCount` | 15 | 5-6 | Split into 3 + new `countErrorStore` mock |

Key fix: `TestFetchAndCount` had a self-admitted mock design compromise where a single `m.err` field conflated `ListTasks` and `CountTasks` error paths. The new `countErrorStore` wrapper independently controls `CountTasks` errors.

## Verification
| Check | Status |
|---|---|
| `go test -race -count=1` (3 packages) | PASS |
| Coverage (analysis/workspace/agenttest) | 99.1% / 98.7% / 98.0% |
| `gofmt` / `go vet` / `golangci-lint` | clean |
| Zero file overlap with #934 | confirmed