### PR TITLE
fix(concurrency): add OnceWithRetry, replace RWMutex in archive reader (#969)

### DIFF
--- a/internal/infrastructure/history/archive_reader.go
+++ b/internal/infrastructure/history/archive_reader.go
@@ -9,11 +9,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gosharplite/tell-me-go/internal/pkg/concurrency"
 	"io"
 	"os"
 	"sort"
 	"strings"
-	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -24,9 +24,8 @@ import (
 type jsonlArchiveReader struct {
 	fs          persistence.FileSystem
 	archivePath string
-	mu          sync.RWMutex
+	indexOnce   concurrency.OnceWithRetry
 	index       []int64 // offsets of each line
-	indexed     bool
 }
 
 // NewJSONLArchiveReader creates a new JSONLArchiveReader.
@@ -57,14 +56,10 @@ func (r *jsonlArchiveReader) ReadPrevious(ctx context.Context, limit int, offset
 		return nil, 0, err
 	}
 
-	r.mu.RLock()
 	if len(r.index) == 0 {
-		r.mu.RUnlock()
 		return nil, 0, nil
 	}
 
-	// Find the current index for the offset
-	// If offset is -1 or greater than file size, we start from the last line.
 	targetIdx := len(r.index)
 	if offset != -1 {
 		targetIdx = sort.Search(len(r.index), func(i int) bool {
@@ -73,7 +68,6 @@ func (r *jsonlArchiveReader) ReadPrevious(ctx context.Context, limit int, offset
 	}
 
 	if targetIdx == 0 {
-		r.mu.RUnlock()
 		return nil, 0, nil
 	}
 
@@ -84,7 +78,6 @@ func (r *jsonlArchiveReader) ReadPrevious(ctx context.Context, limit int, offset
 
 	startOffset := r.index[startIdx]
 	limitToRead := targetIdx - startIdx
-	r.mu.RUnlock()
 
 	dtos, _, err := r.readPageInternal(ctx, limitToRead, startOffset)
 	if err != nil {
@@ -95,24 +88,9 @@ func (r *jsonlArchiveReader) ReadPrevious(ctx context.Context, limit int, offset
 }
 
 func (r *jsonlArchiveReader) ensureIndex(ctx context.Context) error {
-	r.mu.RLock()
-	if r.indexed {
-		r.mu.RUnlock()
-		return nil
-	}
-	r.mu.RUnlock()
-
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.indexed {
-		return nil
-	}
-
-	if err := r.buildIndex(ctx); err != nil {
-		return err // Do not cache transient errors
-	}
-	r.indexed = true
-	return nil
+	return r.indexOnce.Do(func() error {
+		return r.buildIndex(ctx)
+	})
 }
 
 // readLineForIndex reads one complete line from the reader, handling lines

--- a/internal/infrastructure/history/archive_reader_error_test.go
+++ b/internal/infrastructure/history/archive_reader_error_test.go
@@ -61,25 +61,38 @@ func TestJSONLArchiveReader_ReadPage_NonErrNotExistError(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Gap 9 — ensureIndex double-check locking (fast path + double-check branches)
-// Code path: archive_reader.go L104-115
-//   r.mu.RLock() → r.indexed is true → return nil  (fast path)
-//   r.mu.Lock()   → r.indexed is true → return nil  (double-check)
+// Gap 9 — ensureIndex fast path after OnceWithRetry success
+// Code path: archive_reader.go ensureIndex → indexOnce.Do → done.Load()
+//   First call primes OnceWithRetry, second call hits lock-free fast path
 // ---------------------------------------------------------------------------
 
 func TestJSONLArchiveReader_EnsureIndex_AlreadyIndexed(t *testing.T) {
-	reader := &jsonlArchiveReader{
-		indexed: true,
-		index:   []int64{0, 100, 200},
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "archive.jsonl")
+
+	baseFS := persistence.NewOSFileSystem()
+	// Seed with valid JSONL so ensureIndex succeeds
+	if err := baseFS.WriteFile(context.Background(), archivePath,
+		[]byte(`{"role":"user","parts":[{"text":"hello"}]}`+"\n"), 0644); err != nil {
+		t.Fatalf("failed to seed archive: %v", err)
 	}
 
+	reader := &jsonlArchiveReader{
+		fs:          baseFS,
+		archivePath: archivePath,
+	}
+
+	// Prime the OnceWithRetry: first call builds the index
 	err := reader.ensureIndex(context.Background())
+	if err != nil {
+		t.Fatalf("expected nil error on first ensureIndex, got %v", err)
+	}
+
+	// Second call hits the fast path (lock-free atomic check)
+	err = reader.ensureIndex(context.Background())
 	if err != nil {
 		t.Errorf("expected nil error when already indexed (fast path), got %v", err)
 	}
-
-	// The double-check branch under exclusive lock is also exercised
-	// because the RLock sees indexed=true and returns immediately.
 }
 
 // ---------------------------------------------------------------------------
@@ -187,10 +200,10 @@ func TestJSONLArchiveReader_ReadPageInternal_ContextCancelled(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// Gap 3 (Issue #949) — ensureIndex double-check locking under exclusive lock
-// Code path: archive_reader.go L107-109
-//   defer r.mu.Unlock()
-//   if r.indexed { return nil }  ← UNCOVERED (double-check after acquiring Lock)
+// Gap 3 (Issue #949) — OnceWithRetry concurrent deduplication
+// Code path: concurrency/once.go Do() → mu.Lock() + double-check done.Load()
+//   Two goroutines enter Do() simultaneously; Mutex serializes them;
+//   second goroutine observes done==true after first completes
 // ---------------------------------------------------------------------------
 
 func TestJSONLArchiveReader_EnsureIndex_DoubleCheckLocked(t *testing.T) {
@@ -245,8 +258,8 @@ func TestJSONLArchiveReader_EnsureIndex_DoubleCheckLocked(t *testing.T) {
 	}
 
 	// Both calls should succeed and the index should be built
-	if !reader.indexed {
-		t.Error("expected reader to be indexed after concurrent ensureIndex calls")
+	if len(reader.index) == 0 {
+		t.Error("expected reader to have a non-empty index after concurrent ensureIndex calls")
 	}
 	if len(reader.index) != 1000 { // 1000 lines
 		t.Errorf("expected 1000 index entries, got %d", len(reader.index))

--- a/internal/pkg/concurrency/once.go
+++ b/internal/pkg/concurrency/once.go
@@ -1,0 +1,50 @@
+// Package concurrency provides reusable synchronization primitives.
+package concurrency
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// OnceWithRetry allows retrying a function on error while deduplicating
+// concurrent executions. It provides a lock-free fast path for maximum
+// read performance after successful execution.
+//
+// Unlike sync.Once, OnceWithRetry does not cache errors. If the function
+// passed to Do returns an error, the error is propagated to the caller
+// without marking the operation as complete. Subsequent calls to Do will
+// re-execute the function.
+type OnceWithRetry struct {
+	done atomic.Bool
+	mu   sync.Mutex
+}
+
+// Do calls the function f if and only if Do has not yet completed
+// successfully. If f returns an error, Do returns that error and does
+// not mark the operation as complete — subsequent calls will retry f.
+//
+// Once a call to f returns nil, all future calls to Do return nil
+// immediately via a lock-free atomic load of the done flag.
+func (o *OnceWithRetry) Do(f func() error) error {
+	// Fast path: lock-free atomic check
+	if o.done.Load() {
+		return nil
+	}
+
+	// Slow path: exclusive lock and double-check
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.done.Load() {
+		return nil
+	}
+
+	if err := f(); err != nil {
+		return err // Propagate error without caching
+	}
+
+	// Memory barrier: guarantees visibility of external state mutations
+	// prior to this store (Go memory model § happens-before)
+	o.done.Store(true)
+	return nil
+}

--- a/internal/pkg/concurrency/once_test.go
+++ b/internal/pkg/concurrency/once_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package concurrency
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// TestOnceWithRetry_Success — Single call succeeds, function executes exactly
+// once. A second Do() returns nil without re-executing the function.
+// ---------------------------------------------------------------------------
+
+func TestOnceWithRetry_Success(t *testing.T) {
+	var o OnceWithRetry
+	var calls atomic.Int32
+
+	err := o.Do(func() error {
+		calls.Add(1)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("first Do() returned error: %v", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 call, got %d", n)
+	}
+	if !o.done.Load() {
+		t.Error("expected done to be true after successful Do")
+	}
+
+	// Second call — fast path, function must NOT execute
+	err = o.Do(func() error {
+		calls.Add(1)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("second Do() returned error: %v", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected 1 call after two Do() invocations, got %d", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestOnceWithRetry_ConcurrentDedup — 10 goroutines invoke Do() concurrently.
+// The inner function executes exactly once and all callers get nil.
+// ---------------------------------------------------------------------------
+
+func TestOnceWithRetry_ConcurrentDedup(t *testing.T) {
+	var o OnceWithRetry
+	var calls atomic.Int32
+
+	const numGoroutines = 10
+
+	var start sync.WaitGroup
+	start.Add(numGoroutines)
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+
+	errs := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		go func() {
+			defer wg.Done()
+			start.Done()
+			start.Wait() // Barrier: all goroutines enter Do() at ~same time
+			errs <- o.Do(func() error {
+				calls.Add(1)
+				time.Sleep(10 * time.Millisecond) // ensure overlap
+				return nil
+			})
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	if n := calls.Load(); n != 1 {
+		t.Errorf("expected exactly 1 call, got %d", n)
+	}
+
+	for err := range errs {
+		if err != nil {
+			t.Errorf("expected nil from Do(), got %v", err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestOnceWithRetry_ErrorPropagation — Do() returns the function's error and
+// leaves done=false, allowing retry.
+// ---------------------------------------------------------------------------
+
+func TestOnceWithRetry_ErrorPropagation(t *testing.T) {
+	var o OnceWithRetry
+	sentinel := errors.New("transient")
+
+	err := o.Do(func() error {
+		return sentinel
+	})
+
+	if !errors.Is(err, sentinel) {
+		t.Errorf("expected sentinel error, got %v", err)
+	}
+	if o.done.Load() {
+		t.Error("expected done to remain false after error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestOnceWithRetry_RetryAfterError — First Do() errors, second Do() succeeds.
+// Both function invocations execute, and done is true after the second call.
+// ---------------------------------------------------------------------------
+
+func TestOnceWithRetry_RetryAfterError(t *testing.T) {
+	var o OnceWithRetry
+	var calls atomic.Int32
+	sentinel := errors.New("first attempt failed")
+
+	// First call: error
+	err := o.Do(func() error {
+		calls.Add(1)
+		return sentinel
+	})
+
+	if !errors.Is(err, sentinel) {
+		t.Errorf("first Do(): expected sentinel error, got %v", err)
+	}
+	if n := calls.Load(); n != 1 {
+		t.Errorf("first Do(): expected 1 call, got %d", n)
+	}
+	if o.done.Load() {
+		t.Error("expected done to be false after error")
+	}
+
+	// Second call: success
+	err = o.Do(func() error {
+		calls.Add(1)
+		return nil
+	})
+
+	if err != nil {
+		t.Fatalf("second Do(): expected nil, got %v", err)
+	}
+	if n := calls.Load(); n != 2 {
+		t.Errorf("second Do(): expected 2 calls total, got %d", n)
+	}
+	if !o.done.Load() {
+		t.Error("expected done to be true after successful retry")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestOnceWithRetry_FastPath — After successful Do(), subsequent calls return
+// nil via the lock-free atomic fast path without executing the function.
+// ---------------------------------------------------------------------------
+
+func TestOnceWithRetry_FastPath(t *testing.T) {
+	var o OnceWithRetry
+
+	// Prime the OnceWithRetry: successful execution
+	err := o.Do(func() error {
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("first Do() returned error: %v", err)
+	}
+
+	// Second call: function would panic if executed — proves fast path
+	err = o.Do(func() error {
+		panic("should not be called")
+	})
+	if err != nil {
+		t.Errorf("fast-path Do() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
Closes #969.

## Summary
- Introduced `OnceWithRetry` concurrency primitive in `internal/pkg/concurrency/` — lock-free fast path via `atomic.Bool`, errors not cached (unlike `sync.Once`)
- Refactored `jsonlArchiveReader.ensureIndex` from 18-line double-checked RWMutex to 4-line `r.indexOnce.Do(...)`
- Removed all `RLock`/`RUnlock` from `ReadPrevious` — zero lock overhead on the hot path after index is built
- Updated white-box tests in `archive_reader_error_test.go` for the new field name

## Verification
| Check | Status |
|-------|--------|
| go fmt ./... | PASS |
| go mod tidy | PASS |
| go build ./... | PASS |
| golangci-lint run | PASS (0 issues) |
| verify-architecture | PASS |
| govulncheck | PASS (no vulnerabilities) |
| go test -race ./... | PASS |
| dead-code | PASS (none) |
| coverage (concurrency) | 100% |
| coverage (history) | 99.3% |