### PR TITLE
fix: use module root for shared indexer (#1158)

### DIFF
--- a/internal/tools/analysis/common_test.go
+++ b/internal/tools/analysis/common_test.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -16,10 +17,36 @@ var (
 	sharedIdxOnce sync.Once
 )
 
+// findModuleRoot walks up from the current working directory until it finds
+// a go.mod file, returning the absolute path to the module root.
+func findModuleRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	dir, err = filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found in any parent directory")
+		}
+		dir = parent
+	}
+}
+
 func getSharedIndexer(tb testing.TB) *indexer {
 	sharedIdxOnce.Do(func() {
-		var err error
-		sharedIdx, err = newIndexer(".")
+		dir, err := findModuleRoot()
+		if err != nil {
+			tb.Fatalf("failed to find module root for shared indexer: %v", err)
+		}
+		sharedIdx, err = newIndexer(dir)
 		if err != nil {
 			tb.Fatalf("failed to create shared indexer: %v", err)
 		}


### PR DESCRIPTION
Fixes #1158.

getSharedIndexer used sync.Once with newIndexer(".") — the relative path depends on CWD. When run as part of go test ./..., the first caller may have a CWD without go.mod (e.g., a sub-package directory), causing discoverModulePath to fail and the indexer to load zero packages.

Fix: findModuleRoot walks up from CWD to locate go.mod, then passes that absolute path to newIndexer. This ensures the shared indexer always loads from the project root regardless of which test triggers sync.Once first.
