### PR TITLE
fix(config): reduce FuzzLoadConfig complexity from 14 to 10 (#1132)

### DIFF
--- a/internal/infrastructure/config/fuzz_test.go
+++ b/internal/infrastructure/config/fuzz_test.go
@@ -14,65 +14,7 @@ import (
 )
 
 func FuzzLoadConfig(f *testing.F) {
-	// ── Seed corpus ────────────────────────────────────────────────
-
-	// Seed 1 — Minimal valid config
-	f.Add([]byte("MODE: test-mode\nPERSON: test-person\nAIMODEL: test-model\nAIURL: http://test.url"))
-
-	// Seed 2 — Provider with env expansion
-	f.Add([]byte("SELECTED_PROVIDER: work-openai\nPROVIDERS:\n  work-openai:\n    TYPE: openai\n    API_KEY: ${MOCK_SECRET}\n    MODEL: gpt-4"))
-
-	// Seed 3 — Model with dots/slashes
-	f.Add([]byte("MODELS:\n  \"deepseek-ai/deepseek-v3.2-maas\":\n    CONTEXT_WINDOW: 163840\n    PRICING:\n      COMP: 5.40"))
-
-	// Seed 4 — Provider max_tokens
-	f.Add([]byte("SELECTED_PROVIDER: claude\nPROVIDERS:\n  claude:\n    TYPE: anthropic\n    MODEL: claude-opus-4-6\n    API_KEY: test\n    MAX_TOKENS: 16384"))
-
-	// Seed 5 — Invalid YAML from existing test
-	f.Add([]byte(": invalid"))
-
-	// Seed 6 — Type mismatch (scalar where map expected)
-	f.Add([]byte("MODE: test\nMODELS: this-is-a-string-not-a-map"))
-
-	// Seed 7 — Empty input
-	f.Add([]byte(""))
-
-	// Seed 8 — Binary garbage
-	f.Add([]byte("\x00\xFF\xFE"))
-
-	// Seed 9 — Long key (200 "a" chars)
-	f.Add([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: 1"))
-
-	// Seed 10 — Duplicate keys
-	f.Add([]byte("MODE: first\nMODE: second"))
-
-	// Seed 11 — Deeply nested maps (50 levels)
-	func() {
-		var sb strings.Builder
-		for i := 0; i < 50; i++ {
-			sb.WriteString(strings.Repeat(" ", i))
-			sb.WriteString("a:\n")
-		}
-		sb.WriteString(strings.Repeat(" ", 50))
-		sb.WriteString("leaf_value")
-		sb.WriteString(strings.Repeat("\n", 50))
-		f.Add([]byte(sb.String()))
-	}()
-
-	// Seed 12 — Control character in key
-	f.Add([]byte("MOD\x01E: value"))
-
-	// Seed 13 — Null byte embedded in string value
-	f.Add([]byte("MODE: \"test\x00injected\""))
-
-	// Seed 14 — Unicode/emoji in keys and values
-	f.Add([]byte("MODE: \"🚀 production 🚀\"\nPERSON: \"José 🌍\""))
-
-	// Seed 15 — Max_tokens negative (should fail validation)
-	f.Add([]byte("SELECTED_PROVIDER: bad\nPROVIDERS:\n  bad:\n    TYPE: openai\n    API_KEY: x\n    MAX_TOKENS: -1"))
-
-	// Seed 16 — Integer overflow (20-digit value exceeding int64 max)
-	f.Add([]byte("MAX_TURNS: 99999999999999999999"))
+	addSeeds(f)
 
 	// ── Fuzz function ──────────────────────────────────────────────
 
@@ -150,15 +92,86 @@ func FuzzLoadConfig(f *testing.F) {
 		}
 
 		// ── Post-load invariants (defense-in-depth: ValidateBounds should catch these upstream) ──
-
-		if cfg.MaxToolTurns < 0 {
-			t.Errorf("MaxToolTurns is negative: %d", cfg.MaxToolTurns)
-		}
-
-		for name, p := range cfg.Providers {
-			if p.MaxTokens < 0 {
-				t.Errorf("provider %q has negative MaxTokens: %d", name, p.MaxTokens)
-			}
-		}
+		verifyInvariants(t, cfg)
 	})
+}
+
+// deepNestingSeed builds a 50-level nested YAML structure
+// used as a pathological-input seed for the config fuzzer.
+func deepNestingSeed() []byte {
+	var sb strings.Builder
+	for i := 0; i < 50; i++ {
+		sb.WriteString(strings.Repeat(" ", i))
+		sb.WriteString("a:\n")
+	}
+	sb.WriteString(strings.Repeat(" ", 50))
+	sb.WriteString("leaf_value")
+	sb.WriteString(strings.Repeat("\n", 50))
+	return []byte(sb.String())
+}
+
+// addSeeds registers the 16-entry seed corpus for FuzzLoadConfig.
+func addSeeds(f *testing.F) {
+	// Seed 1 — Minimal valid config
+	f.Add([]byte("MODE: test-mode\nPERSON: test-person\nAIMODEL: test-model\nAIURL: http://test.url"))
+
+	// Seed 2 — Provider with env expansion
+	f.Add([]byte("SELECTED_PROVIDER: work-openai\nPROVIDERS:\n  work-openai:\n    TYPE: openai\n    API_KEY: ${MOCK_SECRET}\n    MODEL: gpt-4"))
+
+	// Seed 3 — Model with dots/slashes
+	f.Add([]byte("MODELS:\n  \"deepseek-ai/deepseek-v3.2-maas\":\n    CONTEXT_WINDOW: 163840\n    PRICING:\n      COMP: 5.40"))
+
+	// Seed 4 — Provider max_tokens
+	f.Add([]byte("SELECTED_PROVIDER: claude\nPROVIDERS:\n  claude:\n    TYPE: anthropic\n    MODEL: claude-opus-4-6\n    API_KEY: test\n    MAX_TOKENS: 16384"))
+
+	// Seed 5 — Invalid YAML from existing test
+	f.Add([]byte(": invalid"))
+
+	// Seed 6 — Type mismatch (scalar where map expected)
+	f.Add([]byte("MODE: test\nMODELS: this-is-a-string-not-a-map"))
+
+	// Seed 7 — Empty input
+	f.Add([]byte(""))
+
+	// Seed 8 — Binary garbage
+	f.Add([]byte("\x00\xFF\xFE"))
+
+	// Seed 9 — Long key (200 "a" chars)
+	f.Add([]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa: 1"))
+
+	// Seed 10 — Duplicate keys
+	f.Add([]byte("MODE: first\nMODE: second"))
+
+	// Seed 11 — Deeply nested maps (50 levels)
+	f.Add(deepNestingSeed())
+
+	// Seed 12 — Control character in key
+	f.Add([]byte("MOD\x01E: value"))
+
+	// Seed 13 — Null byte embedded in string value
+	f.Add([]byte("MODE: \"test\x00injected\""))
+
+	// Seed 14 — Unicode/emoji in keys and values
+	f.Add([]byte("MODE: \"🚀 production 🚀\"\nPERSON: \"José 🌍\""))
+
+	// Seed 15 — Max_tokens negative (should fail validation)
+	f.Add([]byte("SELECTED_PROVIDER: bad\nPROVIDERS:\n  bad:\n    TYPE: openai\n    API_KEY: x\n    MAX_TOKENS: -1"))
+
+	// Seed 16 — Integer overflow (20-digit value exceeding int64 max)
+	f.Add([]byte("MAX_TURNS: 99999999999999999999"))
+}
+
+// verifyInvariants checks post-load defensive invariants on a
+// successfully loaded config. Extracted from the fuzz function
+// to keep FuzzLoadConfig complexity within project threshold.
+func verifyInvariants(t *testing.T, cfg *domain_config.Config) {
+	t.Helper()
+	if cfg.MaxToolTurns < 0 {
+		t.Errorf("MaxToolTurns is negative: %d", cfg.MaxToolTurns)
+	}
+	for name, p := range cfg.Providers {
+		if p.MaxTokens < 0 {
+			t.Errorf("provider %q has negative MaxTokens: %d", name, p.MaxTokens)
+		}
+	}
 }


### PR DESCRIPTION
Closes #1132.

## Summary
Extracted seed corpus and post-load invariant checks from `FuzzLoadConfig` into three helper functions:
- `addSeeds(f *testing.F)` — registers all 16 fuzz seeds
- `deepNestingSeed() []byte` — builds 50-level nested YAML
- `verifyInvariants(t, cfg)` — checks post-load invariants

## Results
| Metric | Before | After |
|--------|--------|-------|
| FuzzLoadConfig complexity | 14 | **10** |
| addSeeds complexity | — | 1 |
| deepNestingSeed complexity | — | 2 |
| verifyInvariants complexity | — | 4 |

## Verification
| Check | Status |
|-------|--------|
| go build | ✅ PASS |
| go vet | ✅ PASS |
| golangci-lint | ✅ 0 issues |
| go test | ✅ PASS |
| go test -race | ✅ PASS |
| FuzzLoadConfig (10s) | ✅ PASS |
| FuzzLoadConfig (30s) | ✅ PASS |
| No new complexity alerts | ✅ PASS |
