### PR TITLE
fix: make ToolDuration assertion deterministic on Windows (#1147)

### DIFF
--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -441,8 +441,11 @@ func TestExecutionStep_Process(t *testing.T) {
 
 	t.Run("No trace in context — CumulativeToolDuration not set", func(t *testing.T) {
 		bus := &eventstest.MockEventBus{}
+		mockClock := &agenttest.MockClock{}
+		mockClock.SetCurrentTime(time.Now()) // seed so Now() uses stored time, not real clock
 		ex := &agenttest.MockAgentExecutor{
 			ExecuteFunc: func(ctx context.Context, respContent *llm.Content, turn int, maxToolTurns int) (*llm.Content, error) {
+				mockClock.Sleep(10 * time.Millisecond) // guarantee measurable wall time even on coarse-grained clocks (e.g., Windows)
 				return &llm.Content{Role: "tool"}, nil
 			},
 		}
@@ -455,7 +458,7 @@ func TestExecutionStep_Process(t *testing.T) {
 			Executor:     ex,
 			TokenCounter: counter,
 			CtxManager:   cm,
-			Clock:        &agenttest.MockClock{},
+			Clock:        mockClock,
 			State: &TurnState{
 				HasToolCalls: true,
 				Response: &llm.Content{


### PR DESCRIPTION
## Summary

Fixes #1147 — intermittent timing assertion failure in `TestExecutionStep_Process/No_trace_in_context_—_CumulativeToolDuration_not_set` on Windows.

## Root Cause

`MockClock{}` (zero-value) falls through to real `time.Now()` for both the `toolStart` capture and the `Since()` measurement. On Windows (~15.6ms timer resolution), a synchronous mock executor returning instantly can land both calls in the same tick → `Since()` returns 0 → `assert.Greater(t, ToolDuration, 0)` fails.

## Fix

1. Extract `mockClock` variable and seed with `SetCurrentTime(time.Now())` so `Now()` uses stored time deterministically
2. Call `mockClock.Sleep(10ms)` inside the mock executor to advance the clock during "execution", guaranteeing a measurable `ToolDuration`

`MockClock.Sleep` is pure arithmetic on `m.currentTime` — it does **not** call `time.Sleep` and does **not** violate the ADR-036 `verify-no-test-sleep` guard.

## Verification

- ✅ `TestExecutionStep_Process` — all 6 subtests pass
- ✅ Full orchestrator package — passes
- ✅ `make verify-no-test-sleep` — passes
