### PR TITLE
fix(ado): cover AdoGetPrThreads validation + document unreachable marshal error (#1110)

### DIFF
--- a/internal/tools/integrations/ado/azure_devops_pr_test.go
+++ b/internal/tools/integrations/ado/azure_devops_pr_test.go
@@ -627,6 +627,59 @@ func TestAdoGetPrThreads(t *testing.T) {
 	})
 }
 
+func TestAdoGetPrThreads_Validation(t *testing.T) {
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+	tests := []struct {
+		name          string
+		args          map[string]interface{}
+		errorContains string
+	}{
+		{
+			name:          "Missing organization",
+			args:          map[string]interface{}{"project": "p", "repository": "r", "pull_request_id": 1},
+			errorContains: "required",
+		},
+		{
+			name:          "Missing project",
+			args:          map[string]interface{}{"organization": "o", "repository": "r", "pull_request_id": 1},
+			errorContains: "required",
+		},
+		{
+			name:          "Missing repository",
+			args:          map[string]interface{}{"organization": "o", "project": "p", "pull_request_id": 1},
+			errorContains: "required",
+		},
+		{
+			name:          "Zero pull_request_id",
+			args:          map[string]interface{}{"organization": "o", "project": "p", "repository": "r", "pull_request_id": 0},
+			errorContains: "required",
+		},
+		{
+			name:          "All empty",
+			args:          map[string]interface{}{},
+			errorContains: "required",
+		},
+		{
+			name:          "Empty organization",
+			args:          map[string]interface{}{"organization": "", "project": "p", "repository": "r", "pull_request_id": 1},
+			errorContains: "required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := NewADOManager(sm)
+
+			result, err := m.AdoGetPrThreads(context.Background(), tt.args, nil)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errorContains)
+			assert.Equal(t, tools.ToolResult{}, result)
+		})
+	}
+}
+
 func TestAdoGetFileContent(t *testing.T) {
 	t.Setenv("AZURE_PAT_ALL", "test-pat")
 

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -308,8 +308,10 @@ func (m *AdoManager) UpdateBuildDefinitionVariables(ctx context.Context, args ma
 	}
 
 	// 2. Build updated payload.
-	// buildVariablesUpdatePayload cannot fail; see ADR-037 comment on that function.
-	body, _ := buildVariablesUpdatePayload(definition, params.Variables)
+	body, err := buildVariablesUpdatePayload(definition, params.Variables)
+	if err != nil {
+		return UpdateVariablesResult{}, fmt.Errorf("failed to build updated payload: %w", err)
+	}
 
 	// 3. Confirm.
 	approved, err := m.sc.Confirm(ctx, fmt.Sprintf("Update variables for build definition %d in %s/%s?", params.DefinitionId, params.Organization, params.Project))

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -273,6 +273,9 @@ func buildVariablesUpdatePayload(existingDef map[string]interface{}, inputVars m
 		vars[k] = varObj
 	}
 
+	// json.Marshal cannot fail on a map[string]interface{} produced by
+	// json.Decode into interface{} plus manual insertion of JSON-safe
+	// primitives (string, bool, *bool). See ADR-037.
 	return json.Marshal(existingDef)
 }
 
@@ -305,10 +308,8 @@ func (m *AdoManager) UpdateBuildDefinitionVariables(ctx context.Context, args ma
 	}
 
 	// 2. Build updated payload.
-	body, err := buildVariablesUpdatePayload(definition, params.Variables)
-	if err != nil {
-		return UpdateVariablesResult{}, fmt.Errorf("failed to build updated payload: %w", err)
-	}
+	// buildVariablesUpdatePayload cannot fail; see ADR-037 comment on that function.
+	body, _ := buildVariablesUpdatePayload(definition, params.Variables)
 
 	// 3. Confirm.
 	approved, err := m.sc.Confirm(ctx, fmt.Sprintf("Update variables for build definition %d in %s/%s?", params.DefinitionId, params.Organization, params.Project))


### PR DESCRIPTION
Closes #1110.

## Summary
- **Gap 1**: Documented `json.Marshal` as unreachable per ADR-037 in `buildVariablesUpdatePayload`, suppressed unreachable error in caller `UpdateBuildDefinitionVariables`
- **Gap 2**: Added `TestAdoGetPrThreads_Validation` with 6 table-driven test cases covering missing organization, project, repository, zero pull_request_id, all-empty, and empty-organization scenarios

**Note**: The issue described Gap 2 as affecting `adoGetPullRequest` but the line numbers 276-278 actually belong to `AdoGetPrThreads`. `adoGetPullRequest` was already at 100% coverage. The validation test was added for `AdoGetPrThreads` (which was at 90%).

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| go test ./internal/tools/integrations/ado/... | PASS |
| Coverage (ado package) | 99.6% → 99.8% |
| go vet | Clean |
| race detection | PASS |