### PR TITLE
fix: handle os.Chmod permission model differences on Windows (#1145)

### DIFF
--- a/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
+++ b/internal/infrastructure/persistence/persistencetest/plain_os_fs_test.go
@@ -222,6 +222,7 @@ func TestPlainOSFS_AtomicWrite_InternalErrorPaths(t *testing.T) {
 			name: "Close error",
 			opts: []persistencetest.PlainOSFSOption{
 				persistencetest.WithCloseFunc(func(f *os.File) error {
+					_ = f.Close() // release fd so temp file can be removed on all platforms
 					return errors.New("injected close failure")
 				}),
 			},

--- a/internal/tools/analysis/refactor_test.go
+++ b/internal/tools/analysis/refactor_test.go
@@ -219,6 +219,9 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 
 	t.Run("create_temp_file_error_is_wrapped", func(t *testing.T) {
 		t.Parallel()
+		if runtime.GOOS == "windows" {
+			t.Skip("os.Chmod(0500) does not prevent file creation on Windows")
+		}
 		tmpDir := t.TempDir()
 		path := filepath.Join(tmpDir, "test.go")
 		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))

--- a/internal/tools/analysis/types_error_test.go
+++ b/internal/tools/analysis/types_error_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -378,6 +379,9 @@ func broken() { // missing closing brace
 // silently skipped.
 func TestCollectSymbols_PropagatesWalkError(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
 	tmpDir := t.TempDir()
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
@@ -414,6 +418,9 @@ func ValidFunc() string { return "ok" }
 // walk errors during method discovery propagate through GetTypeInfo.
 func TestGetTypeInfo_PropagatesWalkError(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
 	tmpDir := t.TempDir()
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {
@@ -449,6 +456,9 @@ type MyStruct struct{}
 // walk errors during symbol collection propagate through FindDefinitions.
 func TestFindDefinitions_PropagatesWalkError(t *testing.T) {
 	t.Parallel()
+	if runtime.GOOS == "windows" {
+		t.Skip("os.Chmod(0000) does not prevent directory reads on Windows")
+	}
 	tmpDir := t.TempDir()
 
 	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module example.com/test\n\ngo 1.25"), 0644); err != nil {


### PR DESCRIPTION
## Summary

Fixes #1145 — 5 `os.Chmod`/walk-error test failures on Windows across `internal/tools/analysis` and `internal/infrastructure/persistence/persistencetest`.

## Root Cause

`os.Chmod(0000)` and `os.Chmod(0500)` do not prevent directory reads or file creation on Windows — the Unix permission model does not translate. Additionally, the `Close_error` mock injected a close failure without actually releasing the file descriptor; on Windows, open files cannot be deleted, leaving an orphan temp file.

## Changes

### Walk-error tests (skip on Windows)
- `TestCollectSymbols_PropagatesWalkError` — `t.Skip` on Windows
- `TestGetTypeInfo_PropagatesWalkError` — `t.Skip` on Windows
- `TestFindDefinitions_PropagatesWalkError` — `t.Skip` on Windows
- `create_temp_file_error_is_wrapped` — `t.Skip` on Windows

### Close_error test (mock behavior fix)
- `TestPlainOSFS_AtomicWrite_InternalErrorPaths/Close_error` — mock `CloseFunc` now calls `f.Close()` before returning the injected error, releasing the fd so Windows can delete the temp file (matching real-world close-failure semantics where the kernel releases the fd even when close returns an error).

## Verification

- ✅ All 5 targeted tests pass on Windows
- ✅ `make verify-no-test-sleep` — passes
- ✅ Full `persistencetest` package — passes
