### PR TITLE
fix(events): reduce TestSpinnerInfo complexity from 12 to ≤10 (#1095)

### DIFF
--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -37,6 +37,25 @@ func (e testEvent) Type() string {
 	return "testEvent"
 }
 
+// spinnerEvent is the common interface for event types that provide
+// spinner presentation via the SpinnerInfo() method.
+type spinnerEvent interface {
+	SpinnerInfo() (events.SpinnerInfo, bool)
+}
+
+// assertSpinnerInfo asserts that a spinnerEvent returns the expected SpinnerInfo
+// and that ok is true. Fails the test with t.Fatal if ok is false.
+func assertSpinnerInfo(t *testing.T, e spinnerEvent, want events.SpinnerInfo) {
+	t.Helper()
+	got, ok := e.SpinnerInfo()
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if got != want {
+		t.Errorf("got %+v; want %+v", got, want)
+	}
+}
+
 type errSubscriber struct {
 	err error
 }
@@ -1333,116 +1352,92 @@ func TestSimpleEventBus_Shutdown_ActiveWorkers(t *testing.T) {
 	<-listenDone
 }
 
-func TestSpinnerInfo(t *testing.T) {
+func TestSpinnerInfo_InferenceStartedEvent(t *testing.T) {
 	t.Parallel()
 
-	t.Run("InferenceStartedEvent", func(t *testing.T) {
-		tests := []struct {
-			name  string
-			model string
-			want  events.SpinnerInfo
-		}{
-			{
-				name:  "model present",
-				model: "gpt-5",
-				want:  events.SpinnerInfo{Status: " Thinking [gpt-5]..."},
-			},
-			{
-				name:  "model absent",
-				model: "",
-				want:  events.SpinnerInfo{Status: " Thinking..."},
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				e := events.InferenceStartedEvent{Model: tt.model}
-				got, ok := e.SpinnerInfo()
-				if !ok {
-					t.Fatal("expected ok=true")
-				}
-				if got != tt.want {
-					t.Errorf("got %+v; want %+v", got, tt.want)
-				}
-			})
-		}
-	})
+	tests := []struct {
+		name  string
+		model string
+		want  events.SpinnerInfo
+	}{
+		{
+			name:  "model present",
+			model: "gpt-5",
+			want:  events.SpinnerInfo{Status: " Thinking [gpt-5]..."},
+		},
+		{
+			name:  "model absent",
+			model: "",
+			want:  events.SpinnerInfo{Status: " Thinking..."},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertSpinnerInfo(t, events.InferenceStartedEvent{Model: tt.model}, tt.want)
+		})
+	}
+}
 
-	t.Run("SummarizationStartedEvent", func(t *testing.T) {
-		e := events.SummarizationStartedEvent{}
-		got, ok := e.SpinnerInfo()
-		if !ok {
-			t.Fatal("expected ok=true")
-		}
-		want := events.SpinnerInfo{Status: " Compressing context...", ResetRendering: true}
-		if got != want {
-			t.Errorf("got %+v; want %+v", got, want)
-		}
-	})
+func TestSpinnerInfo_SummarizationStartedEvent(t *testing.T) {
+	t.Parallel()
 
-	t.Run("ToolExecutionStartedEvent", func(t *testing.T) {
-		tests := []struct {
-			name      string
-			toolNames []string
-			want      events.SpinnerInfo
-		}{
-			{
-				name:      "no tools",
-				toolNames: nil,
-				want:      events.SpinnerInfo{Status: " Executing tools...", WithMetrics: true, ResetRendering: true},
-			},
-			{
-				name:      "one tool",
-				toolNames: []string{"bash"},
-				want:      events.SpinnerInfo{Status: " Executing [bash]...", WithMetrics: true, ResetRendering: true},
-			},
-			{
-				name:      "two tools",
-				toolNames: []string{"read", "write"},
-				want:      events.SpinnerInfo{Status: " Executing tools [read, write]...", WithMetrics: true, ResetRendering: true},
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				e := events.ToolExecutionStartedEvent{ToolNames: tt.toolNames}
-				got, ok := e.SpinnerInfo()
-				if !ok {
-					t.Fatal("expected ok=true")
-				}
-				if got != tt.want {
-					t.Errorf("got %+v; want %+v", got, tt.want)
-				}
-			})
-		}
-	})
+	want := events.SpinnerInfo{Status: " Compressing context...", ResetRendering: true}
+	assertSpinnerInfo(t, events.SummarizationStartedEvent{}, want)
+}
 
-	t.Run("RetryWaitingEvent", func(t *testing.T) {
-		tests := []struct {
-			name     string
-			duration time.Duration
-			want     events.SpinnerInfo
-		}{
-			{
-				name:     "rounds up to second",
-				duration: 1500 * time.Millisecond,
-				want:     events.SpinnerInfo{Status: " Retrying in 2s...", ResetRendering: true},
-			},
-			{
-				name:     "sub-second rounds to zero",
-				duration: 100 * time.Millisecond,
-				want:     events.SpinnerInfo{Status: " Retrying in 0s...", ResetRendering: true},
-			},
-		}
-		for _, tt := range tests {
-			t.Run(tt.name, func(t *testing.T) {
-				e := events.RetryWaitingEvent{Duration: tt.duration}
-				got, ok := e.SpinnerInfo()
-				if !ok {
-					t.Fatal("expected ok=true")
-				}
-				if got != tt.want {
-					t.Errorf("got %+v; want %+v", got, tt.want)
-				}
-			})
-		}
-	})
+func TestSpinnerInfo_ToolExecutionStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		toolNames []string
+		want      events.SpinnerInfo
+	}{
+		{
+			name:      "no tools",
+			toolNames: nil,
+			want:      events.SpinnerInfo{Status: " Executing tools...", WithMetrics: true, ResetRendering: true},
+		},
+		{
+			name:      "one tool",
+			toolNames: []string{"bash"},
+			want:      events.SpinnerInfo{Status: " Executing [bash]...", WithMetrics: true, ResetRendering: true},
+		},
+		{
+			name:      "two tools",
+			toolNames: []string{"read", "write"},
+			want:      events.SpinnerInfo{Status: " Executing tools [read, write]...", WithMetrics: true, ResetRendering: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertSpinnerInfo(t, events.ToolExecutionStartedEvent{ToolNames: tt.toolNames}, tt.want)
+		})
+	}
+}
+
+func TestSpinnerInfo_RetryWaitingEvent(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		duration time.Duration
+		want     events.SpinnerInfo
+	}{
+		{
+			name:     "rounds up to second",
+			duration: 1500 * time.Millisecond,
+			want:     events.SpinnerInfo{Status: " Retrying in 2s...", ResetRendering: true},
+		},
+		{
+			name:     "sub-second rounds to zero",
+			duration: 100 * time.Millisecond,
+			want:     events.SpinnerInfo{Status: " Retrying in 0s...", ResetRendering: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertSpinnerInfo(t, events.RetryWaitingEvent{Duration: tt.duration}, tt.want)
+		})
+	}
 }


### PR DESCRIPTION
Closes #1095.

## Summary
Refactored `TestSpinnerInfo` in `internal/domain/events/events_test.go` to reduce cyclomatic complexity from 12 to ≤10:
- Extracted `assertSpinnerInfo` helper using `spinnerEvent` interface to eliminate duplicated assertion boilerplate
- Split the monolithic test into 4 independent test functions, one per event type:
  - `TestSpinnerInfo_InferenceStartedEvent`
  - `TestSpinnerInfo_SummarizationStartedEvent`
  - `TestSpinnerInfo_ToolExecutionStartedEvent`
  - `TestSpinnerInfo_RetryWaitingEvent`
- All 8 leaf test cases preserved (verified by gocyclo → no functions >10)
- No `time.Sleep` (ADR-036 compliant)

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| gocyclo -over 10 | PASS (no output) |
| go test -race | PASS |