### PR TITLE
fix(executor): decompose failRemainingTasks to reduce cyclomatic complexity (#986)

### DIFF
--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -114,6 +114,37 @@ func applyGenericErrorHandling(result tools.ToolResult, call *llm.FunctionCall, 
 	return result
 }
 
+// buildSkippedResult constructs a ToolResult for a task that was skipped
+// due to plan halting (serial failure, context cancellation, etc.).
+// When err is non-nil, both Text and Error include the error detail.
+func buildSkippedResult(reason string, err error) tools.ToolResult {
+	if err != nil {
+		return tools.ToolResult{
+			Text:  fmt.Sprintf("%s: %v", reason, err),
+			Error: fmt.Errorf("%s: %w", reason, err),
+		}
+	}
+	return tools.ToolResult{Text: reason}
+}
+
+// isTriggerTask returns true when taskIdx is the task that triggered plan
+// halting in the halting batch — i.e., it is at or before skipTaskIdx within
+// startBatchIdx. This task's existing result must be preserved.
+func isTriggerTask(batchIdx, taskIdx, startBatchIdx, skipTaskIdx int) bool {
+	return batchIdx == startBatchIdx && taskIdx <= skipTaskIdx
+}
+
+// shouldSkipTask returns true when a task in failRemainingTasks should be
+// skipped rather than overwritten with an error result. A task is skipped
+// if it's the trigger task within the halting batch, or if its result slot
+// has already been filled.
+func shouldSkipTask(batchIdx, taskIdx, startBatchIdx, skipTaskIdx int, results []tools.ToolResult) bool {
+	if isTriggerTask(batchIdx, taskIdx, startBatchIdx, skipTaskIdx) {
+		return true
+	}
+	return results[taskIdx].Text != "" || results[taskIdx].Error != nil
+}
+
 func newDefaultToolPipeline(
 	registry tools.Registry,
 	sm domain_security.Manager,
@@ -418,7 +449,7 @@ func (e *Dispatcher) runExecutionPlan(ctx context.Context, calls []*llm.Function
 func (e *Dispatcher) checkPreconditions(ctx context.Context, batchIdx int, batches []taskBatch, calls []*llm.FunctionCall, results []tools.ToolResult) error {
 	if err := ctx.Err(); err != nil {
 		e.logger.Debug("Execution plan interrupted", "reason", "context cancelled", "batch_idx", batchIdx)
-		e.failRemainingTasks(batches, batchIdx, -1, calls, results, err, "batch interrupted")
+		e.failRemainingTasks(batches, batchIdx, -1, results, err, "batch interrupted")
 		return err
 	}
 	return nil
@@ -571,7 +602,7 @@ func (e *Dispatcher) evaluateBatchOutcome(ctx context.Context, batchIdx int, bat
 			e.logger.Debug("Serial batch failed or interrupted, halting execution plan",
 				"batch_idx", batchIdx,
 				"tool_name", calls[batch.tasks[0]].Name)
-			e.failRemainingTasks(batches, batchIdx, batch.tasks[0], calls, results, nil, "skipped: execution halted due to previous serial tool error, timeout or cancellation")
+			e.failRemainingTasks(batches, batchIdx, batch.tasks[0], results, nil, "skipped: execution halted due to previous serial tool error, timeout or cancellation")
 
 			if ctx.Err() != nil {
 				return true, ctx.Err()
@@ -581,38 +612,20 @@ func (e *Dispatcher) evaluateBatchOutcome(ctx context.Context, batchIdx int, bat
 	} else {
 		if err := ctx.Err(); err != nil {
 			e.logger.Debug("Parallel batch interrupted, halting execution plan", "batch_idx", batchIdx)
-			e.failRemainingTasks(batches, batchIdx, -1, calls, results, err, "batch interrupted")
+			e.failRemainingTasks(batches, batchIdx, -1, results, err, "batch interrupted")
 			return true, err
 		}
 	}
 	return false, nil
 }
 
-func (e *Dispatcher) failRemainingTasks(batches []taskBatch, startBatchIdx int, skipTaskIdx int, calls []*llm.FunctionCall, results []tools.ToolResult, err error, reason string) {
+func (e *Dispatcher) failRemainingTasks(batches []taskBatch, startBatchIdx int, skipTaskIdx int, results []tools.ToolResult, err error, reason string) {
 	for j := startBatchIdx; j < len(batches); j++ {
-		for _, skippedIdx := range batches[j].tasks {
-			if j == startBatchIdx && skippedIdx <= skipTaskIdx {
+		for _, taskIdx := range batches[j].tasks {
+			if shouldSkipTask(j, taskIdx, startBatchIdx, skipTaskIdx, results) {
 				continue
 			}
-
-			if results[skippedIdx].Text != "" || results[skippedIdx].Error != nil {
-				continue
-			}
-
-			var text string
-			var resErr error
-			if err != nil {
-				text = fmt.Sprintf("%s: %v", reason, err)
-				resErr = fmt.Errorf("%s: %w", reason, err)
-			} else {
-				text = reason
-				resErr = nil
-			}
-
-			results[skippedIdx] = tools.ToolResult{
-				Text:  text,
-				Error: resErr,
-			}
+			results[taskIdx] = buildSkippedResult(reason, err)
 		}
 	}
 }

--- a/internal/agent/executor/executor_test.go
+++ b/internal/agent/executor/executor_test.go
@@ -1156,6 +1156,147 @@ func TestHandleClassifiedError(t *testing.T) {
 	}
 }
 
+func TestBuildSkippedResult(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		reason      string
+		err         error
+		wantTextHas string
+		wantErrNil  bool
+		wantErrIs   error
+	}{
+		{
+			name:        "with_error_wraps_and_includes_detail",
+			reason:      "batch interrupted",
+			err:         errors.New("ctx cancelled"),
+			wantTextHas: "batch interrupted: ctx cancelled",
+			wantErrNil:  false,
+			wantErrIs:   nil, // no sentinel to check, just verify non-nil
+		},
+		{
+			name:        "without_error_text_is_reason_only",
+			reason:      "skipped: execution halted",
+			err:         nil,
+			wantTextHas: "skipped: execution halted",
+			wantErrNil:  true,
+			wantErrIs:   nil,
+		},
+		{
+			name:        "with_error_wraps_with_fmt_errorf_w_verb",
+			reason:      "batch interrupted",
+			err:         context.Canceled,
+			wantTextHas: "batch interrupted: context canceled",
+			wantErrNil:  false,
+			wantErrIs:   context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildSkippedResult(tt.reason, tt.err)
+
+			assert.Contains(t, got.Text, tt.wantTextHas)
+			if tt.wantErrNil {
+				assert.NoError(t, got.Error)
+			} else {
+				assert.Error(t, got.Error)
+				if tt.wantErrIs != nil {
+					assert.ErrorIs(t, got.Error, tt.wantErrIs)
+				}
+			}
+		})
+	}
+}
+
+func TestShouldSkipTask(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		batchIdx      int
+		taskIdx       int
+		startBatchIdx int
+		skipTaskIdx   int
+		results       []tools.ToolResult
+		want          bool
+	}{
+		{
+			name:          "skip_trigger_task_in_halting_batch",
+			batchIdx:      1,
+			taskIdx:       0,
+			startBatchIdx: 1,
+			skipTaskIdx:   0,
+			results:       []tools.ToolResult{{}, {}},
+			want:          true,
+		},
+		{
+			name:          "skip_task_before_skipTaskIdx_in_halting_batch",
+			batchIdx:      1,
+			taskIdx:       0,
+			startBatchIdx: 1,
+			skipTaskIdx:   2,
+			results:       []tools.ToolResult{{}, {}, {}, {}},
+			want:          true,
+		},
+		{
+			name:          "process_task_after_skipTaskIdx_in_halting_batch",
+			batchIdx:      1,
+			taskIdx:       3,
+			startBatchIdx: 1,
+			skipTaskIdx:   2,
+			results:       []tools.ToolResult{{}, {}, {}, {}, {}},
+			want:          false,
+		},
+		{
+			name:          "skip_already_filled_text_in_later_batch",
+			batchIdx:      2,
+			taskIdx:       0,
+			startBatchIdx: 1,
+			skipTaskIdx:   -1,
+			results:       []tools.ToolResult{{Text: "already done"}},
+			want:          true,
+		},
+		{
+			name:          "skip_already_filled_error_in_later_batch",
+			batchIdx:      2,
+			taskIdx:       0,
+			startBatchIdx: 1,
+			skipTaskIdx:   -1,
+			results:       []tools.ToolResult{{Error: errors.New("previous failure")}},
+			want:          true,
+		},
+		{
+			name:          "process_empty_slot_in_later_batch",
+			batchIdx:      2,
+			taskIdx:       0,
+			startBatchIdx: 1,
+			skipTaskIdx:   -1,
+			results:       []tools.ToolResult{{}},
+			want:          false,
+		},
+		{
+			name:          "skipTaskIdx_negative_allows_all_in_start_batch",
+			batchIdx:      0,
+			taskIdx:       0,
+			startBatchIdx: 0,
+			skipTaskIdx:   -1,
+			results:       []tools.ToolResult{{}},
+			want:          false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldSkipTask(tt.batchIdx, tt.taskIdx, tt.startBatchIdx, tt.skipTaskIdx, tt.results)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestAssembleResponse_BinaryData(t *testing.T) {
 	t.Parallel()
 
@@ -1487,7 +1628,6 @@ func TestFailRemainingTasks_SkipsAlreadyFilledSlots(t *testing.T) {
 	t.Run("skips_slot_with_existing_text", func(t *testing.T) {
 		t.Parallel()
 
-		calls := []*llm.FunctionCall{{Name: "a"}, {Name: "b"}}
 		results := []tools.ToolResult{
 			{Text: "already filled", Error: nil}, // slot 0 pre-filled
 			{},                                   // slot 1 empty
@@ -1496,7 +1636,7 @@ func TestFailRemainingTasks_SkipsAlreadyFilledSlots(t *testing.T) {
 			{isSerial: false, tasks: []int{0, 1}},
 		}
 
-		d.failRemainingTasks(batches, 0, -1, calls, results,
+		d.failRemainingTasks(batches, 0, -1, results,
 			errors.New("ctx cancelled"), "batch interrupted")
 
 		// Slot 0 must be UNCHANGED (skip guard fired)
@@ -1511,7 +1651,6 @@ func TestFailRemainingTasks_SkipsAlreadyFilledSlots(t *testing.T) {
 	t.Run("skips_slot_with_existing_error", func(t *testing.T) {
 		t.Parallel()
 
-		calls := []*llm.FunctionCall{{Name: "a"}, {Name: "b"}}
 		results := []tools.ToolResult{
 			{Text: "", Error: errors.New("previous failure")}, // slot 0 has error
 			{}, // slot 1 empty
@@ -1520,7 +1659,7 @@ func TestFailRemainingTasks_SkipsAlreadyFilledSlots(t *testing.T) {
 			{isSerial: false, tasks: []int{0, 1}},
 		}
 
-		d.failRemainingTasks(batches, 0, -1, calls, results,
+		d.failRemainingTasks(batches, 0, -1, results,
 			errors.New("ctx cancelled"), "batch interrupted")
 
 		// Slot 0 must be UNCHANGED


### PR DESCRIPTION
Closes #986.

## Summary
Decomposed `failRemainingTasks` in `internal/agent/executor/executor.go` from cyclomatic complexity 8 to 4 by extracting three focused helper functions:

| Function | Complexity | Role |
|----------|-----------|------|
| `buildSkippedResult` | 2 | Constructs `ToolResult` for skipped tasks (error formatting) |
| `isTriggerTask` | 2 | Checks if a task index is at/before the halting trigger in the start batch |
| `shouldSkipTask` | 3 | Combines trigger-task guard + already-filled-slot guard |
| `failRemainingTasks` | 4 | Orchestrates batch iteration using the helpers above |

Also removed the unused `calls` parameter from `failRemainingTasks` and updated all 5 call sites.

Added table-driven tests: `TestBuildSkippedResult` (3 cases) and `TestShouldSkipTask` (7 cases).

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| executor coverage | 100% |
| `go test -race` | PASS |
| Linter | 0 issues |