### PR TITLE
fix(telemetry): cache external daily cost to eliminate sync disk I/O in GetDailyCost hot path (#977)

### DIFF
--- a/internal/infrastructure/telemetry/metrics_daily_test.go
+++ b/internal/infrastructure/telemetry/metrics_daily_test.go
@@ -5,6 +5,7 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -274,4 +275,201 @@ func TestGetDailyCost_UnmarshalError(t *testing.T) {
 	if got != 12.0 {
 		t.Errorf("expected in-memory cost 12.0 for invalid JSON ledger, got %f", got)
 	}
+}
+
+func TestGetDailyCost_CachedPathAfterFirstCall(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	if err := os.WriteFile(logFile, []byte(`{"model": "test", "prompt_tokens": 100, "response_tokens": 50}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate the ledger with a different session's cost for today.
+	loc := time.FixedZone("UTC-8", -8*3600)
+	now := time.Now().In(loc)
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	records := []sessionCostRecord{
+		{
+			Session:   "mode/other_session.tokens.log",
+			TotalCost: 3.0,
+			Timestamp: now,
+		},
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &sessionCostTracker{
+		totalCost:        2.0,
+		logFile:          logFile,
+		mode:             "mode",
+		currentSessionID: generateSessionID("mode", logFile),
+	}
+
+	// First call: cache is empty, triggers refresh from ledger.
+	first := tracker.GetDailyCost(context.Background())
+	expected := 5.0 // 3.0 (other session) + 2.0 (current)
+	if first != expected {
+		t.Errorf("first GetDailyCost() = %v, want %v", first, expected)
+	}
+
+	// Now remove the ledger file to prove the second call does NOT read from disk.
+	if err := os.Remove(historyPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second call: cached path, should return same value despite missing ledger.
+	second := tracker.GetDailyCost(context.Background())
+	if second != expected {
+		t.Errorf("second GetDailyCost() = %v, want %v (cached, no disk read)", second, expected)
+	}
+
+	// Verify cachedExternalDailyCost is set.
+	tracker.mu.Lock()
+	if tracker.cachedExternalDailyCost != 3.0 {
+		t.Errorf("cachedExternalDailyCost = %v, want 3.0", tracker.cachedExternalDailyCost)
+	}
+	tracker.mu.Unlock()
+}
+
+func TestWarmup_PopulatesDailyCostCache(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	// Write a session log so ensureInitialized() succeeds.
+	if err := os.WriteFile(logFile, []byte(`{"model": "test", "prompt_tokens": 100, "response_tokens": 50}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-populate the ledger.
+	loc := time.FixedZone("UTC-8", -8*3600)
+	now := time.Now().In(loc)
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	records := []sessionCostRecord{
+		{
+			Session:   "mode/other.tokens.log",
+			TotalCost: 7.5,
+			Timestamp: now,
+		},
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &sessionCostTracker{
+		logFile: logFile,
+		mode:    "mode",
+	}
+
+	// Warmup should populate both the stats/totalCost and the daily cache.
+	tracker.Warmup()
+
+	tracker.mu.Lock()
+	if tracker.cachedDate == "" {
+		t.Error("expected cachedDate to be set after Warmup()")
+	}
+	// External cost should be 7.5 (other session) and totalCost from parseUsage.
+	if tracker.cachedExternalDailyCost != 7.5 {
+		t.Errorf("cachedExternalDailyCost = %v, want 7.5", tracker.cachedExternalDailyCost)
+	}
+	tracker.mu.Unlock()
+
+	// GetDailyCost should use the cache (not re-read the ledger).
+	if err := os.Remove(historyPath); err != nil {
+		t.Fatal(err)
+	}
+	daily := tracker.GetDailyCost(context.Background())
+	expected := 7.5 + tracker.totalCost // external + current
+	if daily != expected {
+		t.Errorf("GetDailyCost after Warmup = %v, want %v", daily, expected)
+	}
+}
+
+func TestGetDailyCost_DateRolloverRefreshesCache(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	outputDir := filepath.Join(tempDir, "mode")
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logFile := filepath.Join(outputDir, "tokens.log")
+	if err := os.WriteFile(logFile, []byte(`{"model": "test", "prompt_tokens": 10, "response_tokens": 5}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Ledger: one record for today, one for tomorrow.
+	loc := time.FixedZone("UTC-8", -8*3600)
+	now := time.Now().In(loc)
+	tomorrow := now.Add(24 * time.Hour)
+
+	historyPath := filepath.Join(tempDir, "global_costs.json")
+	records := []sessionCostRecord{
+		{
+			Session:   "mode/today_other.tokens.log",
+			TotalCost: 4.0,
+			Timestamp: now,
+		},
+		{
+			Session:   "mode/tomorrow_other.tokens.log",
+			TotalCost: 99.0,
+			Timestamp: tomorrow,
+		},
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(historyPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &sessionCostTracker{
+		totalCost:        1.0,
+		logFile:          logFile,
+		mode:             "mode",
+		currentSessionID: generateSessionID("mode", logFile),
+	}
+
+	// Prime the cache with yesterday's date so today triggers a refresh.
+	tracker.mu.Lock()
+	tracker.cachedDate = now.Add(-24 * time.Hour).Format("2006-01-02")
+	tracker.cachedExternalDailyCost = 999.0 // stale value
+	tracker.mu.Unlock()
+
+	// GetDailyCost: cachedDate != today, so refresh.
+	daily := tracker.GetDailyCost(context.Background())
+
+	// Should be 4.0 (today_other) + 1.0 (current) = 5.0.
+	// The 99.0 from tomorrow and 999.0 stale cache should be ignored.
+	expected := 5.0
+	if daily != expected {
+		t.Errorf("GetDailyCost() = %v, want %v (date rollover should refresh)", daily, expected)
+	}
+
+	// Verify the cache was updated.
+	tracker.mu.Lock()
+	if tracker.cachedExternalDailyCost != 4.0 {
+		t.Errorf("cachedExternalDailyCost = %v, want 4.0 (refreshed)", tracker.cachedExternalDailyCost)
+	}
+	tracker.mu.Unlock()
 }

--- a/internal/infrastructure/telemetry/metrics_tracker.go
+++ b/internal/infrastructure/telemetry/metrics_tracker.go
@@ -30,6 +30,13 @@ type sessionCostTracker struct {
 	mode      string
 	sm        domain_security.Manager
 	initiated bool
+
+	// cachedExternalDailyCost holds the sum of today's other-session costs from the global ledger.
+	cachedExternalDailyCost float64
+	// cachedDate is the UTC-8 date ("2006-01-02") the cache is valid for; zero-value "" triggers refresh on first use.
+	cachedDate string
+	// currentSessionID is computed once from generateSessionID(t.mode, t.logFile) and set inside ensureInitialized().
+	currentSessionID string
 }
 
 // NewSessionCostTracker creates a new tracker.
@@ -51,6 +58,8 @@ func (t *sessionCostTracker) GetTotalCost(ctx context.Context) float64 {
 }
 
 // GetDailyCost aggregates costs from the global ledger for the current date in UTC-8.
+// Uses a cached external cost to avoid synchronous disk I/O on every invocation.
+// The cache is refreshed when the UTC-8 date changes.
 func (t *sessionCostTracker) GetDailyCost(ctx context.Context) float64 {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -59,17 +68,41 @@ func (t *sessionCostTracker) GetDailyCost(ctx context.Context) float64 {
 		return t.totalCost
 	}
 
+	now := time.Now()
+	loc := time.FixedZone("UTC-8", -8*3600)
+	today := now.In(loc).Format("2006-01-02")
+
+	if t.cachedDate != today {
+		t.refreshExternalDailyCache(now)
+	}
+
+	return t.cachedExternalDailyCost + t.totalCost
+}
+
+// refreshExternalDailyCache reads the global ledger and caches the
+// external (other-session) cost for today's UTC-8 date.
+// Must be called with t.mu held.
+func (t *sessionCostTracker) refreshExternalDailyCache(now time.Time) {
+	loc := time.FixedZone("UTC-8", -8*3600)
+	today := now.In(loc).Format("2006-01-02")
+
+	// Always set cachedDate so we don't retry on every call after a failure.
+	t.cachedDate = today
+
+	if t.logFile == "" {
+		t.cachedExternalDailyCost = 0
+		return
+	}
+
 	globalDir := filepath.Dir(filepath.Dir(t.logFile))
 	historyPath := filepath.Join(globalDir, "global_costs.json")
 
-	// Synchronize access to the global ledger file.
-	// Acquire ledgerMu after t.mu to maintain consistent lock ordering.
 	ledgerMu.Lock()
 	defer ledgerMu.Unlock()
 
-	// If recovery is in progress, return the in-memory cost to avoid blocking or inconsistent reads.
 	if _, recovering := recoveryInProgress.Load(historyPath); recovering {
-		return t.totalCost
+		t.cachedExternalDailyCost = 0
+		return
 	}
 
 	content, err := os.ReadFile(historyPath)
@@ -77,19 +110,23 @@ func (t *sessionCostTracker) GetDailyCost(ctx context.Context) float64 {
 		if !os.IsNotExist(err) {
 			log.Printf("Warning: Failed to read global ledger at %s: %v", historyPath, err)
 		}
-		return t.totalCost
+		t.cachedExternalDailyCost = 0
+		return
 	}
 
 	var history []sessionCostRecord
 	if err := json.Unmarshal(content, &history); err != nil {
 		log.Printf("Warning: Failed to parse global ledger at %s: %v", historyPath, err)
-		return t.totalCost
+		t.cachedExternalDailyCost = 0
+		return
 	}
 
-	// CRITICAL: Must match the ID generated in EstimateCost
-	currentSessionID := generateSessionID(t.mode, t.logFile)
-
-	return t.calculateDailyCost(history, time.Now(), currentSessionID)
+	if t.currentSessionID == "" {
+		t.currentSessionID = generateSessionID(t.mode, t.logFile)
+	}
+	// calculateDailyCost returns external + t.totalCost, so subtract to get external-only.
+	fullDaily := t.calculateDailyCost(history, now, t.currentSessionID)
+	t.cachedExternalDailyCost = fullDaily - t.totalCost
 }
 
 func (t *sessionCostTracker) calculateDailyCost(records []sessionCostRecord, now time.Time, currentSessionID string) float64 {
@@ -141,11 +178,15 @@ func (t *sessionCostTracker) GetStats(ctx context.Context) (domain_pricing.Usage
 	return t.stats, t.totalCost
 }
 
-// Warmup pre-loads the session state from the log file.
+// Warmup pre-loads the session state from the log file and caches
+// the external daily cost from the global ledger.
 func (t *sessionCostTracker) Warmup() {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.ensureInitialized()
+	if t.logFile != "" && t.cachedDate == "" {
+		t.refreshExternalDailyCache(time.Now())
+	}
 }
 
 func (t *sessionCostTracker) ensureInitialized() {
@@ -155,6 +196,7 @@ func (t *sessionCostTracker) ensureInitialized() {
 			t.totalCost = totalCost
 		}
 		t.initiated = true
+		t.currentSessionID = generateSessionID(t.mode, t.logFile)
 	}
 }
 


### PR DESCRIPTION
Closes #977.

## Summary
Replaced synchronous disk I/O in `GetDailyCost` with an O(1) cached-path implementation. Historical (external) daily cost from `global_costs.json` is now cached in `sessionCostTracker` on `Warmup()` or first `GetDailyCost()` call, and refreshed only on UTC-8 date rollover. The hot path in `publishTurnStatus` (called during `PhaseInference` and `PhasePersisting`) no longer acquires `ledgerMu` or reads from the filesystem.

### Changes
- `metrics_tracker.go`: Added `cachedExternalDailyCost`, `cachedDate`, `currentSessionID` fields; extracted `refreshExternalDailyCache` method; simplified `GetDailyCost` to O(1); updated `Warmup()` to eagerly populate the cache
- `metrics_daily_test.go`: Added 3 new tests (cached path, Warmup cache, date rollover refresh)

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint (golangci-lint) | 0 issues |
| vulncheck | No vulnerabilities |
| test (all packages) | PASS |
| test-race | PASS (no races) |
| dead-code | No dead code |
| Test coverage | 99.6% (telemetry package) |
| GetDailyCost coverage | 100.0% |
| Warmup coverage | 100.0% |
| refreshExternalDailyCache coverage | 92.9% |