### PR TITLE
fix: resolve Unix path assumption failures on Windows (#1144)

### DIFF
--- a/internal/infrastructure/security/paths.go
+++ b/internal/infrastructure/security/paths.go
@@ -323,8 +323,9 @@ func (p *pathPolicy) checkBoundary(target, boundary string) (bool, error) {
 		return false, err
 	}
 	realBoundary := p.resolveSymlinks(absBoundary)
+	realTarget := p.resolveSymlinks(target)
 
-	rel, err := filepath.Rel(realBoundary, target)
+	rel, err := filepath.Rel(realBoundary, realTarget)
 	ok := err == nil && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
 	return ok, nil
 }

--- a/internal/tools/analysis/analysistest/mock_security.go
+++ b/internal/tools/analysis/analysistest/mock_security.go
@@ -37,8 +37,19 @@ func (m *MockSecurityProvider) IsPathSafe(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if m.TempDir != "" && !strings.HasPrefix(abs, m.TempDir) {
-		return "", fmt.Errorf("path out of bounds")
+	if m.TempDir != "" {
+		// Normalize to forward slashes for cross-platform prefix comparison.
+		// On Windows, filepath.Abs prepends a volume (e.g., C:); strip it
+		// so that TempDir="/safe" matches both "/safe/file.go" (Unix) and
+		// "C:/safe/file.go" (Windows).
+		normalizedAbs := filepath.ToSlash(abs)
+		if vol := filepath.VolumeName(normalizedAbs); vol != "" {
+			normalizedAbs = normalizedAbs[len(vol):]
+		}
+		normalizedTempDir := filepath.ToSlash(m.TempDir)
+		if !strings.HasPrefix(normalizedAbs, normalizedTempDir) {
+			return "", fmt.Errorf("path out of bounds")
+		}
 	}
 	return abs, nil
 }

--- a/internal/tools/analysis/analysistest/mock_security_test.go
+++ b/internal/tools/analysis/analysistest/mock_security_test.go
@@ -58,13 +58,19 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/sub/file.go",
-			want: "/safe/sub/file.go",
+			want: func() string {
+				abs, _ := filepath.Abs("/safe/sub/file.go")
+				return abs
+			}(), // platform-dependent: Unix preserves "/safe/sub/file.go", Windows prepends volume
 		},
 		{
 			name: "zero_value_happy_path",
 			mock: &MockSecurityProvider{},
 			path: "/tmp/test.go",
-			want: "/tmp/test.go", // filepath.Abs preserves absolute paths
+			want: func() string {
+				abs, _ := filepath.Abs("/tmp/test.go")
+				return abs
+			}(), // platform-dependent: Unix preserves "/tmp/test.go", Windows prepends volume like "C:\\tmp\\test.go"
 		},
 	}
 
@@ -178,7 +184,10 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/file.go",
-			want: "/safe/file.go",
+			want: func() string {
+				abs, _ := filepath.Abs("/safe/file.go")
+				return abs
+			}(), // platform-dependent: Unix preserves "/safe/file.go", Windows prepends volume
 		},
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1144 — 4 Unix path assumption failures on Windows across `internal/infrastructure/security` and `internal/tools/analysis/analysistest`.

## Root Cause

`checkBoundary` resolved the boundary via `resolveSymlinks` (which calls `filepath.EvalSymlinks`) but not the target. On Windows, `EvalSymlinks` normalizes short/long path names, junction points, and symlinks, causing `filepath.Rel(resolvedBoundary, unresolvedTarget)` to produce incorrect results when paths differ in format.

Additionally, `MockSecurityProvider.IsPathSafe` used raw `strings.HasPrefix(abs, TempDir)` with mixed slash formats and Windows volume prefixes.

## Changes

| File | Change |
|------|--------|
| `internal/infrastructure/security/paths.go` | `checkBoundary` now resolves **both** target and boundary via `resolveSymlinks` |
| `internal/tools/analysis/analysistest/mock_security.go` | `IsPathSafe` normalizes to forward slashes and strips Windows volume prefix before `HasPrefix` |
| `internal/tools/analysis/analysistest/mock_security_test.go` | Three test cases compute `want` at runtime via `filepath.Abs(...)` instead of hardcoding Unix paths |

## Verification

- ✅ `internal/infrastructure/security` — full suite passes
- ✅ `internal/tools/analysis/analysistest` — full suite passes
- ✅ `internal/tools/analysis` — TypeManager tests pass
- ✅ `make verify-no-test-sleep` — passes
