### PR TITLE
fix(analysis): add test coverage for 3 uncovered error-handling paths (#940)

### DIFF
--- a/internal/tools/analysis/complexity_test.go
+++ b/internal/tools/analysis/complexity_test.go
@@ -497,15 +497,12 @@ func TestGatherComplexities_ContextCancelled(t *testing.T) {
 // g.Wait() is ever reached. To hit g.Wait(), Walk must finish successfully
 // and goroutines must still be running when the context expires.
 //
-// Strategy: use context.WithTimeout with a 50ms timeout. Walk (directory
+// Strategy: use context.WithTimeout with a 10ms timeout. Walk (directory
 // traversal) completes in microseconds, launching all goroutines. Then
 // g.Wait() blocks until the timeout fires; goroutines blocked on
 // sem.Acquire see context.DeadlineExceeded; g.Wait() captures and wraps it
 // with "gathering complexity metrics: %w".
 func TestComplexityAnalyzer_ErrgroupError(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration-style test in short mode")
-	}
 	t.Parallel()
 	tmpDir := t.TempDir()
 
@@ -515,37 +512,21 @@ func TestComplexityAnalyzer_ErrgroupError(t *testing.T) {
 		[]byte("module example.com/test\ngo 1.25"), 0644,
 	))
 
-	// Build a complex function body to make parsing + complexity analysis
-	// take measurable time per file.
-	complexBody := strings.Repeat("if true {\n", 20) +
-		"_ = 1\n" +
-		strings.Repeat("}\n", 20)
-
-	// Create files each with many complex functions. The total work must
-	// exceed what NumCPU workers can finish in the brief window before
-	// we cancel.
-	const numFiles = 500
-	const funcsPerFile = 100
-	var sb strings.Builder
+	// Create enough files that goroutine count exceeds semaphore slots
+	// (runtime.NumCPU). Walk launches all goroutines in microseconds;
+	// most block on sem.Acquire. The timeout fires during g.Wait(),
+	// and blocked goroutines return context.DeadlineExceeded.
+	const numFiles = 1000
 	for i := 0; i < numFiles; i++ {
-		sb.Reset()
-		sb.WriteString("package test\n")
-		for j := 0; j < funcsPerFile; j++ {
-			sb.WriteString("func F")
-			fmt.Fprintf(&sb, "%d_%d", i, j)
-			sb.WriteString("() {\n")
-			sb.WriteString(complexBody)
-			sb.WriteString("}\n")
-		}
 		path := filepath.Join(tmpDir, fmt.Sprintf("file%d.go", i))
-		require.NoError(t, os.WriteFile(path, []byte(sb.String()), 0644))
+		require.NoError(t, os.WriteFile(path, []byte("package test\nfunc F() {}\n"), 0644))
 	}
 
 	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 	analyzer := newComplexityAnalyzer(cache, sp)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
 
 	type result struct {

--- a/internal/tools/analysis/imports.go
+++ b/internal/tools/analysis/imports.go
@@ -41,7 +41,7 @@ func (t *importCleanupTransform) formatAndReprocess(fset *token.FileSet, file *a
 	var buf bytes.Buffer
 	if t.testFormatNode != nil {
 		if err := t.testFormatNode(&buf, fset, file); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("formatting %s: %w", t.Path, err)
 		}
 	} else if err := format.Node(&buf, fset, file); err != nil {
 		return nil, fmt.Errorf("formatting %s: %w", t.Path, err)

--- a/internal/tools/analysis/imports_test.go
+++ b/internal/tools/analysis/imports_test.go
@@ -63,6 +63,9 @@ func TestImportCleanupTransform_Apply(t *testing.T) {
 		err = tx.Apply(context.Background(), fset, files)
 		require.Error(t, err)
 		require.ErrorIs(t, err, formatErr)
+		if !strings.Contains(err.Error(), "formatting test.go") {
+			t.Errorf("expected wrapping message 'formatting test.go', got: %v", err)
+		}
 	})
 }
 
@@ -147,6 +150,9 @@ func TestFormatAndReprocess(t *testing.T) {
 		_, err = tx.formatAndReprocess(fset, file)
 		require.Error(t, err)
 		require.ErrorIs(t, err, formatErr)
+		if !strings.Contains(err.Error(), "formatting test.go") {
+			t.Errorf("expected wrapping message 'formatting test.go', got: %v", err)
+		}
 	})
 
 	t.Run("process error via test hook", func(t *testing.T) {

--- a/internal/tools/analysis/types_error_test.go
+++ b/internal/tools/analysis/types_error_test.go
@@ -218,6 +218,9 @@ func TestGetTypeInfo_FindMethodsError(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for cancelled context during findMethods, got nil")
 	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
 }
 
 // TestGetTypeInfo_ShortCircuit verifies that early-return conditions prevent


### PR DESCRIPTION
Closes #940.

## Summary
Added test coverage for 3 medium-priority uncovered error-handling paths in `internal/tools/analysis/`:

| # | File | Change |
|---|------|--------|
| 1 | `types_error_test.go` | Enhanced `TestGetTypeInfo_FindMethodsError` with `errors.Is(err, context.Canceled)` assertion |
| 2 | `imports.go` + `imports_test.go` | Hook path now wraps errors identically to production path; tests verify wrapping message |
| 3 | `complexity_test.go` | Hardened `TestComplexityAnalyzer_ErrgroupError`: removed `-short` skip, simplified file gen (1000 trivial files), tightened timeout to 10ms |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Coverage `./internal/tools/analysis/` | 99.1% |
| Target error paths | All 3 now covered |
