### PR TITLE
fix(ui): remove redundant TestHandleToolEvents_ContextTODO test (#1118)

### DIFF
--- a/internal/agent/session/ui/dispatcher_test.go
+++ b/internal/agent/session/ui/dispatcher_test.go
@@ -148,22 +148,6 @@ func TestHandleToolEvents_EmptyNameGuard(t *testing.T) {
 	assert.Contains(t, logger.GetDebugs(), "handleToolEvents: ToolResultEvent missing Name")
 }
 
-func TestHandleToolEvents_ContextTODO(t *testing.T) {
-	t.Parallel()
-
-	d, renderer, _ := newTestDispatcher(t)
-	calls := []*llm.FunctionCall{{Name: "search"}}
-
-	// dispatch with context.TODO() — must not panic (SA1012-compliant)
-	d.dispatch(context.TODO(), events.ToolCallEvent{
-		Calls:    calls,
-		Turn:     1,
-		MaxTurns: 3,
-	})
-
-	assert.Len(t, renderer.logToolCallCalls, 1, "LogToolCall should still be called with context.TODO()")
-}
-
 func TestHandleToolEvents_UnexpectedType(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Closes #1118.

## Summary
Removed the redundant `TestHandleToolEvents_ContextTODO` test from `internal/agent/session/ui/dispatcher_test.go`. The behavior this test exercised (context.TODO() passthrough through ensureContext) is already covered by `TestEnsureContext` sub-tests and the dispatch routing is tested by every other test in the file. This is Option B from the issue — a clean removal with no coverage gap.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Coverage (ui package) | 100.0% |
