### PR TITLE
fix(llmerr): consolidate error classification to pure regex (#1002)

### DIFF
--- a/internal/infrastructure/llm/doc.go
+++ b/internal/infrastructure/llm/doc.go
@@ -7,41 +7,41 @@
 //
 // Error recovery is split across two layers with distinct responsibilities:
 //
-//   Layer 1 — resilientClient (per-provider, resilient_client.go):
-//     Wraps a single provider client. On SendChat failure:
-//       1. Classifies the raw error into a domain sentinel via llmerr.Classify
-//          (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
-//       2. On ErrAuth (first attempt only): refreshes the auth token and retries
-//          once. If the refresh succeeds, the retry proceeds; otherwise it returns
-//          ErrAuth to the caller.
-//       3. On transient errors or final attempt: resets the HTTP connection pool
-//          to evict poisoned keep-alive connections.
-//       4. Returns the classified domain sentinel — it does NOT perform
-//          exponential-backoff retry loops. That responsibility belongs to the
-//          TurnEngine's RecoveryStep (see internal/agent/orchestrator).
+//	Layer 1 — resilientClient (per-provider, resilient_client.go):
+//	  Wraps a single provider client. On SendChat failure:
+//	    1. Classifies the raw error into a domain sentinel via llmerr.Classify
+//	       (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
+//	    2. On ErrAuth (first attempt only): refreshes the auth token and retries
+//	       once. If the refresh succeeds, the retry proceeds; otherwise it returns
+//	       ErrAuth to the caller.
+//	    3. On transient errors or final attempt: resets the HTTP connection pool
+//	       to evict poisoned keep-alive connections.
+//	    4. Returns the classified domain sentinel — it does NOT perform
+//	       exponential-backoff retry loops. That responsibility belongs to the
+//	       TurnEngine's RecoveryStep (see internal/agent/orchestrator).
 //
-//     Max attempts: 2 (initial + one auth-refresh retry).
+//	  Max attempts: 2 (initial + one auth-refresh retry).
 //
-//   Layer 2 — FailoverGateway (cross-provider, failover.go):
-//     Iterates through an ordered list of resilientClient-wrapped providers.
-//     On Generate:
-//       - Success: returns immediately, annotating metrics with the provider name.
-//       - ErrTransient / ErrRateLimit: tries the next provider in the chain.
-//       - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
-//         these are not retryable by switching providers.
-//       - All providers exhausted: wraps the last error as ErrTerminal.
+//	Layer 2 — FailoverGateway (cross-provider, failover.go):
+//	  Iterates through an ordered list of resilientClient-wrapped providers.
+//	  On Generate:
+//	    - Success: returns immediately, annotating metrics with the provider name.
+//	    - ErrTransient / ErrRateLimit: tries the next provider in the chain.
+//	    - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
+//	      these are not retryable by switching providers.
+//	    - All providers exhausted: wraps the last error as ErrTerminal.
 //
-//     Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
-//     the primary (first) provider only.
+//	  Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
+//	  the primary (first) provider only.
 //
-//     Key invariant: every client in a FailoverGateway MUST be wrapped in
-//     resilientClient. This is enforced by newFailoverChain in factory.go.
+//	  Key invariant: every client in a FailoverGateway MUST be wrapped in
+//	  resilientClient. This is enforced by newFailoverChain in factory.go.
 //
-//   Error flow summary:
-//     Raw HTTP/gRPC error
-//       → resilientClient.wrapError → llmerr.Classify → domain sentinel
-//         → FailoverGateway reads sentinel, decides: try-next or abort
-//           → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
+//	Error flow summary:
+//	  Raw HTTP/gRPC error
+//	    → resilientClient.wrapError → llmerr.Classify → domain sentinel
+//	      → FailoverGateway reads sentinel, decides: try-next or abort
+//	        → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
 //
 // # Components
 //

--- a/internal/infrastructure/llm/llmerr/errors.go
+++ b/internal/infrastructure/llm/llmerr/errors.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"regexp"
-	"strings"
 	"syscall"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -27,7 +26,10 @@ var (
 	// 2. Uses word boundaries (\b) and specific prefix requirements to avoid greedy false positives
 	//    like "500 tokens" or "context window: 128000".
 	// 3. Delimiters are flexible (space, underscore, colon) to handle varied SDK logging formats.
-	reTransient = regexp.MustCompile(`(?i)(\b(?:HTTP|STATUS|CODE|ERROR|ERR|STATUS_CODE)[\s_:]*(?:5\d{2}|499|408)\b|[:]\s*(?:5\d{2}|499|408)\b|CANCELLED|INTERNAL[\s_:]+SERVER[\s_:]+ERROR|BAD[\s_:]+GATEWAY|SERVICE[\s_:]+UNAVAILABLE|DEADLINE[\s_:]+EXCEEDED|UNAVAILABLE|\b(?:CONNECTION|REQUEST|GATEWAY|OPERATION)[\s_:]+TIMEOUT\b)`)
+	reTransient = regexp.MustCompile(`(?i)(\b(?:HTTP|STATUS|CODE|ERROR|ERR|STATUS_CODE)[\s_:]*(?:5\d{2}|499|408)\b|[:]\s*(?:5\d{2}|499|408)\b|CANCELLED|INTERNAL[\s_:]+SERVER[\s_:]+ERROR|BAD[\s_:]+GATEWAY|SERVICE[\s_:]+UNAVAILABLE|DEADLINE[\s_:]+EXCEEDED|UNAVAILABLE|\b(?:CONNECTION|REQUEST|GATEWAY|OPERATION)[\s_:]+TIMEOUT\b|(?:\bCONNECTION\s+RESET\s+BY\s+PEER\b)|(?:\bBROKEN\s+PIPE\b)|(?:\bEOF\b))`)
+
+	// reAuth identifies authentication and authorization failures in opaque error strings.
+	reAuth = regexp.MustCompile(`(?i)\b(UNAUTHENTICATED|API_KEY_INVALID)\b`)
 )
 
 // APIError represents an error returned by an LLM provider's API.
@@ -162,16 +164,9 @@ func classifyStandard(err error) (error, bool) {
 
 func classifyString(err error) (error, bool) {
 	msg := err.Error() // Regex handles (?i) case-insensitivity
-	upperMsg := strings.ToUpper(msg)
 
-	// Fallback for brittle network errors that wrap syscalls in opaque strings
-	if strings.Contains(upperMsg, "CONNECTION RESET BY PEER") ||
-		strings.Contains(upperMsg, "BROKEN PIPE") ||
-		strings.Contains(upperMsg, "EOF") {
-		return fmt.Errorf("%w: %w", llm.ErrTransient, err), true
-	}
-
-	if strings.Contains(upperMsg, "UNAUTHENTICATED") || strings.Contains(upperMsg, "API_KEY_INVALID") {
+	// Auth must be checked first: auth failures are non-retryable
+	if reAuth.MatchString(msg) {
 		return fmt.Errorf("%w: %w", llm.ErrAuth, err), true
 	}
 
@@ -179,6 +174,8 @@ func classifyString(err error) (error, bool) {
 		return fmt.Errorf("%w: %w", llm.ErrRateLimit, err), true
 	}
 
+	// Transient is the broadest category; evaluate last to let more specific
+	// classifiers (auth, rate-limit) take priority.
 	if reTransient.MatchString(msg) {
 		return fmt.Errorf("%w: %w", llm.ErrTransient, err), true
 	}


### PR DESCRIPTION
Closes #1002.

## Summary
Consolidated hybrid error classification in `classifyString` from a mix of `strings.ToUpper`/`strings.Contains` and pre-compiled regex to a 100% declarative, regex-driven pattern:

- **Added** `reAuth` regex for auth error detection (UNAUTHENTICATED, API_KEY_INVALID)
- **Updated** `reTransient` regex: appended `CONNECTION RESET BY PEER`, `BROKEN PIPE`, `EOF` alternations with word-boundary anchors
- **Removed** `strings` import and all `strings.ToUpper`/`strings.Contains` calls from `classifyString`
- **Reordered** checks: auth -> rate-limit -> transient (broadest last, prevents auth errors from being misclassified as transient)
- **Reduced** `classifyString` cyclomatic complexity from 8 to 4

## Verification
| Check | Status |
|-------|--------|
| build | PASS |
| lint (golangci-lint) | PASS (0 issues) |
| vet | PASS |
| test (all packages) | PASS (all 71 packages) |
| test-race (llm/*) | PASS |
| coverage (llmerr) | 100% |
