### PR TITLE
fix(infra): cover untested error branches and add canary docs (#1013)

### DIFF
--- a/internal/infrastructure/history/global_prompt_tracker_error_test.go
+++ b/internal/infrastructure/history/global_prompt_tracker_error_test.go
@@ -472,3 +472,114 @@ func TestAppend_MarshalErrorUnreachable(t *testing.T) {
 		t.Error("error format string mismatch")
 	}
 }
+
+// TestPerformCompactionPass_EmptyData covers the gap at
+// global_prompt_tracker.go:332-334: len(data) == 0 → return false.
+//
+// When the tracker file exists but is empty (0 bytes), prepareCompactedEntries
+// returns nil, nil (len(entries) == 0 → return nil, nil). performCompactionPass
+// must detect this, return false, and leave the file untouched.
+func TestPerformCompactionPass_EmptyData(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	outputDir := filepath.Join(tmpDir, "output")
+	trackerPath := filepath.Join(outputDir, "global_prompts.jsonl")
+
+	// Create an empty file
+	if err := baseFS.MkdirAll(context.Background(), outputDir, 0755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	if err := baseFS.WriteFile(context.Background(), trackerPath, []byte{}, 0644); err != nil {
+		t.Fatalf("failed to write empty tracker file: %v", err)
+	}
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: trackerPath,
+	}
+
+	success := tracker.performCompactionPass(context.Background())
+	if success {
+		t.Error("expected performCompactionPass to return false for empty data")
+	}
+
+	// Verify file is still empty (no compaction artifacts)
+	content, err := baseFS.ReadFile(context.Background(), trackerPath)
+	if err != nil {
+		t.Fatalf("failed to read file after aborted pass: %v", err)
+	}
+	if len(content) != 0 {
+		t.Errorf("expected empty file after aborted pass, got %d bytes", len(content))
+	}
+}
+
+// TestShouldStillCompact_BelowThreshold covers the gap at
+// global_prompt_tracker.go:348-350: newInfo.Size() <= compactionThresholdBytes
+// → return false.
+//
+// When the tracker file is below the compaction threshold (150KB),
+// shouldStillCompact must return false, preventing unnecessary retries.
+func TestShouldStillCompact_BelowThreshold(t *testing.T) {
+	tmpDir := t.TempDir()
+	baseFS := persistence.NewOSFileSystem()
+	outputDir := filepath.Join(tmpDir, "output")
+	trackerPath := filepath.Join(outputDir, "global_prompts.jsonl")
+
+	// Write a small file (well below 150KB threshold)
+	smallContent := []byte(`{"timestamp":"t","prompt":"small"}` + "\n")
+	if err := baseFS.MkdirAll(context.Background(), outputDir, 0755); err != nil {
+		t.Fatalf("failed to create output dir: %v", err)
+	}
+	if err := baseFS.WriteFile(context.Background(), trackerPath, smallContent, 0644); err != nil {
+		t.Fatalf("failed to write small tracker file: %v", err)
+	}
+
+	tracker := &globalPromptTracker{
+		fs:       baseFS,
+		filepath: trackerPath,
+	}
+
+	backoff := 100 * time.Millisecond
+	shouldCompact := tracker.shouldStillCompact(context.Background(), &backoff)
+	if shouldCompact {
+		t.Error("expected shouldStillCompact to return false for file below threshold")
+	}
+}
+
+// TestWriteCompactedData_MarshalErrorUnreachable documents that the
+// json.Marshal error path in writeCompactedData
+// (global_prompt_tracker.go:367-369) is UNREACHABLE.
+//
+// writeCompactedData marshals promptEntry values, which contain only
+// string fields (Timestamp string, Prompt string). json.Marshal on a
+// struct with only string fields cannot fail. The error-handling branch
+// exists for defensive future-proofing.
+//
+// This test proves that promptEntry always marshals cleanly and serves
+// as a canary in case the struct fields change.
+func TestWriteCompactedData_MarshalErrorUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Every valid promptEntry must marshal without error
+	entries := []promptEntry{
+		{Timestamp: "2026-01-01T00:00:00Z", Prompt: "normal"},
+		{Timestamp: "", Prompt: ""},
+		{Timestamp: "2026-01-01T00:00:00Z", Prompt: "unicode: 🚀\n\t\"escaped\""},
+		{Timestamp: "2026-01-01T00:00:00Z", Prompt: "\x00\x01\x7f"},
+		{Timestamp: "2026-01-01T00:00:00Z", Prompt: strings.Repeat("X", 10000)},
+	}
+
+	for i, entry := range entries {
+		data, err := json.Marshal(entry)
+		if err != nil {
+			t.Fatalf("entry %d: json.Marshal unexpectedly failed: %v", i, err)
+		}
+		if len(data) == 0 {
+			t.Errorf("entry %d: expected non-empty marshaled data", i)
+		}
+	}
+
+	t.Log("[UNREACHABLE] json.Marshal(promptEntry{...}) never fails; " +
+		"all fields are string types. " +
+		"Error path in writeCompactedData is defensive future-proofing")
+}

--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -947,3 +947,60 @@ func TestPrepareAnthropicRequest_MarshalFailure(t *testing.T) {
 		}
 	})
 }
+
+// TestPrepareAnthropicRequest_MarshalErrorUnreachable documents that the
+// json.Marshal(reqPayload) error path in prepareAnthropicRequest
+// (client.go:375-377) is UNREACHABLE with the current messagesRequest type tree.
+//
+// Every field in messagesRequest resolves to strings, ints, or interface{}
+// populated with JSON-safe types. No float64 fields exist, so NaN/Inf cannot
+// appear. The error branch is defensive dead code that serves as a safety net
+// if a future field addition introduces a marshal-unfriendly type.
+//
+// This test proves that all valid payloads marshal cleanly and serves as a
+// canary in case the struct fields change.
+func TestPrepareAnthropicRequest_MarshalErrorUnreachable(t *testing.T) {
+	t.Parallel()
+
+	// Build a representative payload with all optional fields populated
+	payload := messagesRequest{
+		Model:     "claude-3-5-sonnet",
+		Messages:  []message{{Role: "user", Content: []contentBlock{{Type: "text", Text: "hello"}}}},
+		MaxTokens: 16384,
+		Tools: []tool{{
+			Name:        "test_tool",
+			Description: "A test tool",
+			InputSchema: map[string]interface{}{"type": "object", "properties": map[string]interface{}{"param": map[string]string{"type": "string"}}},
+		}},
+		System: []systemBlock{{
+			Type:         "text",
+			Text:         "You are a helpful assistant.",
+			CacheControl: &cacheControl{Type: "ephemeral"},
+		}},
+		Thinking: &thinking{Type: "enabled", Budget: 4096},
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("json.Marshal on messagesRequest unexpectedly failed: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty marshaled data")
+	}
+
+	// Round-trip: unmarshal and verify key fields preserved
+	var restored messagesRequest
+	if err := json.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if restored.Model != "claude-3-5-sonnet" {
+		t.Errorf("Model: got %q, want %q", restored.Model, "claude-3-5-sonnet")
+	}
+	if restored.MaxTokens != 16384 {
+		t.Errorf("MaxTokens: got %d, want %d", restored.MaxTokens, 16384)
+	}
+
+	t.Log("[UNREACHABLE] json.Marshal on messagesRequest never fails; " +
+		"all fields are marshal-safe Go types. " +
+		"Error path exists for defensive future-proofing.")
+}

--- a/internal/infrastructure/llm/openai/client_responses_edge_test.go
+++ b/internal/infrastructure/llm/openai/client_responses_edge_test.go
@@ -6,6 +6,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,8 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // getResponsesAPIEdgeGap1And2 covers Gap 1 & 2: Direct content blocks
@@ -552,11 +555,16 @@ func TestErrUnhandledBlockTypePropagation(t *testing.T) {
 
 	t.Run("errUnhandledBlockType propagation", func(t *testing.T) {
 		t.Parallel()
-		t.Log("[DEFENSIVE] The !errors.Is(err, errUnhandledBlockType) branch " +
-			"in processDirectOutputItem is defensive future-proofing for new block types. " +
-			"Covered by existing edge-case tests: " +
-			"getResponsesAPIEdgeGap3b (child-block propagation), " +
-			"getResponsesAPIEdgeADR024Sentinel (direct-item suppression), " +
-			"getResponsesAPIEdgeADR022 (fail-loud for unrecognized types).")
+
+		// Verify the sentinel exists and errors.Is behaves correctly.
+		// Runtime coverage of the !errors.Is guard in processDirectOutputItem
+		// is provided by: getResponsesAPIEdgeGap3b (child-block propagation),
+		// getResponsesAPIEdgeADR024Sentinel (direct-item suppression),
+		// getResponsesAPIEdgeADR022 (fail-loud for unrecognized types).
+		require.NotNil(t, errUnhandledBlockType, "sentinel must exist")
+		assert.True(t, errors.Is(errUnhandledBlockType, errUnhandledBlockType),
+			"sentinel must match itself via errors.Is")
+		assert.False(t, errors.Is(errors.New("other"), errUnhandledBlockType),
+			"errors.Is must not produce false positives on unrelated errors")
 	})
 }

--- a/internal/infrastructure/llm/openai/client_responses_edge_test.go
+++ b/internal/infrastructure/llm/openai/client_responses_edge_test.go
@@ -533,3 +533,30 @@ func TestResponsesAPIRouting(t *testing.T) {
 		}
 	})
 }
+
+// TestErrUnhandledBlockTypePropagation documents the defensive
+// !errors.Is(err, errUnhandledBlockType) branch in processDirectOutputItem
+// (responses.go:154-156).
+//
+// When a direct output item's type is not a recognised content-block type,
+// appendPartsFromBlock returns errUnhandledBlockType, which
+// processDirectOutputItem suppresses via errors.Is. Execution then falls
+// through to the child Content loop. The child loop has NO sentinel
+// suppression, so an unknown child content block type propagates as an error.
+//
+// Covered by: getResponsesAPIEdgeGap3b (child-content unknown type),
+// getResponsesAPIEdgeADR024Sentinel (suppression in direct output item),
+// and getResponsesAPIEdgeADR022 (fail-loud for unrecognized top-level types).
+func TestErrUnhandledBlockTypePropagation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("errUnhandledBlockType propagation", func(t *testing.T) {
+		t.Parallel()
+		t.Log("[DEFENSIVE] The !errors.Is(err, errUnhandledBlockType) branch " +
+			"in processDirectOutputItem is defensive future-proofing for new block types. " +
+			"Covered by existing edge-case tests: " +
+			"getResponsesAPIEdgeGap3b (child-block propagation), " +
+			"getResponsesAPIEdgeADR024Sentinel (direct-item suppression), " +
+			"getResponsesAPIEdgeADR022 (fail-loud for unrecognized types).")
+	})
+}

--- a/internal/infrastructure/security/paths_test.go
+++ b/internal/infrastructure/security/paths_test.go
@@ -1214,4 +1214,13 @@ func TestSystemDependentBranches_Documented(t *testing.T) {
 			"covered by TestBoundaryChecks_ErrorLogging on platforms where " +
 			"filepath.Abs rejects NUL bytes. Skipped on this platform.")
 	})
+
+	t.Run("G5-line324: tryBoundary error logging", func(t *testing.T) {
+		t.Parallel()
+		t.Log("[SYSTEM-DEPENDENT] line 324: tryBoundary error logging — " +
+			"checkBoundary only errors when filepath.Abs(boundary) fails. " +
+			"Default boundaries (CWD, TempDir, extra temp dirs) are always valid paths. " +
+			"Covered by TestBoundaryChecks_ErrorLogging on platforms where " +
+			"filepath.Abs rejects NUL bytes.")
+	})
 }

--- a/internal/infrastructure/security/policy_error_test.go
+++ b/internal/infrastructure/security/policy_error_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -270,10 +271,11 @@ func TestPolicyTool_ErrorPaths(t *testing.T) {
 		// json.Marshal on a []string never fails, so the error path in
 		// persistPaths is unreachable in practice. This test documents
 		// that fact and serves as a canary in case the type changes.
-		data, err := json.Marshal([]string{"/a", "/b"})
+		data, err := json.Marshal([]string{"/a", "/b", "/c"})
 		require.NoError(t, err)
 		require.NotNil(t, data)
-		t.Log("[UNREACHABLE] json.Marshal([]string{...}) never returns an error")
+		t.Log("[UNREACHABLE] json.Marshal([]string{...}) never returns an error; " +
+			"the error path in persistPaths exists for defensive future-proofing")
 	})
 
 	// 10. RemoveSafePath persist error after removal succeeds
@@ -506,6 +508,46 @@ func TestPolicyTool_ErrorPaths(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "user aborted")
 	})
+
+	// 21. RemoveSafePath user denial
+	t.Run("RemoveSafePath user denial", func(t *testing.T) {
+		t.Parallel()
+
+		kv := &funcMockKVStore{}
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "n"}
+		})
+		pt := &policyTool{sm: sm, kv: kv}
+		ctx := context.Background()
+
+		path := filepath.Join(t.TempDir(), "remove-safe-denied")
+		res, err := pt.RemoveSafePath(ctx, map[string]interface{}{
+			"path": path,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Removal denied by user.", res.Text)
+	})
+
+	// 22. RemoveReadPath user denial
+	t.Run("RemoveReadPath user denial", func(t *testing.T) {
+		t.Parallel()
+
+		kv := &funcMockKVStore{}
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "n"}
+		})
+		pt := &policyTool{sm: sm, kv: kv}
+		ctx := context.Background()
+
+		path := filepath.Join(t.TempDir(), "remove-ro-denied")
+		res, err := pt.RemoveReadPath(ctx, map[string]interface{}{
+			"path": path,
+		}, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "Removal denied by user.", res.Text)
+	})
 }
 
 // TestPolicyTool_UnmarshalArgsErrors verifies that all five CRUD functions
@@ -601,4 +643,114 @@ func TestPolicyTool_UnmarshalArgsErrors(t *testing.T) {
 
 		require.Error(t, err)
 	})
+}
+
+func TestPolicy_FilepathAbsErrors(t *testing.T) {
+	origDir, err := os.Getwd()
+	require.NoError(t, err)
+	origPWD, hadPWD := os.LookupEnv("PWD")
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir), "failed to chdir into temp directory")
+	_ = os.Unsetenv("PWD")
+	require.NoError(t, os.RemoveAll(tmpDir), "failed to remove temp directory")
+
+	t.Cleanup(func() {
+		if hadPWD {
+			_ = os.Setenv("PWD", origPWD)
+		} else {
+			_ = os.Unsetenv("PWD")
+		}
+		if err := os.Chdir(origDir); err != nil {
+			t.Logf("failed to restore working directory: %v", err)
+		}
+	})
+
+	_, wdErr := os.Getwd()
+	require.Error(t, wdErr, "os.Getwd() should fail after deleting CWD and unsetting PWD")
+
+	t.Run("RegisterSafePath filepath.Abs error", func(t *testing.T) {
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "y"}
+		})
+		p, pErr := newPolicyTool(sm, new(mockKVStore))
+		require.NoError(t, pErr)
+
+		_, err := p.RegisterSafePath(context.Background(), map[string]interface{}{
+			"path":   "relative/safe/path",
+			"reason": "test",
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid path")
+	})
+
+	t.Run("RemoveSafePath filepath.Abs error", func(t *testing.T) {
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "y"}
+		})
+		p, pErr := newPolicyTool(sm, new(mockKVStore))
+		require.NoError(t, pErr)
+
+		_, err := p.RemoveSafePath(context.Background(), map[string]interface{}{
+			"path": "relative/safe/path",
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid path")
+	})
+
+	t.Run("RegisterReadPath filepath.Abs error", func(t *testing.T) {
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "y"}
+		})
+		p, pErr := newPolicyTool(sm, new(mockKVStore))
+		require.NoError(t, pErr)
+
+		_, err := p.RegisterReadPath(context.Background(), map[string]interface{}{
+			"path":   "relative/read/path",
+			"reason": "test",
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid path")
+	})
+
+	t.Run("RemoveReadPath filepath.Abs error", func(t *testing.T) {
+		sm := NewSecurityManager(func() domain.UserInteractor {
+			return &mockInteractor{Answer: "y"}
+		})
+		p, pErr := newPolicyTool(sm, new(mockKVStore))
+		require.NoError(t, pErr)
+
+		_, err := p.RemoveReadPath(context.Background(), map[string]interface{}{
+			"path": "relative/read/path",
+		}, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid path")
+	})
+}
+
+func TestActionTitle_Default(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		action actionType
+		want   string
+	}{
+		{"path write", actionPathWrite, "persistent access to:"},
+		{"path remove", actionPathRemove, "to REMOVE authorization for:"},
+		{"path read", actionPathRead, "persistent READ-ONLY access to:"},
+		{"path remove read", actionPathRemoveRead, "to REMOVE read-only authorization for:"},
+		{"bypass enable", actionBypassEnable, "to DISABLE ALL interactive security prompts."},
+		{"session update", actionSessionUpdate, "to update session setting:"},
+		{"unknown action type", actionType(999), ""},
+		{"negative action type", actionType(-1), ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := actionTitle(tt.action)
+			assert.Equal(t, tt.want, got)
+		})
+	}
 }

--- a/internal/infrastructure/security/policy_error_test.go
+++ b/internal/infrastructure/security/policy_error_test.go
@@ -650,11 +650,9 @@ func TestPolicy_FilepathAbsErrors(t *testing.T) {
 	require.NoError(t, err)
 	origPWD, hadPWD := os.LookupEnv("PWD")
 
-	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir), "failed to chdir into temp directory")
-	_ = os.Unsetenv("PWD")
-	require.NoError(t, os.RemoveAll(tmpDir), "failed to remove temp directory")
-
+	// Register cleanup BEFORE any destructive process-wide state changes.
+	// This guarantees restoration even if an intermediate require.NoError
+	// fires t.Fatal during the destructive operations below.
 	t.Cleanup(func() {
 		if hadPWD {
 			_ = os.Setenv("PWD", origPWD)
@@ -665,6 +663,11 @@ func TestPolicy_FilepathAbsErrors(t *testing.T) {
 			t.Logf("failed to restore working directory: %v", err)
 		}
 	})
+
+	tmpDir := t.TempDir()
+	require.NoError(t, os.Chdir(tmpDir), "failed to chdir into temp directory")
+	_ = os.Unsetenv("PWD")
+	require.NoError(t, os.RemoveAll(tmpDir), "failed to remove temp directory")
 
 	_, wdErr := os.Getwd()
 	require.Error(t, wdErr, "os.Getwd() should fail after deleting CWD and unsetting PWD")


### PR DESCRIPTION
Closes #1013.

## Summary
Covers remaining medium-priority ERROR_HANDLING and ADAPTER gaps in `internal/infrastructure/*` (excluding telemetry and auth files owned by #1008, #1009b, #1010).

### Changes
- **security/policy_error_test.go**: Added `TestPolicy_FilepathAbsErrors` (4 `filepath.Abs` error branches), `TestActionTitle_Default` (default case), denial tests for `RemoveSafePath`/`RemoveReadPath` user denial, and updated canary docs
- **security/paths_test.go**: Added G5 subtest documenting `tryBoundary` error logging as [SYSTEM-DEPENDENT]
- **history/global_prompt_tracker_error_test.go**: Added `TestPerformCompactionPass_EmptyData`, `TestShouldStillCompact_BelowThreshold`, and `TestWriteCompactedData_MarshalErrorUnreachable` canary
- **llm/anthropic/client_test.go**: Added `TestPrepareAnthropicRequest_MarshalErrorUnreachable` canary
- **llm/openai/client_responses_edge_test.go**: Added `TestErrUnhandledBlockTypePropagation` documentation subtest

### Gap Reduction
| Package | Before | After | Notes |
|---------|:------:|:-----:|-------|
| security/ | 12 | 5 | 5 remaining are [UNREACHABLE]/[SYSTEM-DEPENDENT] |
| history/ | 5 | 3 | 3 remaining are [UNREACHABLE] |
| llm/ | 2 | 2 | Both [UNREACHABLE]/[DEFENSIVE], canary docs added |
| persistence/ | 3 | 0 | Already covered |
| registry/ | 0 | 0 | Fully covered |
| toolchain/ | 0 | 0 | Fully covered |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test ./internal/infrastructure/... | PASS (all 11 packages) |
| No production code changes | ✅ (test files only) |
