### PR TITLE
fix(integrations): remove unreachable error branches per ADR-037 (#1088)

### DIFF
--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -197,10 +197,9 @@ func (m *AdoManager) executeCreatePipeline(ctx context.Context, org, project, na
 		},
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return 0, fmt.Errorf("failed to marshal payload: %w", err)
-	}
+	// json.Marshal cannot fail on a struct composed entirely of JSON-safe
+	// primitives (string, int, bool, *bool). See ADR-037.
+	body, _ := json.Marshal(payload)
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines?api-version=7.1-preview.1",
 		m.BaseURL, url.PathEscape(org), url.PathEscape(project))

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -150,10 +150,9 @@ func (m *AdoManager) executeRunPipeline(ctx context.Context, org, project string
 		Variables:          variables,
 	}
 
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return 0, "", fmt.Errorf("failed to marshal payload: %w", err)
-	}
+	// json.Marshal cannot fail on a struct composed entirely of JSON-safe
+	// primitives (string, bool, *bool). See ADR-037.
+	body, _ := json.Marshal(payload)
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs?api-version=7.1-preview.1",
 		m.BaseURL, url.PathEscape(org), url.PathEscape(project), pipelineID)

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -59,15 +59,10 @@ func (m *ConfluenceManager) fetchPageContent(ctx context.Context, pageID string)
 	q.Set("body-format", "storage")
 	u.RawQuery = q.Encode()
 
-	// NOTE: This branch is structurally unreachable because:
-	//  1. url.Parse(m.provider.baseURL) above already validates the URL
-	//  2. http.NewRequestWithContext internally calls url.Parse on u.String(),
-	//     which is the canonical form of the already-validated URL
-	// Kept as defense-in-depth against future refactoring.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
-	}
+	// http.NewRequestWithContext cannot fail here: u.String() returns the
+	// canonical form of a URL already validated by url.Parse above.
+	// See ADR-037: unreachable error branches are removed, not tested.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 
 	req.Header.Set("Accept", "application/json")
 
@@ -162,15 +157,10 @@ func (m *ConfluenceManager) getCurrentPageVersion(ctx context.Context, pageID st
 	}
 	u = u.JoinPath("/wiki/api/v2/pages", pageID)
 
-	// NOTE: This branch is structurally unreachable because:
-	//  1. url.Parse(m.provider.baseURL) above already validates the URL
-	//  2. http.NewRequestWithContext internally calls url.Parse on u.String(),
-	//     which is the canonical form of the already-validated URL
-	// Kept as defense-in-depth against future refactoring.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create version fetch request: %w", err)
-	}
+	// http.NewRequestWithContext cannot fail here: u.String() returns the
+	// canonical form of a URL already validated by url.Parse above.
+	// See ADR-037: unreachable error branches are removed, not tested.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := m.provider.Do(ctx, m.client, req)
@@ -202,15 +192,10 @@ func (m *ConfluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 		return fmt.Errorf("failed to marshal update payload: %w", err)
 	}
 
-	// NOTE: This branch is structurally unreachable because:
-	//  1. url.Parse(m.provider.baseURL) above already validates the URL
-	//  2. http.NewRequestWithContext internally calls url.Parse on u.String(),
-	//     which is the canonical form of the already-validated URL
-	// Kept as defense-in-depth against future refactoring.
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), bytes.NewBuffer(bodyBytes))
-	if err != nil {
-		return fmt.Errorf("failed to create update request: %w", err)
-	}
+	// http.NewRequestWithContext cannot fail here: u.String() returns the
+	// canonical form of a URL already validated by url.Parse above.
+	// See ADR-037: unreachable error branches are removed, not tested.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 

--- a/internal/tools/integrations/atlassian/confluence_search.go
+++ b/internal/tools/integrations/atlassian/confluence_search.go
@@ -35,15 +35,10 @@ func (m *ConfluenceManager) fetchSpaceByKey(ctx context.Context, spaceKey string
 	q.Set("keys", spaceKey)
 	u.RawQuery = q.Encode()
 
-	// NOTE: This branch is structurally unreachable because:
-	//  1. url.Parse(m.provider.baseURL) above already validates the URL
-	//  2. http.NewRequestWithContext internally calls url.Parse on u.String(),
-	//     which is the canonical form of the already-validated URL
-	// Kept as defense-in-depth against future refactoring.
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to create space fetch request: %w", err)
-	}
+	// http.NewRequestWithContext cannot fail here: u.String() returns the
+	// canonical form of a URL already validated by url.Parse above.
+	// See ADR-037: unreachable error branches are removed, not tested.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := m.provider.Do(ctx, m.client, req)


### PR DESCRIPTION
Closes #1088.

## Summary
Removed 6 structurally unreachable error branches across ADO and Atlassian integration packages, per the ADR-037 pattern (unreachable error branches are removed, not tested). Two gaps (#2 and #4) were already covered by existing tests.

### Changes
- **ADO** (`pipeline_crud.go`, `pipeline_runs.go`): Replaced unreachable `json.Marshal` error checks with `_` discards + ADR-037 comments
- **Atlassian** (`confluence.go`, `confluence_search.go`): Replaced unreachable `http.NewRequestWithContext` error checks with `_` discards + ADR-037 comments

### Gap Resolution
| # | Gap | Resolution |
|---|-----|-----------|
| 1 | `executeCreatePipeline` json.Marshal | Removed (unreachable) |
| 2 | `buildVariablesUpdatePayload` error | Already tested |
| 3 | `executeRunPipeline` json.Marshal | Removed (unreachable) |
| 4 | `validateGetPrDiffParams` | Already tested |
| 5 | `fetchPageContent` NewRequestWithContext | Removed (unreachable) |
| 6 | `getCurrentPageVersion` NewRequestWithContext | Removed (unreachable) |
| 7 | `executeUpdate` NewRequestWithContext | Removed (unreachable) |
| 8 | `fetchSpaceByKey` NewRequestWithContext | Removed (unreachable) |

## Verification
| Check | Status |
|-------|--------|
| `go build ./...` | PASS |
| `go vet ./...` | PASS |
| `golangci-lint run ./...` | PASS |
| `go test -race ./internal/tools/integrations/ado/ ./internal/tools/integrations/atlassian/` | PASS |
| No `time.Sleep` (ADR-036) | PASS |