### PR TITLE
fix(infrastructure): reduce 11 test functions from complexity 10 to ≤5 (#955)

### DIFF
--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -795,61 +795,73 @@ func TestServiceAccountAuth_EmptyKeyFilePath(t *testing.T) {
 }
 
 func TestVertexAuth_GetToken_CorruptCache(t *testing.T) {
-	t.Run("corrupt cache falls back to gcloud", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Chmod 0000 not reliable on Windows")
-		}
+	if runtime.GOOS == "windows" {
+		t.Skip("Chmod 0000 not reliable on Windows")
+	}
+	t.Parallel()
 
-		ctx := context.Background()
-		tmpDir := t.TempDir()
+	ctx := context.Background()
+	tmpDir := t.TempDir()
 
-		auth := &VertexAuth{
-			CacheDir: tmpDir,
-			tokenCmdFunc: func() ([]byte, error) {
-				return []byte("fresh-gcloud-token"), nil
-			},
-		}
+	auth := &VertexAuth{
+		CacheDir: tmpDir,
+		tokenCmdFunc: func() ([]byte, error) {
+			return []byte("fresh-gcloud-token"), nil
+		},
+	}
 
-		cachePath := auth.getCachePath()
-		dir := filepath.Dir(cachePath)
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			t.Fatalf("failed to create cache dir: %v", err)
-		}
-		if err := os.WriteFile(cachePath, []byte("stale-token"), 0600); err != nil {
-			t.Fatalf("failed to write cache file: %v", err)
-		}
+	cachePath := setupUnreadableCache(t, auth)
 
-		// Make the cache file unreadable to simulate corruption
-		if err := os.Chmod(cachePath, 0000); err != nil {
-			t.Fatalf("failed to chmod cache file: %v", err)
-		}
-
-		// Restore permissions so t.TempDir cleanup can remove the file
-		t.Cleanup(func() {
-			_ = os.Chmod(cachePath, 0600)
-		})
-
-		token, err := auth.getToken(ctx)
-		if err != nil {
-			t.Fatalf("getToken should fall back to gcloud, got error: %v", err)
-		}
-		if token != "fresh-gcloud-token" {
-			t.Errorf("got %q, want fresh-gcloud-token", token)
-		}
-
-		// Verify the corrupt cache was overwritten with the fresh token
-		// (restore readability first)
-		if err := os.Chmod(cachePath, 0600); err != nil {
-			t.Fatalf("failed to restore cache file permissions: %v", err)
-		}
-		content, err := os.ReadFile(cachePath)
-		if err != nil {
-			t.Fatalf("failed to read cache file after getToken: %v", err)
-		}
-		if strings.TrimSpace(string(content)) != "fresh-gcloud-token" {
-			t.Errorf("cache file contains %q, want fresh-gcloud-token", string(content))
-		}
+	// Restore permissions so t.TempDir cleanup can remove the file
+	t.Cleanup(func() {
+		_ = os.Chmod(cachePath, 0600)
 	})
+
+	token, err := auth.getToken(ctx)
+	if err != nil {
+		t.Fatalf("getToken should fall back to gcloud, got error: %v", err)
+	}
+	if token != "fresh-gcloud-token" {
+		t.Errorf("got %q, want fresh-gcloud-token", token)
+	}
+
+	// Verify the corrupt cache was overwritten with the fresh token
+	assertCacheContent(t, cachePath, "fresh-gcloud-token")
+}
+
+// setupUnreadableCache creates the cache directory, writes a stale token,
+// and makes the file unreadable via chmod 0000. Returns the cache path.
+func setupUnreadableCache(t *testing.T, auth *VertexAuth) string {
+	t.Helper()
+
+	cachePath := auth.getCachePath()
+	dir := filepath.Dir(cachePath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("failed to create cache dir: %v", err)
+	}
+	if err := os.WriteFile(cachePath, []byte("stale-token"), 0600); err != nil {
+		t.Fatalf("failed to write cache file: %v", err)
+	}
+	if err := os.Chmod(cachePath, 0000); err != nil {
+		t.Fatalf("failed to chmod cache file: %v", err)
+	}
+	return cachePath
+}
+
+func assertCacheContent(t *testing.T, cachePath, wantToken string) {
+	t.Helper()
+
+	// Restore readability first
+	if err := os.Chmod(cachePath, 0600); err != nil {
+		t.Fatalf("failed to restore cache file permissions: %v", err)
+	}
+	content, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("failed to read cache file after getToken: %v", err)
+	}
+	if strings.TrimSpace(string(content)) != wantToken {
+		t.Errorf("cache file contains %q, want %s", string(content), wantToken)
+	}
 }
 
 // TestNewVertexAuth_DefaultTokenCmdFunc_ExecError verifies that the default

--- a/internal/infrastructure/history/store_test.go
+++ b/internal/infrastructure/history/store_test.go
@@ -1079,52 +1079,53 @@ func TestJSONLStore_Archive(t *testing.T) {
 		{Role: "model", Parts: []*llm.Part{{Text: "Msg 2"}}},
 	}
 
-	// 1. Test Archive empty contents
-	if err := store.Archive(ctx, []*llm.Content{}); err != nil {
-		t.Errorf("expected no error for empty archive, got %v", err)
-	}
+	t.Run("ArchiveEmpty", func(t *testing.T) {
+		if err := store.Archive(ctx, []*llm.Content{}); err != nil {
+			t.Errorf("expected no error for empty archive, got %v", err)
+		}
+	})
 
-	// 2. Test Archive contents
-	if err := store.Archive(ctx, contents); err != nil {
-		t.Fatalf("Archive failed: %v", err)
-	}
+	t.Run("ArchiveContents", func(t *testing.T) {
+		if err := store.Archive(ctx, contents); err != nil {
+			t.Fatalf("Archive failed: %v", err)
+		}
 
-	// 3. Verify archive file exists and contains contents
-	archivePath := filepath.Join(tmpDir, "archive.jsonl")
+		archivePath := filepath.Join(tmpDir, "archive.jsonl")
+		verifyArchiveContents(t, archivePath, 2, "Msg 1")
+	})
+
+	t.Run("ArchiveAppend", func(t *testing.T) {
+		moreContents := []*llm.Content{
+			{Role: "user", Parts: []*llm.Part{{Text: "Msg 3"}}},
+		}
+		if err := store.Archive(ctx, moreContents); err != nil {
+			t.Fatalf("Archive failed: %v", err)
+		}
+
+		archivePath := filepath.Join(tmpDir, "archive.jsonl")
+		verifyArchiveContents(t, archivePath, 3, "")
+	})
+}
+
+func verifyArchiveContents(t *testing.T, archivePath string, wantCount int, firstText string) {
+	t.Helper()
+
 	if _, err := os.Stat(archivePath); os.IsNotExist(err) {
 		t.Fatal("archive file does not exist")
 	}
 
-	// Use a temporary store to load the archive file
 	archiveStore := newJSONLStore(infrapersistence.NewOSFileSystem(), archivePath, filepath.Join(filepath.Dir(archivePath), "archive.jsonl"))
-	archivedContents, err := archiveStore.Load(ctx)
+	archivedContents, err := archiveStore.Load(context.Background())
 	if err != nil {
 		t.Fatalf("failed to load archive: %v", err)
 	}
 
-	if len(archivedContents) != 2 {
-		t.Fatalf("expected 2 archived entries, got %d", len(archivedContents))
+	if len(archivedContents) != wantCount {
+		t.Fatalf("expected %d archived entries, got %d", wantCount, len(archivedContents))
 	}
 
-	if archivedContents[0].Parts[0].Text != "Msg 1" {
-		t.Errorf("expected 'Msg 1', got %q", archivedContents[0].Parts[0].Text)
-	}
-
-	// 4. Test Archive more contents (append mode)
-	moreContents := []*llm.Content{
-		{Role: "user", Parts: []*llm.Part{{Text: "Msg 3"}}},
-	}
-	if err := store.Archive(ctx, moreContents); err != nil {
-		t.Fatalf("Archive failed: %v", err)
-	}
-
-	archivedContents, err = archiveStore.Load(ctx)
-	if err != nil {
-		t.Fatalf("failed to load archive again: %v", err)
-	}
-
-	if len(archivedContents) != 3 {
-		t.Fatalf("expected 3 archived entries, got %d", len(archivedContents))
+	if firstText != "" && archivedContents[0].Parts[0].Text != firstText {
+		t.Errorf("expected %q, got %q", firstText, archivedContents[0].Parts[0].Text)
 	}
 }
 

--- a/internal/infrastructure/persistence/atomic_error_test.go
+++ b/internal/infrastructure/persistence/atomic_error_test.go
@@ -408,33 +408,40 @@ func TestFallbackCopy_Errors(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			m := tt.setupMock()
 
 			err := fallbackCopy(ctx, m, "/src", "/dst", 0644)
 
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("fallbackCopy() error = %v, wantErr %v", err, tt.wantErr)
-			}
-
-			if tt.wantErr && tt.errContains != "" {
-				if !strings.Contains(err.Error(), tt.errContains) {
-					t.Errorf("fallbackCopy() error = %q, want it to contain %q", err.Error(), tt.errContains)
-				}
-			}
-
-			if tt.expectRemoved != "" {
-				found := false
-				for _, r := range m.removedFiles {
-					if r == tt.expectRemoved {
-						found = true
-						break
-					}
-				}
-				if !found {
-					t.Errorf("expected %s to be removed, but it wasn't. Removed: %v", tt.expectRemoved, m.removedFiles)
-				}
-			}
+			assertFallbackCopyResult(t, err, tt.wantErr, tt.errContains, tt.expectRemoved, m.removedFiles)
 		})
+	}
+}
+
+func assertFallbackCopyResult(t *testing.T, err error, wantErr bool, errContains, expectRemoved string, removedFiles []string) {
+	t.Helper()
+
+	if (err != nil) != wantErr {
+		t.Fatalf("fallbackCopy() error = %v, wantErr %v", err, wantErr)
+	}
+
+	if wantErr && errContains != "" {
+		if !strings.Contains(err.Error(), errContains) {
+			t.Errorf("fallbackCopy() error = %q, want it to contain %q", err.Error(), errContains)
+		}
+	}
+
+	if expectRemoved != "" {
+		found := false
+		for _, r := range removedFiles {
+			if r == expectRemoved {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %s to be removed, but it wasn't. Removed: %v", expectRemoved, removedFiles)
+		}
 	}
 }
 

--- a/internal/infrastructure/persistence/os_fs_test.go
+++ b/internal/infrastructure/persistence/os_fs_test.go
@@ -168,72 +168,116 @@ func TestIsBinary(t *testing.T) {
 	}
 }
 
-func TestOSFileSystem_ContextCancellation(t *testing.T) {
+func TestOSFileSystem_ReadDir_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.ReadDir(ctx, "."); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_ReadFile_Cancelled(t *testing.T) {
 	t.Parallel()
 	fs := NewOSFileSystem()
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "test.txt")
 	_ = os.WriteFile(path, []byte("data"), 0644)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
+	if _, err := fs.ReadFile(ctx, path); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
 
-	t.Run("ReadDir cancelled", func(t *testing.T) {
-		t.Parallel()
-		if _, err := fs.ReadDir(ctx, "."); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("ReadFile cancelled", func(t *testing.T) {
-		t.Parallel()
-		if _, err := fs.ReadFile(ctx, path); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("MkdirAll cancelled", func(t *testing.T) {
-		t.Parallel()
-		if err := fs.MkdirAll(ctx, filepath.Join(tmpDir, "new"), 0755); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("Stat cancelled", func(t *testing.T) {
-		t.Parallel()
-		if _, err := fs.Stat(ctx, path); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("Open cancelled", func(t *testing.T) {
-		t.Parallel()
-		if _, err := fs.Open(ctx, path); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("OpenFile cancelled", func(t *testing.T) {
-		t.Parallel()
-		if _, err := fs.OpenFile(ctx, path, os.O_RDONLY, 0644); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("remove cancelled", func(t *testing.T) {
-		t.Parallel()
-		if err := fs.Remove(ctx, path); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("removeAll cancelled", func(t *testing.T) {
-		t.Parallel()
-		if err := fs.RemoveAll(ctx, path); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
-	t.Run("Walk cancelled", func(t *testing.T) {
-		t.Parallel()
-		if err := fs.Walk(ctx, tmpDir, func(path string, info os.FileInfo, err error) error {
-			return nil
-		}); err == nil {
-			t.Error("expected error for cancelled context")
-		}
-	})
+func TestOSFileSystem_MkdirAll_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := fs.MkdirAll(ctx, filepath.Join(tmpDir, "new"), 0755); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_Stat_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	_ = os.WriteFile(path, []byte("data"), 0644)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.Stat(ctx, path); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_Open_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	_ = os.WriteFile(path, []byte("data"), 0644)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.Open(ctx, path); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_OpenFile_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	_ = os.WriteFile(path, []byte("data"), 0644)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := fs.OpenFile(ctx, path, os.O_RDONLY, 0644); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_Remove_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	_ = os.WriteFile(path, []byte("data"), 0644)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := fs.Remove(ctx, path); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_RemoveAll_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.txt")
+	_ = os.WriteFile(path, []byte("data"), 0644)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := fs.RemoveAll(ctx, path); err == nil {
+		t.Error("expected error for cancelled context")
+	}
+}
+
+func TestOSFileSystem_Walk_Cancelled(t *testing.T) {
+	t.Parallel()
+	fs := NewOSFileSystem()
+	tmpDir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := fs.Walk(ctx, tmpDir, func(path string, info os.FileInfo, err error) error {
+		return nil
+	}); err == nil {
+		t.Error("expected error for cancelled context")
+	}
 }
 
 func TestOSFileSystem_OpenFile(t *testing.T) {

--- a/internal/infrastructure/registry/registry_test.go
+++ b/internal/infrastructure/registry/registry_test.go
@@ -199,62 +199,61 @@ func TestRegistry_RegisterToToolkitWithOptions(t *testing.T) {
 	assert.True(t, found, "git_serial should be in git toolkit")
 }
 
-func TestRegistry_GetOptions(t *testing.T) {
+func TestRegistry_GetOptions_SerialTool(t *testing.T) {
 	t.Parallel()
 	r := registry.New()
-
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "serial_tool"}, nil, registry.ToolOptions{Serial: true}); err != nil {
 		t.Fatalf("failed to register serial_tool: %v", err)
 	}
+	got := r.GetOptions("serial_tool")
+	if !got.Serial {
+		t.Errorf("expected serial_tool to have Serial=true, got %+v", got)
+	}
+}
+
+func TestRegistry_GetOptions_LongRunningTool(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "long_tool"}, nil, registry.ToolOptions{LongRunning: true}); err != nil {
 		t.Fatalf("failed to register long_tool: %v", err)
 	}
+	got := r.GetOptions("long_tool")
+	if !got.LongRunning {
+		t.Errorf("expected long_tool to have LongRunning=true, got %+v", got)
+	}
+}
+
+func TestRegistry_GetOptions_BothTool(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{Name: "both_tool"}, nil, registry.ToolOptions{Serial: true, LongRunning: true}); err != nil {
 		t.Fatalf("failed to register both_tool: %v", err)
 	}
+	got := r.GetOptions("both_tool")
+	if !got.Serial {
+		t.Errorf("expected both_tool to have Serial=true, got %+v", got)
+	}
+	if !got.LongRunning {
+		t.Errorf("expected both_tool to have LongRunning=true, got %+v", got)
+	}
+}
 
-	t.Run("serial tool", func(t *testing.T) {
-		t.Parallel()
-		got := r.GetOptions("serial_tool")
-		if !got.Serial {
-			t.Errorf("expected serial_tool to have Serial=true, got %+v", got)
-		}
-	})
+func TestRegistry_GetOptions_NonexistentTool(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+	got := r.GetOptions("no_such_tool")
+	if got != (registry.ToolOptions{}) {
+		t.Errorf("expected zero-value ToolOptions for nonexistent tool, got %+v", got)
+	}
+}
 
-	t.Run("long-running tool", func(t *testing.T) {
-		t.Parallel()
-		got := r.GetOptions("long_tool")
-		if !got.LongRunning {
-			t.Errorf("expected long_tool to have LongRunning=true, got %+v", got)
-		}
-	})
-
-	t.Run("tool with both options", func(t *testing.T) {
-		t.Parallel()
-		got := r.GetOptions("both_tool")
-		if !got.Serial {
-			t.Errorf("expected both_tool to have Serial=true, got %+v", got)
-		}
-		if !got.LongRunning {
-			t.Errorf("expected both_tool to have LongRunning=true, got %+v", got)
-		}
-	})
-
-	t.Run("nonexistent tool", func(t *testing.T) {
-		t.Parallel()
-		got := r.GetOptions("no_such_tool")
-		if got != (registry.ToolOptions{}) {
-			t.Errorf("expected zero-value ToolOptions for nonexistent tool, got %+v", got)
-		}
-	})
-
-	t.Run("empty name", func(t *testing.T) {
-		t.Parallel()
-		got := r.GetOptions("")
-		if got != (registry.ToolOptions{}) {
-			t.Errorf("expected zero-value ToolOptions for empty name, got %+v", got)
-		}
-	})
+func TestRegistry_GetOptions_EmptyName(t *testing.T) {
+	t.Parallel()
+	r := registry.New()
+	got := r.GetOptions("")
+	if got != (registry.ToolOptions{}) {
+		t.Errorf("expected zero-value ToolOptions for empty name, got %+v", got)
+	}
 }
 
 func TestRegistry_RegisterToToolkit_EmptyDefaultsToCore(t *testing.T) {

--- a/internal/infrastructure/security/policy_test.go
+++ b/internal/infrastructure/security/policy_test.go
@@ -214,124 +214,115 @@ func TestPolicyTool_SafePathManagement_List(t *testing.T) {
 	})
 }
 
-func TestPolicyTool_SafePathManagement_Remove(t *testing.T) {
+func TestPolicyTool_SafePathManagement_Remove_Existing(t *testing.T) {
 	t.Parallel()
+	sm, p, ctx := setupPolicyTest(t)
+	path := filepath.Join(t.TempDir(), "safe_to_remove")
+	_, _ = p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
+	_, _ = p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
 
-	t.Run("Remove Safe Path", func(t *testing.T) {
-		t.Parallel()
-		sm, p, ctx := setupPolicyTest(t)
-		path := filepath.Join(t.TempDir(), "safe_to_remove")
-		_, _ = p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
-		_, _ = p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
-
-		found := false
-		absPath, _ := filepath.Abs(path)
-		for _, sp := range sm.GetSafePaths() {
-			if sp == absPath {
-				found = true
-				break
-			}
+	found := false
+	absPath, _ := filepath.Abs(path)
+	for _, sp := range sm.GetSafePaths() {
+		if sp == absPath {
+			found = true
+			break
 		}
-		if found {
-			t.Errorf("path still in safe list after removal")
-		}
-	})
-
-	t.Run("Remove Safe Path not found", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyTest(t)
-		path := filepath.Join(t.TempDir(), "nonexistent_to_remove")
-		res, err := p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(res.Text, "Error:") && !strings.Contains(res.Text, "not found") {
-			t.Errorf("Expected not-found error message, got %q", res.Text)
-		}
-	})
-
-	t.Run("Remove Safe Path persist error", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyWithKVRemoveError(t, fmt.Errorf("persist failed"))
-		path := filepath.Join(t.TempDir(), "safe-rm-persist")
-		_, err := p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		res, err := p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(res.Text, "failed to update persistence") {
-			t.Errorf("Expected persist error message, got %q", res.Text)
-		}
-	})
+	}
+	if found {
+		t.Errorf("path still in safe list after removal")
+	}
 }
 
-func TestPolicyTool_ReadPathManagement(t *testing.T) {
+func TestPolicyTool_SafePathManagement_Remove_NotFound(t *testing.T) {
 	t.Parallel()
+	_, p, ctx := setupPolicyTest(t)
+	path := filepath.Join(t.TempDir(), "nonexistent_to_remove")
+	res, err := p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "Error:") && !strings.Contains(res.Text, "not found") {
+		t.Errorf("Expected not-found error message, got %q", res.Text)
+	}
+}
 
-	t.Run("Register and Remove Read Path", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyTest(t)
-		path := filepath.Join(t.TempDir(), "ro")
-		_, _ = p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
+func TestPolicyTool_SafePathManagement_Remove_PersistError(t *testing.T) {
+	t.Parallel()
+	_, p, ctx := setupPolicyWithKVRemoveError(t, fmt.Errorf("persist failed"))
+	path := filepath.Join(t.TempDir(), "safe-rm-persist")
+	_, err := p.RegisterSafePath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-		res, _ := p.ListReadPaths(ctx, nil, nil)
+	res, err := p.RemoveSafePath(ctx, map[string]interface{}{"path": path}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "failed to update persistence") {
+		t.Errorf("Expected persist error message, got %q", res.Text)
+	}
+}
 
-		// Use filepath.Abs to ensure we compare absolute paths consistently
-		absPath, _ := filepath.Abs(path)
-		if !strings.Contains(res.Text, absPath) && !strings.Contains(res.Text, path) {
-			t.Errorf("Expected read-only path %q in list: %s", absPath, res.Text)
-		}
+func TestPolicyTool_ReadPathManagement_RegisterAndRemove(t *testing.T) {
+	t.Parallel()
+	_, p, ctx := setupPolicyTest(t)
+	path := filepath.Join(t.TempDir(), "ro")
+	_, _ = p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
 
-		_, _ = p.RemoveReadPath(ctx, map[string]interface{}{"path": path}, nil)
-		res, _ = p.ListReadPaths(ctx, nil, nil)
-		if strings.Contains(res.Text, absPath) {
-			t.Errorf("Did not expect read-only path %q in list after removal", absPath)
-		}
-	})
+	res, _ := p.ListReadPaths(ctx, nil, nil)
 
-	t.Run("Register Read Path persist error", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyWithKVError(t, fmt.Errorf("persist failed"))
-		path := filepath.Join(t.TempDir(), "ro-persist-err")
-		res, err := p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(res.Text, "failed to persist") {
-			t.Errorf("Expected persist error message, got %q", res.Text)
-		}
-	})
+	absPath, _ := filepath.Abs(path)
+	if !strings.Contains(res.Text, absPath) && !strings.Contains(res.Text, path) {
+		t.Errorf("Expected read-only path %q in list: %s", absPath, res.Text)
+	}
 
-	t.Run("Remove Read Path persist error", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyWithKVRemoveError(t, fmt.Errorf("persist failed"))
-		path := filepath.Join(t.TempDir(), "ro-rm-persist")
-		_, err := p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+	_, _ = p.RemoveReadPath(ctx, map[string]interface{}{"path": path}, nil)
+	res, _ = p.ListReadPaths(ctx, nil, nil)
+	if strings.Contains(res.Text, absPath) {
+		t.Errorf("Did not expect read-only path %q in list after removal", absPath)
+	}
+}
 
-		res, err := p.RemoveReadPath(ctx, map[string]interface{}{"path": path}, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(res.Text, "failed to update persistence") {
-			t.Errorf("Expected persist error message, got %q", res.Text)
-		}
-	})
+func TestPolicyTool_ReadPathManagement_RegisterPersistError(t *testing.T) {
+	t.Parallel()
+	_, p, ctx := setupPolicyWithKVError(t, fmt.Errorf("persist failed"))
+	path := filepath.Join(t.TempDir(), "ro-persist-err")
+	res, err := p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "failed to persist") {
+		t.Errorf("Expected persist error message, got %q", res.Text)
+	}
+}
 
-	t.Run("List Empty Read Paths", func(t *testing.T) {
-		t.Parallel()
-		_, p, ctx := setupPolicyTest(t)
-		res, _ := p.ListReadPaths(ctx, nil, nil)
-		if !strings.Contains(res.Text, "No additional read-only paths") {
-			t.Error("Expected no read-only paths message")
-		}
-	})
+func TestPolicyTool_ReadPathManagement_RemovePersistError(t *testing.T) {
+	t.Parallel()
+	_, p, ctx := setupPolicyWithKVRemoveError(t, fmt.Errorf("persist failed"))
+	path := filepath.Join(t.TempDir(), "ro-rm-persist")
+	_, err := p.RegisterReadPath(ctx, map[string]interface{}{"path": path, "reason": "test"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := p.RemoveReadPath(ctx, map[string]interface{}{"path": path}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(res.Text, "failed to update persistence") {
+		t.Errorf("Expected persist error message, got %q", res.Text)
+	}
+}
+
+func TestPolicyTool_ReadPathManagement_ListEmpty(t *testing.T) {
+	t.Parallel()
+	_, p, ctx := setupPolicyTest(t)
+	res, _ := p.ListReadPaths(ctx, nil, nil)
+	if !strings.Contains(res.Text, "No additional read-only paths") {
+		t.Error("Expected no read-only paths message")
+	}
 }
 
 func TestPolicyTool_BypassManagement(t *testing.T) {

--- a/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
+++ b/internal/infrastructure/telemetry/infra_telemetry_extended_test.go
@@ -263,79 +263,76 @@ func TestTraceTelemetry(t *testing.T) {
 	})
 }
 
-func TestLedger_Extended(t *testing.T) {
+func TestLedger_Extended_IsStale(t *testing.T) {
 	t.Parallel()
-	t.Run("IsStale", func(t *testing.T) {
-		t.Parallel()
-		tempFile := filepath.Join(t.TempDir(), "stale.lock")
-		_ = os.WriteFile(tempFile, []byte(""), 0644)
+	tempFile := filepath.Join(t.TempDir(), "stale.lock")
+	_ = os.WriteFile(tempFile, []byte(""), 0644)
 
-		if isStale(tempFile) {
-			t.Error("New file should not be stale")
+	if isStale(tempFile) {
+		t.Error("New file should not be stale")
+	}
+
+	oldTime := time.Now().Add(-10 * time.Minute)
+	_ = os.Chtimes(tempFile, oldTime, oldTime)
+
+	if !isStale(tempFile) {
+		t.Error("Old file should be stale")
+	}
+}
+
+func TestLedger_Extended_FindLogFiles(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	subDir := filepath.Join(tempDir, "subdir")
+	_ = os.Mkdir(subDir, 0755)
+
+	logPath := filepath.Join(subDir, "session_tokens.log")
+	_ = os.WriteFile(logPath, []byte("data"), 0644)
+
+	ls := &ledgerStore{}
+	files, err := ls.findLogFiles(tempDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, f := range files {
+		if filepath.Base(f) == "session_tokens.log" {
+			found = true
+			break
 		}
+	}
+	if !found {
+		t.Error("Expected to find session_tokens.log")
+	}
+}
 
-		oldTime := time.Now().Add(-10 * time.Minute)
-		_ = os.Chtimes(tempFile, oldTime, oldTime)
+func TestLedger_Extended_AcquireAndReleaseLock(t *testing.T) {
+	t.Parallel()
+	tempDir := t.TempDir()
+	historyPath := filepath.Join(tempDir, "global_costs.json")
 
-		if !isStale(tempFile) {
-			t.Error("Old file should be stale")
-		}
-	})
+	ls := &ledgerStore{}
+	f, err := acquireLedgerLock(historyPath + ".lock")
+	if err != nil {
+		t.Fatalf("Failed to acquire lock: %v", err)
+	}
 
-	t.Run("FindLogFiles", func(t *testing.T) {
-		t.Parallel()
-		tempDir := t.TempDir()
-		subDir := filepath.Join(tempDir, "subdir")
-		_ = os.Mkdir(subDir, 0755)
+	// Try to acquire again
+	f2, err := acquireLedgerLock(historyPath + ".lock")
+	if err == nil {
+		_ = f2.Close()
+		t.Error("Should not be able to acquire lock again")
+	}
 
-		logPath := filepath.Join(subDir, "session_tokens.log")
-		_ = os.WriteFile(logPath, []byte("data"), 0644)
+	ls.releaseLedgerLock(historyPath, f)
 
-		ls := &ledgerStore{}
-		files, err := ls.findLogFiles(tempDir)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		found := false
-		for _, f := range files {
-			if filepath.Base(f) == "session_tokens.log" {
-				found = true
-				break
-			}
-		}
-		if !found {
-			t.Error("Expected to find session_tokens.log")
-		}
-	})
-
-	t.Run("AcquireAndReleaseLock", func(t *testing.T) {
-		t.Parallel()
-		tempDir := t.TempDir()
-		historyPath := filepath.Join(tempDir, "global_costs.json")
-
-		ls := &ledgerStore{}
-		f, err := acquireLedgerLock(historyPath + ".lock")
-		if err != nil {
-			t.Fatalf("Failed to acquire lock: %v", err)
-		}
-
-		// Try to acquire again
-		f2, err := acquireLedgerLock(historyPath + ".lock")
-		if err == nil {
-			_ = f2.Close()
-			t.Error("Should not be able to acquire lock again")
-		}
-
-		ls.releaseLedgerLock(historyPath, f)
-
-		// Should be able to acquire now
-		f3, err := acquireLedgerLock(historyPath + ".lock")
-		if err != nil {
-			t.Errorf("Failed to acquire lock after release: %v", err)
-		}
-		ls.releaseLedgerLock(historyPath, f3)
-	})
+	// Should be able to acquire now
+	f3, err := acquireLedgerLock(historyPath + ".lock")
+	if err != nil {
+		t.Errorf("Failed to acquire lock after release: %v", err)
+	}
+	ls.releaseLedgerLock(historyPath, f3)
 }
 
 func TestMetricsManager_LoadHistory_Corrupted(t *testing.T) {

--- a/internal/infrastructure/telemetry/ledger_recovery_test.go
+++ b/internal/infrastructure/telemetry/ledger_recovery_test.go
@@ -256,33 +256,21 @@ func TestMergeRecords_DuplicateKey(t *testing.T) {
 		t.Errorf("expected 2 merged records, got %d", len(merged))
 	}
 
-	// Find the "same-session" record and verify new wins.
-	found := false
-	for _, r := range merged {
-		if r.Session == "same-session" {
-			found = true
-			if r.TotalCost != 2.0 {
-				t.Errorf("expected TotalCost 2.0 for same-session (new wins), got %f", r.TotalCost)
-			}
-		}
-	}
-	if !found {
-		t.Error("expected 'same-session' in merged result")
-	}
+	assertRecordInMerged(t, merged, "same-session", 2.0)
+	assertRecordInMerged(t, merged, "unique-old", 0.5)
+}
 
-	// Verify unique-old is still there.
-	foundOld := false
-	for _, r := range merged {
-		if r.Session == "unique-old" {
-			foundOld = true
-			if r.TotalCost != 0.5 {
-				t.Errorf("expected TotalCost 0.5 for unique-old, got %f", r.TotalCost)
+func assertRecordInMerged(t *testing.T, records []sessionCostRecord, session string, wantCost float64) {
+	t.Helper()
+	for _, r := range records {
+		if r.Session == session {
+			if r.TotalCost != wantCost {
+				t.Errorf("expected TotalCost %f for %s, got %f", wantCost, session, r.TotalCost)
 			}
+			return
 		}
 	}
-	if !foundOld {
-		t.Error("expected 'unique-old' in merged result")
-	}
+	t.Errorf("expected %q in merged result", session)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/telemetry/metrics_util_test.go
+++ b/internal/infrastructure/telemetry/metrics_util_test.go
@@ -257,68 +257,64 @@ func TestCalculate_UnifiedOutputRate(t *testing.T) {
 	}
 }
 
-func TestGetPricing(t *testing.T) {
+func TestGetPricing_LoadFromFile(t *testing.T) {
 	t.Parallel()
-
-	t.Run("Load from file", func(t *testing.T) {
-		t.Parallel()
-		tmpDir := t.TempDir()
-		assetsDir := filepath.Join(tmpDir, "assets")
-		if err := os.MkdirAll(assetsDir, 0755); err != nil {
-			t.Fatalf("failed to create assets dir: %v", err)
-		}
-		outputDir := filepath.Join(tmpDir, "output")
-		pricingFile := filepath.Join(assetsDir, "pricing.json")
-		content := `{
-			"updated_at": "2026-02-03T12:00:00Z",
-			"models": {
-				"test-model": {
-					"hit": 1.0,
-					"miss": 2.0,
-					"comp": 3.0
-				}
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	outputDir := filepath.Join(tmpDir, "output")
+	pricingFile := filepath.Join(assetsDir, "pricing.json")
+	content := `{
+		"updated_at": "2026-02-03T12:00:00Z",
+		"models": {
+			"test-model": {
+				"hit": 1.0,
+				"miss": 2.0,
+				"comp": 3.0
 			}
-		}`
-		if err := os.WriteFile(pricingFile, []byte(content), 0644); err != nil {
-			t.Fatalf("failed to write pricing file: %v", err)
 		}
+	}`
+	if err := os.WriteFile(pricingFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write pricing file: %v", err)
+	}
 
-		pd := GetPricing(context.Background(), nil, outputDir)
-		if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
-			t.Errorf("expected UpdatedAt 2026-02-03T12:00:00Z, got %q", pd.UpdatedAt)
-		}
-		if mp, ok := pd.Models["test-model"]; !ok || mp.Hit != 1.0 {
-			t.Errorf("expected test-model hit 1.0, got %v", mp.Hit)
-		}
-	})
+	pd := GetPricing(context.Background(), nil, outputDir)
+	if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
+		t.Errorf("expected UpdatedAt 2026-02-03T12:00:00Z, got %q", pd.UpdatedAt)
+	}
+	if pd.Models["test-model"].Hit != 1.0 {
+		t.Errorf("expected test-model hit 1.0, got %v", pd.Models["test-model"].Hit)
+	}
+}
 
-	t.Run("Fallback on missing file", func(t *testing.T) {
-		t.Parallel()
-		anotherDir := t.TempDir()
-		pd := GetPricing(context.Background(), nil, filepath.Join(anotherDir, "output"))
-		if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
-			t.Errorf("expected hardcoded fallback, got %q", pd.UpdatedAt)
-		}
-	})
+func TestGetPricing_FallbackOnMissingFile(t *testing.T) {
+	t.Parallel()
+	anotherDir := t.TempDir()
+	pd := GetPricing(context.Background(), nil, filepath.Join(anotherDir, "output"))
+	if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
+		t.Errorf("expected hardcoded fallback, got %q", pd.UpdatedAt)
+	}
+}
 
-	t.Run("Fallback on invalid JSON", func(t *testing.T) {
-		t.Parallel()
-		tmpDir := t.TempDir()
-		assetsDir := filepath.Join(tmpDir, "assets")
-		if err := os.MkdirAll(assetsDir, 0755); err != nil {
-			t.Fatalf("failed to create assets dir: %v", err)
-		}
-		outputDir := filepath.Join(tmpDir, "output")
-		pricingFile := filepath.Join(assetsDir, "pricing.json")
-		if err := os.WriteFile(pricingFile, []byte("invalid json"), 0644); err != nil {
-			t.Fatalf("failed to write invalid pricing file: %v", err)
-		}
+func TestGetPricing_FallbackOnInvalidJSON(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	outputDir := filepath.Join(tmpDir, "output")
+	pricingFile := filepath.Join(assetsDir, "pricing.json")
+	if err := os.WriteFile(pricingFile, []byte("invalid json"), 0644); err != nil {
+		t.Fatalf("failed to write invalid pricing file: %v", err)
+	}
 
-		pd := GetPricing(context.Background(), nil, outputDir)
-		if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
-			t.Errorf("expected hardcoded fallback on invalid JSON, got %q", pd.UpdatedAt)
-		}
-	})
+	pd := GetPricing(context.Background(), nil, outputDir)
+	if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
+		t.Errorf("expected hardcoded fallback on invalid JSON, got %q", pd.UpdatedAt)
+	}
 }
 
 func TestProcessLogLine_SkipsSummaryLine(t *testing.T) {

--- a/internal/infrastructure/telemetry/stale_lock_test.go
+++ b/internal/infrastructure/telemetry/stale_lock_test.go
@@ -448,6 +448,12 @@ func TestMetricsManager_AcquireLedgerLock_StaleLock_RemoveSucceeds(t *testing.T)
 		t.Fatal(err)
 	}
 
+	assertLockAcquiredAndReleased(t, lockPath)
+}
+
+func assertLockAcquiredAndReleased(t *testing.T, lockPath string) {
+	t.Helper()
+
 	f, err := acquireLedgerLock(lockPath)
 	if err != nil {
 		t.Fatalf("expected no error, got: %v", err)


### PR DESCRIPTION
Closes #955.

## Summary
Pre-emptively reduced cyclomatic complexity of 11 infrastructure test functions from 10 to ≤5 across 6 packages (persistence, telemetry, history, security, auth, registry). Applied two refactoring strategies:

- **[SUBTEST-PROMOTE]**: Promoted `t.Run` subtests to standalone `TestXxx` functions with `t.Parallel()` (8 functions)
- **[TABLE-EXTRACT]**: Extracted inline assertion logic into `t.Helper()` functions (3 functions)

No production code changed — test-only refactoring.

## Verification
| Check | Status |
|-------|--------|
| Build | ✅ PASS |
| Lint (golangci-lint) | ✅ 0 issues |
| Vulnerability check | ✅ No vulnerabilities |
| Tests (no race) | ✅ 21/21 packages PASS |
| Tests (race) | ✅ 21/21 packages PASS |
| Complexity (>10 alerts) | ✅ 0 alerts |
| fmt + tidy | ✅ Clean |
