### PR TITLE
fix(llm): cover anthropic marshal error path with test (#1075)

### DIFF
--- a/internal/infrastructure/llm/anthropic/client.go
+++ b/internal/infrastructure/llm/anthropic/client.go
@@ -67,6 +67,11 @@ type client struct {
 	persona        string
 	logger         ports.Logger
 	timeout        time.Duration
+
+	// marshalFunc serializes a value to JSON. Defaults to json.Marshal.
+	// Overridable in tests to exercise the marshal-error path in
+	// prepareAnthropicRequest without modifying the type tree.
+	marshalFunc func(interface{}) ([]byte, error)
 }
 
 // anthropicOption defines a functional option for configuring the Anthropic Client.
@@ -138,6 +143,7 @@ func NewClient(baseURL, model string, authenticator auth.Authenticator, opts ...
 		baseURL:       strings.TrimSuffix(baseURL, "/"),
 		model:         model,
 		logger:        &ports.NoOpLogger{},
+		marshalFunc:   json.Marshal,
 		maxTokens:     defaultMaxTokens,
 	}
 
@@ -364,18 +370,19 @@ func (c *client) prepareAnthropicRequest(ctx context.Context, history []*llm.Con
 		}
 	}
 
-	// ADR-024 corollary (Issue #782): json.Marshal(reqPayload) cannot fail
+	// ADR-024 corollary (Issue #782): c.marshalFunc(reqPayload) cannot fail
 	// with the current messagesRequest type tree — every field resolves to
 	// strings, ints, or interface{} populated exclusively with JSON-safe
 	// types (json.RawMessage, string, map[string]interface{}, typed string-only
 	// structs). No float64 fields exist, so NaN/Inf cannot appear. The error
 	// branch below is defensive dead code that serves as a safety net if a
-	// future field addition introduces a marshal-unfriendly type.
+	// future field addition introduces a marshal-unfriendly type, or if a
+	// test overrides marshalFunc to inject a synthetic error.
 	// Coverage: accepted gap (defensive dead code per Issue #782 / ADR-024).
-	// json.Marshal(reqPayload) cannot fail with the current messagesRequest
+	// c.marshalFunc(reqPayload) cannot fail with the current messagesRequest
 	// type tree. See TestPrepareAnthropicRequest_MarshalFailure in client_test.go
 	// for the sentinel test that verifies the wrapping format.
-	body, err := json.Marshal(reqPayload)
+	body, err := c.marshalFunc(reqPayload)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}

--- a/internal/infrastructure/llm/anthropic/client_test.go
+++ b/internal/infrastructure/llm/anthropic/client_test.go
@@ -1037,3 +1037,39 @@ func TestPrepareAnthropicRequest_MarshalErrorUnreachable(t *testing.T) {
 		"all fields are marshal-safe Go types. " +
 		"Error path exists for defensive future-proofing.")
 }
+
+// TestPrepareAnthropicRequest_MarshalFuncError exercises the json.Marshal
+// error branch in prepareAnthropicRequest via the injectable marshalFunc
+// field (ADR-024 / Issue #1075). When marshalFunc returns an error,
+// prepareAnthropicRequest must wrap it with "failed to marshal request: %w"
+// and return a nil *http.Request.
+func TestPrepareAnthropicRequest_MarshalFuncError(t *testing.T) {
+	t.Parallel()
+
+	c := NewClient("https://api.anthropic.com/v1", "claude-3-5-sonnet",
+		&auth.AnthropicAuth{APIKey: "test-key"},
+	)
+
+	// Override marshalFunc with a failing implementation
+	c.marshalFunc = func(v interface{}) ([]byte, error) {
+		return nil, errors.New("injected marshal failure")
+	}
+
+	history := []*llm.Content{
+		{Role: "user", Parts: []*llm.Part{{Text: "hello"}}},
+	}
+
+	req, err := c.prepareAnthropicRequest(context.Background(), history, nil)
+	if err == nil {
+		t.Fatal("expected error from marshalFunc, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to marshal request") {
+		t.Errorf("expected error containing %q, got %q", "failed to marshal request", err.Error())
+	}
+	if !strings.Contains(err.Error(), "injected marshal failure") {
+		t.Errorf("expected error containing %q, got %q", "injected marshal failure", err.Error())
+	}
+	if req != nil {
+		t.Error("expected nil request on marshal error, got non-nil")
+	}
+}

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -151,6 +151,9 @@ func (c *client) processDirectOutputItem(content *llm.Content, out *responseOutp
 		// Reviewed: Issue #782 (2026-06) — branch remains structurally
 		// unreachable; no testable error path exists without refactoring
 		// appendPartsFromBlock. Accepted as defensive future-proofing.
+		// Re-reviewed: Issue #1075 (2026-07) — architect decision: ACCEPT
+		// as permanent defensive dead code. Do not refactor
+		// appendPartsFromBlock solely for coverage.
 		if !errors.Is(err, errUnhandledBlockType) {
 			return err
 		}


### PR DESCRIPTION
Closes #1075.

## Summary
Covered two coverage gaps in LLM infrastructure:
- **Anthropic**: Added `marshalFunc` testability seam to `prepareAnthropicRequest`, enabling `TestPrepareAnthropicRequest_MarshalFuncError` → **100.0% coverage**
- **OpenAI**: Architecturally accepted the `!errors.Is` guard in `processDirectOutputItem` as permanently unreachable defensive dead code (documented with Issue #1075 reference)

## Changes
| File | Change |
|------|--------|
| `internal/infrastructure/llm/anthropic/client.go` | Added `marshalFunc` field, initialized to `json.Marshal`, used in `prepareAnthropicRequest` |
| `internal/infrastructure/llm/anthropic/client_test.go` | Added `TestPrepareAnthropicRequest_MarshalFuncError` |
| `internal/infrastructure/llm/openai/responses.go` | Updated ADR comment with Issue #1075 acceptance note |

## Verification
| Check | Status |
|-------|--------|
| make check-full (fmt, tidy, build, lint, verify-architecture, vulncheck, test, dead-code) | ✅ PASS |
| test-race (affected packages) | ✅ PASS |
| anthropic coverage | 100.0% |
| golangci-lint | 0 issues |
| govulncheck | No vulnerabilities found |