### PR TITLE
fix(test): reduce cyclomatic complexity of final 3 test functions (#946)

### DIFF
--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -617,69 +617,76 @@ func seedTaskServiceWithN(t *testing.T, s ports.TaskStore, n int) {
 	}
 }
 
-func TestTaskService_ListTasks_LimitOffset(t *testing.T) {
+// TestListTasks_Limit3Offset0 verifies that listing with limit=3 offset=0
+// returns the first 3 of 5 seeded tasks.
+func TestListTasks_Limit3Offset0(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	seedTaskServiceWithN(t, s, 5)
 
-	t.Run("limit3_offset0_returns_first_3", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		seedTaskServiceWithN(t, s, 5)
+	tasks, err := s.ListTasks(ctx, "", 3, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 3 {
+		t.Errorf("expected 3 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Content != "Task 1" || tasks[2].Content != "Task 3" {
+		t.Errorf("expected Task 1, Task 2, Task 3, got %v", tasks)
+	}
+}
 
-		tasks, err := s.ListTasks(ctx, "", 3, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 3 {
-			t.Errorf("expected 3 tasks, got %d", len(tasks))
-		}
-		if tasks[0].Content != "Task 1" || tasks[2].Content != "Task 3" {
-			t.Errorf("expected Task 1, Task 2, Task 3, got %v", tasks)
-		}
-	})
+// TestListTasks_Limit2Offset3 verifies that listing with limit=2 offset=3
+// returns tasks 4 and 5 of 5 seeded tasks.
+func TestListTasks_Limit2Offset3(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	seedTaskServiceWithN(t, s, 5)
 
-	t.Run("limit2_offset3_returns_tasks_4_5", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		seedTaskServiceWithN(t, s, 5)
+	tasks, err := s.ListTasks(ctx, "", 2, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 2 {
+		t.Errorf("expected 2 tasks, got %d", len(tasks))
+	}
+	if tasks[0].Content != "Task 4" || tasks[1].Content != "Task 5" {
+		t.Errorf("expected Task 4, Task 5, got %v", tasks)
+	}
+}
 
-		tasks, err := s.ListTasks(ctx, "", 2, 3)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 2 {
-			t.Errorf("expected 2 tasks, got %d", len(tasks))
-		}
-		if tasks[0].Content != "Task 4" || tasks[1].Content != "Task 5" {
-			t.Errorf("expected Task 4, Task 5, got %v", tasks)
-		}
-	})
+// TestListTasks_OffsetBeyondTotal verifies that an offset exceeding the
+// total task count returns an empty result.
+func TestListTasks_OffsetBeyondTotal(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	seedTaskServiceWithN(t, s, 5)
 
-	t.Run("offset_beyond_total_returns_empty", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		seedTaskServiceWithN(t, s, 5)
+	tasks, err := s.ListTasks(ctx, "", 10, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 0 {
+		t.Errorf("expected 0 tasks, got %d", len(tasks))
+	}
+}
 
-		tasks, err := s.ListTasks(ctx, "", 10, 100)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 0 {
-			t.Errorf("expected 0 tasks, got %d", len(tasks))
-		}
-	})
+// TestListTasks_Limit0ReturnsAll verifies that limit=0 returns all tasks
+// (limit=0 disables the limit).
+func TestListTasks_Limit0ReturnsAll(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	s, _ := setupTaskService(t)
+	seedTaskServiceWithN(t, s, 5)
 
-	t.Run("limit0_returns_all", func(t *testing.T) {
-		t.Parallel()
-		s, _ := setupTaskService(t)
-		seedTaskServiceWithN(t, s, 5)
-
-		tasks, err := s.ListTasks(ctx, "", 0, 0)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if len(tasks) != 5 {
-			t.Errorf("expected 5 tasks, got %d", len(tasks))
-		}
-	})
+	tasks, err := s.ListTasks(ctx, "", 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tasks) != 5 {
+		t.Errorf("expected 5 tasks, got %d", len(tasks))
+	}
 }

--- a/internal/tools/analysis/move_test.go
+++ b/internal/tools/analysis/move_test.go
@@ -238,11 +238,12 @@ func TestMatchesTypeName_StarExpr_UnhandledExpr(t *testing.T) {
 	}
 }
 
-func TestDeclMatchers(t *testing.T) {
+// TestMatchFuncDecl verifies the matchFuncDecl helper correctly identifies
+// FuncDecl nodes by name and rejects non-FuncDecl or BadDecl inputs.
+func TestMatchFuncDecl(t *testing.T) {
 	t.Parallel()
 
-	// ---- matchFuncDecl ----
-	t.Run("matchFuncDecl matches by name", func(t *testing.T) {
+	t.Run("matches by name", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "Hello"}}
 		if !matchFuncDecl(decl, "Hello") {
@@ -250,22 +251,27 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchFuncDecl returns false for non-FuncDecl", func(t *testing.T) {
+	t.Run("non-FuncDecl", func(t *testing.T) {
 		t.Parallel()
 		if matchFuncDecl(&ast.BadDecl{}, "Hello") {
 			t.Error("matchFuncDecl should return false for BadDecl")
 		}
 	})
 
-	t.Run("matchFuncDecl returns false for BadDecl", func(t *testing.T) {
+	t.Run("BadDecl", func(t *testing.T) {
 		t.Parallel()
 		if matchFuncDecl(&ast.BadDecl{}, "Nope") {
 			t.Error("matchFuncDecl should return false for BadDecl")
 		}
 	})
+}
 
-	// ---- matchTypeSpec ----
-	t.Run("matchTypeSpec matches type by name", func(t *testing.T) {
+// TestMatchTypeSpec verifies the matchTypeSpec helper identifies TypeSpec
+// nodes within GenDecl and rejects non-GenDecl inputs like FuncDecl.
+func TestMatchTypeSpec(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches type by name", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.GenDecl{
 			Specs: []ast.Spec{
@@ -277,16 +283,22 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchTypeSpec returns false for FuncDecl", func(t *testing.T) {
+	t.Run("returns false for FuncDecl", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "MyType"}}
 		if matchTypeSpec(decl, "MyType") {
 			t.Error("matchTypeSpec should return false for FuncDecl")
 		}
 	})
+}
 
-	// ---- matchValueSpec ----
-	t.Run("matchValueSpec matches const by name", func(t *testing.T) {
+// TestMatchValueSpec verifies the matchValueSpec helper identifies
+// ValueSpec nodes (const, var, multi-name) and rejects ImportSpec
+// or non-GenDecl inputs.
+func TestMatchValueSpec(t *testing.T) {
+	t.Parallel()
+
+	t.Run("matches const by name", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.GenDecl{
 			Specs: []ast.Spec{
@@ -298,7 +310,7 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchValueSpec matches var by name", func(t *testing.T) {
+	t.Run("matches var by name", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.GenDecl{
 			Specs: []ast.Spec{
@@ -310,7 +322,7 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchValueSpec matches second name in multi-name ValueSpec", func(t *testing.T) {
+	t.Run("matches second name in multi-name ValueSpec", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.GenDecl{
 			Specs: []ast.Spec{
@@ -322,7 +334,7 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchValueSpec returns false for import GenDecl", func(t *testing.T) {
+	t.Run("returns false for import GenDecl", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.GenDecl{
 			Specs: []ast.Spec{
@@ -334,7 +346,7 @@ func TestDeclMatchers(t *testing.T) {
 		}
 	})
 
-	t.Run("matchValueSpec returns false for FuncDecl", func(t *testing.T) {
+	t.Run("returns false for FuncDecl", func(t *testing.T) {
 		t.Parallel()
 		decl := &ast.FuncDecl{Name: &ast.Ident{Name: "MyFunc"}}
 		if matchValueSpec(decl, "MyFunc") {

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -812,6 +812,33 @@ func TestTaskIcon(t *testing.T) {
 	}
 }
 
+// assertRenderOutput validates renderTaskPage output against expected
+// contains, exact-match, and not-contains criteria. The wantExact check
+// short-circuits: when wantExact is non-empty, contains/not-contains
+// checks are skipped.
+func assertRenderOutput(t *testing.T, got string, wantContains []string, wantExact string, notContains []string) {
+	t.Helper()
+
+	if wantExact != "" {
+		if got != wantExact {
+			t.Errorf("renderTaskPage = %q; want exact %q", got, wantExact)
+		}
+		return
+	}
+
+	for _, want := range wantContains {
+		if !strings.Contains(got, want) {
+			t.Errorf("renderTaskPage missing %q in:\n%s", want, got)
+		}
+	}
+
+	for _, notWant := range notContains {
+		if strings.Contains(got, notWant) {
+			t.Errorf("renderTaskPage unexpectedly contains %q in:\n%s", notWant, got)
+		}
+	}
+}
+
 func TestRenderTaskPage(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -940,25 +967,7 @@ func TestRenderTaskPage(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := renderTaskPage(tt.tasks, tt.totalCount, tt.offset, tt.limit)
-
-			if tt.wantExact != "" {
-				if got != tt.wantExact {
-					t.Errorf("renderTaskPage = %q; want exact %q", got, tt.wantExact)
-				}
-				return
-			}
-
-			for _, want := range tt.wantContains {
-				if !strings.Contains(got, want) {
-					t.Errorf("renderTaskPage missing %q in:\n%s", want, got)
-				}
-			}
-
-			for _, notWant := range tt.notContains {
-				if strings.Contains(got, notWant) {
-					t.Errorf("renderTaskPage unexpectedly contains %q in:\n%s", notWant, got)
-				}
-			}
+			assertRenderOutput(t, got, tt.wantContains, tt.wantExact, tt.notContains)
 		})
 	}
 }


### PR DESCRIPTION
Closes #946.

## Summary
Refactored the final 3 high-complexity test functions (completing the 13→0 cyclomatic complexity cleanup):

| Function | Before | After | Approach |
|---|---|---|---|
| `TestTaskService_ListTasks_LimitOffset` | 13 | 4× ≤5 | Split into 4 standalone `TestListTasks_*` functions |
| `TestDeclMatchers` | 11 | 3× ≤6 | Split into 3 standalone functions by matcher type |
| `TestRenderTaskPage` | 11 | 5 | Extracted `assertRenderOutput` `t.Helper()` |

All 3 files were previously touched by #934 and #936 — consistent patterns followed.

## Verification
| Check | Status |
|-------|--------|
| `make check-full` (all 10 steps) | ✅ PASS |
| `go test -race -count=1 ./...` | ✅ PASS |
| `golangci-lint` | ✅ 0 issues |
| `govulncheck` | ✅ No vulnerabilities |
| Coverage (3 packages) | ✅ analysis: 99.1%, workspace: 98.7%, services: 100% |
| Merge conflicts (#939, #940, #941) | ✅ None (disjoint file sets)