### PR TITLE
fix(ado): add zero-value params error-path test for adoGetPullRequest (#1035)

### DIFF
--- a/internal/tools/integrations/ado/azure_devops_pr_test.go
+++ b/internal/tools/integrations/ado/azure_devops_pr_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 )
@@ -158,6 +159,14 @@ func TestAdoGetPullRequest(t *testing.T) {
 		_, err := m.adoGetPullRequest(context.Background(), args, nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "required")
+	})
+
+	t.Run("ZeroValueParams", func(t *testing.T) {
+		m := NewADOManager(sm)
+		result, err := m.adoGetPullRequest(context.Background(), map[string]interface{}{}, nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "required")
+		assert.Equal(t, tools.ToolResult{}, result)
 	})
 
 	t.Run("Missing PAT", func(t *testing.T) {


### PR DESCRIPTION
Closes #1035.

## Summary
Adds a `ZeroValueParams` subtest to `TestAdoGetPullRequest` in `internal/tools/integrations/ado/azure_devops_pr_test.go`. This test verifies that calling `adoGetPullRequest` with an empty argument map (`map[string]interface{}{}`) returns an error mentioning "required" and a zero-value `tools.ToolResult{}`.

The issue referenced non-existent symbols (`GetPullRequest`, `PullRequestParams`), so the test was translated to the actual code surface: the unexported `adoGetPullRequest` method on `*AdoManager`.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| ado package tests | PASS (6/6 subtests) |
| No regressions | PASS |