### PR TITLE
fix(config): guard against Viper integer overflow producing negative values (#1119)

### DIFF
--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -139,6 +139,36 @@ func (c *Config) ValidateProviders(logger *slog.Logger) error {
 	return nil
 }
 
+// ValidateBounds checks every non-negative int field on Config and returns
+// an error for any negative value. Viper's WeaklyTypedInput can silently
+// produce negative values from integer overflow, so this is the guard.
+// Zero is valid for all fields (e.g. MaxHistoryTurns=0 means no pruning,
+// ThinkingBudget=0 means use the provider default).
+func (c *Config) ValidateBounds() error {
+	if c.MaxToolTurns < 0 {
+		return fmt.Errorf("MAX_TURNS must be >= 0, got %d", c.MaxToolTurns)
+	}
+	if c.MaxHistoryTurns < 0 {
+		return fmt.Errorf("MAX_HISTORY_TURNS must be >= 0, got %d", c.MaxHistoryTurns)
+	}
+	if c.MaxHistoryTokens < 0 {
+		return fmt.Errorf("MAX_HISTORY_TOKENS must be >= 0, got %d", c.MaxHistoryTokens)
+	}
+	if c.ThinkingBudget < 0 {
+		return fmt.Errorf("THINKING_BUDGET must be >= 0, got %d", c.ThinkingBudget)
+	}
+	if c.MaxConcurrentTools < 0 {
+		return fmt.Errorf("MAX_CONCURRENT_TOOLS must be >= 0, got %d", c.MaxConcurrentTools)
+	}
+	if c.ToolTimeoutSeconds < 0 {
+		return fmt.Errorf("TOOL_TIMEOUT must be >= 0, got %d", c.ToolTimeoutSeconds)
+	}
+	if c.HTTPTimeoutSeconds < 0 {
+		return fmt.Errorf("HTTP_TIMEOUT must be >= 0, got %d", c.HTTPTimeoutSeconds)
+	}
+	return nil
+}
+
 // ModelConfig defines capabilities and limits for a specific model.
 type ModelConfig struct {
 	MaxThinkingBudget int                  `yaml:"MAX_THINKING_BUDGET"`

--- a/internal/domain/config/config_test.go
+++ b/internal/domain/config/config_test.go
@@ -454,3 +454,110 @@ func TestLLMProvider_Validate_EdgeCases(t *testing.T) {
 		})
 	}
 }
+
+// TestConfig_ValidateBounds pins the contract for Config.ValidateBounds(): every
+// non-negative int field is validated, zero is always accepted, and the function
+// short-circuits on the first invalid field found. Viper's WeaklyTypedInput can
+// silently produce negative values from integer overflow, so this guard is
+// critical for startup-time diagnosis.
+func TestConfig_ValidateBounds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		config        Config
+		expectError   bool
+		errorContains []string // substrings expected in the error message
+	}{
+		{
+			name:        "all valid (defaults / zero value)",
+			config:      Config{},
+			expectError: false,
+		},
+		{
+			name:          "MAX_TURNS negative",
+			config:        Config{MaxToolTurns: -1},
+			expectError:   true,
+			errorContains: []string{"MAX_TURNS", "-1"},
+		},
+		{
+			name:          "MAX_HISTORY_TURNS negative",
+			config:        Config{MaxHistoryTurns: -1},
+			expectError:   true,
+			errorContains: []string{"MAX_HISTORY_TURNS", "-1"},
+		},
+		{
+			name:          "MAX_HISTORY_TOKENS negative",
+			config:        Config{MaxHistoryTokens: -1},
+			expectError:   true,
+			errorContains: []string{"MAX_HISTORY_TOKENS", "-1"},
+		},
+		{
+			name:          "THINKING_BUDGET negative",
+			config:        Config{ThinkingBudget: -1},
+			expectError:   true,
+			errorContains: []string{"THINKING_BUDGET", "-1"},
+		},
+		{
+			name:          "MAX_CONCURRENT_TOOLS negative",
+			config:        Config{MaxConcurrentTools: -1},
+			expectError:   true,
+			errorContains: []string{"MAX_CONCURRENT_TOOLS", "-1"},
+		},
+		{
+			name:          "TOOL_TIMEOUT negative",
+			config:        Config{ToolTimeoutSeconds: -1},
+			expectError:   true,
+			errorContains: []string{"TOOL_TIMEOUT", "-1"},
+		},
+		{
+			name:          "HTTP_TIMEOUT negative",
+			config:        Config{HTTPTimeoutSeconds: -1},
+			expectError:   true,
+			errorContains: []string{"HTTP_TIMEOUT", "-1"},
+		},
+		{
+			name: "zero values all valid (explicit)",
+			config: Config{
+				MaxToolTurns:       0,
+				MaxHistoryTurns:    0,
+				MaxHistoryTokens:   0,
+				ThinkingBudget:     0,
+				MaxConcurrentTools: 0,
+				ToolTimeoutSeconds: 0,
+				HTTPTimeoutSeconds: 0,
+			},
+			expectError: false,
+		},
+		{
+			name: "first of multiple negatives short-circuits on MAX_TURNS",
+			config: Config{
+				MaxToolTurns:    -5,
+				MaxHistoryTurns: -3, // should not be reached
+			},
+			expectError:   true,
+			errorContains: []string{"MAX_TURNS", "-5"},
+		},
+		{
+			name:          "large overflow value",
+			config:        Config{MaxToolTurns: -1593095861524629081},
+			expectError:   true,
+			errorContains: []string{"MAX_TURNS", "-1593095861524629081"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.config.ValidateBounds()
+			if tt.expectError {
+				require.Error(t, err)
+				for _, sub := range tt.errorContains {
+					assert.Contains(t, err.Error(), sub)
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -69,6 +69,11 @@ func load(path string) (*domain_config.Config, error) {
 				slog.Float64("pricing_miss", v.Pricing.Miss))
 		}
 	}
+
+	if err := cfg.ValidateBounds(); err != nil {
+		return nil, err
+	}
+
 	syncLegacyFields(&cfg)
 
 	// Domain-level provider validation. Hard errors fail the load;

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -682,48 +682,46 @@ PROVIDERS:
 	}
 }
 
-// TestLoad_IntegerOverflowIsDetected documents the known behavior when
-// MAX_TURNS is set to a value exceeding int64 range (e.g., 20-digit integer).
-// Viper+mapstructure with WeaklyTypedInput silently coerces the overflow,
-// wrapping it to a negative value. This test pins the current behavior:
-// either load() returns an error (ideal), or MaxToolTurns lands as a non-negative
-// value. If neither holds, we log the known WeaklyTypedInput limitation.
-//
-// The fuzz test's post-load invariants catch negative MaxToolTurns; this
-// test exists purely to document that such overflow inputs are a recognized
-// limitation rather than a bug that needs fixing.
+// TestLoad_IntegerOverflowIsDetected verifies that load() rejects
+// integer-overflow values for every overflow-vulnerable int field.
+// Viper+mapstructure with WeaklyTypedInput silently wraps a 20-digit
+// integer past the int64 ceiling to a negative value; ValidateBounds()
+// then rejects the negative value with a "must be >= 0" error naming
+// the offending YAML field.
 func TestLoad_IntegerOverflowIsDetected(t *testing.T) {
-	t.Setenv("TELL_ME_MODE", "") // neutralize ambient env pollution
-
-	tmpDir := t.TempDir()
-	configPath := filepath.Join(tmpDir, "test_overflow.yaml")
 	// 99999999999999999999 is 20 digits — well beyond int64 max (9223372036854775807)
-	yamlContent := "MAX_TURNS: 99999999999999999999\n"
-	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
-		t.Fatalf("failed to write test config: %v", err)
+	const overflow = "99999999999999999999"
+
+	tests := []struct {
+		name    string
+		yamlVal string // "KEY: overflow" line
+		errFrag string // substring expected in the error message
+	}{
+		{name: "MAX_TURNS overflow", yamlVal: "MAX_TURNS: " + overflow, errFrag: "MAX_TURNS"},
+		{name: "MAX_HISTORY_TURNS overflow", yamlVal: "MAX_HISTORY_TURNS: " + overflow, errFrag: "MAX_HISTORY_TURNS"},
+		{name: "MAX_HISTORY_TOKENS overflow", yamlVal: "MAX_HISTORY_TOKENS: " + overflow, errFrag: "MAX_HISTORY_TOKENS"},
 	}
 
-	cfg, err := load(configPath)
-	if err != nil {
-		// Ideal outcome: load() rejects the overflow before it reaches the domain.
-		return
-	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TELL_ME_MODE", "") // neutralize ambient env pollution
 
-	if cfg == nil {
-		t.Fatal("expected non-nil config")
-	}
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "test_overflow.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.yamlVal+"\n"), 0644); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
 
-	if cfg.MaxToolTurns >= 0 {
-		// Also acceptable: the value was somehow coerced to a valid int.
-		return
+			_, err := load(configPath)
+			if err == nil {
+				t.Fatal("expected error for integer overflow, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.errFrag) {
+				t.Errorf("expected error containing %q, got %q", tt.errFrag, err.Error())
+			}
+			if !strings.Contains(err.Error(), "must be >= 0") {
+				t.Errorf("expected error containing \"must be >= 0\", got %q", err.Error())
+			}
+		})
 	}
-
-	// If we reach here, MaxToolTurns is negative — this is the known
-	// WeaklyTypedInput overflow case. The fuzz invariant flags this as a
-	// real invariant violation; this test documents that it's a known
-	// limitation, not an unexpected regression.
-	t.Logf("KNOWN LIMITATION: MaxToolTurns overflowed to negative (%d) "+
-		"due to Viper WeaklyTypedInput coercion. "+
-		"The fuzz test post-load invariant correctly catches this.",
-		cfg.MaxToolTurns)
 }

--- a/internal/infrastructure/config/fuzz_test.go
+++ b/internal/infrastructure/config/fuzz_test.go
@@ -70,6 +70,9 @@ func FuzzLoadConfig(f *testing.F) {
 	// Seed 15 — Max_tokens negative (should fail validation)
 	f.Add([]byte("SELECTED_PROVIDER: bad\nPROVIDERS:\n  bad:\n    TYPE: openai\n    API_KEY: x\n    MAX_TOKENS: -1"))
 
+	// Seed 16 — Integer overflow (20-digit value exceeding int64 max)
+	f.Add([]byte("MAX_TURNS: 99999999999999999999"))
+
 	// ── Fuzz function ──────────────────────────────────────────────
 
 	// ensure domain_config import is retained for type resolution
@@ -108,7 +111,7 @@ func FuzzLoadConfig(f *testing.F) {
 			return
 		}
 
-		// ── Post-load invariants ────────────────────────────────
+		// ── Post-load invariants (defense-in-depth: ValidateBounds should catch these upstream) ──
 
 		if cfg.MaxToolTurns < 0 {
 			t.Errorf("MaxToolTurns is negative: %d", cfg.MaxToolTurns)


### PR DESCRIPTION
Closes #1119.

## Summary
Added explicit bounds validation at the config load boundary to reject negative integer values caused by Viper's WeaklyTypedInput integer overflow. Previously, a 20-digit value exceeding int64 range (e.g., MAX_TURNS: 99999999999999999999) would silently wrap to a negative number and propagate into the domain. Now, `ValidateBounds()` rejects these at load time with a clear error message.

### Changes
| File | Change |
|------|--------|
| `internal/domain/config/config.go` | Added `ValidateBounds()` method checking 7 non-negative int fields |
| `internal/domain/config/config_test.go` | Added 11 table-driven test cases for `ValidateBounds` |
| `internal/infrastructure/config/config.go` | Call `cfg.ValidateBounds()` in `load()` after unmarshal, before syncLegacyFields |
| `internal/infrastructure/config/config_test.go` | Rewrote `TestLoad_IntegerOverflowIsDetected` as positive assertion; removed KNOWN LIMITATION doc |
| `internal/infrastructure/config/fuzz_test.go` | Added Seed 16 (overflow), updated invariants comment to defense-in-depth |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS (all 10 steps) |
| Coverage (config packages) | 100% |