### PR TITLE
fix(llm): dedup buildBaseClient with fallthrough (#1025)

### DIFF
--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -56,16 +56,7 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 			anthropic.WithLogger(logger),
 		)
 	case "google", "gemini", "":
-		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
-			gemini.WithHeaders(p.Headers),
-			gemini.WithThinking(p.ThinkingBudget, p.ThinkingLevel, maxBudget),
-			gemini.WithMaxOutputTokens(p.MaxTokens),
-			gemini.WithSystemInstruction(persona),
-			gemini.WithSearch(useSearch),
-			gemini.WithEventBus(bus),
-			gemini.WithTimeout(timeout),
-			gemini.WithLogger(logger),
-		)
+		fallthrough
 	default:
 		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,
 			gemini.WithHeaders(p.Headers),


### PR DESCRIPTION
Closes #1025.

## Summary
Replace duplicated `gemini.NewClient(...)` call in the `"google", "gemini", ""` case of `buildBaseClient` with `fallthrough` into the `default` case. Removes ~11 lines of duplicated code with no behavioral change.

## Changes
- `internal/infrastructure/llm/factory.go`: Replace `case "google", "gemini", "":` body with `fallthrough`

## Verification
| Check | Status |
|-------|--------|
| fmt | PASS |
| tidy | PASS |
| build | PASS |
| lint (0 issues) | PASS |
| verify-architecture | PASS |
| verify-mock-pattern | PASS |
| verify-no-test-sleep | PASS |
| verify-adr-index | PASS |
| vulncheck | PASS |
| test | PASS |
| dead-code | PASS |
| test-race | PASS |
| test-coverage | PASS |
| bench | PASS |