### PR TITLE
fix(telemetry): add error-path test coverage for empty logFile and unreadable ledger (#1034)

### DIFF
--- a/internal/infrastructure/telemetry/metrics_acc_test.go
+++ b/internal/infrastructure/telemetry/metrics_acc_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
@@ -308,5 +309,18 @@ func TestSessionCostTracker_AccumulateAndReturn_EmptyModel(t *testing.T) {
 	}
 	if totalCost < wantCost-1e-12 || totalCost > wantCost+1e-12 {
 		t.Errorf("expected total cost %f, got %f", wantCost, totalCost)
+	}
+}
+
+func TestSessionCostTracker_EmptyLogFile(t *testing.T) {
+	tracker := &sessionCostTracker{
+		logFile: "",
+	}
+	tracker.refreshExternalDailyCache(time.Now())
+	if tracker.cachedExternalDailyCost != 0 {
+		t.Errorf("cachedExternalDailyCost should be 0 for empty logFile, got %f", tracker.cachedExternalDailyCost)
+	}
+	if tracker.cachedDate == "" {
+		t.Errorf("cachedDate should not be empty; refreshExternalDailyCache sets it before early return")
 	}
 }

--- a/internal/infrastructure/telemetry/metrics_cost_test.go
+++ b/internal/infrastructure/telemetry/metrics_cost_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -594,4 +595,40 @@ func BenchmarkEstimateCost_Batch100(b *testing.B) {
 		}
 		_, _ = benchSinkEstimate, benchSinkEstimateErr
 	})
+}
+
+// ---------------------------------------------------------------------------
+// TestCostLedger_RecoverySkipsUnreadableFile — verifies graceful degradation
+// when global_costs.json exists but is unreadable (e.g., 0000 permissions).
+// os.ReadFile returns EACCES, which is not os.IsNotExist, so loadHistoryFromDisk
+// returns fileExisted=false with a non-nil error. The error is discarded by
+// loadHistory, and since m.ledger is nil, recovery is a no-op. The function
+// returns an empty slice without panicking.
+// ---------------------------------------------------------------------------
+
+func TestCostLedger_RecoverySkipsUnreadableFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file reads on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	historyPath := filepath.Join(tmpDir, "global_costs.json")
+
+	if err := os.WriteFile(historyPath, []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chmod(historyPath, 0000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(historyPath, 0644) })
+
+	// nil ledger means checkLedgerAndTriggerRecovery is a no-op even if reached.
+	m := &metricsManager{}
+
+	history := m.loadHistory(context.Background(), historyPath, tmpDir)
+
+	if len(history) != 0 {
+		t.Errorf("expected empty history for unreadable file, got %d records", len(history))
+	}
 }


### PR DESCRIPTION
Closes #1034.

## Summary
Adds 2 tests closing error-path coverage gaps in `internal/infrastructure/telemetry/`:

1. **`TestSessionCostTracker_EmptyLogFile`** (`metrics_acc_test.go`) — exercises the `logFile == ""` early-return branch in `refreshExternalDailyCache`, asserting `cachedExternalDailyCost == 0` and `cachedDate` is set.

2. **`TestCostLedger_RecoverySkipsUnreadableFile`** (`metrics_cost_test.go`) — exercises the silently-discarded `loadHistoryFromDisk` error path when a ledger file exists with `0000` permissions, verifying graceful degradation (empty history, no panic).

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage | 2 new error-paths covered |
| Package tests | PASS (0.361s telemetry)