### PR TITLE
fix(llm): reduce test complexity from 10 to ≤5 in 8 LLM test functions (#954)

### DIFF
--- a/internal/infrastructure/llm/anthropic/client_messages_test.go
+++ b/internal/infrastructure/llm/anthropic/client_messages_test.go
@@ -332,30 +332,38 @@ func TestPartToContentBlock(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got, ok, err := c.partToContentBlock(tt.part, tt.role)
-
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
-					t.Errorf("error %q should contain %q", err.Error(), tt.errContains)
-				}
-				return
-			}
-
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if ok != tt.wantOk {
-				t.Errorf("expected ok=%v, got ok=%v", tt.wantOk, ok)
-			}
-
-			if tt.wantOk && got.Type != tt.wantType {
-				t.Errorf("expected type %q, got %q", tt.wantType, got.Type)
-			}
+			assertPartToContentBlockResult(t, got, ok, err, tt.wantErr, tt.wantOk, tt.wantType, tt.errContains)
 		})
+	}
+}
+
+// assertPartToContentBlockResult validates the result of partToContentBlock
+// against the test case expectations for error, ok, and block type.
+func assertPartToContentBlockResult(t *testing.T, got contentBlock, ok bool, err error, wantErr bool, wantOk bool, wantType, errContains string) {
+	t.Helper()
+
+	if wantErr {
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if errContains != "" && !strings.Contains(err.Error(), errContains) {
+			t.Errorf("error %q should contain %q", err.Error(), errContains)
+		}
+		return
+	}
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if ok != wantOk {
+		t.Errorf("expected ok=%v, got ok=%v", wantOk, ok)
+	}
+
+	if wantOk && got.Type != wantType {
+		t.Errorf("expected type %q, got %q", wantType, got.Type)
 	}
 }
 

--- a/internal/infrastructure/llm/anthropic/client_vertex_test.go
+++ b/internal/infrastructure/llm/anthropic/client_vertex_test.go
@@ -321,28 +321,50 @@ func assertMetricsMapping(t *testing.T, m *llm.Metrics, wantPrompt, wantCached, 
 	}
 }
 
+// assertPromptCachingBetaHeader checks the anthropic-beta header is set
+// for prompt caching.
+func assertPromptCachingBetaHeader(t *testing.T, r *http.Request) {
+	t.Helper()
+	if r.Header.Get("anthropic-beta") != "prompt-caching-2024-07-31" {
+		t.Errorf("expected beta header prompt-caching-2024-07-31, got %s", r.Header.Get("anthropic-beta"))
+	}
+}
+
+// assertPromptCachingSystemBlock validates that the system block in a
+// prompt-caching request has the correct text and ephemeral cache_control.
+func assertPromptCachingSystemBlock(t *testing.T, req messagesRequest) {
+	t.Helper()
+	systemBlocks, ok := req.System.([]interface{})
+	if !ok || len(systemBlocks) != 1 {
+		t.Errorf("expected 1 system block, got %v", req.System)
+		return
+	}
+	block := systemBlocks[0].(map[string]interface{})
+	if block["type"] != "text" || block["text"] != "You are a helpful assistant" {
+		t.Errorf("unexpected system block text: %v", block["text"])
+	}
+	assertPromptCachingCacheControl(t, block)
+}
+
+// assertPromptCachingCacheControl checks that the block has ephemeral
+// cache_control set.
+func assertPromptCachingCacheControl(t *testing.T, block map[string]interface{}) {
+	t.Helper()
+	cache, ok := block["cache_control"].(map[string]interface{})
+	if !ok || cache["type"] != "ephemeral" {
+		t.Errorf("expected ephemeral cache control, got %v", block["cache_control"])
+	}
+}
+
 func TestPromptCaching(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("anthropic-beta") != "prompt-caching-2024-07-31" {
-			t.Errorf("expected beta header, got %s", r.Header.Get("anthropic-beta"))
-		}
+		assertPromptCachingBetaHeader(t, r)
 
 		var req messagesRequest
 		_ = json.NewDecoder(r.Body).Decode(&req)
 
-		systemBlocks, ok := req.System.([]interface{})
-		if !ok || len(systemBlocks) != 1 {
-			t.Errorf("expected 1 system block, got %v", req.System)
-		} else {
-			block := systemBlocks[0].(map[string]interface{})
-			if block["type"] != "text" || block["text"] != "You are a helpful assistant" {
-				t.Errorf("unexpected system block text: %v", block["text"])
-			}
-			cache, ok := block["cache_control"].(map[string]interface{})
-			if !ok || cache["type"] != "ephemeral" {
-				t.Errorf("expected ephemeral cache control, got %v", block["cache_control"])
-			}
-		}
+		assertPromptCachingSystemBlock(t, req)
 
 		resp := messagesResponse{
 			Usage: usage{

--- a/internal/infrastructure/llm/factory_test.go
+++ b/internal/infrastructure/llm/factory_test.go
@@ -122,30 +122,14 @@ func TestCreateAuthenticator_MissingKeysAndFallbacks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			p := &config.LLMProvider{
 				Type:   tt.provider,
 				APIKey: tt.apiKey,
 				URL:    tt.url,
 			}
 			a, err := createAuthenticator(p)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("createAuthenticator() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if !tt.wantErr {
-				if tt.url != "" && strings.Contains(tt.url, "aiplatform.googleapis.com") {
-					if _, ok := a.(*auth.VertexAuth); !ok {
-						t.Errorf("expected *auth.VertexAuth for vertex url, got %T", a)
-					}
-				}
-
-				// If it's the unknown provider with a key, verify it uses APIKeyAuth
-				if tt.provider == "unknown" && tt.apiKey != "" {
-					if _, ok := a.(*auth.APIKeyAuth); !ok {
-						t.Errorf("expected *auth.APIKeyAuth for unknown provider with key, got %T", a)
-					}
-				}
-			}
+			assertMissingKeysResult(t, a, err, tt.wantErr, tt.provider, tt.apiKey, tt.url)
 		})
 	}
 }
@@ -183,29 +167,62 @@ func TestCreateAuthenticator_Public(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			a, err := CreateAuthenticator(&tt.provider)
-
-			if (err != nil) != tt.wantErr {
-				t.Errorf("CreateAuthenticator() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if (a == nil) != tt.wantAuthNil {
-				t.Errorf("CreateAuthenticator() auth = %v, wantAuthNil %v", a, tt.wantAuthNil)
-			}
-
-			if !tt.wantErr && a != nil {
-				switch tt.wantType {
-				case "bearer":
-					if _, ok := a.(*auth.BearerAuth); !ok {
-						t.Errorf("expected *auth.BearerAuth, got %T", a)
-					}
-				case "vertex":
-					if _, ok := a.(*auth.VertexAuth); !ok {
-						t.Errorf("expected *auth.VertexAuth, got %T", a)
-					}
-				}
-			}
+			assertCreateAuthenticatorResult(t, a, err, tt.wantErr, tt.wantAuthNil, tt.wantType)
 		})
+	}
+}
+
+func assertCreateAuthenticatorResult(t *testing.T, a auth.Authenticator, err error, wantErr, wantAuthNil bool, wantType string) {
+	t.Helper()
+	if (err != nil) != wantErr {
+		t.Errorf("CreateAuthenticator() error = %v, wantErr %v", err, wantErr)
+	}
+	if (a == nil) != wantAuthNil {
+		t.Errorf("CreateAuthenticator() auth = %v, wantAuthNil %v", a, wantAuthNil)
+	}
+	if !wantErr && a != nil {
+		assertAuthType(t, a, wantType)
+	}
+}
+
+func assertAuthType(t *testing.T, a auth.Authenticator, wantType string) {
+	t.Helper()
+	switch wantType {
+	case "bearer":
+		if _, ok := a.(*auth.BearerAuth); !ok {
+			t.Errorf("expected *auth.BearerAuth, got %T", a)
+		}
+	case "vertex":
+		if _, ok := a.(*auth.VertexAuth); !ok {
+			t.Errorf("expected *auth.VertexAuth, got %T", a)
+		}
+	}
+}
+
+// assertMissingKeysResult validates the result of createAuthenticator for
+// the missing-keys-and-fallbacks test table. It checks the error contract
+// and, on success, verifies the correct authenticator type was selected
+// (VertexAuth for Vertex URLs, APIKeyAuth for unknown providers with keys).
+func assertMissingKeysResult(t *testing.T, a auth.Authenticator, err error, wantErr bool, provider, apiKey, url string) {
+	t.Helper()
+	if (err != nil) != wantErr {
+		t.Errorf("createAuthenticator() error = %v, wantErr %v", err, wantErr)
+	}
+
+	if !wantErr {
+		if url != "" && strings.Contains(url, "aiplatform.googleapis.com") {
+			if _, ok := a.(*auth.VertexAuth); !ok {
+				t.Errorf("expected *auth.VertexAuth for vertex url, got %T", a)
+			}
+		}
+
+		if provider == "unknown" && apiKey != "" {
+			if _, ok := a.(*auth.APIKeyAuth); !ok {
+				t.Errorf("expected *auth.APIKeyAuth for unknown provider with key, got %T", a)
+			}
+		}
 	}
 }
 

--- a/internal/infrastructure/llm/gemini/gemini_test.go
+++ b/internal/infrastructure/llm/gemini/gemini_test.go
@@ -724,64 +724,64 @@ func TestToSDKTool(t *testing.T) {
 	}
 }
 
-func TestApplyThinkingBudget(t *testing.T) {
-
+func TestApplyThinkingBudget_UnderBudget(t *testing.T) {
+	t.Parallel()
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	eventstest.CleanupBus(t, bus)
 	client := &Client{eventBus: bus}
-	ctx := context.Background()
 
-	t.Run("Under Budget", func(t *testing.T) {
-		config := &genai.ThinkingConfig{}
-		client.applyThinkingBudget(ctx, config, 1000, 2000, "test-model")
+	config := &genai.ThinkingConfig{}
+	client.applyThinkingBudget(context.Background(), config, 1000, 2000, "test-model")
 
-		if config.ThinkingBudget == nil || *config.ThinkingBudget != 1000 {
-			t.Errorf("expected budget 1000, got %v", config.ThinkingBudget)
-		}
-	})
+	if config.ThinkingBudget == nil || *config.ThinkingBudget != 1000 {
+		t.Errorf("expected budget 1000, got %v", config.ThinkingBudget)
+	}
+}
 
-	t.Run("Exceeds Max Budget", func(t *testing.T) {
-		localBus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
-		eventstest.CleanupBus(t, localBus)
-		localClient := &Client{eventBus: localBus}
+func TestApplyThinkingBudget_ExceedsMaxBudget(t *testing.T) {
+	t.Parallel()
+	localBus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, localBus)
+	localClient := &Client{eventBus: localBus}
 
-		var mu sync.Mutex
-		var publishedEvents []events.Event
-		localBus.Subscribe(func(ctx context.Context, e events.Event) {
-			mu.Lock()
-			defer mu.Unlock()
-			publishedEvents = append(publishedEvents, e)
-		})
-
-		config := &genai.ThinkingConfig{}
-		localClient.applyThinkingBudget(ctx, config, 3000, 1024, "test-model")
-
-		// Flush to ensure the event is processed
-		if err := localBus.Flush(context.Background()); err != nil {
-			t.Fatalf("failed to flush event bus: %v", err)
-		}
-
-		if config.ThinkingBudget == nil || *config.ThinkingBudget != 1024 {
-			t.Errorf("expected budget to be capped at 1024, got %v", config.ThinkingBudget)
-		}
-
+	var mu sync.Mutex
+	var publishedEvents []events.Event
+	localBus.Subscribe(func(ctx context.Context, e events.Event) {
 		mu.Lock()
-		count := len(publishedEvents)
-		var firstEvent events.Event
-		if count > 0 {
-			firstEvent = publishedEvents[0]
-		}
-		mu.Unlock()
-
-		if count != 1 {
-			t.Fatalf("expected 1 warning event, got %d", count)
-		}
-
-		msgEvent, ok := firstEvent.(events.SystemMessageEvent)
-		if !ok || msgEvent.Level != "warning" {
-			t.Errorf("expected warning SystemMessageEvent")
-		}
+		defer mu.Unlock()
+		publishedEvents = append(publishedEvents, e)
 	})
+
+	config := &genai.ThinkingConfig{}
+	localClient.applyThinkingBudget(context.Background(), config, 3000, 1024, "test-model")
+
+	if err := localBus.Flush(context.Background()); err != nil {
+		t.Fatalf("failed to flush event bus: %v", err)
+	}
+
+	if config.ThinkingBudget == nil || *config.ThinkingBudget != 1024 {
+		t.Errorf("expected budget capped at 1024, got %v", config.ThinkingBudget)
+	}
+
+	mu.Lock()
+	events := make([]events.Event, len(publishedEvents))
+	copy(events, publishedEvents)
+	mu.Unlock()
+
+	assertSingleWarningEvent(t, events)
+}
+
+// assertSingleWarningEvent validates that exactly one warning SystemMessageEvent
+// was published to the event slice.
+func assertSingleWarningEvent(t *testing.T, publishedEvents []events.Event) {
+	t.Helper()
+	if len(publishedEvents) != 1 {
+		t.Fatalf("expected 1 warning event, got %d", len(publishedEvents))
+	}
+	msgEvent, ok := publishedEvents[0].(events.SystemMessageEvent)
+	if !ok || msgEvent.Level != "warning" {
+		t.Errorf("expected warning SystemMessageEvent")
+	}
 }
 
 // captureErrorLogger implements ports.Logger and captures the last Error call.

--- a/internal/infrastructure/llm/openai/client_chat_test.go
+++ b/internal/infrastructure/llm/openai/client_chat_test.go
@@ -204,56 +204,8 @@ func TestOpenAIReasoningTokens(t *testing.T) {
 }
 
 func TestToolCalling(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		var req chatRequest
-		_ = json.NewDecoder(r.Body).Decode(&req)
-
-		// If it's the first call, return a tool call
-		if len(req.Messages) == 1 {
-			resp := chatResponse{
-				Choices: []choice{
-					{
-						Message: message{
-							Role: "assistant",
-							ToolCalls: []toolCall{
-								{
-									ID:   "call_123",
-									Type: "function",
-									Function: functionCall{
-										Name:      "get_weather",
-										Arguments: `{"location": "London"}`,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-			return
-		}
-
-		// If it's the second call, check for tool response
-		if len(req.Messages) == 3 {
-			lastMsg := req.Messages[2]
-			if lastMsg.Role != "tool" || lastMsg.ToolCallID != "call_123" || lastMsg.Content != "Sunny" {
-				t.Errorf("unexpected tool response message: %+v", lastMsg)
-			}
-
-			resp := chatResponse{
-				Choices: []choice{
-					{
-						Message: message{
-							Role:    "assistant",
-							Content: "The weather is sunny",
-						},
-					},
-				},
-			}
-			_ = json.NewEncoder(w).Encode(resp)
-			return
-		}
-	}))
+	t.Parallel()
+	server := httptest.NewServer(newToolCallingHandler(t))
 	defer server.Close()
 
 	client := NewClient(server.URL, "gpt-4", &auth.BearerAuth{Token: "key"})
@@ -264,33 +216,86 @@ func TestToolCalling(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if resp.Parts[0].FunctionCall.ID != "call_123" {
-		t.Errorf("expected tool call ID call_123, got %s", resp.Parts[0].FunctionCall.ID)
-	}
+	assertToolCallResponse(t, resp)
 
 	// 2. Respond to tool call
 	history = append(history, resp)
 	history = append(history, &llm.Content{
 		Role: "tool",
-		Parts: []*llm.Part{
-			{
-				FunctionResponse: &llm.FunctionResponse{
-					ID:       "call_123",
-					Name:     "get_weather",
-					Response: map[string]interface{}{"result": "Sunny"},
-				},
+		Parts: []*llm.Part{{
+			FunctionResponse: &llm.FunctionResponse{
+				ID:       "call_123",
+				Name:     "get_weather",
+				Response: map[string]interface{}{"result": "Sunny"},
 			},
-		},
+		}},
 	})
 
 	resp2, _, err := client.SendChat(context.Background(), history, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	assertFinalToolResponse(t, resp2)
+}
 
-	if resp2.Parts[0].Text != "The weather is sunny" {
-		t.Errorf("unexpected response: %s", resp2.Parts[0].Text)
+// newToolCallingHandler returns an http.HandlerFunc that simulates a two-turn
+// tool-calling conversation: first call returns a tool_call, second call
+// (with tool response in history) returns the final text.
+func newToolCallingHandler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req chatRequest
+		_ = json.NewDecoder(r.Body).Decode(&req)
+
+		if len(req.Messages) == 1 {
+			resp := chatResponse{
+				Choices: []choice{{
+					Message: message{
+						Role: "assistant",
+						ToolCalls: []toolCall{{
+							ID:   "call_123",
+							Type: "function",
+							Function: functionCall{
+								Name:      "get_weather",
+								Arguments: `{"location": "London"}`,
+							},
+						}},
+					},
+				}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+
+		if len(req.Messages) == 3 {
+			lastMsg := req.Messages[2]
+			if lastMsg.Role != "tool" || lastMsg.ToolCallID != "call_123" || lastMsg.Content != "Sunny" {
+				t.Errorf("unexpected tool response message: %+v", lastMsg)
+			}
+			resp := chatResponse{
+				Choices: []choice{{
+					Message: message{
+						Role:    "assistant",
+						Content: "The weather is sunny",
+					},
+				}},
+			}
+			_ = json.NewEncoder(w).Encode(resp)
+		}
+	}
+}
+
+func assertToolCallResponse(t *testing.T, resp *llm.Content) {
+	t.Helper()
+	if resp.Parts[0].FunctionCall.ID != "call_123" {
+		t.Errorf("expected tool call ID call_123, got %s", resp.Parts[0].FunctionCall.ID)
+	}
+}
+
+func assertFinalToolResponse(t *testing.T, resp *llm.Content) {
+	t.Helper()
+	if resp.Parts[0].Text != "The weather is sunny" {
+		t.Errorf("unexpected response: %s", resp.Parts[0].Text)
 	}
 }
 

--- a/internal/infrastructure/llm/openai/endpoint_test.go
+++ b/internal/infrastructure/llm/openai/endpoint_test.go
@@ -452,10 +452,10 @@ func TestModernTextTypesAndPerItemUsage(t *testing.T) {
 }
 
 func TestTopLevelToolCallsInResponses(t *testing.T) {
+	t.Parallel()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
-		// Heterogeneous output: thought then top-level call
 		_, _ = w.Write([]byte(`{
 			"id": "resp_top_call",
 			"output": [
@@ -483,16 +483,24 @@ func TestTopLevelToolCallsInResponses(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	assertThoughtAndToolCallParts(t, resp.Parts, "I need to call a tool.", "get_time", "c123")
+}
+
+// assertThoughtAndToolCallParts validates that the response parts contain
+// both a thought part with the expected text and a tool call part with the
+// expected name and ID. This is used for testing heterogeneous Responses API
+// output (thought block + top-level call block).
+func assertThoughtAndToolCallParts(t *testing.T, parts []*llm.Part, wantThought string, wantCallName, wantCallID string) {
+	t.Helper()
 	var hasThought, hasCall bool
-	for _, p := range resp.Parts {
-		if p.IsThought && p.Text == "I need to call a tool." {
+	for _, p := range parts {
+		if p.IsThought && p.Text == wantThought {
 			hasThought = true
 		}
-		if p.FunctionCall != nil && p.FunctionCall.Name == "get_time" && p.FunctionCall.ID == "c123" {
+		if p.FunctionCall != nil && p.FunctionCall.Name == wantCallName && p.FunctionCall.ID == wantCallID {
 			hasCall = true
 		}
 	}
-
 	if !hasThought {
 		t.Error("missing expected thought part")
 	}
@@ -502,6 +510,7 @@ func TestTopLevelToolCallsInResponses(t *testing.T) {
 }
 
 func TestBlockBasedToolCallsInHistory(t *testing.T) {
+	t.Parallel()
 	var capturedBody string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -513,7 +522,6 @@ func TestBlockBasedToolCallsInHistory(t *testing.T) {
 
 	c := NewClient(server.URL, "gpt-5.4", &auth.BearerAuth{Token: "key"}, WithHeaders(map[string]string{"reasoning_effort": "high"}), WithThinkingBudget(100))
 
-	// History item: assistant message with a tool call
 	history := []*llm.Content{
 		{
 			Role: "model",
@@ -529,36 +537,42 @@ func TestBlockBasedToolCallsInHistory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Verify the structure of the first message in the input array (the assistant message)
-	// For Responses API, tool calls must be in content blocks, not at top level
-	if strings.Contains(capturedBody, `"input":[{"role":"assistant","content":`) {
-		// It's in block mode. Ensure tool_calls is NOT at top level of this message.
-		// A simple check: if we see "assistant" followed by "tool_calls" before the next message or end of object
-		// But "tool_calls" IS valid at the TOP level of the request (the tool declarations).
-		// We care about the message in the "input" array.
+	assertNoTopLevelToolCallsInAssistantMessage(t, capturedBody)
+	assertFunctionCallBlockPresent(t, capturedBody, "call_123", "get_weather")
+}
 
-		// In block mode, we specifically set msg.ToolCalls = nil
-
-		// Let's check for the absence of "tool_calls" specifically within the assistant message object
-		// Assistant message starts with {"role":"assistant"
-		idx := strings.Index(capturedBody, `"role":"assistant"`)
-		if idx != -1 {
-			// Find the end of this message object (next message or end of array)
-			endIdx := strings.Index(capturedBody[idx:], `},{"role"`)
-			if endIdx == -1 {
-				endIdx = strings.Index(capturedBody[idx:], `]}],"tools"`)
-			}
-			if endIdx != -1 {
-				msgSegment := capturedBody[idx : idx+endIdx]
-				if strings.Contains(msgSegment, `"tool_calls":`) {
-					t.Errorf("found forbidden top-level 'tool_calls' in assistant message in Responses API mode: %s", msgSegment)
-				}
-			}
+// assertNoTopLevelToolCallsInAssistantMessage validates that in Responses API
+// mode, the assistant message in the input array does NOT contain top-level
+// "tool_calls" keys — tool calls must be in content blocks instead.
+func assertNoTopLevelToolCallsInAssistantMessage(t *testing.T, body string) {
+	t.Helper()
+	if !strings.Contains(body, `"input":[{"role":"assistant","content":`) {
+		return // not in block mode; nothing to check
+	}
+	idx := strings.Index(body, `"role":"assistant"`)
+	if idx == -1 {
+		return
+	}
+	endIdx := strings.Index(body[idx:], `},{"role"`)
+	if endIdx == -1 {
+		endIdx = strings.Index(body[idx:], `]}],"tools"`)
+	}
+	if endIdx != -1 {
+		msgSegment := body[idx : idx+endIdx]
+		if strings.Contains(msgSegment, `"tool_calls":`) {
+			t.Errorf("found forbidden top-level 'tool_calls' in assistant message in Responses API mode: %s", msgSegment)
 		}
 	}
+}
 
-	if !strings.Contains(capturedBody, `"type":"function_call"`) || !strings.Contains(capturedBody, `"call_id":"call_123"`) || !strings.Contains(capturedBody, `"name":"get_weather"`) {
-		t.Errorf("expected JSON to contain function_call item with call_id and name, got %s", capturedBody)
+// assertFunctionCallBlockPresent validates that the captured JSON body
+// contains a function_call content block with the expected call_id and name.
+func assertFunctionCallBlockPresent(t *testing.T, body, callID, name string) {
+	t.Helper()
+	if !strings.Contains(body, `"type":"function_call"`) ||
+		!strings.Contains(body, `"call_id":"`+callID+`"`) ||
+		!strings.Contains(body, `"name":"`+name+`"`) {
+		t.Errorf("expected JSON to contain function_call item with call_id and name, got %s", body)
 	}
 }
 


### PR DESCRIPTION
Closes #954.

## Summary
Pre-emptive complexity reduction: 8 LLM test functions at cyclomatic complexity 10 reduced to ≤5 each. Extracted assertion logic into t.Helper() functions and promoted independent subtests to standalone TestXxx functions with t.Parallel().

| # | Function | Before | After | File |
|---|----------|--------|-------|------|
| 1 | TestCreateAuthenticator_Public | 10 | 2 | factory_test.go |
| 2 | TestCreateAuthenticator_MissingKeysAndFallbacks | 10 | 2 | factory_test.go |
| 3 | TestPartToContentBlock | 10 | 2 | anthropic/client_messages_test.go |
| 4 | TestPromptCaching | 10 | 3 | anthropic/client_vertex_test.go |
| 5 | TestTopLevelToolCallsInResponses | 10 | 2 | openai/endpoint_test.go |
| 6 | TestBlockBasedToolCallsInHistory | 10 | 2 | openai/endpoint_test.go |
| 7 | TestToolCalling | 10 | 3 | openai/client_chat_test.go |
| 8 | TestApplyThinkingBudget | 10 | 3+3 | gemini/gemini_test.go |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Lint (golangci-lint) | 0 issues |
| Race detector | All pass |
| Coverage | All targets met |
| Complexity alerts (>10) | 0 |