### PR TITLE
fix(agenttest): cover untested nil-func and boundary branches in mocks (#1011)

### DIFF
--- a/internal/agent/agenttest/mock_health_test.go
+++ b/internal/agent/agenttest/mock_health_test.go
@@ -176,3 +176,47 @@ func TestMockHealthCheckManager_RaceCondition(t *testing.T) {
 		t.Errorf("calledMethods length: got %d, want %d", len(methods), goroutines*iterations)
 	}
 }
+
+// TestMockHealthCheckManager_NilFuncs exercises the two nil-func fallthrough
+// branches in mock_health.go where CheckAllFunc or CheckComponentFunc is nil.
+func TestMockHealthCheckManager_NilFuncs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(m *MockHealthCheckManager)
+	}{
+		{
+			name: "CheckAll_nil_func",
+			call: func(m *MockHealthCheckManager) {
+				got, err := m.CheckAll(context.Background())
+				if got != nil {
+					t.Errorf("CheckAll nil func: got %+v, want nil", got)
+				}
+				if err != nil {
+					t.Errorf("CheckAll nil func: unexpected error %v", err)
+				}
+			},
+		},
+		{
+			name: "CheckComponent_nil_func",
+			call: func(m *MockHealthCheckManager) {
+				got, err := m.CheckComponent(context.Background(), ports.CompLLMProvider)
+				if got != nil {
+					t.Errorf("CheckComponent nil func: got %+v, want nil", got)
+				}
+				if err != nil {
+					t.Errorf("CheckComponent nil func: unexpected error %v", err)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MockHealthCheckManager{}
+			tt.call(m)
+		})
+	}
+}

--- a/internal/agent/agenttest/mock_history_manager_test.go
+++ b/internal/agent/agenttest/mock_history_manager_test.go
@@ -199,6 +199,26 @@ func TestMockHistoryManager_GetWindow_WithError(t *testing.T) {
 	}
 }
 
+func TestMockHistoryManager_GetWindow_NegativeStartIdx(t *testing.T) {
+	t.Parallel()
+
+	m := newMockWithContents(3)
+
+	window, err := m.GetWindow(context.Background(), -1, 3)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(window) != 3 {
+		t.Fatalf("got %d items; want 3 (startIdx clamped to 0)", len(window))
+	}
+	// Verify deep copy: mutating window should not affect internal contents.
+	window[0].Parts[0].Text = "mutated"
+	internal := m.GetContents()
+	if internal[0].Parts[0].Text == "mutated" {
+		t.Error("GetWindow did not deep-copy; internal state was mutated")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // RollbackTurns
 // ---------------------------------------------------------------------------

--- a/internal/agent/agenttest/mock_session_provider_test.go
+++ b/internal/agent/agenttest/mock_session_provider_test.go
@@ -211,3 +211,57 @@ func TestMockSessionProvider_RaceCondition(t *testing.T) {
 		t.Errorf("total calls: got %d, want %d", got, want)
 	}
 }
+
+func TestMockSessionProvider_NilFuncs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(m *MockSessionProvider)
+	}{
+		{
+			name: "GetSettings_nil_func",
+			call: func(m *MockSessionProvider) {
+				got := m.GetSettings()
+				if got != nil {
+					t.Errorf("GetSettings nil func: got %+v, want nil", got)
+				}
+			},
+		},
+		{
+			name: "GetInfo_nil_func",
+			call: func(m *MockSessionProvider) {
+				got := m.GetInfo()
+				if got.Model != "" {
+					t.Errorf("GetInfo nil func: got Model %q, want empty", got.Model)
+				}
+			},
+		},
+		{
+			name: "Close_nil_func",
+			call: func(m *MockSessionProvider) {
+				err := m.Close()
+				if err != nil {
+					t.Errorf("Close nil func: unexpected error %v", err)
+				}
+			},
+		},
+		{
+			name: "GetHealthChecker_nil_func",
+			call: func(m *MockSessionProvider) {
+				got := m.GetHealthChecker()
+				if got != nil {
+					t.Errorf("GetHealthChecker nil func: got %+v, want nil", got)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			m := &MockSessionProvider{}
+			tt.call(m)
+		})
+	}
+}

--- a/internal/agent/agenttest/mock_ui_renderer_test.go
+++ b/internal/agent/agenttest/mock_ui_renderer_test.go
@@ -794,3 +794,75 @@ func TestMockUIRenderer_Concurrency(t *testing.T) {
 		t.Errorf("LogTurnStatus = %d; want %d", snap.LogTurnStatus, n)
 	}
 }
+
+// Run: go test -race -run TestMockUIRenderer_SwapLogSystemMessageFn
+func TestMockUIRenderer_SwapLogSystemMessageFn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// Create initial function and capture whether it was called.
+	origCalled := false
+	origFn := func(_ context.Context, msg string, level string) {
+		origCalled = true
+	}
+
+	m := &MockUIRenderer{
+		LogSystemMessageFn: origFn,
+	}
+
+	// Create new function and capture whether it was called.
+	newCalled := false
+	newFn := func(_ context.Context, msg string, level string) {
+		newCalled = true
+	}
+
+	// Swap and verify returned function is the original.
+	returned := m.SwapLogSystemMessageFn(newFn)
+
+	// Call LogSystemMessage — should invoke newFn.
+	m.LogSystemMessage(ctx, "test", "info")
+	if !newCalled {
+		t.Error("newFn was not called after swap; swap did not take effect")
+	}
+
+	// Call the returned function directly — should invoke origFn.
+	returned(ctx, "test", "info")
+	if !origCalled {
+		t.Error("returned origFn was not called when invoked directly")
+	}
+
+	// Verify the count is exactly 1 (one call to LogSystemMessage).
+	snap := m.Snapshot()
+	if snap.LogSystemMessage != 1 {
+		t.Errorf("LogSystemMessage = %d; want 1", snap.LogSystemMessage)
+	}
+}
+
+// Run: go test -race -run TestMockUIRenderer_SwapLogSystemMessageFn_Concurrency
+func TestMockUIRenderer_SwapLogSystemMessageFn_Concurrency(t *testing.T) {
+	t.Parallel()
+
+	m := &MockUIRenderer{}
+	var wg sync.WaitGroup
+	n := 10
+
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			// Each goroutine creates a unique closure capturing i.
+			fn := func(_ context.Context, msg string, level string) {
+				_ = i // unique per goroutine
+			}
+			_ = m.SwapLogSystemMessageFn(fn)
+			m.LogSystemMessage(context.Background(), "msg", "info")
+		}(i)
+	}
+	wg.Wait()
+
+	snap := m.Snapshot()
+	if snap.LogSystemMessage != n {
+		t.Errorf("LogSystemMessage = %d; want %d", snap.LogSystemMessage, n)
+	}
+}


### PR DESCRIPTION
Closes #1011.

## Summary
Added table-driven tests covering all 8 medium-priority BUSINESS_LOGIC gaps in `internal/agent/agenttest/` mock files:
- `mock_health_test.go`: Nil-func fallthrough tests for CheckAll and CheckComponent
- `mock_history_manager_test.go`: `startIdx < 0` boundary test for GetWindow
- `mock_session_provider_test.go`: Nil-func fallthrough tests for GetSettings, GetInfo, Close, GetHealthChecker
- `mock_ui_renderer_test.go`: Single-threaded and concurrent tests for SwapLogSystemMessageFn

No behavioral changes to mock implementations — only `*_test.go` files modified.

## Verification
| Check | Status |
|-------|--------|
| make check | PASS |
| make test-race | PASS |
| Coverage (agenttest) | 100.0% (up from 98.0%) |
| golangci-lint | 0 issues |
