### PR TITLE
fix(ui): add SetWriters non-*os.File coverage for IsTerminalContext (#1037)

### DIFF
--- a/internal/ui/renderer_test.go
+++ b/internal/ui/renderer_test.go
@@ -1288,3 +1288,12 @@ func TestIsTerminalContext_RedirectedFile(t *testing.T) {
 		t.Error("expected IsTerminalContext() = false for redirected *os.File (pipe)")
 	}
 }
+
+func TestIsTerminalContext_SetWritersNonFileStderr(t *testing.T) {
+	locker := ui.NewMockLocker()
+	r := ui.NewRenderer(locker, os.Stdout, os.Stderr, nil, nil).(*ui.StdUIRenderer)
+	r.SetWriters(os.Stdout, new(bytes.Buffer))
+	if r.IsTerminalContext() {
+		t.Error("expected IsTerminalContext() = false when SetWriters injects non-*os.File stderr")
+	}
+}


### PR DESCRIPTION
Closes #1037.

## Summary
Added a test `TestIsTerminalContext_SetWritersNonFileStderr` that exercises the `SetWriters` post-construction mutation path for `IsTerminalContext()`. When `SetWriters` replaces stderr with a non-`*os.File` writer (e.g., `*bytes.Buffer`), `IsTerminalContext()` must return `false`. This was already structurally correct in production code — the type assertion falls through to `return false` — but the `SetWriters` to `IsTerminalContext` chain had no explicit test coverage.

## Changes
| File | Change |
|------|--------|
| `internal/ui/renderer_test.go` | +9 lines, 1 new test function |

No production code changes.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| All 10 quality steps | PASS |
| Lint (golangci-lint) | 0 issues |
| Race detector | PASS |
| Coverage (internal/ui) | 96.6% |
