### PR TITLE
fix(history): add architect-accepted coverage gap comment (#972)

### DIFF
--- a/internal/infrastructure/history/global_prompt_tracker.go
+++ b/internal/infrastructure/history/global_prompt_tracker.go
@@ -353,6 +353,9 @@ func (t *globalPromptTracker) performCompactionPass(ctx context.Context) bool {
 
 	// 2. Prepare compacted data in memory (safe for small threshold)
 	var buf bytes.Buffer
+	// bytes.Buffer.Write never returns an error per the Go spec, and
+	// json.Marshal cannot fail for promptEntry (all fields are string).
+	// Coverage gap accepted by architect — structurally unreachable.
 	if !t.writeCompactedData(&buf, entries) {
 		return false
 	}


### PR DESCRIPTION
Closes #972.

## Summary

Added architect-accepted coverage gap comment for lines 356–358 in `performCompactionPass` (`global_prompt_tracker.go`). This gap is structurally unreachable — `bytes.Buffer.Write` never returns an error per the Go spec, and `json.Marshal` cannot fail for `promptEntry` (all fields are `string`).

The other 7 gaps from the issue were already covered by existing tests or previously documented.

## Verification

| Check | Status |
|-------|--------|
| make check-full | PASS |
| `global_prompt_tracker.go` coverage | 98.6% (≥95%) |
| Package coverage | 99.0% |
| Race detector | Clean |
| No new tests | ✅ (comment only)