### PR TITLE
fix: output file redirection fails on Windows (#1148)

### DIFF
--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -284,6 +284,13 @@ func (e *processExecutor) formatPipelineResult(stdoutStr, stderrStr string, trun
 
 // withinParent reports whether target resides inside the parent directory.
 func withinParent(parent, target string) bool {
+	// Resolve both paths to a canonical form for consistent cross-platform
+	// comparison. On Windows, os.Getwd() and filepath.Abs may return paths
+	// with different normalization (short vs long names, case differences)
+	// causing filepath.Rel to fail even for valid parent-child relationships.
+	parent = resolveSymlinks(parent)
+	target = resolveSymlinks(target)
+
 	rel, err := filepath.Rel(parent, target)
 	if err != nil {
 		return false
@@ -292,6 +299,22 @@ func withinParent(parent, target string) bool {
 		return false
 	}
 	return true
+}
+
+// resolveSymlinks resolves symbolic links in path. When EvalSymlinks fails
+// (e.g., the path doesn't exist yet), it recursively resolves the parent
+// directory and reconstructs the path. This mirrors pathPolicy.resolveSymlinks
+// for consistent path normalization across the codebase.
+func resolveSymlinks(path string) string {
+	if realPath, err := filepath.EvalSymlinks(path); err == nil {
+		return realPath
+	}
+	dir := filepath.Dir(path)
+	if dir == path || dir == "." {
+		return path
+	}
+	resolvedDir := resolveSymlinks(dir)
+	return filepath.Join(resolvedDir, filepath.Base(path))
 }
 
 // validateAbsPath checks an absolute cleanedPath against CWD and TempDir boundaries.


### PR DESCRIPTION
## Summary

Fixes #1148 — 2 e2e output file redirection failures on Windows.

## Root Cause

The double-validation chain for output file paths fails on Windows:

1. `security-manager.IsPathWritable("out.txt")` → resolves to absolute path correctly
2. `openOutputFile` → `resolveAndValidateOutputPath` → `validateAbsPath` → `withinParent(cwd, absPath)`
3. `filepath.Rel(cwd, absPath)` fails silently because `os.Getwd()` and `filepath.Abs` may return paths with different normalization on Windows (short vs long names, case differences)

The failed validation causes `openOutputFile` to return nil, and the command output goes to stdout/stderr capture only — the output file is never created.

## Fix

`withinParent` now resolves symlinks on both paths using the same recursive fallback as `pathPolicy.resolveSymlinks` (fix #1144): `filepath.EvalSymlinks` → recursive parent resolution for non-existent targets. This ensures both paths use the same canonical form before `filepath.Rel`.

A new helper `resolveSymlinks` is added to the workspace package, mirroring `pathPolicy.resolveSymlinks`.

## Verification

- ✅ `TestWithinParent` — all 7 subtests pass
- ✅ `TestWithinParent_BareDotDot` — passes
- ✅ `TestOpenOutputFile_Security` — all 9 subtests pass
- ✅ `TestResolveAndValidateOutputPath_Escape` — all 8 subtests pass
- ✅ `TestRunCommand_OutputFile` / `TestRunCommand_Append` / `TestRunCommand_FileCloseError` / `TestRunCommand_OutputFileCloseError` / `TestRunCommand_CloseFileIntegration` — all pass
- ✅ `make verify-no-test-sleep` — passes
