### PR TITLE
fix(context): add isTurnEmpty multi-message empty turn test coverage (#1071)

### DIFF
--- a/internal/agent/session/context/context_transformers_test.go
+++ b/internal/agent/session/context/context_transformers_test.go
@@ -643,6 +643,31 @@ func TestEmptyTurnFilter_Transform(t *testing.T) {
 			},
 			expected: 2,
 		},
+		{
+			name: "all parts empty across entire multi-message turn",
+			input: []*llm.Content{
+				{Role: "user", Parts: []*llm.Part{{Text: ""}}},
+				{Role: "model", Parts: []*llm.Part{{Text: ""}}},
+			},
+			expected: 0,
+		},
+		{
+			name: "multiple messages all with empty parts across two turns",
+			input: []*llm.Content{
+				{Role: "user", Parts: []*llm.Part{{Text: ""}, {Text: ""}}},
+				{Role: "model", Parts: []*llm.Part{{Text: ""}}},
+				{Role: "user", Parts: []*llm.Part{{Text: ""}}},
+			},
+			expected: 1,
+		},
+		{
+			name: "one non-empty part keeps turn",
+			input: []*llm.Content{
+				{Role: "user", Parts: []*llm.Part{{Text: ""}}},
+				{Role: "model", Parts: []*llm.Part{{Text: "hello"}}},
+			},
+			expected: 2,
+		},
 	}
 
 	for _, tt := range tests {
@@ -733,6 +758,10 @@ func TestIsTurnEmpty_Helper(t *testing.T) {
 		wantErr  bool
 	}{
 		{name: "Empty", turn: []*llm.Content{{Parts: []*llm.Part{{Text: ""}}}}, expected: true},
+		{name: "Multi-message all empty", turn: []*llm.Content{
+			{Parts: []*llm.Part{{Text: ""}}},
+			{Parts: []*llm.Part{{Text: ""}}},
+		}, expected: true},
 		{name: "Text", turn: []*llm.Content{{Parts: []*llm.Part{{Text: "hi"}}}}, expected: false},
 		{name: "AssetID", turn: []*llm.Content{{Parts: []*llm.Part{{AssetID: "123"}}}}, expected: false},
 		{name: "Thought", turn: []*llm.Content{{Parts: []*llm.Part{{IsThought: true}}}}, expected: false},


### PR DESCRIPTION
Closes #1071.

## Summary
Added 4 table-driven test cases covering the `isTurnEmpty` green-path (`return true, nil` at line 155 in `transformers.go`) for multi-message turns where all parts are empty:
- 3 new cases in `TestEmptyTurnFilter_Transform` (integration level)
- 1 new case in `TestIsTurnEmpty_Helper` (unit level)

This closes the BUSINESS_LOGIC coverage gap where the 'turn is genuinely empty' path was never exercised.

## Verification
| Check | Status |
|-------|--------|
| go build | PASS |
| go vet | PASS |
| golangci-lint | 0 issues |
| go test ./... | PASS |
| go test -race (context pkg) | PASS |
| go test -cover (context pkg) | 99.9% |
| TestEmptyTurnFilter_Transform (11 subtests) | PASS |
| TestIsTurnEmpty_Helper (8 subtests) | PASS |