### PR TITLE
fix(telemetry): replace log.Printf with slog.Warn in metrics and metrics_cost (#982)

### DIFF
--- a/internal/infrastructure/telemetry/log_trace_write_error_test.go
+++ b/internal/infrastructure/telemetry/log_trace_write_error_test.go
@@ -66,7 +66,7 @@ func TestLogTrace_CloseError_Mock(t *testing.T) {
 	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
 	logTrace(context.Background(), traceFile, trace)
 
-	assert.Contains(t, logBuf.String(), "Warning: Failed to close trace file")
+	assert.Contains(t, logBuf.String(), "WARN failed to close trace file")
 	assert.Contains(t, logBuf.String(), "injected close error")
 }
 
@@ -90,6 +90,6 @@ func TestLogTrace_MarshalError(t *testing.T) {
 	trace := &domain_telemetry.TurnTrace{FinalStatus: "test"}
 	logTrace(context.Background(), traceFile, trace)
 
-	assert.Contains(t, logBuf.String(), "Warning: Failed to marshal TurnTrace")
+	assert.Contains(t, logBuf.String(), "WARN failed to marshal TurnTrace")
 	assert.Contains(t, logBuf.String(), "injected marshal error")
 }

--- a/internal/infrastructure/telemetry/metrics.go
+++ b/internal/infrastructure/telemetry/metrics.go
@@ -8,7 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"sync"
@@ -236,7 +236,8 @@ func appendSummaryToLog(logPath string, usage domain_pricing.UsageStats, totalCo
 // without interrupting the caller. Extracted for testability.
 func (m *metricsManager) recordCostSilently(ctx context.Context) {
 	if _, err := m.EstimateCost(ctx, true, ""); err != nil {
-		log.Printf("Warning: Failed to record cost before summary: %v", err)
+		slog.Warn("failed to record cost before summary",
+			slog.Any("error", err))
 	}
 }
 
@@ -261,24 +262,31 @@ func logTrace(ctx context.Context, traceFile string, trace *domain_telemetry.Tur
 
 	data, err := jsonMarshal(trace)
 	if err != nil {
-		log.Printf("Warning: Failed to marshal TurnTrace: %v", err)
+		slog.Warn("failed to marshal TurnTrace",
+			slog.Any("error", err))
 		return
 	}
 
 	// 2. Use context-aware AtomicWrite if available or at least check context before I/O
 	wc, err := openTraceFile(traceFile)
 	if err != nil {
-		log.Printf("Warning: Failed to open trace file %s: %v", traceFile, err)
+		slog.Warn("failed to open trace file",
+			slog.String("path", traceFile),
+			slog.Any("error", err))
 		return
 	}
 	defer func() {
 		if cerr := wc.Close(); cerr != nil {
-			log.Printf("Warning: Failed to close trace file %s: %v", traceFile, cerr)
+			slog.Warn("failed to close trace file",
+				slog.String("path", traceFile),
+				slog.Any("error", cerr))
 		}
 	}()
 
 	if _, err := wc.Write(append(data, '\n')); err != nil {
-		log.Printf("Warning: Failed to write to trace file %s: %v", traceFile, err)
+		slog.Warn("failed to write to trace file",
+			slog.String("path", traceFile),
+			slog.Any("error", err))
 	}
 }
 

--- a/internal/infrastructure/telemetry/metrics_cost.go
+++ b/internal/infrastructure/telemetry/metrics_cost.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -33,7 +33,9 @@ func (m *metricsManager) recordCost(ctx context.Context, outputDir string, mode 
 	// 1. Acquire simple file-based lock (with stale lock protection)
 	lock, err := acquireLedgerLock(lockPath)
 	if err != nil {
-		log.Printf("Warning: Failed to acquire ledger lock (contention) for %s: %v", lockPath, err)
+		slog.Warn("failed to acquire ledger lock (contention)",
+			slog.String("path", lockPath),
+			slog.Any("error", err))
 		return
 	}
 	defer func() {
@@ -49,9 +51,12 @@ func (m *metricsManager) loadHistory(ctx context.Context, historyPath, globalDir
 	var history []sessionCostRecord
 	if content, err := os.ReadFile(historyPath); err == nil {
 		if err := json.Unmarshal(content, &history); err != nil {
-			log.Printf("Warning: Failed to parse ledger %s: %v. Backing up and starting fresh.", historyPath, err)
+			slog.Warn("failed to parse ledger, backing up and starting fresh",
+				slog.String("path", historyPath),
+				slog.Any("error", err))
 			if err := os.Rename(historyPath, historyPath+".bak"); err != nil {
-				log.Printf("Warning: Failed to backup corrupted ledger: %v", err)
+				slog.Warn("failed to backup corrupted ledger",
+					slog.Any("error", err))
 			}
 			return []sessionCostRecord{}
 		}
@@ -80,11 +85,15 @@ func (m *metricsManager) updateLedgerHistory(ctx context.Context, historyPath, g
 	// Write back atomically
 	bytes, err := json.Marshal(history)
 	if err != nil {
-		log.Printf("Warning: Failed to marshal ledger for %s: %v", historyPath, err)
+		slog.Warn("failed to marshal ledger",
+			slog.String("path", historyPath),
+			slog.Any("error", err))
 		return
 	}
 	if err := persistence.AtomicWrite(ctx, &persistence.OSFileSystem{}, historyPath, bytes, 0644); err != nil {
-		log.Printf("Warning: Failed to write ledger %s: %v", historyPath, err)
+		slog.Warn("failed to write ledger",
+			slog.String("path", historyPath),
+			slog.Any("error", err))
 	}
 }
 

--- a/internal/infrastructure/telemetry/metrics_summary_error_gaps_test.go
+++ b/internal/infrastructure/telemetry/metrics_summary_error_gaps_test.go
@@ -262,6 +262,6 @@ func TestGetCostSummary_SilentCostUpdateWarning(t *testing.T) {
 
 	m.recordCostSilently(context.Background())
 
-	assert.Contains(t, logBuf.String(), "Warning: Failed to record cost before summary")
+	assert.Contains(t, logBuf.String(), "WARN failed to record cost before summary")
 	assert.Contains(t, logBuf.String(), "path not safe")
 }


### PR DESCRIPTION
Closes #982.

## Summary
Replaced all 10 bare `log.Printf` calls with structured `slog.Warn` in `metrics.go` (5 calls) and `metrics_cost.go` (5 calls). This is the same pattern already applied in `ledger.go` (#981). Updated 3 test assertions to match `slog.Warn` output format.

## Changes
- `metrics.go`: 5 `log.Printf` → `slog.Warn`, removed `"log"` import, added `"log/slog"`
- `metrics_cost.go`: 5 `log.Printf` → `slog.Warn`, removed `"log"` import, added `"log/slog"`
- `log_trace_write_error_test.go`: 2 assertion updates (`"Warning:"` → `"WARN"`)
- `metrics_summary_error_gaps_test.go`: 1 assertion update

## Verification
| Check | Status |
|-------|--------|
| `go fmt` | PASS |
| `go mod tidy` | PASS |
| `go build` | PASS |
| `golangci-lint` | 0 issues |
| `go test -race ./internal/infrastructure/telemetry/...` | PASS |
| `go test -cover ./internal/infrastructure/telemetry/...` | 99.6% |
| `govulncheck` | No vulnerabilities |
