### PR TITLE
fix: skip deleted-CWD test on Windows (#1157)

### DIFF
--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -1779,6 +1780,9 @@ func TestResolveCrossPackage_NilTypesInfo(t *testing.T) {
 // =============================================================================
 func TestHarvestPackageSymbols_AbsError(t *testing.T) {
 	// NOT parallel — changes working directory
+	if runtime.GOOS == "windows" {
+		t.Skip("deleted-CWD technique cannot restore directory on Windows; file handles prevent cleanup")
+	}
 
 	origDir, err := os.Getwd()
 	require.NoError(t, err)


### PR DESCRIPTION
Fixes #1157.

TestHarvestPackageSymbols_AbsError deletes the current working directory to force filepath.Abs to fail. On Windows, the process cannot delete its own CWD — t.TempDir() cleanup fails with "file in use" because Windows locks open file handles.

Fix: t.Skip on Windows with a clear message. This test is Unix-only — the deleted-CWD technique is inherently incompatible with Windows file locking.
