### PR TITLE
fix(persistencetest): add error-path injection hooks and tests for AtomicWrite (#1055)

### DIFF
--- a/internal/infrastructure/persistence/persistencetest/plain_os_fs.go
+++ b/internal/infrastructure/persistence/persistencetest/plain_os_fs.go
@@ -22,7 +22,15 @@ import (
 // persistence.FileSystem. It performs no retries, no atomic-write routing,
 // and no context checks during Walk. It is intended exclusively for tests
 // that need to assert behaviour at the bare os.* call boundary.
-type plainOSFS struct{}
+//
+// Function fields allow error-path injection in tests. Constructors
+// always set defaults, so fields are never nil at runtime — "make the
+// zero value useful" is preserved via the constructors.
+type plainOSFS struct {
+	writeFunc func(f *os.File, data []byte) (int, error) // default: f.Write
+	closeFunc func(f *os.File) error                     // default: f.Close
+	chmodFunc func(name string, mode os.FileMode) error  // default: os.Chmod
+}
 
 // NewPlainOSFileSystem returns a FileSystem backed directly by os.* calls
 // with NO atomic-write routing, NO retry wrapper, and NO context check
@@ -38,7 +46,45 @@ type plainOSFS struct{}
 // semantics, use persistence.NewOSFileSystem (in
 // internal/infrastructure/persistence) instead.
 func NewPlainOSFileSystem() persistence.FileSystem {
-	return &plainOSFS{}
+	return &plainOSFS{
+		writeFunc: func(f *os.File, data []byte) (int, error) { return f.Write(data) },
+		closeFunc: func(f *os.File) error { return f.Close() },
+		chmodFunc: os.Chmod,
+	}
+}
+
+// PlainOSFSOption configures a plainOSFS for error-path testing.
+type PlainOSFSOption func(*plainOSFS)
+
+// WithWriteFunc overrides the Write call inside AtomicWrite.
+func WithWriteFunc(fn func(f *os.File, data []byte) (int, error)) PlainOSFSOption {
+	return func(p *plainOSFS) { p.writeFunc = fn }
+}
+
+// WithCloseFunc overrides the Close call inside AtomicWrite.
+func WithCloseFunc(fn func(f *os.File) error) PlainOSFSOption {
+	return func(p *plainOSFS) { p.closeFunc = fn }
+}
+
+// WithChmodFunc overrides the Chmod call inside AtomicWrite.
+func WithChmodFunc(fn func(name string, mode os.FileMode) error) PlainOSFSOption {
+	return func(p *plainOSFS) { p.chmodFunc = fn }
+}
+
+// NewPlainOSFileSystemWithOpts returns a plain OS filesystem with injected
+// error-path hooks for testing. Use WithWriteFunc, WithCloseFunc, or
+// WithChmodFunc to override specific operations inside AtomicWrite.
+// A nil option leaves the default os.* behavior in place.
+func NewPlainOSFileSystemWithOpts(opts ...PlainOSFSOption) persistence.FileSystem {
+	p := &plainOSFS{
+		writeFunc: func(f *os.File, data []byte) (int, error) { return f.Write(data) },
+		closeFunc: func(f *os.File) error { return f.Close() },
+		chmodFunc: os.Chmod,
+	}
+	for _, o := range opts {
+		o(p)
+	}
+	return p
 }
 
 func (m *plainOSFS) ReadDir(ctx context.Context, name string) ([]os.DirEntry, error) {
@@ -64,14 +110,14 @@ func (m *plainOSFS) AtomicWrite(ctx context.Context, name string, data []byte, p
 	tempName := tempFile.Name()
 	defer func() { _ = os.Remove(tempName) }()
 
-	if _, err := tempFile.Write(data); err != nil {
-		_ = tempFile.Close()
+	if _, err := m.writeFunc(tempFile, data); err != nil {
+		_ = m.closeFunc(tempFile)
 		return err
 	}
-	if err := tempFile.Close(); err != nil {
+	if err := m.closeFunc(tempFile); err != nil {
 		return err
 	}
-	if err := os.Chmod(tempName, perm); err != nil {
+	if err := m.chmodFunc(tempName, perm); err != nil {
 		return err
 	}
 	return os.Rename(tempName, name)

--- a/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
+++ b/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
@@ -9,9 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/require"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
@@ -198,49 +197,67 @@ func TestPlainOSFileSystem_AtomicWrite(t *testing.T) {
 func TestPlainOSFS_AtomicWrite_ErrorPaths(t *testing.T) {
 	t.Parallel()
 
-	// Gap #1: Write error → Close (L69-71)
-	t.Run("write error on read-only descriptor", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		f, err := os.CreateTemp(dir, "write-err-*")
-		require.NoError(t, err)
-		tempName := f.Name()
-		t.Cleanup(func() { _ = os.Remove(tempName) })
-		require.NoError(t, f.Close())
+	// Internal error paths (Write failure, Close failure, Chmod failure)
+	// are now exercised by TestPlainOSFS_AtomicWrite_InternalErrorPaths.
+}
 
-		f, err = os.OpenFile(tempName, os.O_RDONLY, 0)
-		require.NoError(t, err)
-		defer func() { _ = f.Close() }()
+func TestPlainOSFS_AtomicWrite_InternalErrorPaths(t *testing.T) {
+	t.Parallel()
 
-		_, err = f.Write([]byte("data"))
-		require.Error(t, err, "Write on read-only fd must fail")
-		// The AtomicWrite L70 pattern: Close after Write error
-		_ = f.Close()
-	})
+	tests := []struct {
+		name    string
+		opts    []persistencetest.PlainOSFSOption
+		wantErr string
+	}{
+		{
+			name: "Write error",
+			opts: []persistencetest.PlainOSFSOption{
+				persistencetest.WithWriteFunc(func(f *os.File, data []byte) (int, error) {
+					return 0, errors.New("injected write failure")
+				}),
+			},
+			wantErr: "injected write failure",
+		},
+		{
+			name: "Close error",
+			opts: []persistencetest.PlainOSFSOption{
+				persistencetest.WithCloseFunc(func(f *os.File) error {
+					return errors.New("injected close failure")
+				}),
+			},
+			wantErr: "injected close failure",
+		},
+		{
+			name: "Chmod error",
+			opts: []persistencetest.PlainOSFSOption{
+				persistencetest.WithChmodFunc(func(name string, mode os.FileMode) error {
+					return errors.New("injected chmod failure")
+				}),
+			},
+			wantErr: "injected chmod failure",
+		},
+	}
 
-	// Gap #2: Close error after successful Write (L73-74)
-	t.Run("close error branch documented", func(t *testing.T) {
-		t.Parallel()
-		t.Skip("*os.File.Close() on regular files returns nil on all standard " +
-			"Linux filesystems. Fails only on network/FUSE fs with pending " +
-			"writeback errors or kernel bugs. Branch verified by code review.")
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	// Gap #3: Chmod error after Close (L76-77)
-	t.Run("chmod error on nonexistent path", func(t *testing.T) {
-		t.Parallel()
-		dir := t.TempDir()
-		f, err := os.CreateTemp(dir, "chmod-err-*")
-		require.NoError(t, err)
-		tempName := f.Name()
-		_, err = f.Write([]byte("data"))
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-		require.NoError(t, os.Remove(tempName))
+			fs := persistencetest.NewPlainOSFileSystemWithOpts(tt.opts...)
+			dir := t.TempDir()
+			path := filepath.Join(dir, "target.txt")
 
-		err = os.Chmod(tempName, 0644)
-		require.Error(t, err, "Chmod on removed file must fail")
-	})
+			err := fs.AtomicWrite(context.Background(), path, []byte("data"), 0644)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error %q should contain %q", err.Error(), tt.wantErr)
+			}
+
+			// Verify no orphan temp file remains
+			assertNoOrphanTempFiles(t, dir)
+		})
+	}
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #1055.

## Summary
Added function-field injection hooks (`writeFunc`, `closeFunc`, `chmodFunc`) to `plainOSFS` with Functional Options constructors (`WithWriteFunc`, `WithCloseFunc`, `WithChmodFunc`, `NewPlainOSFileSystemWithOpts`). Constructors seed defaults so fields are never nil — `AtomicWrite` dispatches unconditionally, achieving 100% coverage. Replaced 3 non-`AtomicWrite` subtests with a table-driven `TestPlainOSFS_AtomicWrite_InternalErrorPaths` test exercising Write/Close/Chmod failures deterministically.

The other two gaps in the issue (state.go:121 WAL checkpoint, tasks.go:54 corrupted task line) were already covered by existing tests.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage (persistencetest) | 100% |
| AtomicWrite coverage | 100% |
