### PR TITLE
fix(history): close remaining coverage gaps in archive_reader.go (#971)

### DIFF
--- a/internal/infrastructure/history/archive_reader_error_test.go
+++ b/internal/infrastructure/history/archive_reader_error_test.go
@@ -265,3 +265,130 @@ func TestJSONLArchiveReader_EnsureIndex_DoubleCheckLocked(t *testing.T) {
 		t.Errorf("expected 1000 index entries, got %d", len(reader.index))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// readLines L181-183 — context cancellation during line iteration
+// Code path: archive_reader.go L181-183
+//   if err := r.checkContext(ctx); err != nil { return nil, 0, err }
+//
+// We bypass readPageInternal and call readLines directly with a live *os.File
+// opened via os.Open (not through the FS) so fsRetry doesn't pre-empt the
+// cancellation before the loop begins.
+// ---------------------------------------------------------------------------
+
+func TestJSONLArchiveReader_ReadLines_ContextCancelledMidIteration(t *testing.T) {
+	tmpDir := t.TempDir()
+	archivePath := filepath.Join(tmpDir, "archive.jsonl")
+
+	baseFS := persistence.NewOSFileSystem()
+
+	// Write 3+ lines so the loop enters and hits checkContext
+	if err := baseFS.WriteFile(context.Background(), archivePath,
+		[]byte(
+			`{"role":"user","parts":[{"text":"line1"}]}`+"\n"+
+				`{"role":"model","parts":[{"text":"line2"}]}`+"\n"+
+				`{"role":"user","parts":[{"text":"line3"}]}`+"\n",
+		), 0644); err != nil {
+		t.Fatalf("failed to write archive: %v", err)
+	}
+
+	reader := &jsonlArchiveReader{
+		fs:          baseFS,
+		archivePath: archivePath,
+	}
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		wantErr error
+	}{
+		{
+			name: "canceled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			wantErr: context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+				cancel()
+				return ctx
+			}(),
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			file, err := os.Open(archivePath)
+			if err != nil {
+				t.Fatalf("failed to open archive: %v", err)
+			}
+			defer func() { _ = file.Close() }()
+
+			_, _, err = reader.readLines(tt.ctx, 10, 0, file)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// checkContext L203-204 — ctx.Done() signal handling
+// Code path: archive_reader.go L203-204
+//   case <-ctx.Done(): return ctx.Err()
+// ---------------------------------------------------------------------------
+
+func TestJSONLArchiveReader_CheckContext_Done(t *testing.T) {
+	reader := &jsonlArchiveReader{}
+
+	tests := []struct {
+		name    string
+		ctx     context.Context
+		wantErr error
+	}{
+		{
+			name: "canceled",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				return ctx
+			}(),
+			wantErr: context.Canceled,
+		},
+		{
+			name: "deadline exceeded",
+			ctx: func() context.Context {
+				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+				cancel()
+				return ctx
+			}(),
+			wantErr: context.DeadlineExceeded,
+		},
+		{
+			name:    "not cancelled",
+			ctx:     context.Background(),
+			wantErr: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := reader.checkContext(tt.ctx)
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Errorf("expected nil, got %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("expected %v, got %v", tt.wantErr, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #971.

## Summary
Added two table-driven tests to close the remaining 2 uncovered statements in `archive_reader.go`, bringing file coverage from **98.4% → 100.0%**.

### Changes
- **`TestJSONLArchiveReader_ReadLines_ContextCancelledMidIteration`** — Covers `readLines` L181-183 (context cancellation during line iteration). Bypasses `fsRetry` pre-check by opening files with `os.Open` directly and calling `readLines` with pre-cancelled contexts.
- **`TestJSONLArchiveReader_CheckContext_Done`** — Covers `checkContext` L203-204 (`ctx.Done()` signal handling). Table-driven with `canceled`, `deadline exceeded`, and `not cancelled` cases.

### Acceptance Criteria
| Criterion | Status |
|-----------|--------|
| `archive_reader.go` coverage ≥95% | ✅ **100.0%** |
| No `time.Sleep` in new tests | ✅ Pre-cancelled contexts only |
| `go test -race ./...` | ✅ PASS |
| `golangci-lint` | ✅ 0 issues |

## Verification
| Check | Status |
|-------|--------|
| `go test -race ./internal/infrastructure/history/...` | ✅ PASS (99.6% package coverage) |
| `golangci-lint run ./...` | ✅ 0 issues |
| `readLines` coverage | ✅ 100.0% (was 93.3%) |
| `checkContext` coverage | ✅ 100.0% (was 66.7%) |
| All 17 archive_reader.go functions | ✅ 100.0% |
| `make check-full` (non-race steps) | ✅ All passed |
| `test-race` (pre-existing failure) | ⚠️ Unrelated failure in `internal/agent/executor` |