### PR TITLE
fix(telemetry): close error-handling coverage gaps in metrics.go and ledger.go (#948)

### DIFF
--- a/internal/infrastructure/telemetry/ledger.go
+++ b/internal/infrastructure/telemetry/ledger.go
@@ -37,6 +37,9 @@ var (
 	ledgerMu           sync.Mutex
 )
 
+// filepathRel is the filepath.Rel function, overridable in tests.
+var filepathRel = filepath.Rel
+
 const ledgerRecoveryTimeout = 10 * time.Minute
 
 // ledgerStore handles persistence and recovery of cost metrics.
@@ -212,7 +215,7 @@ func (ls *ledgerStore) getSessionID(path, globalDir string) (string, error) {
 	if ls.getSessionIDFunc != nil {
 		return ls.getSessionIDFunc(path, globalDir)
 	}
-	rel, err := filepath.Rel(globalDir, path)
+	rel, err := filepathRel(globalDir, path)
 	if err != nil {
 		return "", fmt.Errorf("resolving session ID for %s relative to %s: %w", path, globalDir, err)
 	}

--- a/internal/infrastructure/telemetry/ledger_error_gaps_test.go
+++ b/internal/infrastructure/telemetry/ledger_error_gaps_test.go
@@ -488,3 +488,32 @@ func TestDiscoverNewRecords_GetSessionIDError(t *testing.T) {
 			"discovered record should be from the valid path")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Gap 5 — getSessionID filepath.Rel error (ledger.go:216-218)
+// ---------------------------------------------------------------------------
+
+// TestGetSessionID_FilepathRelError covers the gap at ledger.go:216-218
+// where filepathRel (the injectable filepath.Rel) fails and getSessionID
+// returns a wrapped error.
+//
+// NOTE: This test modifies the package-level filepathRel variable and
+// therefore must NOT use t.Parallel() to avoid races with other tests
+// that read the default filepathRel concurrently.
+func TestGetSessionID_FilepathRelError(t *testing.T) {
+	// Override filepathRel to simulate a cross-volume error on any platform
+	originalRel := filepathRel
+	filepathRel = func(base, target string) (string, error) {
+		return "", fmt.Errorf("cannot compute relative path from %s to %s", base, target)
+	}
+	t.Cleanup(func() { filepathRel = originalRel })
+
+	ls := &ledgerStore{}
+
+	result, err := ls.getSessionID("/some/path", "/other/dir")
+
+	assert.Error(t, err, "expected error when filepathRel returns an error")
+	assert.Contains(t, err.Error(), "resolving session ID",
+		"error should wrap with 'resolving session ID'")
+	assert.Empty(t, result, "expected empty result on error")
+}

--- a/internal/infrastructure/telemetry/log_trace_write_error_test.go
+++ b/internal/infrastructure/telemetry/log_trace_write_error_test.go
@@ -4,17 +4,17 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	domain_telemetry "github.com/gosharplite/tell-me-go/internal/domain/telemetry"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestLogTrace_WriteError_DevFull covers the f.Write failure branch in logTrace
@@ -36,125 +36,60 @@ func TestLogTrace_WriteError_DevFull(t *testing.T) {
 	// If we reach here without panicking, the write-error branch was exercised.
 }
 
-// TestLogTrace_CloseErrorUnreachable documents that the f.Close() error path
-// inside logTrace (metrics.go:258-260) is UNREACHABLE at the unit-test level.
-//
-// logTrace takes a file path (string), opens it internally with os.OpenFile,
-// and defers f.Close(). Close errors on a regular file only occur due to:
-//   - Disk full (ENOSPC on final metadata flush)
-//   - NFS disconnect during close
-//   - Hardware failure
-//
-// These are integration-level concerns that cannot be triggered in unit tests
-// without filesystem mocking (which the telemetry package does not use, unlike
-// the history package which accepts persistence.FileSystem).
-//
-// This test documents the happy path and confirms the defer structure is correct
-// by verifying logTrace produces valid output to a normal file.
-func TestLogTrace_CloseErrorUnreachable(t *testing.T) {
-	t.Parallel()
+// errCloser wraps an io.Writer and returns an error on Close.
+type errCloser struct {
+	io.Writer
+}
+
+func (e *errCloser) Close() error {
+	return errors.New("injected close error")
+}
+
+// TestLogTrace_CloseError_Mock verifies that when the injected openTraceFile
+// returns an io.WriteCloser whose Close() method returns an error,
+// logTrace logs a warning containing the error message.
+func TestLogTrace_CloseError_Mock(t *testing.T) {
+	// NOT parallel — overrides package-level var
+	originalOpen := openTraceFile
+	openTraceFile = func(path string) (io.WriteCloser, error) {
+		return &errCloser{Writer: &bytes.Buffer{}}, nil
+	}
+	t.Cleanup(func() { openTraceFile = originalOpen })
 
 	tmpDir := t.TempDir()
 	traceFile := filepath.Join(tmpDir, "trace.jsonl")
 
-	// Verify logTrace succeeds with a valid TurnTrace and writable file.
-	trace := &domain_telemetry.TurnTrace{
-		FinalStatus:       "completed",
-		StartTime:         time.Now(),
-		EndTime:           time.Now().Add(time.Second),
-		InferenceDuration: 500 * time.Millisecond,
-		ToolExecutions: []domain_telemetry.ToolExecutionTrace{
-			{
-				ToolName:  "search",
-				StartTime: time.Now(),
-				Duration:  200 * time.Millisecond,
-				Status:    "success",
-			},
-		},
-	}
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
 
-	// Must not panic. The defer f.Close() executes and succeeds silently
-	// on a normal file.
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
 	logTrace(context.Background(), traceFile, trace)
 
-	// Verify the file was created and contains valid JSON.
-	data, err := os.ReadFile(traceFile)
-	require.NoError(t, err)
-	require.True(t, len(data) > 0, "trace file should not be empty")
-
-	// NOTE: f.Close() on a regular file opened with O_APPEND|O_CREATE|O_WRONLY
-	// only fails on disk-full or hardware failure. The defer in logTrace
-	// handles this gracefully by logging a warning. This defense is correct
-	// but structurally unreachable in unit tests without filesystem mocking.
-	// Integration tests with fault injection (e.g., /dev/full for write,
-	// filesystem quota exhaustion for close) would be required to exercise
-	// the close-error branch at metrics.go:258-260.
+	assert.Contains(t, logBuf.String(), "Warning: Failed to close trace file")
+	assert.Contains(t, logBuf.String(), "injected close error")
 }
 
-// TestLogTrace_MarshalErrorUnreachable documents that the json.Marshal error
-// path in logTrace (metrics.go:246-249) is UNREACHABLE.
-//
-// The marshaled value is *domain_telemetry.TurnTrace, which contains only
-// standard JSON-serializable types: string, time.Time, time.Duration, int,
-// []ToolExecutionTrace, and a sync.Mutex tagged json:"-". json.Marshal on
-// this struct cannot fail.
-//
-// This test exercises edge-case TurnTrace values—zero values, Unicode strings,
-// max durations, nil slices—and verifies they all marshal successfully with
-// round-trip fidelity.
-func TestLogTrace_MarshalErrorUnreachable(t *testing.T) {
-	t.Parallel()
-
-	// Build edge-case TurnTraces that exercise all field types
-	traces := []domain_telemetry.TurnTrace{
-		{
-			FinalStatus:       "completed",
-			StartTime:         time.Now(),
-			EndTime:           time.Now(),
-			InferenceDuration: 500 * time.Millisecond,
-			ToolExecutions: []domain_telemetry.ToolExecutionTrace{
-				{ToolName: "search", StartTime: time.Now(), Duration: 200 * time.Millisecond, Status: "success"},
-				{ToolName: "", StartTime: time.Time{}, Duration: 0, Status: ""},
-			},
-		},
-		{
-			// Zero/empty values
-			FinalStatus:       "",
-			StartTime:         time.Time{},
-			EndTime:           time.Time{},
-			InferenceDuration: 0,
-			ToolExecutions:    nil,
-		},
-		{
-			// Unicode + max values
-			FinalStatus:       "failed: ❌ timeout",
-			StartTime:         time.Now(),
-			EndTime:           time.Now().Add(24 * time.Hour),
-			InferenceDuration: 1<<63 - 1,
-			ToolExecutions: []domain_telemetry.ToolExecutionTrace{
-				{ToolName: "modèle-🎉", StartTime: time.Now(), Duration: 999999, Status: "cancelled"},
-			},
-		},
+// TestLogTrace_MarshalError verifies that when the injected jsonMarshal
+// function returns an error, logTrace logs a warning and returns early.
+func TestLogTrace_MarshalError(t *testing.T) {
+	// NOT parallel — overrides package-level var
+	originalMarshal := jsonMarshal
+	jsonMarshal = func(v interface{}) ([]byte, error) {
+		return nil, errors.New("injected marshal error")
 	}
+	t.Cleanup(func() { jsonMarshal = originalMarshal })
 
-	for i := range traces {
-		tr := &traces[i]
-		data, err := json.Marshal(tr)
-		if err != nil {
-			t.Fatalf("entry %d: json.Marshal unexpectedly failed: %v", i, err)
-		}
+	tmpDir := t.TempDir()
+	traceFile := filepath.Join(tmpDir, "trace.jsonl")
 
-		// Round-trip verification
-		var restored domain_telemetry.TurnTrace
-		if err := json.Unmarshal(data, &restored); err != nil {
-			t.Fatalf("entry %d: json.Unmarshal failed: %v", i, err)
-		}
-		if restored.FinalStatus != tr.FinalStatus {
-			t.Errorf("entry %d: FinalStatus mismatch: got %q, want %q", i, restored.FinalStatus, tr.FinalStatus)
-		}
-	}
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
 
-	// Verify the error-format string exists in source (compile-time check)
-	// The format is: "Warning: Failed to marshal TurnTrace: %v"
-	log.Printf("Warning: Failed to marshal TurnTrace: %v", errors.New("test"))
+	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
+	logTrace(context.Background(), traceFile, trace)
+
+	assert.Contains(t, logBuf.String(), "Warning: Failed to marshal TurnTrace")
+	assert.Contains(t, logBuf.String(), "injected marshal error")
 }

--- a/internal/infrastructure/telemetry/metrics.go
+++ b/internal/infrastructure/telemetry/metrics.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -43,6 +44,17 @@ type costSummaryArgs struct {
 }
 
 type estimateCostArgs struct{}
+
+// jsonMarshal is the json.Marshal function, overridable in tests.
+var jsonMarshal = json.Marshal
+
+// openTraceFile opens a trace file for appending, overridable in tests.
+var openTraceFile = func(path string) (io.WriteCloser, error) {
+	return os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+}
+
+// resolveUsageForSummaryFunc is the resolveUsageForSummary function, overridable in tests.
+var resolveUsageForSummaryFunc = resolveUsageForSummary
 
 // RegisterMetrics adds tools for usage and cost analysis to the registry.
 func RegisterMetrics(r tools.Registry, sm domain_security.Manager, logFile, traceFile string, model string, mode string, pricingOverrides map[string]domain_pricing.ModelPricing, kvStore ports.KVStore) error {
@@ -105,10 +117,7 @@ func RegisterMetrics(r tools.Registry, sm domain_security.Manager, logFile, trac
 			return tools.ToolResult{}, fmt.Errorf("invalid arguments: %w", err)
 		}
 
-		// Silent update: Calculate and record the current session's latest cost before summary.
-		if _, err := m.EstimateCost(ctx, true, ""); err != nil {
-			log.Printf("Warning: Failed to record cost before summary: %v", err)
-		}
+		m.recordCostSilently(ctx)
 		res, err := m.getCostSummary(ctx, sArgs)
 		return tools.ToolResult{Text: res}, err
 	}, tools.ToolOptions{Serial: true}); err != nil {
@@ -135,7 +144,7 @@ func RecordSessionCost(ctx context.Context, sm domain_security.Manager, tracker 
 	}
 
 	// 2. Resolve usage stats
-	usage, totalCost, err := resolveUsageForSummary(ctx, sm, tracker, logPath, model, pricingOverrides)
+	usage, totalCost, err := resolveUsageForSummaryFunc(ctx, sm, tracker, logPath, model, pricingOverrides)
 	if err != nil {
 		return err
 	}
@@ -223,6 +232,14 @@ func appendSummaryToLog(logPath string, usage domain_pricing.UsageStats, totalCo
 	return nil
 }
 
+// recordCostSilently calls EstimateCost and logs a warning on failure
+// without interrupting the caller. Extracted for testability.
+func (m *metricsManager) recordCostSilently(ctx context.Context) {
+	if _, err := m.EstimateCost(ctx, true, ""); err != nil {
+		log.Printf("Warning: Failed to record cost before summary: %v", err)
+	}
+}
+
 // generateSessionID creates a unique identifier for a session based on its mode and log file name.
 // This ID is used as the unique key in global_costs.json to identify and update session records.
 func generateSessionID(mode, logFile string) string {
@@ -242,25 +259,25 @@ func logTrace(ctx context.Context, traceFile string, trace *domain_telemetry.Tur
 	default:
 	}
 
-	data, err := json.Marshal(trace)
+	data, err := jsonMarshal(trace)
 	if err != nil {
 		log.Printf("Warning: Failed to marshal TurnTrace: %v", err)
 		return
 	}
 
 	// 2. Use context-aware AtomicWrite if available or at least check context before I/O
-	f, err := os.OpenFile(traceFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	wc, err := openTraceFile(traceFile)
 	if err != nil {
 		log.Printf("Warning: Failed to open trace file %s: %v", traceFile, err)
 		return
 	}
 	defer func() {
-		if cerr := f.Close(); cerr != nil {
+		if cerr := wc.Close(); cerr != nil {
 			log.Printf("Warning: Failed to close trace file %s: %v", traceFile, cerr)
 		}
 	}()
 
-	if _, err := f.Write(append(data, '\n')); err != nil {
+	if _, err := wc.Write(append(data, '\n')); err != nil {
 		log.Printf("Warning: Failed to write to trace file %s: %v", traceFile, err)
 	}
 }

--- a/internal/infrastructure/telemetry/metrics_cost_test.go
+++ b/internal/infrastructure/telemetry/metrics_cost_test.go
@@ -152,61 +152,64 @@ func TestRecordSessionCost_EstimateCostFails(t *testing.T) {
 	}
 }
 
-// TestRecordSessionCost_ResolveUsageSummaryErrorUnreachable documents that
-// the resolveUsageForSummary error return branch in RecordSessionCost
-// (metrics.go:134-137) is unreachable in practice.
-//
-// Reasoning:
-//   - When tracker == nil: resolveUsageForSummary calls parseUsage.
-//     If parseUsage returns os.IsNotExist, the error is suppressed (nil returned).
-//     If parseUsage returns any other error, EstimateCost (called first in
-//     RecordSessionCost) would have already hit the same error and returned
-//     before reaching resolveUsageForSummary.
-//   - When tracker != nil: GetStats() returns (UsageStats, float64) with no
-//     error — the signature has no error return.
-//
-// Therefore the "if err != nil { return err }" after resolveUsageForSummary
-// can never execute.
-func TestRecordSessionCost_ResolveUsageSummaryErrorUnreachable(t *testing.T) {
-	t.Parallel()
+// TestRecordSessionCost_ResolveUsageSummaryError covers the gap at
+// metrics.go:145-147 where resolveUsageForSummary returns an error
+// inside RecordSessionCost. Uses the resolveUsageForSummaryFunc injection
+// so EstimateCost succeeds but the injected function returns an error.
+func TestRecordSessionCost_ResolveUsageSummaryError(t *testing.T) {
+	// NOT parallel — overrides package-level var AND uses global ledger mutexes
+	originalFunc := resolveUsageForSummaryFunc
+	resolveUsageForSummaryFunc = func(ctx context.Context, sm domain_security.Manager,
+		tracker domain_pricing.CostTracker, logPath, model string,
+		overrides map[string]domain_pricing.ModelPricing) (domain_pricing.UsageStats, float64, error) {
+		return domain_pricing.UsageStats{}, 0, errors.New("injected resolveUsageForSummary error")
+	}
+	t.Cleanup(func() { resolveUsageForSummaryFunc = originalFunc })
 
-	// Verify the two code paths that make the error branch unreachable.
-
-	// Path A: tracker != nil → GetStats never errors.
-	sm := &mockSM{}
 	tempDir := t.TempDir()
-	logPath := filepath.Join(tempDir, "test.log")
-	if err := os.WriteFile(logPath, []byte(`{"model":"m","prompt_tokens":10,"response_tokens":5}`+"\n"), 0644); err != nil {
+
+	// Place tokens.log inside an output subdirectory so that globalDir
+	// (filepath.Dir(outputDir)) is tempDir itself — keeping all ledger
+	// files (global_costs.json, locks, AtomicWrite temp files) inside
+	// the tempDir for clean teardown.
+	outputDir := filepath.Join(tempDir, "output")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(outputDir, "tokens.log")
+	logContent := `{"prompt_tokens":100,"response_tokens":50,"cost":0.01,"timestamp":"2025-06-15T12:00:00Z"}` + "\n"
+	if err := os.WriteFile(logPath, []byte(logContent), 0644); err != nil {
 		t.Fatal(err)
 	}
 
-	pricing := domain_pricing.PricingData{
-		Models: map[string]domain_pricing.ModelPricing{
-			"m": {Hit: 0.1, Miss: 1.0, Comp: 2.0},
-		},
-	}
-	tracker := NewSessionCostTracker(sm, logPath, "mode", "m", pricing.Models["m"], pricing)
-	usage, cost := tracker.GetStats(context.Background())
-	// Confirm GetStats returns zero values without error (no error return in signature).
-	_ = usage
-	_ = cost
-	// If this compiles and runs without panic, the error branch is unreachable
-	// when tracker != nil.
-
-	// Path B: tracker == nil + file doesn't exist → os.IsNotExist → nil error.
-	nonexistent := filepath.Join(t.TempDir(), "nonexistent.log")
-	u, c, err := resolveUsageForSummary(context.Background(), sm, nil, nonexistent, "m", nil)
-	if err != nil {
-		t.Fatalf("expected nil error for nonexistent file (IsNotExist suppressed), got: %v", err)
-	}
-	if u.PromptTokens != 0 || c != 0 {
-		t.Errorf("expected zero usage/cost, got %+v / %f", u, c)
+	// Pre-create empty global_costs.json so loadHistory does NOT trigger
+	// async ledger recovery. This avoids a race between the background
+	// recovery goroutine and subsequent RecordSessionCost calls.
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	if err := os.WriteFile(historyPath, []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
-	// Path B.2: tracker == nil + parseUsage non-NotExist error.
-	// But with tracker==nil in RecordSessionCost, EstimateCost runs first
-	// and would hit the same parseUsage error before resolveUsageForSummary.
-	// This is structurally unreachable within RecordSessionCost.
+	// Write valid pricing data so EstimateCost succeeds.
+	assetsDir := filepath.Join(tempDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	pricingContent := `{"updated_at":"2025-06-15T00:00:00Z","models":{"test-model":{"hit":0.5,"miss":1.0,"comp":2.0}}}`
+	if err := os.WriteFile(filepath.Join(assetsDir, "pricing.json"), []byte(pricingContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := &mockSM{}
+
+	err := RecordSessionCost(context.Background(), sm, nil, logPath, "test-model", "manual", "session-1", nil)
+
+	if err == nil {
+		t.Fatal("expected error from injected resolveUsageForSummaryFunc")
+	}
+	if !strings.Contains(err.Error(), "injected resolveUsageForSummary error") {
+		t.Errorf("error should contain 'injected resolveUsageForSummary error', got: %v", err)
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/telemetry/metrics_summary_error_gaps_test.go
+++ b/internal/infrastructure/telemetry/metrics_summary_error_gaps_test.go
@@ -4,10 +4,12 @@
 package telemetry
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -236,4 +238,30 @@ func TestAppendSummaryToLog_MarshalErrorUnreachable(t *testing.T) {
 	if !strings.Contains(err.Error(), "failed to marshal cost summary") {
 		t.Error("error format string mismatch")
 	}
+}
+
+// =============================================================================
+// Gap — Silent cost-update warning (metrics.go:109-111)
+// =============================================================================
+
+// TestGetCostSummary_SilentCostUpdateWarning covers the gap at
+// metrics.go:109-111 where recordCostSilently calls EstimateCost
+// and silently logs a warning when EstimateCost fails.
+func TestGetCostSummary_SilentCostUpdateWarning(t *testing.T) {
+	t.Parallel()
+
+	m := &metricsManager{
+		sm:      &mockSMWithError{pathErr: errors.New("path not safe")},
+		logFile: "/nonexistent/path/tokens.log",
+		model:   "test-model",
+	}
+
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
+
+	m.recordCostSilently(context.Background())
+
+	assert.Contains(t, logBuf.String(), "Warning: Failed to record cost before summary")
+	assert.Contains(t, logBuf.String(), "path not safe")
 }


### PR DESCRIPTION
Closes #948.

## Summary
Adds test coverage for 5 previously uncovered error-handling branches in the telemetry package, reducing medium-priority coverage gaps in metrics.go from 4→0 and ledger.go from 1→0.

### Changes
| # | File | Gap | Fix |
|---|---|---|---|
| 1 | metrics.go:109-111 | Silent cost-update warning | Extracted `recordCostSilently` method + direct test |
| 2 | metrics.go:139-141 | resolveUsageForSummary error | `resolveUsageForSummaryFunc` var injection |
| 3 | metrics.go:246-249 | json.Marshal failure | `jsonMarshal` var injection |
| 4 | metrics.go:258-260 | f.Close() error | `openTraceFile` var injection returning io.WriteCloser |
| 5 | ledger.go:216-218 | filepath.Rel error | `filepathRel` var injection |

### Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps including race detection) |
| go test -race ./internal/infrastructure/telemetry/... | PASS (1.533s) |
| Coverage gaps (telemetry) | 6→1 (only out-of-scope system_metrics_shared remains) |
| Zero merge conflicts | ✅ (files untouched by #946, #940, #947)