### PR TITLE
fix(orchestrator): reduce costtracker mutex acquisitions from 3 to 2 in publishTurnStatus (#979)

### DIFF
--- a/internal/agent/orchestrator/middleware.go
+++ b/internal/agent/orchestrator/middleware.go
@@ -13,6 +13,7 @@ import (
 	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 )
 
 const LoopWarning = "SYSTEM WARNING: Infinite loop detected. You are repeating the exact same tool call or response. The previous action was aborted. Please analyze your previous steps and try a DIFFERENT tool or strategy."
@@ -58,9 +59,9 @@ func (e *Engine) publishTurnStatus(ctx context.Context, Turn *Turn, isPostCall b
 	var dailyCost float64
 	var totalM, totalH, totalO int64
 	if Turn.CostTracker != nil {
-		cost = Turn.CostTracker.GetTotalCost(ctx)
+		var stats domain_pricing.UsageStats
+		stats, cost = Turn.CostTracker.GetStats(ctx)
 		dailyCost = Turn.CostTracker.GetDailyCost(ctx)
-		stats, _ := Turn.CostTracker.GetStats(ctx)
 		totalM = stats.PromptTokens - stats.CachedTokens
 		totalH = stats.CachedTokens
 		totalO = stats.ResponseTokens + stats.ThinkingTokens

--- a/internal/agent/orchestrator/middleware_test.go
+++ b/internal/agent/orchestrator/middleware_test.go
@@ -524,7 +524,7 @@ func TestPublishTurnStatus_WithCostTracker(t *testing.T) {
 	}
 
 	// Must not panic. The CostTracker branch will execute, calling
-	// GetTotalCost, GetDailyCost, and GetStats on the mock.
+	// GetStats and GetDailyCost on the mock.
 	assert.NotPanics(t, func() {
 		engine.publishTurnStatus(context.Background(), turn, false, false)
 	})
@@ -533,8 +533,8 @@ func TestPublishTurnStatus_WithCostTracker(t *testing.T) {
 	found := false
 	for _, e := range bus.GetEvents() {
 		if evt, ok := e.(events.TurnStatusEvent); ok {
-			// MockCostTracker returns GetTotalCost → 0.05, GetDailyCost → 0.05,
-			// GetStats → (UsageStats{}, 0.05) — UsageStats fields are all zero.
+			// MockCostTracker returns GetStats → (UsageStats{}, 0.05), GetDailyCost → 0.05,
+			// — UsageStats fields are all zero.
 			assert.Equal(t, 0.05, evt.Status.SessionCost)
 			assert.Equal(t, 0.05, evt.Status.DailyCost)
 			assert.Equal(t, int64(0), evt.Status.TotalM)


### PR DESCRIPTION
Closes #979.

## Summary
Eliminated the redundant `GetTotalCost` call in `publishTurnStatus` (`internal/agent/orchestrator/middleware.go`). The hot path now sources `cost` from the second return value of `GetStats` instead of a separate `GetTotalCost` call, reducing mutex acquisitions per status event from 3 to 2 (33% reduction).

### Changes
- `middleware.go`: Replaced `cost = GetTotalCost()` + `stats, _ = GetStats()` with `stats, cost = GetStats()`
- `middleware_test.go`: Updated comments to reflect the dual-call pattern

### Acceptance Criteria
| Criterion | Status |
|-----------|--------|
| `GetStats` called once instead of `GetTotalCost` + `GetStats` | ✅ |
| `cost` sourced from `GetStats` return value | ✅ |
| All orchestrator middleware tests pass | ✅ |
| No change to `CostTracker` interface | ✅ |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint | 0 issues |
| test-race | PASS |
| test-coverage | >90% |