### PR TITLE
fix(context): decompose isTurnBoundary into single-responsibility helpers (#1060)

### DIFF
--- a/internal/agent/session/context/transformers.go
+++ b/internal/agent/session/context/transformers.go
@@ -141,34 +141,47 @@ func validateTurnContent(ctx context.Context, msg *llm.Content, index int) error
 }
 
 func isTurnBoundary(msg *llm.Content, current []*llm.Content) (bool, error) {
-	if len(current) == 0 {
+	if isNewTurnStart(current) {
 		return false, nil
 	}
 
-	// Boundary usually starts with user or system
-	if msg.Role != "user" && msg.Role != "system" {
+	if !isBoundaryRole(msg.Role) {
 		return false, nil
 	}
 
-	// If the last message was a tool call, and this is a user message,
-	// it's likely a tool response and should stay in the same turn.
-	// System messages always break turns.
 	if msg.Role == "user" {
-		last := current[len(current)-1]
-		if last == nil {
-			return false, fmt.Errorf("%w: nil message in current turn", ErrInvalidPayload)
-		}
-		if last.Role == "model" {
-			toolCall, err := isToolCall(last)
-			if err != nil {
-				return false, err
-			}
-			if toolCall {
-				return false, nil
-			}
-		}
+		return isUserTurnBoundary(current)
 	}
+	return true, nil
+}
 
+func isNewTurnStart(current []*llm.Content) bool {
+	return len(current) == 0
+}
+
+func isBoundaryRole(role string) bool {
+	return role == "user" || role == "system"
+}
+
+func isUserTurnBoundary(current []*llm.Content) (bool, error) {
+	last := current[len(current)-1]
+	if last == nil {
+		return false, fmt.Errorf("%w: nil message in current turn", ErrInvalidPayload)
+	}
+	if last.Role != "model" {
+		return true, nil
+	}
+	return isModelToolCallBoundary(last)
+}
+
+func isModelToolCallBoundary(last *llm.Content) (bool, error) {
+	toolCall, err := isToolCall(last)
+	if err != nil {
+		return false, err
+	}
+	if toolCall {
+		return false, nil
+	}
 	return true, nil
 }
 


### PR DESCRIPTION
Closes #1060.

## Summary
Decomposed `isTurnBoundary` (complexity 9) into four single-responsibility helpers:
- `isNewTurnStart` — checks if the current turn is empty
- `isBoundaryRole` — checks if a role is a turn boundary
- `isUserTurnBoundary` — handles user-turn boundary logic
- `isModelToolCallBoundary` — handles tool-call continuation

All existing tests pass. No behavioral changes.

## Verification
| Check | Status |
|-------|--------|
| go fmt | PASS |
| go build | PASS |
| go vet | PASS |
| golangci-lint | PASS (0 issues) |
| go test -race | PASS |
| go test -cover | 99.9% |
| go mod tidy | PASS (no changes) |

### Complexity
| Function | Complexity | Target | Status |
|---|---|---|---|
| isTurnBoundary | 4 | ≤4 | ✓ |
| isNewTurnStart | 1 | ≤3 | ✓ |
| isBoundaryRole | 2 | ≤3 | ✓ |
| isUserTurnBoundary | 3 | ≤3 | ✓ |
| isModelToolCallBoundary | 3 | ≤3 | ✓