### PR TITLE
fix(persistence): close 4 adapter/error-handling coverage gaps (#949)

### DIFF
--- a/internal/infrastructure/history/archive_reader_error_test.go
+++ b/internal/infrastructure/history/archive_reader_error_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -182,5 +183,72 @@ func TestJSONLArchiveReader_ReadPageInternal_ContextCancelled(t *testing.T) {
 				t.Errorf("expected %v, got %v", tt.wantErr, err)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gap 3 (Issue #949) — ensureIndex double-check locking under exclusive lock
+// Code path: archive_reader.go L107-109
+//   defer r.mu.Unlock()
+//   if r.indexed { return nil }  ← UNCOVERED (double-check after acquiring Lock)
+// ---------------------------------------------------------------------------
+
+func TestJSONLArchiveReader_EnsureIndex_DoubleCheckLocked(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "archive.jsonl")
+
+	baseFS := persistence.NewOSFileSystem()
+	// Seed with enough lines to make index building take non-zero time
+	var content string
+	for i := 0; i < 1000; i++ {
+		content += `{"role":"user","parts":[{"text":"msg"}]}` + "\n"
+	}
+	if err := baseFS.WriteFile(context.Background(), archivePath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to seed archive: %v", err)
+	}
+
+	reader := &jsonlArchiveReader{
+		fs:          baseFS,
+		archivePath: archivePath,
+	}
+
+	// Barrier to ensure both goroutines enter ensureIndex at roughly the same time
+	var start sync.WaitGroup
+	start.Add(2)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	errs := make(chan error, 2)
+
+	go func() {
+		defer wg.Done()
+		start.Done()
+		start.Wait()
+		errs <- reader.ensureIndex(context.Background())
+	}()
+
+	go func() {
+		defer wg.Done()
+		start.Done()
+		start.Wait()
+		errs <- reader.ensureIndex(context.Background())
+	}()
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("ensureIndex should not error: %v", err)
+		}
+	}
+
+	// Both calls should succeed and the index should be built
+	if !reader.indexed {
+		t.Error("expected reader to be indexed after concurrent ensureIndex calls")
+	}
+	if len(reader.index) != 1000 { // 1000 lines
+		t.Errorf("expected 1000 index entries, got %d", len(reader.index))
 	}
 }

--- a/internal/infrastructure/history/archive_reader_test.go
+++ b/internal/infrastructure/history/archive_reader_test.go
@@ -675,3 +675,31 @@ func TestJSONLArchiveReader_ReadPage_ReadError(t *testing.T) {
 		t.Errorf("expected injected read error, got %v", err)
 	}
 }
+
+func TestJSONLArchiveReader_ReadLineForIndex_EOFWithData(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "eof_no_newline.jsonl")
+
+	// Last line deliberately has NO trailing \n to trigger the EOF-with-data branch
+	// in readLineForIndex (line 134 of archive_reader.go).
+	line1 := `{"role":"user","parts":[{"text":"line1"}]}` + "\n"
+	line2 := `{"role":"user","parts":[{"text":"line2"}]}`
+	content := line1 + line2
+
+	err := os.WriteFile(archivePath, []byte(content), 0644)
+	require.NoError(t, err, "failed to write test file")
+
+	ctx := context.Background()
+	fs := persistence.NewOSFileSystem()
+	reader := history.NewJSONLArchiveReader(fs, archivePath)
+
+	dtos, startOffset, err := reader.ReadPrevious(ctx, 10, -1)
+	require.NoError(t, err, "ReadPrevious should not error on EOF-with-data")
+
+	require.Len(t, dtos, 2, "expected 2 DTOs from the two JSON lines")
+	assert.Equal(t, "line1", dtos[0].ContentPreview, "first line content mismatch")
+	assert.Equal(t, "line2", dtos[1].ContentPreview, "second line content mismatch")
+	assert.Equal(t, int64(0), startOffset, "startOffset should be 0")
+}

--- a/internal/infrastructure/persistence/session_paths_test.go
+++ b/internal/infrastructure/persistence/session_paths_test.go
@@ -408,3 +408,34 @@ func TestRotateSession_CleanupError(t *testing.T) {
 		t.Errorf("expected os.ErrPermission, got %v", err)
 	}
 }
+
+// =============================================================================
+// RotateSession with no session files — archiveSessionFiles early return
+// =============================================================================
+
+func TestRotateSession_NoSessionFiles(t *testing.T) {
+	t.Parallel()
+
+	m := newMockFS()
+	// All Stat calls return ErrNotExist → hasFiles stays false →
+	// archiveSessionFiles returns nil without creating backup dir.
+	m.StatFunc = func(ctx context.Context, name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+	// Track whether MkdirAll was called — it should NOT be.
+	mkdirCalled := false
+	m.MkdirAllFunc = func(ctx context.Context, path string, perm os.FileMode) error {
+		mkdirCalled = true
+		return nil
+	}
+
+	paths := persistence.ResolvePaths("/home/test", "default")
+	var buf bytes.Buffer
+	err := RotateSession(context.Background(), m, &buf, *paths, 7, slog.Default())
+	if err != nil {
+		t.Fatalf("RotateSession should not error when no files exist: %v", err)
+	}
+	if mkdirCalled {
+		t.Error("MkdirAll should NOT be called when no session files exist")
+	}
+}

--- a/internal/infrastructure/persistence/state.go
+++ b/internal/infrastructure/persistence/state.go
@@ -118,6 +118,10 @@ func (s *sessionState) Close() error {
 	return nil
 }
 
+// initServicesFn is the function variable for initServices, allowing tests
+// to inject a failure and exercise the error propagation path in NewSessionState.
+var initServicesFn = initServices
+
 // NewSessionState initializes repositories and services.
 func NewSessionState(ctx context.Context, configDir string) (ports.SessionProvider, error) {
 	storageType := os.Getenv("STORAGE_TYPE")
@@ -130,7 +134,7 @@ func NewSessionState(ctx context.Context, configDir string) (ports.SessionProvid
 		return nil, fmt.Errorf("initializing persistence repositories: %w", err)
 	}
 
-	tasks, err := initServices(ctx, taskStore)
+	tasks, err := initServicesFn(ctx, taskStore)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -454,3 +454,23 @@ func (c *initServicesFailingConn) ExecContext(ctx context.Context, q string, arg
 	}
 	return nil, driver.ErrSkip
 }
+
+func TestNewSessionState_InitServicesError(t *testing.T) {
+	// NOT parallel: overrides package-level initServicesFn, must run sequentially.
+
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	origInit := initServicesFn
+	t.Cleanup(func() { initServicesFn = origInit })
+
+	injectedErr := errors.New("injected initServices failure")
+	initServicesFn = func(ctx context.Context, _ ports.ListStore[ports.Task]) (ports.TaskStore, error) {
+		return nil, injectedErr
+	}
+
+	state, err := NewSessionState(ctx, tempDir)
+	assert.Nil(t, state, "state should be nil when initServices fails")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, injectedErr, "error should be the injected initServices error")
+}


### PR DESCRIPTION
Closes #949.

## Summary
Add tests for 4 uncovered branches in persistence and history packages:
1. **`session_paths.go:76-78`** — `archiveSessionFiles` empty file list early return
2. **`state.go:134-136`** — `initServices` error propagation in `NewSessionState`
3. **`archive_reader.go:107-109`** — `buildIndexLocked` already-indexed idempotency guard (double-check under exclusive lock)
4. **`archive_reader.go:134`** — `readLineForIndex` EOF-with-data scanner return

## Changes
| File | Change |
|------|--------|
| `archive_reader_test.go` | +28 lines — EOF-with-data test |
| `archive_reader_error_test.go` | +68 lines — already-indexed concurrency test + sync import |
| `session_paths_test.go` | +31 lines — empty file list early return test |
| `state.go` | +6/-1 — add `initServicesFn` function variable for test injection |
| `state_test.go` | +20 lines — `initServices` error propagation test |

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `golangci-lint` | PASS (0 issues) |
| `govulncheck` | PASS (0 vulnerabilities) |
| `go test -race ./...` | PASS |
| Coverage `persistence` | 100.0% |
| Coverage `history` | 99.2% |