### PR TITLE
fix(telemetry): release locks before pure computation in getCostSummary (#980)

### DIFF
--- a/internal/infrastructure/telemetry/metrics_summary.go
+++ b/internal/infrastructure/telemetry/metrics_summary.go
@@ -17,17 +17,17 @@ import (
 )
 
 func (m *metricsManager) getCostSummary(ctx context.Context, args costSummaryArgs) (string, error) {
-	m.metricsMu.Lock()
-	defer m.metricsMu.Unlock()
-
-	ledgerMu.Lock()
-	defer ledgerMu.Unlock()
-
 	outputDir := filepath.Dir(m.logFile)
 	globalDir := filepath.Dir(outputDir)
 	historyPath := filepath.Join(globalDir, "global_costs.json")
 
-	history, status, err := m.ensureLedgerReady(ctx, historyPath, globalDir)
+	history, status, err := func() ([]sessionCostRecord, string, error) {
+		m.metricsMu.Lock()
+		defer m.metricsMu.Unlock()
+		ledgerMu.Lock()
+		defer ledgerMu.Unlock()
+		return m.ensureLedgerReady(ctx, historyPath, globalDir)
+	}()
 	if err != nil {
 		return status, err
 	}


### PR DESCRIPTION
Closes #980.

## Summary
Scoped the lock acquisition in `getCostSummary` to cover only the critical section (`ensureLedgerReady`). Path computation (`outputDir`, `globalDir`, `historyPath`) was moved before the locks, and `aggregateCosts`/`formatSummaryTable` now execute outside the critical section using an anonymous function scope for lock management — idiomatic Go for reducing lock hold duration.

## Changes
- `internal/infrastructure/telemetry/metrics_summary.go`: Wrapped lock acquisition in anonymous function; moved path computation before locks

## Verification
| Check | Status |
|-------|--------|
| fmt, tidy, build | PASS |
| lint (golangci-lint) | PASS (0 issues) |
| verify-architecture | PASS |
| vulncheck | PASS (0 CVEs) |
| test (all packages) | PASS |
| dead-code | PASS |
| test-race (package-by-package) | PASS |
| test-coverage (telemetry) | 99.6% |
