### PR TITLE
fix(integrations): add error propagation tests for ado and atlassian plugin registration (#1138)

### DIFF
--- a/internal/tools/integrations/ado/registry_test.go
+++ b/internal/tools/integrations/ado/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 
 	"github.com/stretchr/testify/assert"
@@ -392,4 +393,25 @@ func TestAppendTruncationNote(t *testing.T) {
 			tt.assert(t, result)
 		})
 	}
+}
+
+// TestAdoPlugin_Register_ErrorPropagation verifies that adoPlugin.Register
+// propagates errors from the underlying Register function. This closes
+// the coverage gap at plugin.go:19-21.
+func TestAdoPlugin_Register_ErrorPropagation(t *testing.T) {
+	t.Run("registration failure propagates", func(t *testing.T) {
+		r := &mockRegistry{returnErr: fmt.Errorf("mock registration error")}
+		sm := &toolstest.MockSecurityManager{AllowAll: true}
+
+		p := NewPlugin()
+		deps := plugin.PluginDependencies{
+			SecurityMgr: sm,
+			HTTPClient:  nil,
+		}
+
+		err := p.Register(r, deps)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "mock registration error")
+	})
 }

--- a/internal/tools/integrations/atlassian/plugin_test.go
+++ b/internal/tools/integrations/atlassian/plugin_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package atlassian
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtlassianPlugin_Register(t *testing.T) {
+	t.Run("RegisterConfluence failure wraps error with confluence prefix", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		confluenceErr := errors.New("confluence boom")
+
+		// Fail on the 1st RegisterToToolkit call (confluence_search).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 1 {
+				return confluenceErr
+			}
+			return nil
+		}
+
+		p := NewPlugin()
+		deps := plugin.PluginDependencies{SecurityMgr: sm, HTTPClient: nil}
+		err := p.Register(reg, deps)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "confluence:")
+		assert.ErrorIs(t, err, confluenceErr)
+	})
+
+	t.Run("RegisterJira failure wraps error with jira prefix", func(t *testing.T) {
+		setAtlassianEnv(t)
+		reg := &mockRegistry{}
+		jiraErr := errors.New("jira boom")
+
+		// Allow Confluence (RegisterToToolkit calls 1-2 +
+		// RegisterToToolkitWithOptions call 1) to succeed, fail on
+		// RegisterToToolkit call 4 (jira_get_issue).
+		reg.registerToToolkitErrProvider = func(callNum int) error {
+			if callNum == 4 {
+				return jiraErr
+			}
+			return nil
+		}
+
+		p := NewPlugin()
+		deps := plugin.PluginDependencies{SecurityMgr: sm, HTTPClient: nil}
+		err := p.Register(reg, deps)
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "jira:")
+		assert.ErrorIs(t, err, jiraErr)
+	})
+}


### PR DESCRIPTION
Closes #1138.

## Summary
Adds test coverage for 3 error-propagation gaps in ADO and Atlassian plugin registration:

- **Gap A:** `ado/plugin.go:19-21` — `TestAdoPlugin_Register_ErrorPropagation` verifies error propagation from the underlying `Register` function through `adoPlugin.Register`.
- **Gap B:** `atlassian/plugin.go:24-26` — Tests `RegisterConfluence` failure wrapping with `"confluence:"` prefix.
- **Gap C:** `atlassian/plugin.go:27-29` — Tests `RegisterJira` failure wrapping with `"jira:"` prefix.

Gap D (`pipeline_crud.go:312-314`) and all remaining gaps classified as architect-accepted (structurally unreachable with existing function-level coverage).

## Verification
| Check | Status |
|-------|--------|
| fmt, tidy, build, lint | PASS |
| verify-architecture | PASS |
| vulncheck | PASS |
| go test ./... | PASS (all packages) |
| dead-code | No dead code found |
| Target coverage | >= 98.9% maintained |
