### PR TITLE
fix(ui): simplify getSpinnerInfo with interface dispatch (#1059)

### DIFF
--- a/internal/agent/session/ui/bridge.go
+++ b/internal/agent/session/ui/bridge.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -282,10 +281,11 @@ func (b *Bridge) processEvent(ctx context.Context, e events.Event) {
 	b.dispatcher.dispatch(ctx, e)
 }
 
-type spinnerInfo struct {
-	status         string
-	withMetrics    bool
-	resetRendering bool
+// spinnerFormattable is the seam between domain events and the spinner
+// presentation layer. Events that carry spinner-relevant state implement
+// this interface so getSpinnerInfo can avoid a type-switch.
+type spinnerFormattable interface {
+	SpinnerInfo() (events.SpinnerInfo, bool)
 }
 
 func isCriticalEvent(e events.Event) bool {
@@ -300,29 +300,11 @@ func isCriticalEvent(e events.Event) bool {
 		return false
 	}
 }
-func getSpinnerInfo(e events.Event) (spinnerInfo, bool) {
-	switch ev := e.(type) {
-	case events.InferenceStartedEvent:
-		status := " Thinking..."
-		if ev.Model != "" {
-			status = fmt.Sprintf(" Thinking [%s]...", ev.Model)
-		}
-		return spinnerInfo{status: status, withMetrics: false, resetRendering: false}, true
-	case events.SummarizationStartedEvent:
-		return spinnerInfo{status: " Compressing context...", withMetrics: false, resetRendering: true}, true
-	case events.ToolExecutionStartedEvent:
-		status := " Executing tools..."
-		if len(ev.ToolNames) == 1 {
-			status = fmt.Sprintf(" Executing [%s]...", ev.ToolNames[0])
-		} else if len(ev.ToolNames) > 1 {
-			status = fmt.Sprintf(" Executing tools [%s]...", strings.Join(ev.ToolNames, ", "))
-		}
-		return spinnerInfo{status: status, withMetrics: true, resetRendering: true}, true
-	case events.RetryWaitingEvent:
-		return spinnerInfo{status: fmt.Sprintf(" Retrying in %v...", ev.Duration.Round(time.Second)), withMetrics: false, resetRendering: true}, true
-	default:
-		return spinnerInfo{}, false
+func getSpinnerInfo(e events.Event) (events.SpinnerInfo, bool) {
+	if sf, ok := e.(spinnerFormattable); ok {
+		return sf.SpinnerInfo()
 	}
+	return events.SpinnerInfo{}, false
 }
 func (b *Bridge) getLoopContext() context.Context {
 	return b.loopCtx

--- a/internal/agent/session/ui/dispatcher_test.go
+++ b/internal/agent/session/ui/dispatcher_test.go
@@ -361,7 +361,7 @@ func TestStartSpinnerForPhase_UnknownEvent(t *testing.T) {
 	logger := &testfixtures.SpyLogger{}
 	sc := newSpinnerCoord(renderer, logger)
 
-	// TurnStarted is not a spinner event → getSpinnerInfo returns spinnerInfo{}, false.
+	// TurnStarted is not a spinner event → getSpinnerInfo returns events.SpinnerInfo{}, false.
 	started := sc.startSpinnerForPhase(context.Background(), events.TurnStarted{}, stateIdle, nil)
 
 	assert.False(t, started, "expected spinner not to be started for unknown event")

--- a/internal/agent/session/ui/routing_test.go
+++ b/internal/agent/session/ui/routing_test.go
@@ -47,73 +47,73 @@ func TestGetSpinnerInfo(t *testing.T) {
 	tests := []struct {
 		name     string
 		event    events.Event
-		expected spinnerInfo
+		expected events.SpinnerInfo
 		ok       bool
 	}{
 		{
 			name:  "InferenceStartedEvent with model",
 			event: events.InferenceStartedEvent{Model: "gpt-4"},
-			expected: spinnerInfo{
-				status:         " Thinking [gpt-4]...",
-				withMetrics:    false,
-				resetRendering: false,
+			expected: events.SpinnerInfo{
+				Status:         " Thinking [gpt-4]...",
+				WithMetrics:    false,
+				ResetRendering: false,
 			},
 			ok: true,
 		},
 		{
 			name:  "InferenceStartedEvent without model",
 			event: events.InferenceStartedEvent{},
-			expected: spinnerInfo{
-				status:         " Thinking...",
-				withMetrics:    false,
-				resetRendering: false,
+			expected: events.SpinnerInfo{
+				Status:         " Thinking...",
+				WithMetrics:    false,
+				ResetRendering: false,
 			},
 			ok: true,
 		},
 		{
 			name:  "SummarizationStartedEvent",
 			event: events.SummarizationStartedEvent{},
-			expected: spinnerInfo{
-				status:         " Compressing context...",
-				withMetrics:    false,
-				resetRendering: true,
+			expected: events.SpinnerInfo{
+				Status:         " Compressing context...",
+				WithMetrics:    false,
+				ResetRendering: true,
 			},
 			ok: true,
 		},
 		{
 			name:  "ToolExecutionStartedEvent single tool",
 			event: events.ToolExecutionStartedEvent{ToolNames: []string{"search"}},
-			expected: spinnerInfo{
-				status:         " Executing [search]...",
-				withMetrics:    true,
-				resetRendering: true,
+			expected: events.SpinnerInfo{
+				Status:         " Executing [search]...",
+				WithMetrics:    true,
+				ResetRendering: true,
 			},
 			ok: true,
 		},
 		{
 			name:  "ToolExecutionStartedEvent multiple tools",
 			event: events.ToolExecutionStartedEvent{ToolNames: []string{"search", "calculator"}},
-			expected: spinnerInfo{
-				status:         " Executing tools [search, calculator]...",
-				withMetrics:    true,
-				resetRendering: true,
+			expected: events.SpinnerInfo{
+				Status:         " Executing tools [search, calculator]...",
+				WithMetrics:    true,
+				ResetRendering: true,
 			},
 			ok: true,
 		},
 		{
 			name:  "RetryWaitingEvent",
 			event: events.RetryWaitingEvent{Duration: 5 * time.Second},
-			expected: spinnerInfo{
-				status:         " Retrying in 5s...",
-				withMetrics:    false,
-				resetRendering: true,
+			expected: events.SpinnerInfo{
+				Status:         " Retrying in 5s...",
+				WithMetrics:    false,
+				ResetRendering: true,
 			},
 			ok: true,
 		},
 		{
 			name:     "Other event",
 			event:    events.ResponseEvent{},
-			expected: spinnerInfo{},
+			expected: events.SpinnerInfo{},
 			ok:       false,
 		},
 	}

--- a/internal/agent/session/ui/spinner.go
+++ b/internal/agent/session/ui/spinner.go
@@ -79,15 +79,15 @@ func (sc *spinnerCoord) startSpinnerForPhase(ctx context.Context, e events.Event
 
 	// If the event requires a rendering reset and we are currently rendering,
 	// invoke the callback to transition to idle before starting the spinner.
-	if info.resetRendering && state == stateRendering && resetRendering != nil {
+	if info.ResetRendering && state == stateRendering && resetRendering != nil {
 		state = resetRendering()
 	}
 
 	return sc.transitionSpinner(state, func() func() {
-		if info.withMetrics {
-			return sc.renderer.StartSpinnerWithMetrics(ctx, info.status)
+		if info.WithMetrics {
+			return sc.renderer.StartSpinnerWithMetrics(ctx, info.Status)
 		}
-		return sc.renderer.StartSpinnerWithStatus(ctx, info.status)
+		return sc.renderer.StartSpinnerWithStatus(ctx, info.Status)
 	})
 }
 

--- a/internal/domain/events/types.go
+++ b/internal/domain/events/types.go
@@ -6,6 +6,7 @@ package events
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -108,10 +109,25 @@ type InferenceStartedEvent struct {
 
 func (e InferenceStartedEvent) Type() string { return "InferenceStartedEvent" }
 
+// SpinnerInfo returns the spinner presentation for an inference-started event.
+// When Model is set, the model name is included in the status text.
+func (e InferenceStartedEvent) SpinnerInfo() (SpinnerInfo, bool) {
+	status := " Thinking..."
+	if e.Model != "" {
+		status = fmt.Sprintf(" Thinking [%s]...", e.Model)
+	}
+	return SpinnerInfo{Status: status}, true
+}
+
 // SummarizationStartedEvent signals that the history summarization process has begun.
 type SummarizationStartedEvent struct{}
 
 func (e SummarizationStartedEvent) Type() string { return "SummarizationStartedEvent" }
+
+// SpinnerInfo returns the spinner presentation for a summarization-started event.
+func (e SummarizationStartedEvent) SpinnerInfo() (SpinnerInfo, bool) {
+	return SpinnerInfo{Status: " Compressing context...", ResetRendering: true}, true
+}
 
 // ResponseEvent carries the final LLM output.
 type ResponseEvent struct {
@@ -135,6 +151,18 @@ type ToolExecutionStartedEvent struct {
 }
 
 func (e ToolExecutionStartedEvent) Type() string { return "ToolExecutionStartedEvent" }
+
+// SpinnerInfo returns the spinner presentation for a tool-execution-started event.
+// The status text includes tool names when available.
+func (e ToolExecutionStartedEvent) SpinnerInfo() (SpinnerInfo, bool) {
+	status := " Executing tools..."
+	if len(e.ToolNames) == 1 {
+		status = fmt.Sprintf(" Executing [%s]...", e.ToolNames[0])
+	} else if len(e.ToolNames) > 1 {
+		status = fmt.Sprintf(" Executing tools [%s]...", strings.Join(e.ToolNames, ", "))
+	}
+	return SpinnerInfo{Status: status, WithMetrics: true, ResetRendering: true}, true
+}
 
 // ToolResultEvent signals that a tool has finished execution.
 type ToolResultEvent struct {
@@ -192,6 +220,23 @@ type RetryWaitingEvent struct {
 }
 
 func (e RetryWaitingEvent) Type() string { return "RetryWaitingEvent" }
+
+// SpinnerInfo returns the spinner presentation for a retry-waiting event.
+// The status text includes the rounded wait duration.
+func (e RetryWaitingEvent) SpinnerInfo() (SpinnerInfo, bool) {
+	return SpinnerInfo{
+		Status:         fmt.Sprintf(" Retrying in %v...", e.Duration.Round(time.Second)),
+		ResetRendering: true,
+	}, true
+}
+
+// SpinnerInfo describes the spinner presentation for an event.
+// It is a DTO consumed by the UI bridge's spinner coordinator.
+type SpinnerInfo struct {
+	Status         string // The spinner status text (e.g. " Thinking...")
+	WithMetrics    bool   // If true, use StartSpinnerWithMetrics instead of StartSpinnerWithStatus
+	ResetRendering bool   // If true, the spinner transition resets the rendering state
+}
 
 // ConsentStartedEvent signals that the user is being prompted for tool consent.
 type ConsentStartedEvent struct{}


### PR DESCRIPTION
Closes #1059.

## Summary
Replaced the 4-case type-switch in `getSpinnerInfo` (complexity 9) with a single type-assertion against a new `spinnerFormattable` interface (complexity 2). Each event type now owns its spinner presentation via a `SpinnerInfo()` method in `internal/domain/events/types.go`, following SRP and Open/Closed principles.

### Changes
- `internal/domain/events/types.go`: Added exported `SpinnerInfo` DTO struct + `SpinnerInfo()` methods on 4 event types
- `internal/agent/session/ui/bridge.go`: Replaced `spinnerInfo` struct with `spinnerFormattable` interface; simplified `getSpinnerInfo` to single type-assertion
- `internal/agent/session/ui/spinner.go`: Updated field accesses to exported names
- `internal/agent/session/ui/routing_test.go`: Updated test expectations
- `internal/agent/session/ui/dispatcher_test.go`: Updated comment

## Verification
| Check | Status |
|-------|--------|
| `make check-full` | PASS (all 10 steps including race detection) |
| `getSpinnerInfo` complexity | 2 (was 9, target ≤4) |
| `go test ./internal/agent/session/ui/...` | PASS |
| `go test ./internal/domain/events/...` | PASS |
| `TestGetSpinnerInfo` (7 subtests) | All PASS |