### PR TITLE
fix(analysis): add error path coverage for checkCancellation and containsGoFiles (#1090)

### DIFF
--- a/internal/tools/analysis/dependency_test.go
+++ b/internal/tools/analysis/dependency_test.go
@@ -578,4 +578,13 @@ func TestListInternalPackages_ContainsGoFilesError(t *testing.T) {
 
 	_, err := a.listInternalPackages(tmpDir)
 	require.Error(t, err, "expected error from listInternalPackages with unreadable subdirectory")
+
+	// Accept either path: the containsGoFiles error wrapping (L193-195)
+	// or Walk's own permission error propagated through the callback
+	// (L178-179). Both exercise the defense-in-depth described in the
+	// GAP ACCEPTED comment at dependency.go:187-189.
+	assert.True(t,
+		strings.Contains(err.Error(), "checking for Go files in") ||
+			strings.Contains(err.Error(), "permission denied"),
+		"error should mention 'checking for Go files in' or 'permission denied', got: %v", err)
 }

--- a/internal/tools/analysis/types_error_test.go
+++ b/internal/tools/analysis/types_error_test.go
@@ -480,6 +480,41 @@ func F() string { return "ok" }
 	}
 }
 
+// TestCollectSymbols_CancelledContext verifies that a cancelled context
+// causes checkCancellation (types.go:423-425) inside collectSymbols to
+// return context.Canceled, which is then propagated by filepath.Walk.
+func TestCollectSymbols_CancelledContext(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+
+	// go.mod required for AST cache to resolve module paths.
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// At least one .go file so Walk enters the callback where
+	// checkCancellation is invoked.
+	if err := os.WriteFile(filepath.Join(tmpDir, "valid.go"), []byte("package test\nfunc F() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before ListSymbols starts
+
+	m := analysis.NewTypeManager(
+		&analysistest.MockSymbolIndex{},
+		analysis.NewASTCache("."),
+		&analysistest.MockSecurityProvider{},
+	)
+
+	_, err := m.ListSymbols(ctx, map[string]interface{}{"path": tmpDir}, nil)
+	if err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
 // =============================================================================
 // Batch 2, Task 3 — Table-driven error path tests
 // =============================================================================


### PR DESCRIPTION
Closes #1090.

## Summary
Added test coverage for 2 error-handling gaps in `internal/tools/analysis/`:

| Gap | File | Resolution |
|-----|------|------------|
| Gap 2 | `dependency.go:193-195` | Strengthened `TestListInternalPackages_ContainsGoFilesError` with wrapped error message assertion |
| Gap 4 | `types.go:423-425` | New `TestCollectSymbols_CancelledContext` verifying context cancellation propagates through `checkCancellation` |

Gaps 1 (`complexity.go:88-90`) and 3 (`imports.go:46-48`) were already covered by existing tests.

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `golangci-lint run` | 0 issues |
| `make verify-architecture` | PASS |
| `make verify-no-test-sleep` | PASS |
| `go test ./internal/tools/analysis/...` | PASS |
| Race tests (all 4 gaps) | PASS |