### PR TITLE
fix(ado): extract executeAdoGet generic HTTP helper (#1003)

### DIFF
--- a/internal/infrastructure/llm/doc.go
+++ b/internal/infrastructure/llm/doc.go
@@ -7,41 +7,41 @@
 //
 // Error recovery is split across two layers with distinct responsibilities:
 //
-//   Layer 1 — resilientClient (per-provider, resilient_client.go):
-//     Wraps a single provider client. On SendChat failure:
-//       1. Classifies the raw error into a domain sentinel via llmerr.Classify
-//          (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
-//       2. On ErrAuth (first attempt only): refreshes the auth token and retries
-//          once. If the refresh succeeds, the retry proceeds; otherwise it returns
-//          ErrAuth to the caller.
-//       3. On transient errors or final attempt: resets the HTTP connection pool
-//          to evict poisoned keep-alive connections.
-//       4. Returns the classified domain sentinel — it does NOT perform
-//          exponential-backoff retry loops. That responsibility belongs to the
-//          TurnEngine's RecoveryStep (see internal/agent/orchestrator).
+//	Layer 1 — resilientClient (per-provider, resilient_client.go):
+//	  Wraps a single provider client. On SendChat failure:
+//	    1. Classifies the raw error into a domain sentinel via llmerr.Classify
+//	       (ErrAuth / ErrTransient / ErrRateLimit / ErrTerminal).
+//	    2. On ErrAuth (first attempt only): refreshes the auth token and retries
+//	       once. If the refresh succeeds, the retry proceeds; otherwise it returns
+//	       ErrAuth to the caller.
+//	    3. On transient errors or final attempt: resets the HTTP connection pool
+//	       to evict poisoned keep-alive connections.
+//	    4. Returns the classified domain sentinel — it does NOT perform
+//	       exponential-backoff retry loops. That responsibility belongs to the
+//	       TurnEngine's RecoveryStep (see internal/agent/orchestrator).
 //
-//     Max attempts: 2 (initial + one auth-refresh retry).
+//	  Max attempts: 2 (initial + one auth-refresh retry).
 //
-//   Layer 2 — FailoverGateway (cross-provider, failover.go):
-//     Iterates through an ordered list of resilientClient-wrapped providers.
-//     On Generate:
-//       - Success: returns immediately, annotating metrics with the provider name.
-//       - ErrTransient / ErrRateLimit: tries the next provider in the chain.
-//       - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
-//         these are not retryable by switching providers.
-//       - All providers exhausted: wraps the last error as ErrTerminal.
+//	Layer 2 — FailoverGateway (cross-provider, failover.go):
+//	  Iterates through an ordered list of resilientClient-wrapped providers.
+//	  On Generate:
+//	    - Success: returns immediately, annotating metrics with the provider name.
+//	    - ErrTransient / ErrRateLimit: tries the next provider in the chain.
+//	    - ErrAuth / ErrTerminal / unrecognized: aborts the chain immediately —
+//	      these are not retryable by switching providers.
+//	    - All providers exhausted: wraps the last error as ErrTerminal.
 //
-//     Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
-//     the primary (first) provider only.
+//	  Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to
+//	  the primary (first) provider only.
 //
-//     Key invariant: every client in a FailoverGateway MUST be wrapped in
-//     resilientClient. This is enforced by newFailoverChain in factory.go.
+//	  Key invariant: every client in a FailoverGateway MUST be wrapped in
+//	  resilientClient. This is enforced by newFailoverChain in factory.go.
 //
-//   Error flow summary:
-//     Raw HTTP/gRPC error
-//       → resilientClient.wrapError → llmerr.Classify → domain sentinel
-//         → FailoverGateway reads sentinel, decides: try-next or abort
-//           → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
+//	Error flow summary:
+//	  Raw HTTP/gRPC error
+//	    → resilientClient.wrapError → llmerr.Classify → domain sentinel
+//	      → FailoverGateway reads sentinel, decides: try-next or abort
+//	        → TurnEngine.RecoveryStep reads sentinel, decides: retry-with-backoff or fail
 //
 // # Components
 //

--- a/internal/tools/integrations/ado/ado_http.go
+++ b/internal/tools/integrations/ado/ado_http.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ado
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// executeAdoGet executes an HTTP GET request against the Azure DevOps API and
+// decodes the JSON response body into a value of type T.
+//
+// The caller is responsible for ensuring T matches the expected API response
+// schema. On HTTP errors (non-2xx), the error is returned without attempting
+// JSON decode. On decode failures, the response body close is handled by the
+// deferred call — double-close is safe per http.Response.Body.Close contract.
+//
+// Headers are optional; when nil, ExecuteRequest applies its default
+// Accept: application/json. Pass a non-nil map to override (e.g.,
+// {"Accept": "*/*"} for endpoints that require a non-standard media type but
+// still return JSON).
+func executeAdoGet[T any](ctx context.Context, m *AdoManager, url string, headers map[string]string) (T, error) {
+	var result T
+	resp, err := m.ExecuteRequest(ctx, http.MethodGet, url, nil, headers)
+	if err != nil {
+		return result, fmt.Errorf("executing request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return result, fmt.Errorf("decoding response: %w", err)
+	}
+	return result, nil
+}

--- a/internal/tools/integrations/ado/azure_devops.go
+++ b/internal/tools/integrations/ado/azure_devops.go
@@ -6,7 +6,6 @@ package ado
 import (
 	"context"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -236,15 +235,9 @@ func (m *AdoManager) AdoListRepositoryItems(ctx context.Context, args map[string
 		return tools.ToolResult{}, fmt.Errorf("building list repository items URL: %w", err)
 	}
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	responseData, err := executeAdoGet[adoRepositoryItemsResponse](ctx, m, requestURL, nil)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("executing list repository items request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var responseData adoRepositoryItemsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
+		return tools.ToolResult{}, fmt.Errorf("listing repository items: %w", err)
 	}
 
 	return formatRepositoryItems(params.ScopePath, params.Version, responseData), nil

--- a/internal/tools/integrations/ado/azure_devops_pr_test.go
+++ b/internal/tools/integrations/ado/azure_devops_pr_test.go
@@ -297,7 +297,7 @@ func TestAdoListPullRequests(t *testing.T) {
 			"organization": "o", "project": "p", "repository": "r",
 		}, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 
 	t.Run("Forbidden", func(t *testing.T) {
@@ -535,7 +535,7 @@ func TestAdoGetPrThreads(t *testing.T) {
 			"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 		}, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 
 	t.Run("Unauthorized", func(t *testing.T) {
@@ -1104,7 +1104,7 @@ func TestAdoListBranchPolicies_DetailedErrors(t *testing.T) {
 
 		_, err := m.adoListBranchPolicies(context.Background(), map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode repository metadata")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 

--- a/internal/tools/integrations/ado/azure_devops_test.go
+++ b/internal/tools/integrations/ado/azure_devops_test.go
@@ -316,7 +316,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			args:           map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 1},
 			httpStatus:     http.StatusOK,
 			respBody:       `{invalid}`,
-			expectedErrMsg: "failed to decode PR metadata",
+			expectedErrMsg: "decoding response",
 		},
 		{
 			name: "AdoGetFileContent - Unauthorized",
@@ -409,7 +409,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 			},
 			httpStatus:     http.StatusOK,
 			respBody:       `{bad_json}`,
-			expectedErrMsg: "failed to decode response",
+			expectedErrMsg: "decoding response",
 		},
 		{
 			name: "RunPipeline - Missing Params",
@@ -528,7 +528,7 @@ func TestAdoTools_DetailedErrors(t *testing.T) {
 
 		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
+		assert.Contains(t, err.Error(), "fetching policy configurations")
 	})
 }
 
@@ -607,44 +607,49 @@ func TestAzureDevOps_JSONDecodeErrors(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		call func() (tools.ToolResult, error)
+		name     string
+		call     func() (tools.ToolResult, error)
+		migrated bool
 	}{
-		{"AdoListPullRequests", func() (tools.ToolResult, error) { return m.AdoListPullRequests(ctx, args, nil) }},
-		{"AdoGetPullRequest", func() (tools.ToolResult, error) { return m.adoGetPullRequest(ctx, args, nil) }},
-		{"AdoGetPrDiff", func() (tools.ToolResult, error) { return m.adoGetPrDiff(ctx, args, nil) }},
-		{"AdoGetPrThreads", func() (tools.ToolResult, error) { return m.AdoGetPrThreads(ctx, args, nil) }},
-		{"AdoListRepositoryItems", func() (tools.ToolResult, error) { return m.AdoListRepositoryItems(ctx, args, nil) }},
+		{"AdoListPullRequests", func() (tools.ToolResult, error) { return m.AdoListPullRequests(ctx, args, nil) }, true},
+		{"AdoGetPullRequest", func() (tools.ToolResult, error) { return m.adoGetPullRequest(ctx, args, nil) }, true},
+		{"AdoGetPrDiff", func() (tools.ToolResult, error) { return m.adoGetPrDiff(ctx, args, nil) }, true},
+		{"AdoGetPrThreads", func() (tools.ToolResult, error) { return m.AdoGetPrThreads(ctx, args, nil) }, true},
+		{"AdoListRepositoryItems", func() (tools.ToolResult, error) { return m.AdoListRepositoryItems(ctx, args, nil) }, true},
 		{"ListPipelineRuns", func() (tools.ToolResult, error) {
 			_, _, err := m.ListPipelineRuns(ctx, args)
 			return tools.ToolResult{}, err
-		}},
+		}, true},
 		{"GetPipelineRun", func() (tools.ToolResult, error) {
 			_, err := m.GetPipelineRun(ctx, args)
 			return tools.ToolResult{}, err
-		}},
+		}, true},
 		{"ListPipelineLogs", func() (tools.ToolResult, error) {
 			_, _, err := m.ListPipelineLogs(ctx, args)
 			return tools.ToolResult{}, err
-		}},
-		{"AdoGetPrStatuses", func() (tools.ToolResult, error) { return m.AdoGetPrStatuses(ctx, args, nil) }},
-		{"AdoGetPrPolicyEvaluations", func() (tools.ToolResult, error) { return m.AdoGetPrPolicyEvaluations(ctx, args, nil) }},
-		{"AdoListBranchPolicies", func() (tools.ToolResult, error) { return m.adoListBranchPolicies(ctx, args, nil) }},
+		}, true},
+		{"AdoGetPrStatuses", func() (tools.ToolResult, error) { return m.AdoGetPrStatuses(ctx, args, nil) }, true},
+		{"AdoGetPrPolicyEvaluations", func() (tools.ToolResult, error) { return m.AdoGetPrPolicyEvaluations(ctx, args, nil) }, true},
+		{"AdoListBranchPolicies", func() (tools.ToolResult, error) { return m.adoListBranchPolicies(ctx, args, nil) }, true},
 		{"AdoGetBuildTimeline", func() (tools.ToolResult, error) {
 			_, err := m.GetBuildTimeline(ctx, args)
 			return tools.ToolResult{}, err
-		}},
+		}, false},
 		{"AdoGetBuildChanges", func() (tools.ToolResult, error) {
 			_, err := m.getBuildChanges(ctx, args)
 			return tools.ToolResult{}, err
-		}},
+		}, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := tt.call()
 			if assert.Error(t, err) {
-				assert.Contains(t, err.Error(), "decode")
+				expected := "decode"
+				if tt.migrated {
+					expected = "decoding"
+				}
+				assert.Contains(t, err.Error(), expected)
 			}
 		})
 	}
@@ -761,7 +766,7 @@ func TestAzureDevOps_HTTPIntegration(t *testing.T) {
 					"organization": "o", "project": "p", "repository": "r", "pull_request_id": 123,
 				}, nil)
 			},
-			expectedErr: "failed to decode response",
+			expectedErr: "decoding response",
 		},
 	}
 

--- a/internal/tools/integrations/ado/negative_test.go
+++ b/internal/tools/integrations/ado/negative_test.go
@@ -207,7 +207,7 @@ func TestAdoManager_GetPipelineRun_Errors(t *testing.T) {
 			name:           "Malformed JSON",
 			mockStatusCode: http.StatusOK,
 			mockResponse:   `{ "id": "invalid" }`, // id is expected to be int
-			expectedErr:    "failed to decode response",
+			expectedErr:    "decoding response",
 		},
 	}
 
@@ -279,7 +279,7 @@ func TestAdoManager_ResolvePipelineID_Errors(t *testing.T) {
 		m := NewADOManager(sm, WithBaseURL(ts.URL), WithHTTPClient(ts.Client()), WithToken("test-pat"))
 		_, err := m.resolvePipelineID(context.Background(), "org", "proj", "name")
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 
@@ -346,7 +346,7 @@ func TestAdoManager_AdoListRepositoryItems_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListRepositoryItems(context.Background(), args, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 
@@ -384,7 +384,7 @@ func TestAdoManager_ListPipelineRuns_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1}
 		_, _, err := m.ListPipelineRuns(context.Background(), args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 
@@ -422,7 +422,7 @@ func TestAdoManager_ListPipelineLogs_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "pipeline_id": 1, "run_id": 101}
 		_, _, err := m.ListPipelineLogs(context.Background(), args)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode logs list")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 
 	t.Run("Fetch Log Content - HTTP Error", func(t *testing.T) {
@@ -497,7 +497,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
 		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to fetch policy configurations")
+		assert.Contains(t, err.Error(), "fetching policy configurations")
 	})
 
 	t.Run("Fetch Policy Configs - JSON Decode Error", func(t *testing.T) {
@@ -516,7 +516,7 @@ func TestAdoManager_AdoListBranchPolicies_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "branch_name": "b"}
 		_, err := m.adoListBranchPolicies(context.Background(), args, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode policy configurations")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 
@@ -554,7 +554,7 @@ func TestAdoManager_AdoListPullRequests_Errors(t *testing.T) {
 		args := map[string]interface{}{"organization": "o", "project": "p", "repository": "r"}
 		_, err := m.AdoListPullRequests(context.Background(), args, nil)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to decode response")
+		assert.Contains(t, err.Error(), "decoding response")
 	})
 }
 

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -17,6 +17,16 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
+// adoPipelinesResponse is the API response envelope for listing pipelines.
+type adoPipelinesResponse struct {
+	Value []adoPipeline `json:"value"`
+}
+
+// adoBuildChangesResponse is the API response envelope for build changes.
+type adoBuildChangesResponse struct {
+	Value []interface{} `json:"value"`
+}
+
 func (m *AdoManager) fetchPipelines(ctx context.Context, org, project string) ([]adoPipeline, error) {
 	cacheKey := org + "/" + project
 
@@ -35,18 +45,9 @@ func (m *AdoManager) fetchPipelines(ctx context.Context, org, project string) ([
 		requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines?api-version=7.1",
 			m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
-		resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+		responseData, err := executeAdoGet[adoPipelinesResponse](ctx, m, requestURL, nil)
 		if err != nil {
-			return nil, fmt.Errorf("executing fetch pipelines request: %w", err)
-		}
-		defer func() { _ = resp.Body.Close() }()
-
-		var responseData struct {
-			Value []adoPipeline `json:"value"`
-		}
-
-		if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
-			return nil, fmt.Errorf("failed to decode response: %w", err)
+			return nil, fmt.Errorf("fetching pipelines: %w", err)
 		}
 
 		// 3. Write to Cache
@@ -345,9 +346,7 @@ func (m *AdoManager) buildGetBuildChangesURL(params adoGetBuildChangesParams) (s
 }
 
 func (m *AdoManager) decodeBuildChangesResponse(body io.Reader) ([]interface{}, error) {
-	var responseData struct {
-		Value []interface{} `json:"value"`
-	}
+	var responseData adoBuildChangesResponse
 
 	if err := json.NewDecoder(body).Decode(&responseData); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -15,6 +15,21 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
+// adoPipelineRunsResponse is the API response envelope for listing pipeline runs.
+type adoPipelineRunsResponse struct {
+	Value []adoPipelineRun `json:"value"`
+}
+
+// adoBuildTimelineResponse is the API response envelope for build timeline records.
+type adoBuildTimelineResponse struct {
+	Records []interface{} `json:"records"`
+}
+
+// adoLogEntriesResponse is the API response envelope for listing pipeline logs.
+type adoLogEntriesResponse struct {
+	Value []adoLogEntry `json:"value"`
+}
+
 // ListPipelineRuns is the infrastructure-layer entry point for fetching pipeline
 // runs. It returns raw domain structs together with the resolved pipeline ID
 // (which the formatter needs to caption the output). Presentation is the
@@ -37,17 +52,9 @@ func (m *AdoManager) ListPipelineRuns(ctx context.Context, args map[string]inter
 		return 0, nil, fmt.Errorf("building list pipeline runs URL: %w", err)
 	}
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	responseData, err := executeAdoGet[adoPipelineRunsResponse](ctx, m, requestURL, nil)
 	if err != nil {
-		return 0, nil, fmt.Errorf("executing list pipeline runs request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var responseData struct {
-		Value []adoPipelineRun `json:"value"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
-		return 0, nil, fmt.Errorf("failed to decode response: %w", err)
+		return 0, nil, fmt.Errorf("listing pipeline runs: %w", err)
 	}
 
 	return params.PipelineId, filterAndLimitRuns(responseData.Value, params.Repository, params.OriginalTop), nil
@@ -90,15 +97,9 @@ func (m *AdoManager) GetPipelineRun(ctx context.Context, args map[string]interfa
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d?api-version=7.1",
 		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId, params.RunId)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	runData, err := executeAdoGet[adoPipelineRunDetail](ctx, m, requestURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("executing get pipeline run request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var runData adoPipelineRunDetail
-	if err := json.NewDecoder(resp.Body).Decode(&runData); err != nil {
-		return nil, fmt.Errorf("failed to decode response: %w", err)
+		return nil, fmt.Errorf("fetching pipeline run %d: %w", params.RunId, err)
 	}
 
 	return &runData, nil
@@ -206,9 +207,7 @@ func (m *AdoManager) GetBuildTimeline(ctx context.Context, args map[string]inter
 	}
 	defer func() { _ = resp.Body.Close() }()
 
-	var timelineData struct {
-		Records []interface{} `json:"records"`
-	}
+	var timelineData adoBuildTimelineResponse
 
 	if err := json.NewDecoder(resp.Body).Decode(&timelineData); err != nil {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
@@ -239,17 +238,9 @@ func (m *AdoManager) ListPipelineLogs(ctx context.Context, args map[string]inter
 	u := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs/%d/logs?api-version=7.1",
 		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), params.PipelineId, params.RunId)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u, nil, nil)
+	logsData, err := executeAdoGet[adoLogEntriesResponse](ctx, m, u, nil)
 	if err != nil {
-		return 0, nil, fmt.Errorf("executing list pipeline logs request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var logsData struct {
-		Value []adoLogEntry `json:"value"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&logsData); err != nil {
-		return 0, nil, fmt.Errorf("failed to decode logs list: %w", err)
+		return 0, nil, fmt.Errorf("listing pipeline logs: %w", err)
 	}
 
 	return params.RunId, logsData.Value, nil

--- a/internal/tools/integrations/ado/pipeline_test.go
+++ b/internal/tools/integrations/ado/pipeline_test.go
@@ -73,7 +73,7 @@ func TestListPipelines(t *testing.T) {
 				"project":      "myproj",
 			},
 			wantError: true,
-			errMsg:    "failed to decode response",
+			errMsg:    "decoding response",
 		},
 		{
 			name: "Missing required parameters",

--- a/internal/tools/integrations/ado/policy.go
+++ b/internal/tools/integrations/ado/policy.go
@@ -5,9 +5,7 @@ package ado
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strings"
 
@@ -66,17 +64,7 @@ func (m *AdoManager) fetchPrStatuses(ctx context.Context, org, project, repo str
 	q.Set("api-version", "7.1")
 	u.RawQuery = q.Encode()
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, u.String(), nil, nil)
-	if err != nil {
-		return adoStatusResponse{}, fmt.Errorf("executing fetch pr statuses request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var statusData adoStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&statusData); err != nil {
-		return adoStatusResponse{}, fmt.Errorf("failed to decode response: %w", err)
-	}
-	return statusData, nil
+	return executeAdoGet[adoStatusResponse](ctx, m, u.String(), nil)
 }
 
 func (m *AdoManager) formatPrStatuses(pullRequestId int, statusData adoStatusResponse) string {
@@ -142,6 +130,25 @@ type adoPolicyType struct {
 	Id          string `json:"id"`
 }
 
+// adoPRMetadataResponse is the minimal PR metadata needed to extract the project ID.
+type adoPRMetadataResponse struct {
+	Repository struct {
+		Project struct {
+			Id string `json:"id"`
+		} `json:"project"`
+	} `json:"repository"`
+}
+
+// adoRepoIDResponse is the minimal repository metadata for ID extraction.
+type adoRepoIDResponse struct {
+	Id string `json:"id"`
+}
+
+// adoPolicyConfigsResponse is the API response envelope for policy configurations.
+type adoPolicyConfigsResponse struct {
+	Value []adoPolicyConfig `json:"value"`
+}
+
 func (m *AdoManager) AdoGetPrPolicyEvaluations(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	var params struct {
 		Organization  string `json:"organization"`
@@ -177,21 +184,9 @@ func (m *AdoManager) fetchPrProjectID(ctx context.Context, org, project, repo st
 	prRequestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=7.1",
 		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo), prID)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, prRequestURL, nil, nil)
+	prData, err := executeAdoGet[adoPRMetadataResponse](ctx, m, prRequestURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("executing fetch pr project ID request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var prData struct {
-		Repository struct {
-			Project struct {
-				Id string `json:"id"`
-			} `json:"project"`
-		} `json:"repository"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&prData); err != nil {
-		return "", fmt.Errorf("failed to decode PR metadata: %w", err)
+		return "", fmt.Errorf("fetching PR metadata: %w", err)
 	}
 
 	if prData.Repository.Project.Id == "" {
@@ -219,17 +214,7 @@ func (m *AdoManager) fetchPolicyEvaluations(ctx context.Context, org, project, a
 }
 
 func (m *AdoManager) performPolicyEvaluationRequest(ctx context.Context, requestURL string) (adoPolicyResponse, error) {
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
-	if err != nil {
-		return adoPolicyResponse{}, fmt.Errorf("performing policy evaluation request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var policyData adoPolicyResponse
-	if err := json.NewDecoder(resp.Body).Decode(&policyData); err != nil {
-		return adoPolicyResponse{}, fmt.Errorf("failed to decode response: %w", err)
-	}
-	return policyData, nil
+	return executeAdoGet[adoPolicyResponse](ctx, m, requestURL, nil)
 }
 
 func (m *AdoManager) formatPolicyEvaluations(pullRequestId int, policyData adoPolicyResponse) (tools.ToolResult, error) {
@@ -302,17 +287,9 @@ func (m *AdoManager) fetchRepositoryId(ctx context.Context, org, project, repo s
 	repoURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s?api-version=7.1",
 		m.BaseURL, url.PathEscape(org), url.PathEscape(project), url.PathEscape(repo))
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, repoURL, nil, nil)
+	repoData, err := executeAdoGet[adoRepoIDResponse](ctx, m, repoURL, nil)
 	if err != nil {
-		return "", fmt.Errorf("failed to fetch repository metadata: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var repoData struct {
-		Id string `json:"id"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&repoData); err != nil {
-		return "", fmt.Errorf("failed to decode repository metadata: %w", err)
+		return "", fmt.Errorf("fetching repository metadata: %w", err)
 	}
 	return repoData.Id, nil
 }
@@ -321,17 +298,9 @@ func (m *AdoManager) fetchPolicyConfigurations(ctx context.Context, org, project
 	policyURL := fmt.Sprintf("%s/%s/%s/_apis/policy/configurations?api-version=7.1",
 		m.BaseURL, url.PathEscape(org), url.PathEscape(project))
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, policyURL, nil, nil)
+	policyConfigs, err := executeAdoGet[adoPolicyConfigsResponse](ctx, m, policyURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch policy configurations: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var policyConfigs struct {
-		Value []adoPolicyConfig `json:"value"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&policyConfigs); err != nil {
-		return nil, fmt.Errorf("failed to decode policy configurations: %w", err)
+		return nil, fmt.Errorf("fetching policy configurations: %w", err)
 	}
 	return policyConfigs.Value, nil
 }

--- a/internal/tools/integrations/ado/policy_test.go
+++ b/internal/tools/integrations/ado/policy_test.go
@@ -218,7 +218,7 @@ func TestAdoGetPrStatuses_Errors(t *testing.T) {
 					_, _ = w.Write([]byte(`{invalid`))
 				}))
 			},
-			expectedErr: "failed to decode response",
+			expectedErr: "decoding response",
 		},
 	}
 
@@ -285,7 +285,7 @@ func TestAdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 					_, _ = w.Write([]byte(`{invalid`))
 				}))
 			},
-			expectedErr: "failed to decode PR metadata",
+			expectedErr: "decoding response",
 		},
 		{
 			name: "fetchPrProjectID - empty project ID",
@@ -333,7 +333,7 @@ func TestAdoGetPrPolicyEvaluations_Errors(t *testing.T) {
 					_, _ = w.Write([]byte(`{bad`))
 				}))
 			},
-			expectedErr: "failed to decode response",
+			expectedErr: "decoding response",
 		},
 	}
 

--- a/internal/tools/integrations/ado/pr.go
+++ b/internal/tools/integrations/ado/pr.go
@@ -5,9 +5,7 @@ package ado
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"strconv"
 	"strings"
@@ -37,15 +35,9 @@ func (m *AdoManager) adoGetPullRequest(ctx context.Context, args map[string]inte
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d?api-version=7.1",
 		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	prData, err := executeAdoGet[adoPullRequestDetail](ctx, m, requestURL, nil)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("executing get pull request request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var prData adoPullRequestDetail
-	if err := json.NewDecoder(resp.Body).Decode(&prData); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
+		return tools.ToolResult{}, fmt.Errorf("fetching pull request %d: %w", params.PullRequestId, err)
 	}
 
 	return tools.ToolResult{Text: m.formatPullRequestDetail(params.PullRequestId, prData)}, nil
@@ -66,6 +58,17 @@ type adoPullRequestDetail struct {
 		Id   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"repository"`
+}
+
+// adoListPRResponse is the API response envelope for listing pull requests.
+type adoListPRResponse struct {
+	Value []adoPullRequestShort `json:"value"`
+	Count int                   `json:"count"`
+}
+
+// adoChangeEntriesResponse is the API response for PR iteration changes.
+type adoChangeEntriesResponse struct {
+	ChangeEntries []prChangeEntry `json:"changeEntries"`
 }
 
 type prChangeEntry struct {
@@ -111,19 +114,9 @@ func (m *AdoManager) AdoListPullRequests(ctx context.Context, args map[string]in
 		return tools.ToolResult{}, fmt.Errorf("building list pull requests URL: %w", err)
 	}
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	responseData, err := executeAdoGet[adoListPRResponse](ctx, m, requestURL, nil)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("executing list pull requests request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var responseData struct {
-		Value []adoPullRequestShort `json:"value"`
-		Count int                   `json:"count"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&responseData); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
+		return tools.ToolResult{}, fmt.Errorf("listing pull requests: %w", err)
 	}
 
 	return tools.ToolResult{Text: m.formatPullRequestsList(responseData.Value)}, nil
@@ -197,18 +190,9 @@ func (m *AdoManager) adoGetPrDiff(ctx context.Context, args map[string]interface
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d/iterations/1/changes?api-version=7.1",
 		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	changeData, err := executeAdoGet[adoChangeEntriesResponse](ctx, m, requestURL, nil)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("executing get pr diff request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var changeData struct {
-		ChangeEntries []prChangeEntry `json:"changeEntries"`
-	}
-
-	if err := json.NewDecoder(resp.Body).Decode(&changeData); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
+		return tools.ToolResult{}, fmt.Errorf("fetching PR diff: %w", err)
 	}
 
 	return tools.ToolResult{Text: formatPrDiffChanges(params.PullRequestId, changeData.ChangeEntries)}, nil
@@ -296,15 +280,9 @@ func (m *AdoManager) AdoGetPrThreads(ctx context.Context, args map[string]interf
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/git/repositories/%s/pullrequests/%d/threads?api-version=7.1",
 		m.BaseURL, url.PathEscape(params.Organization), url.PathEscape(params.Project), url.PathEscape(params.Repository), params.PullRequestId)
 
-	resp, err := m.ExecuteRequest(ctx, http.MethodGet, requestURL, nil, nil)
+	threadData, err := executeAdoGet[adoThreadResponse](ctx, m, requestURL, nil)
 	if err != nil {
-		return tools.ToolResult{}, fmt.Errorf("executing get pr threads request: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	var threadData adoThreadResponse
-	if err := json.NewDecoder(resp.Body).Decode(&threadData); err != nil {
-		return tools.ToolResult{}, fmt.Errorf("failed to decode response: %w", err)
+		return tools.ToolResult{}, fmt.Errorf("fetching PR threads: %w", err)
 	}
 
 	return tools.ToolResult{Text: m.formatPrThreads(params.PullRequestId, threadData)}, nil

--- a/internal/tools/integrations/fault_injection_test.go
+++ b/internal/tools/integrations/fault_injection_test.go
@@ -107,7 +107,7 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 				_, err := m.AdoListRepositoryItems(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Context Cancellation in executeRequest",
@@ -142,7 +142,7 @@ func TestADOManager_ErrorPaths(t *testing.T) {
 				_, err := m.GetPipelineRun(ctx, args)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 	}
 
@@ -403,7 +403,7 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 				_, _, err := m.ListPipelineRuns(ctx, args)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Unmarshal Failure in ListPipelineLogs",
@@ -425,7 +425,7 @@ func TestADOManager_MoreErrorPaths(t *testing.T) {
 				_, _, err := m.ListPipelineLogs(ctx, args)
 				return err
 			},
-			wantErrMsg: "failed to decode logs list",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Unmarshal Failure in adoGetBuildTimeline",
@@ -543,7 +543,7 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 				_, err := m.AdoGetPrStatuses(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Unmarshal Failure in fetchPrProjectID",
@@ -565,7 +565,7 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 				_, err := m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode PR metadata",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Unmarshal Failure in fetchPolicyEvaluations",
@@ -593,7 +593,7 @@ func TestADOManager_PolicyErrorPaths(t *testing.T) {
 				_, err := m.AdoGetPrPolicyEvaluations(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 	}
 
@@ -646,7 +646,7 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 				_, err := m.AdoListPullRequests(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 		{
 			name: "Unmarshal Failure in adoGetPrThreads",
@@ -668,7 +668,7 @@ func TestADOManager_PrErrorPaths(t *testing.T) {
 				_, err := m.AdoGetPrThreads(ctx, args, nil)
 				return err
 			},
-			wantErrMsg: "failed to decode response",
+			wantErrMsg: "decoding response",
 		},
 	}
 


### PR DESCRIPTION
Closes #1003.

## Summary
Extract shared `executeAdoGet[T any]` generic HTTP helper in `ado_http.go` to eliminate DRY violation across the ADO integration package. Replaced ~65 lines of duplicated `ExecuteRequest → defer close → json.Decode` boilerplate across 14 functions in 5 files.

### Changes
- **New:** `ado_http.go` — generic `executeAdoGet[T any]` helper
- **New:** 10 named response types (previously anonymous structs)
- **Migrated:** 14 functions in `pr.go`, `policy.go`, `pipeline_runs.go`, `pipeline_crud.go`, `azure_devops.go`
- **Imports cleaned:** `encoding/json` and `net/http` removed from `pr.go`, `policy.go`, `azure_devops.go`
- **Tests updated:** ~30 error message assertions across 6 test files
- **Excluded:** 6 functions intentionally not migrated (raw body processing, `interface{}` return types)

## Verification
| Check | Status |
|-------|--------|
| make check-full | ✅ PASS |
| go test -race (ADO) | ✅ PASS |
| golangci-lint | ✅ 0 issues |
| Coverage (ADO) | 99.4% |
