### PR TITLE
fix(context): add isTurnEmpty business logic and error path test coverage (#1094)

### DIFF
--- a/internal/agent/session/context/context_transformers_test.go
+++ b/internal/agent/session/context/context_transformers_test.go
@@ -783,6 +783,77 @@ func TestIsTurnEmpty_Helper(t *testing.T) {
 	}
 }
 
+func TestIsTurnEmpty_Line155_Coverage(t *testing.T) {
+	tests := []struct {
+		name     string
+		turn     []*llm.Content
+		expected bool
+		wantErr  bool
+		errIs    error
+	}{
+		// ── Business logic: line 155 return true, nil ──
+		{
+			name: "single message with multiple empty parts",
+			turn: []*llm.Content{
+				{Parts: []*llm.Part{{Text: ""}, {Text: ""}, {Text: ""}}},
+			},
+			expected: true,
+		},
+		{
+			name: "multiple messages each with multiple empty parts",
+			turn: []*llm.Content{
+				{Parts: []*llm.Part{{Text: ""}, {Text: ""}}},
+				{Parts: []*llm.Part{{Text: ""}, {Text: ""}}},
+			},
+			expected: true,
+		},
+		{
+			name: "all parts empty with mix of empty text and empty thought",
+			turn: []*llm.Content{
+				{Parts: []*llm.Part{{Text: ""}, {IsThought: false}}},
+				{Parts: []*llm.Part{{Text: ""}}},
+			},
+			expected: true,
+		},
+
+		// ── Error paths: ErrInvalidPayload ──
+		{
+			name:    "nil message in middle of turn",
+			turn:    []*llm.Content{{Parts: []*llm.Part{{Text: ""}}}, nil},
+			wantErr: true,
+			errIs:   ErrInvalidPayload,
+		},
+		{
+			name: "nil part in second message",
+			turn: []*llm.Content{
+				{Parts: []*llm.Part{{Text: ""}}},
+				{Parts: []*llm.Part{{Text: ""}, nil}},
+			},
+			wantErr: true,
+			errIs:   ErrInvalidPayload,
+		},
+		{
+			name:    "nil part in first position of first message",
+			turn:    []*llm.Content{{Parts: []*llm.Part{nil, {Text: ""}}}},
+			wantErr: true,
+			errIs:   ErrInvalidPayload,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := isTurnEmpty(tt.turn)
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.errIs)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestIsToolCall_Helper(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Closes #1094.

## Summary
Adds `TestIsTurnEmpty_Line155_Coverage` to `internal/agent/session/context/context_transformers_test.go`, covering:
- The previously untested business-logic path at `transformers.go:155` (return true, nil) where all parts across multiple messages are non-nil but semantically empty
- Nil-message error path (`ErrInvalidPayload`)
- Nil-part error path (`ErrInvalidPayload`) — two variants (second message + first position)

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go test ./...` | PASS |
| `go test -race ./internal/agent/session/context/...` | PASS |
| Coverage (`isTurnEmpty`) | 100.0% |
| `golangci-lint run` | 0 issues |
| Architecture verify | PASS |
| Vulncheck | PASS |
