### PR TITLE
refactor(core): decompose complexity-9 production functions (#998)

### DIFF
--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -229,49 +229,65 @@ type ServiceAccountAuth struct {
 	expiry          time.Time
 }
 
+// checkCachedToken returns the cached token if it is still valid.
+// A token is considered valid if it is non-empty and has more than
+// 5 minutes remaining before expiry.
+// Caller MUST hold a.mu.
+func (a *ServiceAccountAuth) checkCachedToken() (string, bool) {
+	if a.token != "" && time.Now().Add(5*time.Minute).Before(a.expiry) {
+		return a.token, true
+	}
+	return "", false
+}
+
+// fetchGoogleToken obtains an OAuth2 token either via the injected
+// tokenSourceFunc (test path) or by reading the service account JSON
+// key from disk and exchanging it with Google's OAuth2 endpoint.
+// Caller MUST hold a.mu.
+func (a *ServiceAccountAuth) fetchGoogleToken(ctx context.Context) (*oauth2.Token, error) {
+	if a.tokenSourceFunc != nil {
+		tok, err := a.tokenSourceFunc()
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch mock oauth2 token: %w", err)
+		}
+		return tok, nil
+	}
+
+	if a.KeyFilePath == "" {
+		return nil, fmt.Errorf("failed to read service account key: KeyFilePath is empty")
+	}
+	data, err := os.ReadFile(a.KeyFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read service account key: %w", err)
+	}
+
+	creds, err := google.CredentialsFromJSONWithType(ctx, data, google.ServiceAccount, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse service account JSON: %w", err)
+	}
+
+	ts := creds.TokenSource
+	tok, err := ts.Token()
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch oauth2 token: %w", err)
+	}
+	return tok, nil
+}
+
 // getToken performs the OAuth2 exchange and returns a valid access token.
 func (a *ServiceAccountAuth) getToken(ctx context.Context) (string, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
-	// 1. Check if cached token is still valid (with 5-minute buffer)
-	if a.token != "" && time.Now().Add(5*time.Minute).Before(a.expiry) {
-		return a.token, nil
+	if token, ok := a.checkCachedToken(); ok {
+		return token, nil
 	}
 
-	var tok *oauth2.Token
-	var err error
-
-	if a.tokenSourceFunc != nil {
-		tok, err = a.tokenSourceFunc()
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch mock oauth2 token: %w", err)
-		}
-	} else {
-		// 2. Read the master secret (key.json) from disk
-		if a.KeyFilePath == "" {
-			return "", fmt.Errorf("failed to read service account key: KeyFilePath is empty")
-		}
-		data, err := os.ReadFile(a.KeyFilePath)
-		if err != nil {
-			return "", fmt.Errorf("failed to read service account key: %w", err)
-		}
-
-		// 3. Exchange JSON key for a Bearer token via Google OAuth2
-		// Scope required for Vertex AI: "https://www.googleapis.com/auth/cloud-platform"
-		creds, err := google.CredentialsFromJSONWithType(ctx, data, google.ServiceAccount, "https://www.googleapis.com/auth/cloud-platform")
-		if err != nil {
-			return "", fmt.Errorf("failed to parse service account JSON: %w", err)
-		}
-
-		ts := creds.TokenSource
-		tok, err = ts.Token()
-		if err != nil {
-			return "", fmt.Errorf("failed to fetch oauth2 token: %w", err)
-		}
+	tok, err := a.fetchGoogleToken(ctx)
+	if err != nil {
+		return "", err
 	}
 
-	// 4. Cache the resulting short-lived token
 	a.token = tok.AccessToken
 	a.expiry = tok.Expiry
 	return a.token, nil

--- a/internal/infrastructure/llm/doc.go
+++ b/internal/infrastructure/llm/doc.go
@@ -7,41 +7,41 @@
 //
 // Error recovery is split across two layers with distinct responsibilities:
 //
-//   Layer 1 — resilientClient (per-provider, resilient_client.go):
-//     Wraps a single provider client. On SendChat failure:
-//       1. Classifies the raw error into a domain sentinel via llmerr.Classify
-//          (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
-//       2. On ErrAuth (first attempt only): refreshes the auth token and retries
-//          once. If the refresh succeeds, the retry proceeds; otherwise it returns
-//          ErrAuth to the caller.
-//       3. On transient errors or final attempt: resets the HTTP connection pool
-//          to evict poisoned keep-alive connections.
-//       4. Returns the classified domain sentinel — it does NOT perform
-//          exponential-backoff retry loops. That responsibility belongs to the
-//          TurnEngine's RecoveryStep (see internal/agent/orchestrator).
+//	Layer 1 — resilientClient (per-provider, resilient_client.go):
+//	  Wraps a single provider client. On SendChat failure:
+//	    1. Classifies the raw error into a domain sentinel via llmerr.Classify
+//	       (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
+//	    2. On ErrAuth (first attempt only): refreshes the auth token and retries
+//	       once. If the refresh succeeds, the retry proceeds; otherwise it returns
+//	       ErrAuth to the caller.
+//	    3. On transient errors or final attempt: resets the HTTP connection pool
+//	       to evict poisoned keep-alive connections.
+//	    4. Returns the classified domain sentinel — it does NOT perform
+//	       exponential-backoff retry loops. That responsibility belongs to the
+//	       TurnEngine's RecoveryStep (see internal/agent/orchestrator).
 //
-//     Max attempts: 2 (initial + one auth-refresh retry).
+//	  Max attempts: 2 (initial + one auth-refresh retry).
 //
-//   Layer 2 — FailoverGateway (cross-provider, failover.go):
-//     Iterates through an ordered list of resilientClient-wrapped providers.
-//     On Generate:
-//       - Success: returns immediately, annotating metrics with the provider name.
-//       - ErrTransient / ErrRateLimit: tries the next provider in the chain.
-//       - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
-//         these are not retryable by switching providers.
-//       - All providers exhausted: wraps the last error as ErrTerminal.
+//	Layer 2 — FailoverGateway (cross-provider, failover.go):
+//	  Iterates through an ordered list of resilientClient-wrapped providers.
+//	  On Generate:
+//	    - Success: returns immediately, annotating metrics with the provider name.
+//	    - ErrTransient / ErrRateLimit: tries the next provider in the chain.
+//	    - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
+//	      these are not retryable by switching providers.
+//	    - All providers exhausted: wraps the last error as ErrTerminal.
 //
-//     Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
-//     the primary (first) provider only.
+//	  Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
+//	  the primary (first) provider only.
 //
-//     Key invariant: every client in a FailoverGateway MUST be wrapped in
-//     resilientClient. This is enforced by newFailoverChain in factory.go.
+//	  Key invariant: every client in a FailoverGateway MUST be wrapped in
+//	  resilientClient. This is enforced by newFailoverChain in factory.go.
 //
-//   Error flow summary:
-//     Raw HTTP/gRPC error
-//       → resilientClient.wrapError → llmerr.Classify → domain sentinel
-//         → FailoverGateway reads sentinel, decides: try-next or abort
-//           → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
+//	Error flow summary:
+//	  Raw HTTP/gRPC error
+//	    → resilientClient.wrapError → llmerr.Classify → domain sentinel
+//	      → FailoverGateway reads sentinel, decides: try-next or abort
+//	        → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
 //
 // # Components
 //

--- a/internal/ui/tui/browser.go
+++ b/internal/ui/tui/browser.go
@@ -327,11 +327,34 @@ func (m *rootBrowserModel) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model
 	return m.handleViewportUpdate(msg)
 }
 
+// handleInitialLoad sets the history from the first page of results.
+// It selects the last turn and does NOT update the viewport — the caller
+// is responsible for calling updateViewportContent, updateViewportHeight,
+// and GotoBottom afterwards.
+func (m *rootBrowserModel) handleInitialLoad(msg historyLoadedMsg) {
+	m.history = msg.dtos
+	m.selectedTurn = len(m.history) - 1
+}
+
+// handlePrependLoad prepends older history pages while maintaining scroll
+// position. It adjusts the viewport YOffset and selectedTurn by the
+// number of added items. The caller is responsible for calling
+// updateViewportContent and updateViewportHeight afterwards.
+func (m *rootBrowserModel) handlePrependLoad(msg historyLoadedMsg) {
+	numAdded := len(msg.dtos)
+	m.history = append(msg.dtos, m.history...)
+	m.updateViewportContent()
+	addedLines := 0
+	if numAdded < len(m.turnOffsets) {
+		addedLines = m.turnOffsets[numAdded]
+	}
+	m.viewport.SetYOffset(m.viewport.YOffset + addedLines)
+	m.selectedTurn += numAdded
+}
+
 func (m *rootBrowserModel) handleHistoryLoadedMsg(msg historyLoadedMsg) (tea.Model, tea.Cmd) {
 	m.isLoading = false
 
-	// If we have data, process it even when there's an error.
-	// Only treat the error as blocking if no data was returned.
 	if msg.err != nil && len(msg.dtos) == 0 {
 		log.Printf("failed to load history: %v", msg.err)
 		m.err = msg.err
@@ -339,32 +362,16 @@ func (m *rootBrowserModel) handleHistoryLoadedMsg(msg historyLoadedMsg) (tea.Mod
 	}
 
 	if msg.err != nil {
-		// Partial result: log the error but still display what we got.
 		log.Printf("partial history load (got %d items): %v", len(msg.dtos), msg.err)
-		// DO NOT set m.err — let the data display. The user can retry by scrolling.
 	}
 
 	isInitialLoad := (m.selectedTurn == -1)
 
 	if len(msg.dtos) > 0 {
 		if isInitialLoad {
-			m.history = msg.dtos
-			m.selectedTurn = len(m.history) - 1
+			m.handleInitialLoad(msg)
 		} else {
-			// Prepend older history
-			numAdded := len(msg.dtos)
-			m.history = append(msg.dtos, m.history...)
-
-			// Update viewport and maintain scroll position
-			m.updateViewportContent()
-			addedLines := 0
-			if numAdded < len(m.turnOffsets) {
-				addedLines = m.turnOffsets[numAdded]
-			}
-			m.viewport.SetYOffset(m.viewport.YOffset + addedLines)
-
-			// Adjust selected turn
-			m.selectedTurn += numAdded
+			m.handlePrependLoad(msg)
 		}
 	}
 

--- a/internal/ui/tui/tasks_model.go
+++ b/internal/ui/tui/tasks_model.go
@@ -119,19 +119,8 @@ func fetchTasksCmd(ctx context.Context, provider ports.TaskStore, status string,
 
 // Update handles incoming messages and updates the model state.
 func (m *taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// Handle key presses when in error state — allow retry or quit
 	if m.err != nil {
-		if key, ok := msg.(tea.KeyMsg); ok {
-			switch key.String() {
-			case "q", "esc", "ctrl+c":
-				return m, tea.Quit
-			default:
-				// Any other key clears error and retries
-				m.err = nil
-				return m, fetchTasksCmd(m.ctx, m.provider, m.statusFilter, m.pageOffset, m.pageSize)
-			}
-		}
-		return m, nil
+		return m.handleErrorMsg(msg)
 	}
 
 	switch msg := msg.(type) {
@@ -148,6 +137,24 @@ func (m *taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleViewportUpdate(msg)
 	}
 	return m, nil
+}
+
+// handleErrorMsg handles all incoming messages when the model is in an error state.
+// Quit keys ("q", "esc", "ctrl+c") return tea.Quit.
+// Any other key clears the error and triggers a retry fetch.
+// Non-KeyMsg messages are silently ignored (error persists).
+func (m *taskListModel) handleErrorMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := msg.(tea.KeyMsg)
+	if !ok {
+		return m, nil
+	}
+	switch key.String() {
+	case "q", "esc", "ctrl+c":
+		return m, tea.Quit
+	default:
+		m.err = nil
+		return m, fetchTasksCmd(m.ctx, m.provider, m.statusFilter, m.pageOffset, m.pageSize)
+	}
 }
 
 func (m *taskListModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {


### PR DESCRIPTION
Closes #998.

## Summary
Decomposed three production functions at cyclomatic complexity 9 into focused single-responsibility methods:

| Function | Before | After | Extracted Methods |
|---|---|---|---|
| `taskListModel.Update` | 9 | **6** | `handleErrorMsg` (4) |
| `ServiceAccountAuth.getToken` | 9 | **3** | `checkCachedToken` (3), `fetchGoogleToken` (7) |
| `rootBrowserModel.handleHistoryLoadedMsg` | 9 | **8** | `handleInitialLoad` (1), `handlePrependLoad` (2) |

**Key architectural decisions:**
- Lock discipline preserved in `ServiceAccountAuth.getToken` — extracted methods operate under caller's lock, verified by `TestServiceAccountAuth_ThreadSafety`
- Shared tail logic kept in `handleHistoryLoadedMsg` caller to avoid duplicate viewport updates
- Error-state extraction in `taskListModel.Update` preserves `tea.Model` interface contract

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Lint | 0 issues |
| Tests (all packages) | PASS |
| Race detection | PASS |
| Coverage | 96.2%+ on changed packages |