### PR TITLE
fix(workspace): cover wirePipes error path in newPipeline (#1112)

### DIFF
--- a/internal/tools/workspace/pipeline.go
+++ b/internal/tools/workspace/pipeline.go
@@ -38,7 +38,11 @@ func (e *processExecutor) newPipeline(ctx context.Context, pipedParts [][]string
 		p.cmds[i] = cmd
 	}
 
-	if err := p.wirePipes(); err != nil {
+	wp := p.wirePipes
+	if e.wirePipesFn != nil {
+		wp = func() error { return e.wirePipesFn(p) }
+	}
+	if err := wp(); err != nil {
 		return nil, err
 	}
 

--- a/internal/tools/workspace/pipeline_test.go
+++ b/internal/tools/workspace/pipeline_test.go
@@ -5,6 +5,7 @@ package workspace
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os/exec"
 	"strings"
@@ -279,6 +280,33 @@ func TestRunPipeline_EnvPropagation(t *testing.T) {
 				t.Errorf("expected no env var output, got %q", res.Output)
 			}
 		})
+	}
+}
+
+// TestNewPipeline_WirePipesError_Propagation verifies that newPipeline
+// correctly propagates an error from wirePipesFn back to the caller.
+// This covers the defensive error path at pipeline.go:41-43 which is
+// structurally unreachable through the normal code path (fresh exec.Cmd
+// objects never fail on the first StderrPipe/StdoutPipe call) but must
+// be exercised via dependency injection.
+func TestNewPipeline_WirePipesError_Propagation(t *testing.T) {
+	e := &processExecutor{
+		wirePipesFn: func(p *pipeline) error {
+			return fmt.Errorf("failed to get stderr pipe for command 0: injected failure")
+		},
+	}
+	ctx := context.Background()
+	pipedParts := [][]string{
+		{helperPath, "echo", "hello"},
+		{helperPath, "cat"},
+	}
+
+	_, err := e.newPipeline(ctx, pipedParts, executionConfig{})
+	if err == nil {
+		t.Fatal("expected error from wirePipes failure, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed to get stderr pipe for command 0") {
+		t.Errorf("expected error containing 'failed to get stderr pipe for command 0', got: %v", err)
 	}
 }
 

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -39,7 +39,13 @@ type executionResult struct {
 }
 
 // processExecutor handles running external commands and pipelines.
-type processExecutor struct{}
+type processExecutor struct {
+	// wirePipesFn is an optional override for pipeline.wirePipes used by newPipeline.
+	// When nil (zero value), newPipeline calls p.wirePipes() as before.
+	// When set, newPipeline delegates to this function instead.
+	// This exists solely to enable testing the defensive error path at pipeline.go:41-43.
+	wirePipesFn func(p *pipeline) error
+}
 
 const maxScannerCapacity = 10 * 1024 * 1024
 


### PR DESCRIPTION
Closes #1112.

## Summary
Added dependency injection via `wirePipesFn` field on `processExecutor` to enable testing the defensive error path at `pipeline.go:41-43`. Added `TestNewPipeline_WirePipesError_Propagation` test that injects a synthetic wirePipes failure and verifies correct error propagation.

### Changes
| File | Change |
|------|--------|
| `process_executor.go` | Added `wirePipesFn func(*pipeline) error` field (nil = default behavior) |
| `pipeline.go` | Refactored `newPipeline` to dispatch via `wirePipesFn` when non-nil |
| `pipeline_test.go` | Added `TestNewPipeline_WirePipesError_Propagation` + `fmt` import |

### Coverage
| Function | Before | After |
|----------|--------|-------|
| `newPipeline` | 88.9% | **100.0%** |
| `wirePipes` | 100.0% | 100.0% |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| Race detector | PASS |
| Coverage | 98.8% (package), no regression |
