### PR TITLE
fix(persistence): replace env-var debug gate with slog level gating (#1022)

### DIFF
--- a/internal/infrastructure/persistence/tasks.go
+++ b/internal/infrastructure/persistence/tasks.go
@@ -38,7 +38,7 @@ func newTaskRepository(fs persistence.FileSystem, filePath string, logger *slog.
 }
 
 // parseJSONLTasks parses tasks from JSONL format (one JSON object per line).
-// Corrupted lines are skipped; debug logging is emitted when TELL_ME_DEBUG=migration.
+// Corrupted lines are skipped; debug logging is emitted when the logger is at Debug level.
 func parseJSONLTasks(trimmed string, filePath string, logger *slog.Logger) []ports.Task {
 	var loaded []ports.Task
 	scanner := bufio.NewScanner(strings.NewReader(trimmed))
@@ -51,13 +51,10 @@ func parseJSONLTasks(trimmed string, filePath string, logger *slog.Logger) []por
 		if err := json.Unmarshal([]byte(line), &t); err != nil {
 			// Skip corrupted lines in legacy tasks to ensure boot continues.
 			// This handles cases where log lines or other non-JSON data may have leaked into the file.
-			// [DEBUG] Log corrupted lines to help identify the source of leakage on Windows.
-			if strings.Contains(os.Getenv("TELL_ME_DEBUG"), "migration") {
-				logger.Debug("corrupted task line during migration",
-					slog.String("path", filePath),
-					slog.String("line", line),
-					slog.Any("error", err))
-			}
+			logger.Debug("corrupted task line during migration",
+				slog.String("path", filePath),
+				slog.String("line", line),
+				slog.Any("error", err))
 			continue
 		}
 		loaded = append(loaded, t)

--- a/internal/infrastructure/persistence/tasks_test.go
+++ b/internal/infrastructure/persistence/tasks_test.go
@@ -89,9 +89,6 @@ func TestTaskRepository_JSONArrayCompatibility(t *testing.T) {
 }
 
 func TestTaskRepository_CorruptedLine(t *testing.T) {
-	// Set the env var that gates the debug log.
-	t.Setenv("TELL_ME_DEBUG", "migration")
-
 	var buf testfixtures.SyncWriter
 	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
@@ -224,13 +221,10 @@ func TestParseJSONLTasks_BlankLine(t *testing.T) {
 }
 
 func TestParseJSONLTasks_CorruptedLineNoDebug(t *testing.T) {
-	// NOTE: t.Parallel() is incompatible with t.Setenv(); this test runs serially.
-
-	// Ensure TELL_ME_DEBUG does NOT contain "migration"
-	t.Setenv("TELL_ME_DEBUG", "")
+	t.Parallel()
 
 	var buf testfixtures.SyncWriter
-	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	testLogger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 	trimmed := `{"id": 1, "content": "Task 1"}
 not valid json
@@ -241,9 +235,9 @@ not valid json
 		t.Fatalf("expected 2 tasks, got %d", len(result))
 	}
 
-	// Verify NO debug message was logged (since TELL_ME_DEBUG doesn't contain migration)
+	// Verify NO debug message was logged (logger is at Info level, above Debug)
 	output := buf.String()
 	if strings.Contains(output, "corrupted task line during migration") {
-		t.Error("expected no debug log when TELL_ME_DEBUG does not contain 'migration'")
+		t.Error("expected no debug log when logger level is above Debug")
 	}
 }


### PR DESCRIPTION
Closes #1022.

## Summary
Replaced the fragile `os.Getenv("TELL_ME_DEBUG")` + `strings.Contains` debug-gating pattern in `parseJSONLTasks` with slog's built-in level gating. The `logger.Debug()` call now runs unconditionally — the logger's own level controls whether output is emitted, consistent with every other debug log in the project.

### Changes
- **`tasks.go`**: Removed env-var guard; `logger.Debug()` is now unguarded (slog gates internally)
- **`tasks_test.go`**: `TestTaskRepository_CorruptedLine` — removed `t.Setenv`; `TestParseJSONLTasks_CorruptedLineNoDebug` — rewritten to gate via `slog.LevelInfo` instead of env var, restored `t.Parallel()`

## Verification
| Check | Status |
|-------|--------|
| make check-full (all 10 steps) | PASS |
| Target coverage | 100% |