### PR TITLE
fix(integrations): add plugin-based auto-registration for tool discovery (#1135)

### DIFF
--- a/docs/adr/2026-06-plugin-auto-registration.md
+++ b/docs/adr/2026-06-plugin-auto-registration.md
@@ -1,0 +1,251 @@
+<!--
+Copyright (c) 2026 gosharplite@gmail.com
+SPDX-License-Identifier: MIT
+-->
+
+# ADR-043: Plugin/Extension System for Tool Discovery via Auto-Registration
+
+## Status
+Accepted
+
+## Context
+
+ADR-028 reduced `registration.go` from 824 lines to ~50 lines by delegating registration logic to integration sub-packages. Each sub-package (`ado/`, `atlassian/`) owns its `Register` function, and same-package registrations (media, network, teams) moved to their domain files. However, `RegisterAll` in `registration.go` still required manual wiring: every new integration needed both an import statement and a hardcoded call added to the orchestrator. The module was still open for modification.
+
+### The Remaining Open/Closed Violation
+
+After ADR-028, adding a new integration (e.g., GitHub, Kubernetes) required touching two places in `registration.go`:
+
+```go
+// Step 1: Add import
+import "github.com/gosharplite/tell-me-go/internal/tools/integrations/github"
+
+// Step 2: Add call to RegisterAll
+func RegisterAll(...) error {
+    // ... existing registrations ...
+    if err := github.Register(r, sm, nil); err != nil {
+        return err
+    }
+    return nil
+}
+```
+
+This is the classic Open/Closed Principle violation: the `integrations` package was open for modification, not closed against it. Each new integration forced a change to the orchestrator's source code, creating a merge-conflict hotspot and increasing the cognitive load of `RegisterAll`.
+
+### Goal
+
+Adding a new integration should require **zero changes** to `registration.go`. The orchestrator should discover all available plugins automatically, with no hardcoded call sequence. The module should be closed for modification but open for extension — new integrations extend the system simply by existing in their sub-package.
+
+### Technical Constraints
+
+- **Circular imports**: `integrations` imports `ado` and `atlassian` (for their blank-import side effects). If `ado` or `atlassian` imported `integrations` to access `RegisterAll` or shared types, a cycle would form: `integrations → ado → integrations`.
+- **Registration order**: The existing call sequence (media → network → teams → confluence → jira → ado) must be preserved. While tool registration is order-independent, deterministic ordering aids debugging and test reproducibility.
+- **Test isolation**: The global plugin registry must not leak state between test runs. A cleanup mechanism is required.
+
+## Decision
+
+### 1. Plugin Interface
+
+Define a `plugin.Plugin` interface in a new `internal/tools/integrations/plugin/` sub-package. The interface has two methods:
+
+- `Name() string` — returns a unique identifier for the plugin, used for duplicate detection
+- `Register(r tools.Registry, deps plugin.PluginDependencies) error` — wires the plugin's tools into the tool registry using the provided dependencies
+
+```go
+// internal/tools/integrations/plugin/plugin.go
+package plugin
+
+type Plugin interface {
+    Name() string
+    Register(r tools.Registry, deps PluginDependencies) error
+}
+```
+
+Each integration implements this interface with a private struct. For example, the ADO plugin:
+
+```go
+// internal/tools/integrations/ado/plugin.go
+package ado
+
+import "github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
+
+type adoPlugin struct{}
+
+func NewPlugin() plugin.Plugin { return &adoPlugin{} }
+
+func (adoPlugin) Name() string { return "azure-devops" }
+
+func (adoPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+    return Register(r, deps.SecurityMgr, deps.HTTPClient)
+}
+```
+
+The existing `ado.Register`, `atlassian.RegisterConfluence`, and `atlassian.RegisterJira` functions remain exported and unchanged — the `Plugin` interface wraps them, adapting their signatures to the uniform `PluginDependencies` contract.
+
+### 2. PluginDependencies Struct
+
+`PluginDependencies` carries all shared dependencies that plugins may need during registration. `HTTPClient` is separated from `LLMClient` because 4 out of 5 plugins (network, teams, confluence/jira, ado) need HTTP capabilities but none of them call LLM APIs:
+
+```go
+type PluginDependencies struct {
+    FileSystem  persistence.FileSystem
+    SecurityMgr domain_security.Manager
+    LLMClient   llm.LLMClient
+    HTTPClient  tools.HTTPClient
+    AssetsDir   string
+}
+```
+
+All fields are optional at the type level — plugins handle nil values gracefully by skipping optional functionality or substituting safe defaults. The zero value of `PluginDependencies` is usable (all fields nil/empty).
+
+### 3. Global Plugin Registry
+
+Three functions manage a thread-safe, copy-on-read global registry:
+
+```go
+var (
+    mu      sync.Mutex
+    plugins []Plugin
+)
+
+func Register(p Plugin) error   // adds plugin; rejects nil and duplicates
+func All() []Plugin              // returns a defensive copy
+func Reset()                     // clears all plugins (test-only)
+```
+
+- **`Register`**: Thread-safe via `sync.Mutex`. Rejects nil plugins and duplicate names.
+- **`All`**: Returns a copy of the internal slice so callers cannot mutate the registry. Safe for concurrent use with `Register`.
+- **`Reset`**: Clears the registry. Intended for test cleanup only (`t.Cleanup(plugin.Reset)`).
+
+### 4. Auto-Registration via `init()`
+
+Each integration sub-package calls `plugin.Register(NewPlugin())` in its `init()` function. This is the mechanism that makes `RegisterAll` a pure loop — the orchestrator no longer needs to know which plugins exist:
+
+**Same-package plugins** (media, network, teams) register in filename lexical order (`media.go` → `network.go` → `teams.go`), determined by Go's `init()` execution within a package:
+
+```go
+// internal/tools/integrations/media.go
+func init() {
+    plugin.Register(&mediaPlugin{})
+}
+```
+
+**Sub-package plugins** (ado, atlassian) register via import order of their blank imports in `registration.go`:
+
+```go
+// internal/tools/integrations/registration.go
+import (
+    _ "github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+    _ "github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
+)
+```
+
+The combined registration order is: azure-devops → atlassian → media → network → teams. This is because Go initializes imported packages before the importing package: `registration.go` blank-imports `ado` and `atlassian`, so their `init()` runs first. Then same-package `init()` functions run in filename lexical order: `media.go` → `network.go` → `teams.go`. The atlassian plugin internally registers Confluence first, then Jira.
+
+### 5. RegisterAll Becomes a Loop
+
+`RegisterAll` iterates over `plugin.All()` instead of maintaining a hardcoded call sequence:
+
+```go
+func RegisterAll(r tools.Registry, fs persistence.FileSystem, sm domain_security.Manager, client llm.LLMClient, assetsDir string) error {
+    deps := plugin.PluginDependencies{
+        FileSystem:  fs,
+        SecurityMgr: sm,
+        LLMClient:   client,
+        AssetsDir:   assetsDir,
+    }
+
+    for _, p := range plugin.All() {
+        if err := p.Register(r, deps); err != nil {
+            return fmt.Errorf("%s: %w", p.Name(), err)
+        }
+    }
+
+    return nil
+}
+```
+
+Adding a new integration now requires only:
+1. Creating a sub-package with a `plugin.Plugin` implementation
+2. Adding one blank import to `registration.go`
+
+The `RegisterAll` function body never changes. `registration.go` shrinks further from ~50 LOC to ~30 LOC (essentially just the loop and its imports).
+
+### 6. Circular Import Avoidance
+
+The `plugin/` sub-package is the critical architectural element that breaks what would otherwise be a `integrations ↔ ado` cycle:
+
+```
+integrations ──blank import──→ integrations/ado ──import──→ integrations/plugin ──import──→ domain packages
+    │                              │                                 │
+    └────────import───────────────┘                                 └── (no integrations import)
+```
+
+Both `integrations` and `ado`/`atlassian` import `plugin`. Nobody imports `integrations` from a sub-package. The import graph remains acyclic:
+
+```
+integrations → ado         (blank import, init() side effect)
+integrations → atlassian   (blank import, init() side effect)
+integrations → plugin      (for Plugin, PluginDependencies, All)
+ado → plugin               (for Plugin, PluginDependencies, Register)
+atlassian → plugin         (for Plugin, PluginDependencies, Register)
+plugin → domain packages   (for tools.Registry, llm.LLMClient, etc.)
+```
+
+## Consequences
+
+### Positive
+
+| Consequence | Detail |
+|---|---|
+| **Open/Closed Principle restored** | New integration = new sub-package + one blank import. `RegisterAll` never changes. |
+| **`registration.go` shrinks further** | From ~50 LOC post-ADR-028 to ~30 LOC (a pure loop). Complexity: 1. |
+| **Plugin interface enables future dynamic loading** | The `plugin.Plugin` contract is a natural extension point for YAML-based or plugin-directory-based discovery, without architectural changes. |
+| **`verify_architecture` remains acyclic** | `plugin/` acts as a shared leaf dependency. Neither `ado` nor `atlassian` imports `integrations`. |
+| **Test isolation via `Reset()`** | Each test can call `t.Cleanup(plugin.Reset)` to start with a clean registry. The copy-on-read `All()` prevents accidental mutation of internal state. |
+| **Duplicate detection** | `Register` rejects duplicate plugin names, catching misconfigured init() ordering or accidental double-imports at startup. |
+
+### Negative
+
+| Consequence | Detail |
+|---|---|
+| **`init()` ordering is implicit** | Registration order depends on Go's `init()` semantics (imports first, then same-package in filename lexical order). This is documented as a constraint but not enforced by the compiler. A developer moving `media.go` → `zmedia.go` would silently change registration order. Mitigation: the registration order is not semantically significant — tools are idempotent and independent — but deterministic ordering aids debugging. |
+| **Global plugin registry is test-hostile without `Reset()`** | Shared mutable global state violates test isolation. Mitigated by `Reset()` and `t.Cleanup` conventions. The `PluginDependencies` zero value is usable so tests can construct minimal plugins without real infrastructure. |
+| **~5 new exported symbols** | `plugin.Plugin`, `plugin.PluginDependencies`, `plugin.Register`, `plugin.All`, `plugin.Reset` are new public API surface. Acceptable: they form a cohesive, minimal interface for a well-defined extension point. |
+
+### Neutral
+
+| Consequence | Detail |
+|---|---|
+| **No behavioral changes to any tool** | Tool names, parameters, handlers, toolkit assignments, and error semantics are unchanged. This is a purely structural refactor. |
+| **`RegisterAll` signature unchanged** | External consumers (CLI, agent) call `integrations.RegisterAll(r, fs, sm, client, assetsDir)` — its signature and error semantics are identical to post-ADR-028. |
+| **Existing exported functions preserved** | `ado.Register`, `atlassian.RegisterConfluence`, `atlassian.RegisterJira` remain exported with unchanged signatures. The `Plugin` interface wraps them; it does not replace them. Direct callers of these functions are unaffected. |
+| **No change to test coverage** | Registration tests remain with their respective sub-packages. Plugin registry tests live in `plugin/plugin_test.go`. |
+
+## Implementation Plan
+
+Executed on GitHub Issue #1135 across 4 commits:
+
+| Commit | Task | Description |
+|---|---|---|
+| T1 | Write ADR-043 | This document |
+| T2 | Create `plugin/` package with interface, registry, and tests | `plugin.go` (~70 LOC) + `plugin_test.go` (~200 LOC) |
+| T3 | Implement `Plugin` in each integration | `ado/plugin.go`, `atlassian/plugin.go`, `media.go` (mediaPlugin), `network.go` (networkPlugin), `teams.go` (teamsPlugin) |
+| T4 | Simplify `RegisterAll` to a loop | Replace hardcoded call sequence with `for _, p := range plugin.All()`; ~30 LOC final |
+
+Acceptance criteria:
+
+| Check | Target |
+|---|---|
+| `registration.go` LOC | ≤ 30 |
+| `go build ./...` | ✅ Full-module build |
+| `go test ./internal/tools/integrations/...` | ✅ All integration packages |
+| `go vet ./...` | ✅ Clean |
+| `golangci-lint run ./internal/tools/integrations/...` | ✅ Clean |
+| `verify_architecture` | ✅ Acyclic |
+
+## References
+
+- ADR-028: "Delegate Registration Logic to Integration Sub-Packages" — established the pattern of sub-packages owning their registration logic; reduced `registration.go` from 824 to ~50 LOC
+- ADR-027: "Integrations and Session UI Sub-Package Extraction" — established the `integrations/ado/` and `integrations/atlassian/` sub-packages
+- GitHub Issue #1135 — execution tracking for this ADR

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -48,6 +48,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-040** | Complete Session Subpackage Extraction (config_watcher, skill_injector) | 2026-05 | Accepted | [2026-05-session-extraction-completion.md](2026-05-session-extraction-completion.md) |
 | **ADR-041** | DI Composition Root — Sub-Provider Decomposition | 2026-05 | Accepted | [2026-05-di-composition-root-decomposition.md](2026-05-di-composition-root-decomposition.md) |
 | **ADR-042** | Pipeline Presentation Extraction via PipelineFormatter Interface | 2026-05 | Accepted | [2026-05-ado-pipeline-formatter.md](2026-05-ado-pipeline-formatter.md) |
+| **ADR-043** | Plugin/Extension System for Tool Discovery via Auto-Registration | 2026-06 | Accepted | [2026-06-plugin-auto-registration.md](2026-06-plugin-auto-registration.md) |
 
 ## How to Create a New ADR
 

--- a/internal/tools/integrations/ado/plugin.go
+++ b/internal/tools/integrations/ado/plugin.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ado
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
+)
+
+// adoPlugin implements plugin.Plugin for the Azure DevOps toolkit.
+type adoPlugin struct{}
+
+// NewPlugin returns a new ADO plugin for the global registry.
+func NewPlugin() plugin.Plugin { return &adoPlugin{} }
+
+func (adoPlugin) Name() string { return "azure-devops" }
+
+func (adoPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+	return Register(r, deps.SecurityMgr, deps.HTTPClient)
+}
+
+func init() {
+	_ = plugin.Register(NewPlugin()) //nolint:errcheck // init() cannot return errors; duplicate names caught in tests
+}

--- a/internal/tools/integrations/atlassian/plugin.go
+++ b/internal/tools/integrations/atlassian/plugin.go
@@ -1,0 +1,35 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package atlassian
+
+import (
+	"fmt"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
+)
+
+// atlassianPlugin implements plugin.Plugin for both Confluence and Jira toolkits.
+// A single plugin registers both toolkits because they share the same Atlassian
+// provider infrastructure.
+type atlassianPlugin struct{}
+
+// NewPlugin returns a new Atlassian plugin for the global registry.
+func NewPlugin() plugin.Plugin { return &atlassianPlugin{} }
+
+func (atlassianPlugin) Name() string { return "atlassian" }
+
+func (atlassianPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+	if err := RegisterConfluence(r, deps.SecurityMgr, deps.HTTPClient); err != nil {
+		return fmt.Errorf("confluence: %w", err)
+	}
+	if err := RegisterJira(r, deps.SecurityMgr, deps.HTTPClient); err != nil {
+		return fmt.Errorf("jira: %w", err)
+	}
+	return nil
+}
+
+func init() {
+	_ = plugin.Register(NewPlugin()) //nolint:errcheck // init() cannot return errors; duplicate names caught in tests
+}

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/telemetry"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 )
 
 type mediaOption func(*mediaManager)
@@ -216,4 +217,17 @@ func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Mana
 		return err
 	}
 	return nil
+}
+
+// mediaPlugin implements plugin.Plugin for the media toolkit.
+type mediaPlugin struct{}
+
+func (mediaPlugin) Name() string { return "media" }
+
+func (mediaPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+	return registerMedia(r, deps.FileSystem, deps.SecurityMgr, deps.LLMClient, deps.AssetsDir)
+}
+
+func init() {
+	_ = plugin.Register(&mediaPlugin{}) //nolint:errcheck // init() cannot return errors; duplicate names caught in tests
 }

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -532,27 +532,28 @@ func TestRegisterAll_ErrorPropagation(t *testing.T) {
 	fs := &mockFileSystem{}
 	client := &mockLLMClient{}
 
-	// Step 1 (registerMedia first call) fails immediately
-	t.Run("media registration fails", func(t *testing.T) {
+	// First plugin (ado) first call fails immediately
+	t.Run("first plugin (ado) fails", func(t *testing.T) {
 		r := newFaultyRegistry(registry.New(), 0)
 		err := RegisterAll(r, fs, sm, client, t.TempDir())
 		if err == nil {
-			t.Fatal("expected error from RegisterAll when media registration fails")
+			t.Fatal("expected error from RegisterAll when ado registration fails")
 		}
-		if !strings.Contains(err.Error(), "simulated registration failure") {
-			t.Errorf("expected simulated error, got: %v", err)
+		if !strings.Contains(err.Error(), "azure-devops") {
+			t.Errorf("expected error to contain 'azure-devops', got: %v", err)
 		}
 	})
 
-	// registerMedia succeeds (2 calls), registerNetwork first call fails (call #3)
-	t.Run("network registration fails", func(t *testing.T) {
-		r := newFaultyRegistry(registry.New(), 2)
+	// ado succeeds (20 calls), atlassian first call fails (call #21)
+	t.Run("atlassian plugin fails", func(t *testing.T) {
+		t.Setenv("ATLASSIAN_BASE_URL", "https://test.atlassian.net")
+		r := newFaultyRegistry(registry.New(), 20)
 		err := RegisterAll(r, fs, sm, client, t.TempDir())
 		if err == nil {
-			t.Fatal("expected error from RegisterAll when network registration fails")
+			t.Fatal("expected error from RegisterAll when atlassian registration fails")
 		}
-		if !strings.Contains(err.Error(), "simulated registration failure") {
-			t.Errorf("expected simulated error, got: %v", err)
+		if !strings.Contains(err.Error(), "atlassian") {
+			t.Errorf("expected error to contain 'atlassian', got: %v", err)
 		}
 	})
 }
@@ -563,17 +564,6 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 	client := &mockLLMClient{}
 	tmpDir := t.TempDir()
 
-	// ── Structural impossibility notes ──
-	//
-	// Gaps 14-17 (atlassian http.NewRequestWithContext errors in fetchPageContent,
-	// getCurrentPageVersion, executeUpdate, resolveSpaceID) are structurally
-	// unreachable: all callers parse URLs via url.Parse before constructing
-	// requests, guaranteeing well-formed URLs.
-	//
-	// Gaps 1, 3 (ado json.Marshal errors) are structurally unreachable because
-	// adoCreatePipelineRequest and adoRunPipelineRequest use string-typed struct
-	// fields, making marshal failure impossible for valid UTF-8 strings.
-
 	tests := []struct {
 		name            string
 		failAfter       int
@@ -581,36 +571,30 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 		setAtlassianEnv bool
 	}{
 		{
-			name:          "registerMedia wraps error",
+			name:          "azure-devops wraps error",
 			failAfter:     0,
-			wantSubstring: "registerMedia",
+			wantSubstring: "azure-devops",
 		},
 		{
-			name:          "registerNetwork wraps error",
-			failAfter:     2,
-			wantSubstring: "registerNetwork",
-		},
-		{
-			name:          "registerTeams wraps error",
-			failAfter:     4,
-			wantSubstring: "registerTeams",
-		},
-		{
-			name:            "atlassian.RegisterConfluence wraps error",
-			failAfter:       5,
-			wantSubstring:   "atlassian.RegisterConfluence",
+			name:            "atlassian wraps error",
+			failAfter:       20,
+			wantSubstring:   "atlassian",
 			setAtlassianEnv: true,
 		},
 		{
-			name:            "atlassian.RegisterJira wraps error",
-			failAfter:       8,
-			wantSubstring:   "atlassian.RegisterJira",
-			setAtlassianEnv: true,
+			name:          "media wraps error",
+			failAfter:     25,
+			wantSubstring: "media",
 		},
 		{
-			name:          "ado.Register wraps error",
-			failAfter:     10,
-			wantSubstring: "ado.Register",
+			name:          "network wraps error",
+			failAfter:     27,
+			wantSubstring: "network",
+		},
+		{
+			name:          "teams wraps error",
+			failAfter:     29,
+			wantSubstring: "teams",
 		},
 	}
 

--- a/internal/tools/integrations/network.go
+++ b/internal/tools/integrations/network.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 	"golang.org/x/net/html"
 )
 
@@ -326,4 +327,18 @@ func registerNetwork(r tools.Registry, net *networkTool) error {
 		return err
 	}
 	return nil
+}
+
+// networkPlugin implements plugin.Plugin for the network toolkit.
+type networkPlugin struct{}
+
+func (networkPlugin) Name() string { return "network" }
+
+func (networkPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+	net := newnetworkTool(deps.SecurityMgr, deps.HTTPClient)
+	return registerNetwork(r, net)
+}
+
+func init() {
+	_ = plugin.Register(&networkPlugin{}) //nolint:errcheck // init() cannot return errors; duplicate names caught in tests
 }

--- a/internal/tools/integrations/plugin/plugin.go
+++ b/internal/tools/integrations/plugin/plugin.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package plugin provides the self-registering plugin interface and global
+// registry for integration tool discovery.
+//
+// Plugins implement the Plugin interface and call Register during init() or
+// at application startup. The registry enforces unique names and provides
+// snapshot access to all registered plugins for batch initialization.
+package plugin
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// Plugin describes an auto-registering integration plugin. Implementations
+// provide a unique name and a Register method that wires the plugin's tools
+// into the tool Registry using the provided PluginDependencies.
+type Plugin interface {
+	// Name returns a unique identifier for this plugin, used for
+	// duplicate detection in the global registry.
+	Name() string
+
+	// Register wires the plugin's tools into r. Implementations must
+	// use the provided dependencies to construct tool handlers.
+	//
+	// Register is called exactly once at application startup. An error
+	// triggers a fail-fast shutdown of the integration subsystem.
+	Register(r tools.Registry, deps PluginDependencies) error
+}
+
+// PluginDependencies provides the injectable dependencies needed by
+// plugin implementations during registration.
+//
+// All fields are optional at the type level; plugins should handle
+// nil values gracefully by skipping optional functionality or
+// substituting safe defaults.
+type PluginDependencies struct {
+	// FileSystem provides filesystem operations for tools that
+	// read or write local files (e.g., media tools, workspace).
+	FileSystem persistence.FileSystem
+
+	// SecurityMgr provides the security manager for path validation,
+	// command authorization, and user consent.
+	SecurityMgr domain_security.Manager
+
+	// LLMClient provides the LLM client for tools that need AI
+	// capabilities (e.g., image generation, summarization).
+	LLMClient llm.LLMClient
+
+	// HTTPClient provides an HTTP client for tools that make HTTP
+	// requests (e.g., network tools, Confluence, Jira, ADO).
+	//
+	// This is separate from LLMClient because integration plugins
+	// call external APIs and do not need the full LLM interface.
+	HTTPClient tools.HTTPClient
+
+	// AssetsDir is the path to the assets directory for serving
+	// static resources (e.g., media tool assets).
+	AssetsDir string
+}
+
+var (
+	mu      sync.Mutex
+	plugins []Plugin
+)
+
+// Register adds p to the global plugin registry. It returns an error if
+// another plugin with the same Name() is already registered. Register is
+// safe for concurrent use.
+//
+// A nil plugin is rejected with an error.
+func Register(p Plugin) error {
+	if p == nil {
+		return fmt.Errorf("plugin.Register: nil plugin")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	name := p.Name()
+	for _, existing := range plugins {
+		if existing.Name() == name {
+			return fmt.Errorf("plugin.Register: duplicate plugin name %q", name)
+		}
+	}
+
+	plugins = append(plugins, p)
+	return nil
+}
+
+// All returns a copy of all registered plugins. The returned slice is
+// safe to mutate without affecting the internal registry.
+//
+// All is safe for concurrent use.
+func All() []Plugin {
+	mu.Lock()
+	defer mu.Unlock()
+
+	out := make([]Plugin, len(plugins))
+	copy(out, plugins)
+	return out
+}
+
+// Reset clears all registered plugins. This is intended for test cleanup
+// only and must not be used in production code paths.
+func Reset() {
+	mu.Lock()
+	defer mu.Unlock()
+	plugins = nil
+}

--- a/internal/tools/integrations/plugin/plugin_test.go
+++ b/internal/tools/integrations/plugin/plugin_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package plugin
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// mockPlugin implements Plugin with configurable name and register error.
+type mockPlugin struct {
+	name        string
+	registerErr error
+	registered  bool // tracks whether Register was called
+}
+
+func (m *mockPlugin) Name() string { return m.name }
+
+func (m *mockPlugin) Register(r tools.Registry, deps PluginDependencies) error {
+	m.registered = true
+	return m.registerErr
+}
+
+func newMock(name string) *mockPlugin {
+	return &mockPlugin{name: name}
+}
+
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func() []Plugin // plugins to pre-register
+		plugin    Plugin          // plugin to register
+		wantErr   bool
+		wantCount int // expected count after Register
+	}{
+		{
+			name: "single plugin",
+			setup: func() []Plugin {
+				return nil
+			},
+			plugin:    newMock("plugin-a"),
+			wantErr:   false,
+			wantCount: 1,
+		},
+		{
+			name: "duplicate name",
+			setup: func() []Plugin {
+				return []Plugin{newMock("plugin-a")}
+			},
+			plugin:    newMock("plugin-a"),
+			wantErr:   true,
+			wantCount: 1,
+		},
+		{
+			name: "multiple distinct",
+			setup: func() []Plugin {
+				return []Plugin{newMock("p1"), newMock("p2")}
+			},
+			plugin:    newMock("p3"),
+			wantErr:   false,
+			wantCount: 3,
+		},
+		{
+			name: "nil plugin",
+			setup: func() []Plugin {
+				return nil
+			},
+			plugin:    nil,
+			wantErr:   true,
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Cleanup(Reset)
+
+			for _, p := range tt.setup() {
+				if err := Register(p); err != nil {
+					t.Fatalf("setup Register(%q): unexpected error: %v", p.Name(), err)
+				}
+			}
+
+			err := Register(tt.plugin)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Register() error = %v, wantErr = %v", err, tt.wantErr)
+			}
+
+			all := All()
+			if len(all) != tt.wantCount {
+				t.Errorf("All() count = %d, want %d", len(all), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestAll_ReturnsCopy(t *testing.T) {
+	t.Cleanup(Reset)
+
+	if err := Register(newMock("p1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Register(newMock("p2")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get a copy and mutate it
+	all := All()
+	if len(all) != 2 {
+		t.Fatalf("All() count = %d, want 2", len(all))
+	}
+
+	// Mutate the returned slice (must not affect internal state)
+	all[0] = nil
+	_ = append(all, newMock("p3")) // append may reallocate; discard result
+
+	// Internal state should be unchanged
+	all2 := All()
+	if len(all2) != 2 {
+		t.Errorf("after mutating returned copy, All() count = %d, want 2", len(all2))
+	}
+	if all2[0] == nil {
+		t.Error("internal registry was mutated via returned slice")
+	}
+	if all2[0].Name() != "p1" {
+		t.Errorf("internal registry first entry = %q, want %q", all2[0].Name(), "p1")
+	}
+}
+
+func TestReset(t *testing.T) {
+	t.Cleanup(Reset)
+
+	if err := Register(newMock("p1")); err != nil {
+		t.Fatal(err)
+	}
+	if err := Register(newMock("p2")); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(All()) != 2 {
+		t.Fatalf("All() count before Reset = %d, want 2", len(All()))
+	}
+
+	Reset()
+
+	if len(All()) != 0 {
+		t.Errorf("All() count after Reset = %d, want 0", len(All()))
+	}
+}
+
+func TestRegister_Concurrency(t *testing.T) {
+	t.Cleanup(Reset)
+
+	const numGoroutines = 50
+	var wg sync.WaitGroup
+	names := make([]string, numGoroutines)
+
+	// Each goroutine registers one plugin with a unique name
+	for i := 0; i < numGoroutines; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			name := fmt.Sprintf("plugin-%d", i)
+			if err := Register(newMock(name)); err != nil {
+				// This is a non-fatal error because we want to see
+				// what happens under contention.
+				t.Logf("Register(%q): %v", name, err)
+			}
+			names[i] = name
+		}()
+	}
+
+	wg.Wait()
+
+	all := All()
+
+	// Every name should appear exactly once
+	seen := make(map[string]int, len(all))
+	for _, p := range all {
+		seen[p.Name()]++
+	}
+
+	for i := 0; i < numGoroutines; i++ {
+		name := fmt.Sprintf("plugin-%d", i)
+		count := seen[name]
+		if count != 1 {
+			t.Errorf("plugin %q appears %d times in registry, want 1", name, count)
+		}
+	}
+
+	if len(all) != numGoroutines {
+		t.Errorf("All() count = %d, want %d", len(all), numGoroutines)
+	}
+}
+
+func TestPluginDependencies_ZeroValue(t *testing.T) {
+	// A zero-value PluginDependencies should be usable: all fields nil,
+	// plugins should check and handle nil gracefully.
+	var deps PluginDependencies
+
+	// Verify all fields are nil/zero
+	if deps.FileSystem != nil {
+		t.Error("zero-value FileSystem should be nil")
+	}
+	if deps.SecurityMgr != nil {
+		t.Error("zero-value SecurityMgr should be nil")
+	}
+	if deps.LLMClient != nil {
+		t.Error("zero-value LLMClient should be nil")
+	}
+	if deps.HTTPClient != nil {
+		t.Error("zero-value HTTPClient should be nil")
+	}
+	if deps.AssetsDir != "" {
+		t.Errorf("zero-value AssetsDir = %q, want empty", deps.AssetsDir)
+	}
+}
+
+func TestRegister_InsertionOrder(t *testing.T) {
+	t.Cleanup(Reset)
+
+	names := []string{"alpha", "beta", "gamma", "delta"}
+	for _, name := range names {
+		if err := Register(newMock(name)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all := All()
+	if len(all) != len(names) {
+		t.Fatalf("All() count = %d, want %d", len(all), len(names))
+	}
+	for i, p := range all {
+		if p.Name() != names[i] {
+			t.Errorf("position %d: got %q, want %q", i, p.Name(), names[i])
+		}
+	}
+}
+
+// TestRegister_Parallel ensures register/read work under parallel access.
+// This test does NOT call Reset, so it can use t.Parallel.
+func TestRegister_Parallel(t *testing.T) {
+	t.Parallel()
+	t.Cleanup(Reset)
+
+	if err := Register(newMock("parallel-a")); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("read", func(t *testing.T) {
+		t.Parallel()
+		all := All()
+		if len(all) == 0 {
+			t.Error("All() returned empty after register in parallel test")
+		}
+	})
+
+	t.Run("register", func(t *testing.T) {
+		t.Parallel()
+		err := Register(newMock("parallel-" + strconv.Itoa(int(^uint(0)>>1)))) // unique-ish
+		if err == nil {
+			// Successfully registered
+			return
+		}
+		// May legitimately collide with another parallel test; that's fine
+		t.Logf("Register in parallel: %v", err)
+	})
+}

--- a/internal/tools/integrations/registration.go
+++ b/internal/tools/integrations/registration.go
@@ -10,41 +10,35 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
-	"github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
+
+	// Side-effect imports: each package's init() calls plugin.Register()
+	// to self-register its integration tools. Registration order is
+	// determined by Go's init() execution order (imports first, then
+	// same-package in filename lexical order).
+	_ "github.com/gosharplite/tell-me-go/internal/tools/integrations/ado"
+	_ "github.com/gosharplite/tell-me-go/internal/tools/integrations/atlassian"
+
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 )
 
-// RegisterAll registers all external integration tools.
+// RegisterAll registers all external integration tools by iterating over
+// auto-registered plugins. Adding a new integration requires only:
+// 1. Creating a sub-package with a plugin.Plugin implementation
+// 2. Adding a blank import above (for the init() side effect)
+//
+// No other changes to this file are needed.
 func RegisterAll(r tools.Registry, fs persistence.FileSystem, sm domain_security.Manager, client llm.LLMClient, assetsDir string) error {
-	// Register Media Tools
-	if err := registerMedia(r, fs, sm, client, assetsDir); err != nil {
-		return fmt.Errorf("registerMedia: %w", err)
+	deps := plugin.PluginDependencies{
+		FileSystem:  fs,
+		SecurityMgr: sm,
+		LLMClient:   client,
+		AssetsDir:   assetsDir,
 	}
 
-	// Register Network Tools
-	net := newnetworkTool(sm, nil)
-	if err := registerNetwork(r, net); err != nil {
-		return fmt.Errorf("registerNetwork: %w", err)
-	}
-
-	// Register Teams Tools
-	if err := registerTeams(r, sm, nil); err != nil {
-		return fmt.Errorf("registerTeams: %w", err)
-	}
-
-	// Register Confluence Tools
-	if err := atlassian.RegisterConfluence(r, sm, nil); err != nil {
-		return fmt.Errorf("atlassian.RegisterConfluence: %w", err)
-	}
-
-	// Register Jira Tools
-	if err := atlassian.RegisterJira(r, sm, nil); err != nil {
-		return fmt.Errorf("atlassian.RegisterJira: %w", err)
-	}
-
-	// Register Azure DevOps Tools
-	if err := ado.Register(r, sm, nil); err != nil {
-		return fmt.Errorf("ado.Register: %w", err)
+	for _, p := range plugin.All() {
+		if err := p.Register(r, deps); err != nil {
+			return fmt.Errorf("%s: %w", p.Name(), err)
+		}
 	}
 
 	return nil

--- a/internal/tools/integrations/teams.go
+++ b/internal/tools/integrations/teams.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 )
 
 type teamsManager struct {
@@ -148,4 +149,17 @@ func registerTeams(r tools.Registry, sm security.Manager, client tools.HTTPClien
 		return err
 	}
 	return nil
+}
+
+// teamsPlugin implements plugin.Plugin for the teams toolkit.
+type teamsPlugin struct{}
+
+func (teamsPlugin) Name() string { return "teams" }
+
+func (teamsPlugin) Register(r tools.Registry, deps plugin.PluginDependencies) error {
+	return registerTeams(r, deps.SecurityMgr, deps.HTTPClient)
+}
+
+func init() {
+	_ = plugin.Register(&teamsPlugin{}) //nolint:errcheck // init() cannot return errors; duplicate names caught in tests
 }


### PR DESCRIPTION
Closes #1135.

## Summary
Implement self-registering Plugin interface so adding a new integration requires zero changes to registration.go. New sub-packages auto-discover via init() + plugin.Register().

### Files Created (5)
| File | Purpose |
|------|---------|
| internal/tools/integrations/plugin/plugin.go | Plugin interface, PluginDependencies, global registry |
| internal/tools/integrations/plugin/plugin_test.go | Table-driven tests (7 tests, race-safe) |
| internal/tools/integrations/ado/plugin.go | ADO plugin wrapper with init() |
| internal/tools/integrations/atlassian/plugin.go | Atlassian plugin wrapper with init() |
| docs/adr/2026-06-plugin-auto-registration.md | ADR-043 |

### Files Modified (6)
| File | Change |
|------|--------|
| internal/tools/integrations/registration.go | Hardcoded 6-call sequence → 3-line plugin.All() loop |
| internal/tools/integrations/media.go | Added mediaPlugin + init() |
| internal/tools/integrations/network.go | Added networkPlugin + init() |
| internal/tools/integrations/teams.go | Added teamsPlugin + init() |
| internal/tools/integrations/media_test.go | Updated error-wrapping tests for plugin order |
| docs/adr/README.md | Added ADR-043 to index |

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| go test ./... | PASS (all 70+ packages) |
| go test -race ./internal/tools/integrations/... | PASS |
| golangci-lint run | 0 issues |
| verify_architecture | Acyclic |