### PR TITLE
fix(telemetry): add coverage for cost calc, pricing fallback, and system metrics gaps (#1076)

### DIFF
--- a/internal/infrastructure/telemetry/metrics_cost_test.go
+++ b/internal/infrastructure/telemetry/metrics_cost_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 )
@@ -119,6 +120,59 @@ func TestEstimateCost_LogFileNotFound(t *testing.T) {
 	}
 	if !strings.Contains(result, "Error: Log file not found") {
 		t.Errorf("result should contain 'Error: Log file not found', got: %q", result)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Gap — calculateLineCost edge cases (nil pricing, zero tokens)
+// ---------------------------------------------------------------------------
+
+func TestCalculateLineCost_NilPricing(t *testing.T) {
+	t.Parallel()
+
+	// Empty pricing data with no models and no default entry.
+	// getModelPricing returns zero-value ModelPricing, which produces zero cost.
+	pd := domain_pricing.PricingData{}
+
+	cost := calculateLineCost(llm.Metrics{}, domain_pricing.UsageStats{}, pd, "unknown-model")
+
+	if cost != 0 {
+		t.Errorf("expected 0 cost for nil pricing, got %f", cost)
+	}
+}
+
+func TestCalculateLineCost_ZeroTokens(t *testing.T) {
+	t.Parallel()
+
+	pd := domain_pricing.PricingData{
+		Models: map[string]domain_pricing.ModelPricing{
+			"test-model": {Hit: 1.0, Miss: 2.0, Comp: 3.0},
+		},
+	}
+
+	// All-zero tokens, zero cost field — should compute cost via pricing arithmetic
+	// but with zero token counts the result is zero.
+	cost := calculateLineCost(llm.Metrics{}, domain_pricing.UsageStats{}, pd, "test-model")
+
+	if cost != 0 {
+		t.Errorf("expected 0 cost with zero tokens, got %f", cost)
+	}
+}
+
+func TestCalculateLineCost_ExplicitCost(t *testing.T) {
+	t.Parallel()
+
+	// When mt.Cost > 0, calculateLineCost returns it immediately without
+	// consulting pricing data — even nil pricing should work.
+	cost := calculateLineCost(
+		llm.Metrics{Cost: 0.456},
+		domain_pricing.UsageStats{},
+		domain_pricing.PricingData{}, // nil pricing
+		"any-model",
+	)
+
+	if cost != 0.456 {
+		t.Errorf("expected 0.456 explicit cost, got %f", cost)
 	}
 }
 

--- a/internal/infrastructure/telemetry/metrics_util_test.go
+++ b/internal/infrastructure/telemetry/metrics_util_test.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -315,6 +316,44 @@ func TestGetPricing_FallbackOnInvalidJSON(t *testing.T) {
 	pd := GetPricing(context.Background(), nil, outputDir)
 	if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
 		t.Errorf("expected hardcoded fallback on invalid JSON, got %q", pd.UpdatedAt)
+	}
+}
+
+func TestGetPricing_FallbackOnUnreadableFile(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod does not prevent file reads on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	assetsDir := filepath.Join(tmpDir, "assets")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatalf("failed to create assets dir: %v", err)
+	}
+	outputDir := filepath.Join(tmpDir, "output")
+	pricingFile := filepath.Join(assetsDir, "pricing.json")
+
+	content := `{"updated_at": "2026-03-01T00:00:00Z", "models": {"m": {"hit": 1.0, "miss": 2.0, "comp": 3.0}}}`
+	if err := os.WriteFile(pricingFile, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write pricing file: %v", err)
+	}
+
+	// Make the file unreadable so defaultLoader.loadFromDisk returns an error.
+	if err := os.Chmod(pricingFile, 0000); err != nil {
+		t.Fatalf("failed to chmod pricing file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(pricingFile, 0644) })
+
+	pd := GetPricing(context.Background(), nil, outputDir)
+
+	// Should fall back to hardcoded default pricing.
+	if pd.UpdatedAt != "2026-02-03T12:00:00Z" {
+		t.Errorf("expected hardcoded fallback on unreadable file, got UpdatedAt=%q", pd.UpdatedAt)
+	}
+	// Also verify we got a real model entry, not a zero-value PricingData.
+	if len(pd.Models) == 0 {
+		t.Error("expected non-empty Models in fallback pricing data")
 	}
 }
 

--- a/internal/infrastructure/telemetry/system_metrics_linux_test.go
+++ b/internal/infrastructure/telemetry/system_metrics_linux_test.go
@@ -167,3 +167,24 @@ func TestGetRoot_DefaultAndCustom(t *testing.T) {
 		})
 	}
 }
+
+// TestLinuxMetricsProvider_FallbackToRuntimeCPU verifies that when /proc/stat
+// is completely absent (not just empty), GetCPUStats falls through to
+// getRuntimeCPUStats and returns valid runtime metrics values.
+func TestLinuxMetricsProvider_FallbackToRuntimeCPU(t *testing.T) {
+	t.Parallel()
+
+	// Create a temp root directory that has NO proc/ subdirectory at all.
+	// os.Open(".../proc/stat") will fail with ENOENT, triggering the fallback.
+	root := t.TempDir()
+
+	p := &linuxMetricsProvider{root: root}
+	total, idle := p.GetCPUStats()
+
+	if total < 0 {
+		t.Errorf("GetCPUStats() total = %d, want >= 0 (runtime fallback)", total)
+	}
+	if idle != 0 {
+		t.Errorf("GetCPUStats() idle = %d, want 0 (runtime/metrics fallback has no idle breakdown)", idle)
+	}
+}

--- a/internal/infrastructure/telemetry/system_metrics_shared_test.go
+++ b/internal/infrastructure/telemetry/system_metrics_shared_test.go
@@ -26,3 +26,19 @@ func TestGetRuntimeCPUStats_KindFloat64Always(t *testing.T) {
 	// If we reach here, KindFloat64 is confirmed, and getRuntimeCPUStats
 	// always takes the if-branch. The else branch is defensive dead code.
 }
+
+// TestGetRuntimeCPUStats_ReturnsValidValues verifies that getRuntimeCPUStats
+// returns non-negative total CPU seconds and zero idle (the runtime/metrics
+// package only exposes total, not idle).
+func TestGetRuntimeCPUStats_ReturnsValidValues(t *testing.T) {
+	t.Parallel()
+
+	total, idle := getRuntimeCPUStats()
+
+	if total < 0 {
+		t.Errorf("getRuntimeCPUStats() total = %d, want >= 0", total)
+	}
+	if idle != 0 {
+		t.Errorf("getRuntimeCPUStats() idle = %d, want 0 (runtime/metrics has no idle breakdown)", idle)
+	}
+}


### PR DESCRIPTION
Closes #1076.

## Summary
Adds targeted test coverage for three gaps in `internal/infrastructure/telemetry/`:

1. **Cost calculation edge cases** (`metrics_cost.go`) — Tests for nil pricing, zero tokens, and explicit cost early-return path via `calculateLineCost`
2. **Pricing fallback path** (`metrics_util.go`) — Permission-denied fallback triggers `slog.Debug` → `DefaultPricing()`
3. **System metrics fallback** (`system_metrics_shared.go` + `system_metrics_linux.go`) — Validates `getRuntimeCPUStats()` return values and `/proc`-absent fallback on Linux

## Verification
| Check | Status |
|-------|--------|
| `go fmt ./...` | PASS |
| `go mod tidy` | PASS |
| `go build ./...` | PASS |
| `golangci-lint` | 0 issues |
| `go test ./...` | PASS |
| `go test -race ./internal/infrastructure/telemetry/` | PASS |
| Coverage (`telemetry` package) | 99.2% |
| Target: `getModelPricing` (was 86.2%) | 100% |
| Target: `GetPricing` (was 93.8%) | 100% |
| Target: `getRuntimeCPUStats` (was 85.7%) | 85.7% (ceiling — unreachable dead code) |