### PR TITLE
fix(history): decompose compactLog and performCompactionPass to reduce complexity (#987)

### DIFF
--- a/internal/infrastructure/history/global_prompt_tracker.go
+++ b/internal/infrastructure/history/global_prompt_tracker.go
@@ -310,22 +310,8 @@ func (t *globalPromptTracker) compactLog(ctx context.Context) {
 		if t.performCompactionPass(ctx) {
 			return
 		}
-
-		// If we aborted because of concurrent writes, check if we still need compaction.
-		// If so, loop and try again. This ensures that a burst of appends doesn't
-		// leave the file uncompacted just because the last append arrived while
-		// a previous compaction attempt was finishing.
-		newInfo, err := t.fs.Stat(ctx, t.filepath)
-		if err != nil || newInfo.Size() <= compactionThresholdBytes {
+		if !t.shouldStillCompact(ctx, &backoff) {
 			return
-		}
-
-		// Scalable: Allows immediate exit if the application is shutting down
-		select {
-		case <-ctx.Done():
-			return // Graceful shutdown
-		case <-time.After(backoff):
-			backoff *= 2 // Exponential backoff is safer for I/O locks
 		}
 	}
 }
@@ -338,39 +324,38 @@ func (t *globalPromptTracker) performCompactionPass(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	initialSize := info.Size()
 
-	// 1. Read entries without holding the lock to allow concurrent appends
-	entries, err := t.doLoadTopUniqueEntries(ctx, maxGlobalPrompts)
-	if err != nil || len(entries) == 0 {
+	data, err := t.prepareCompactedEntries(ctx)
+	if err != nil {
+		return false
+	}
+	if len(data) == 0 {
 		return false
 	}
 
-	// Reverse entries to chronological order (oldest first)
-	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
-		entries[i], entries[j] = entries[j], entries[i]
-	}
+	return t.optimisticWrite(ctx, data, info.Size())
+}
 
-	// 2. Prepare compacted data in memory (safe for small threshold)
-	var buf bytes.Buffer
-	// bytes.Buffer.Write never returns an error per the Go spec, and
-	// json.Marshal cannot fail for promptEntry (all fields are string).
-	// Coverage gap accepted by architect — structurally unreachable.
-	if !t.writeCompactedData(&buf, entries) {
-		return false
-	}
-
-	// 3. Final check and swap under exclusive lock
-	t.mu.Lock()
-	defer t.mu.Unlock()
-
-	// Check if file size has changed (meaning Append was called in the background)
+// shouldStillCompact checks whether compaction should be retried after a
+// failed pass. It verifies the file still exceeds the compaction threshold
+// and applies exponential backoff before returning. Returns true if another
+// compaction attempt is warranted.
+func (t *globalPromptTracker) shouldStillCompact(ctx context.Context, backoff *time.Duration) bool {
 	newInfo, err := t.fs.Stat(ctx, t.filepath)
-	if err != nil || newInfo.Size() != initialSize {
-		return false // Abort this pass
+	if err != nil {
+		return false
+	}
+	if newInfo.Size() <= compactionThresholdBytes {
+		return false
 	}
 
-	return t.fs.AtomicWrite(ctx, t.filepath, buf.Bytes(), 0644) == nil
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(*backoff):
+		*backoff *= 2
+		return true
+	}
 }
 
 func (t *globalPromptTracker) writeCompactedData(w io.Writer, entries []promptEntry) bool {
@@ -387,6 +372,52 @@ func (t *globalPromptTracker) writeCompactedData(w io.Writer, entries []promptEn
 		}
 	}
 	return true
+}
+
+// optimisticWrite atomically writes data to the tracker file only if the file
+// size has not changed since initialSize was observed. It acquires the
+// exclusive lock to serialize with concurrent Append calls and re-stats the
+// file under the lock to detect races. Returns true on successful write.
+func (t *globalPromptTracker) optimisticWrite(ctx context.Context, data []byte, initialSize int64) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	info, err := t.fs.Stat(ctx, t.filepath)
+	if err != nil {
+		return false
+	}
+	if info.Size() != initialSize {
+		return false
+	}
+
+	return t.fs.AtomicWrite(ctx, t.filepath, data, 0644) == nil
+}
+
+// prepareCompactedEntries reads the global prompts file, deduplicates entries,
+// reverses them into chronological order (oldest first), and serializes the
+// result as JSONL bytes. It delegates to doLoadTopUniqueEntries for reading
+// and writeCompactedData for serialization. The caller owns the returned byte
+// slice. Returns nil, nil when no entries exist.
+func (t *globalPromptTracker) prepareCompactedEntries(ctx context.Context) ([]byte, error) {
+	entries, err := t.doLoadTopUniqueEntries(ctx, maxGlobalPrompts)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	// Reverse to chronological order (oldest first)
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+
+	var buf bytes.Buffer
+	if !t.writeCompactedData(&buf, entries) {
+		return nil, fmt.Errorf("failed to serialize compacted entries")
+	}
+
+	return buf.Bytes(), nil
 }
 
 func copyFile(ctx context.Context, fs persistence.FileSystem, src, dst string) (err error) {

--- a/internal/infrastructure/history/global_prompt_tracker_test.go
+++ b/internal/infrastructure/history/global_prompt_tracker_test.go
@@ -771,3 +771,246 @@ func TestWriteCompactedData_WriteError(t *testing.T) {
 		t.Fatal("expected writeCompactedData to fail on write error")
 	}
 }
+
+func TestOptimisticWrite_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	// Seed the file with known content
+	initialData := []byte("original\n")
+	if err := baseFS.WriteFile(context.Background(), filePath, initialData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := baseFS.Stat(context.Background(), filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	initialSize := info.Size()
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: filePath,
+	}
+
+	newData := []byte("replaced\n")
+	ok := tracker.optimisticWrite(context.Background(), newData, initialSize)
+	if !ok {
+		t.Fatal("expected optimisticWrite to succeed")
+	}
+
+	// Verify file was replaced
+	content, err := baseFS.ReadFile(context.Background(), filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, newData) {
+		t.Errorf("file content = %q; want %q", content, newData)
+	}
+}
+
+func TestOptimisticWrite_SizeMismatch(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	initialData := []byte("original content\n")
+	if err := baseFS.WriteFile(context.Background(), filePath, initialData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: filePath,
+	}
+
+	// Pass a deliberately wrong initialSize to simulate concurrent modification
+	wrongSize := int64(0)
+	ok := tracker.optimisticWrite(context.Background(), []byte("should not be written"), wrongSize)
+	if ok {
+		t.Fatal("expected optimisticWrite to fail with size mismatch")
+	}
+
+	// Verify original file untouched
+	content, err := baseFS.ReadFile(context.Background(), filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, initialData) {
+		t.Errorf("file was modified unexpectedly: got %q; want %q", content, initialData)
+	}
+}
+
+func TestOptimisticWrite_StatError(t *testing.T) {
+	baseFS := persistence.NewOSFileSystem()
+	mfs := &mockFS{FileSystem: baseFS, statErr: errors.New("injected stat error")}
+
+	tracker := &globalPromptTracker{
+		fs:       mfs,
+		filepath: "/nonexistent/test.jsonl",
+	}
+
+	ok := tracker.optimisticWrite(context.Background(), []byte("data"), 0)
+	if ok {
+		t.Error("expected optimisticWrite to return false on Stat error")
+	}
+}
+
+func TestOptimisticWrite_AtomicWriteError(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	initialData := []byte("original\n")
+	if err := baseFS.WriteFile(context.Background(), filePath, initialData, 0644); err != nil {
+		t.Fatal(err)
+	}
+	info, err := baseFS.Stat(context.Background(), filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mfs := &mockFS{FileSystem: baseFS, writeErr: errors.New("injected write error")}
+
+	tracker := &globalPromptTracker{
+		fs:       mfs,
+		filepath: filePath,
+	}
+
+	ok := tracker.optimisticWrite(context.Background(), []byte("new data"), info.Size())
+	if ok {
+		t.Error("expected optimisticWrite to return false on AtomicWrite error")
+	}
+
+	// Verify original file untouched (AtomicWrite uses temp file, so original survives)
+	content, err := baseFS.ReadFile(context.Background(), filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, initialData) {
+		t.Errorf("file was modified unexpectedly: got %q; want %q", content, initialData)
+	}
+}
+
+func TestPrepareCompactedEntries_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	// Seed entries: A (oldest), B, A (most recent)
+	// After dedup and reverse: B (oldest), A (most recent)
+	seed := `{"timestamp":"2026-01-01T00:00:00Z","prompt":"A"}` + "\n" +
+		`{"timestamp":"2026-01-01T00:01:00Z","prompt":"B"}` + "\n" +
+		`{"timestamp":"2026-01-01T00:02:00Z","prompt":"A"}` + "\n"
+	if err := baseFS.WriteFile(context.Background(), filePath, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: filePath,
+	}
+
+	data, err := tracker.prepareCompactedEntries(context.Background())
+	if err != nil {
+		t.Fatalf("prepareCompactedEntries failed: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("expected non-empty compacted data")
+	}
+
+	// Parse each JSONL line and verify ordering + dedup
+	lines := bytes.Split(bytes.TrimSpace(data), []byte{'\n'})
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 compacted lines, got %d: %q", len(lines), data)
+	}
+
+	var prompts []string
+	for _, line := range lines {
+		var entry promptEntry
+		if err := json.Unmarshal(line, &entry); err != nil {
+			t.Fatalf("failed to unmarshal compacted line %q: %v", line, err)
+		}
+		prompts = append(prompts, entry.Prompt)
+	}
+
+	// Chronological order: B (oldest) then A (most recent)
+	if len(prompts) != 2 || prompts[0] != "B" || prompts[1] != "A" {
+		t.Errorf("got prompts %v; want [B A]", prompts)
+	}
+}
+
+func TestPrepareCompactedEntries_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "nonexistent.jsonl")
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: filePath,
+	}
+
+	data, err := tracker.prepareCompactedEntries(context.Background())
+	if err != nil {
+		t.Fatalf("prepareCompactedEntries should not error on missing file: %v", err)
+	}
+	if len(data) != 0 {
+		t.Errorf("expected nil/empty data for missing file, got %d bytes", len(data))
+	}
+}
+
+func TestPrepareCompactedEntries_SingleEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	seed := `{"timestamp":"2026-01-01T00:00:00Z","prompt":"only"}` + "\n"
+	if err := baseFS.WriteFile(context.Background(), filePath, []byte(seed), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: filePath,
+	}
+
+	data, err := tracker.prepareCompactedEntries(context.Background())
+	if err != nil {
+		t.Fatalf("prepareCompactedEntries failed: %v", err)
+	}
+
+	var entry promptEntry
+	if err := json.Unmarshal(bytes.TrimSpace(data), &entry); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if entry.Prompt != "only" {
+		t.Errorf("got prompt %q; want %q", entry.Prompt, "only")
+	}
+}
+
+func TestPrepareCompactedEntries_ReadError(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	filePath := filepath.Join(tmpDir, "test.jsonl")
+
+	// Seed a file so Stat succeeds, but ReadAt fails
+	if err := baseFS.WriteFile(context.Background(), filePath,
+		[]byte(`{"timestamp":"t","prompt":"hello"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mfs := &mockFS{FileSystem: baseFS, readAtErr: errors.New("injected read error")}
+
+	tracker := &globalPromptTracker{
+		fs:       mfs,
+		filepath: filePath,
+	}
+
+	data, err := tracker.prepareCompactedEntries(context.Background())
+	if err == nil {
+		t.Error("expected error on read failure, got nil")
+	}
+	if data != nil {
+		t.Errorf("expected nil data on error, got %d bytes", len(data))
+	}
+}


### PR DESCRIPTION
Closes #987.

## Summary
Extracted three helper methods from `compactLog` and `performCompactionPass` to reduce cyclomatic complexity:

- **`optimisticWrite`** — standalone optimistic-concurrency write pattern (Stat → compare → AtomicWrite under exclusive lock)
- **`prepareCompactedEntries`** — reads, deduplicates, reverses, and serializes compaction entries
- **`shouldStillCompact`** — retry-decision logic (re-stat, threshold check, exponential backoff with context awareness)

Simplified `performCompactionPass` (8→4 complexity) and `compactLog` (8→5 complexity).

Added 8 new unit tests (4 for `optimisticWrite`, 4 for `prepareCompactedEntries`) covering happy path, concurrency, error propagation, dedup, ordering, and edge cases.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test -race ./internal/infrastructure/history/... | PASS (0 data races) |
| Coverage (history pkg) | 99.3% |
| Lint | 0 issues |
| Vulncheck | No vulnerabilities |