### PR TITLE
fix(integrations): close buildTeamsRequestBody error path (#1056)

### DIFF
--- a/internal/tools/integrations/teams.go
+++ b/internal/tools/integrations/teams.go
@@ -22,6 +22,9 @@ type teamsManager struct {
 	client tools.HTTPClient
 }
 
+// marshalJSON is the json.Marshal function, overridable in tests.
+var marshalJSON = json.Marshal
+
 func newteamsManager(sm teamsSecurity, client tools.HTTPClient) *teamsManager {
 	if client == nil {
 		client = &http.Client{Timeout: 30 * time.Second}
@@ -88,7 +91,7 @@ func buildTeamsRequestBody(message, reason string) ([]byte, error) {
 		"body":    body,
 		"$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
 	}
-	return json.Marshal(payload)
+	return marshalJSON(payload)
 }
 
 func (m *teamsManager) postToWebhook(ctx context.Context, url string, body []byte) (string, error) {

--- a/internal/tools/integrations/teams_test.go
+++ b/internal/tools/integrations/teams_test.go
@@ -86,10 +86,25 @@ func TestTeamsManager_SendTeamsMessage(t *testing.T) {
 			},
 			wantInText: []string{"failed to send message to Teams", "403 Forbidden"},
 		},
+		{
+			name: "Marshal Error",
+			args: map[string]interface{}{
+				"webhook_url": "https://example.com/webhook",
+				"message":     "Hello",
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "Marshal Error" {
+				original := marshalJSON
+				marshalJSON = func(v interface{}) ([]byte, error) {
+					return nil, errors.New("injected marshal failure")
+				}
+				defer func() { marshalJSON = original }()
+			}
 			mock := &mockHTTPClient{
 				DoFunc: func(req *http.Request) (*http.Response, error) {
 					if tt.mockErr != nil {
@@ -170,6 +185,22 @@ func TestBuildTeamsRequestBody(t *testing.T) {
 		bodyStr := string(body)
 		if strings.Contains(bodyStr, "Reason:") {
 			t.Errorf("Expected no reason in body when reason is empty, got: %s", bodyStr)
+		}
+	})
+
+	t.Run("marshal error", func(t *testing.T) {
+		original := marshalJSON
+		marshalJSON = func(v interface{}) ([]byte, error) {
+			return nil, errors.New("injected marshal failure")
+		}
+		t.Cleanup(func() { marshalJSON = original })
+
+		_, err := buildTeamsRequestBody("hello", "testing")
+		if err == nil {
+			t.Fatal("expected error from injected marshal failure, got nil")
+		}
+		if !strings.Contains(err.Error(), "injected marshal failure") {
+			t.Errorf("expected 'injected marshal failure', got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes #1056.

## Summary
Added a `marshalJSON` injection point (package-level variable defaulting to `json.Marshal`) to `teams.go`, following the established pattern from `internal/infrastructure/telemetry/metrics.go:50`. This allows tests to swap in a failing marshal function to exercise the previously unreachable error path at lines 55-57.

Added two new test cases:
- `TestBuildTeamsRequestBody/marshal_error` — injects failing marshal, verifies error propagation
- `TestTeamsManager_SendTeamsMessage/Marshal_Error` — verifies the error-wrapping in `sendTeamsMessage` call chain

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| sendTeamsMessage coverage | 100% |
| buildTeamsRequestBody coverage | 100% |
