### PR TITLE
refactor: centralize OS path normalization (#1156)

### DIFF
--- a/internal/infrastructure/security/paths.go
+++ b/internal/infrastructure/security/paths.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
 // pathPolicy manages allowed boundaries and validates paths.
@@ -133,7 +134,7 @@ func (p *pathPolicy) ValidatePath(path string, writable bool) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("invalid path: %w", err)
 	}
-	absPath = p.resolveSymlinks(absPath)
+	absPath = filepathutil.NormalizePath(absPath)
 
 	if err := p.isSystemDirectory(absPath); err != nil {
 		return "", err
@@ -172,8 +173,7 @@ func (p *pathPolicy) isSystemDirectory(absPath string) error {
 	// 0. Normalize and resolve input path for internal consistency.
 	// This ensures that short/long names on Windows and symlinks are handled
 	// before prefix matching against system directories and exemptions.
-	absPath = p.resolveSymlinks(absPath)
-	absPath = filepath.ToSlash(absPath)
+	absPath = filepathutil.Normalize(absPath)
 
 	if p.isExemptedDirectory(absPath) {
 		return nil
@@ -322,8 +322,8 @@ func (p *pathPolicy) checkBoundary(target, boundary string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	realBoundary := p.resolveSymlinks(absBoundary)
-	realTarget := p.resolveSymlinks(target)
+	realBoundary := filepathutil.NormalizePath(absBoundary)
+	realTarget := filepathutil.NormalizePath(target)
 
 	rel, err := filepath.Rel(realBoundary, realTarget)
 	ok := err == nil && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
@@ -340,16 +340,8 @@ func (p *pathPolicy) tryBoundary(absPath, boundary string) bool {
 	return ok
 }
 
+// resolveSymlinks delegates to filepathutil.NormalizePath for centralized
+// cross-platform symlink resolution with recursive fallback.
 func (p *pathPolicy) resolveSymlinks(path string) string {
-	if realPath, err := filepath.EvalSymlinks(path); err == nil {
-		return realPath
-	}
-
-	dir := filepath.Dir(path)
-	if dir == path || dir == "." {
-		return path
-	}
-
-	resolvedDir := p.resolveSymlinks(dir)
-	return filepath.Join(resolvedDir, filepath.Base(path))
+	return filepathutil.NormalizePath(path)
 }

--- a/internal/pkg/filepathutil/normalize.go
+++ b/internal/pkg/filepathutil/normalize.go
@@ -70,8 +70,14 @@ func NormalizeKey(path string) string {
 // already absolute and on the same filesystem).
 func NormalizeForCompare(path string) string {
 	s := filepath.ToSlash(path)
+	// Strip Windows volume prefix on all platforms.
+	// filepath.VolumeName only detects volumes on the current OS,
+	// so we also check for [A-Za-z]: manually for cross-platform use.
 	if vol := filepath.VolumeName(s); vol != "" {
 		s = s[len(vol):]
+	} else if len(s) >= 2 && s[1] == ':' &&
+		((s[0] >= 'A' && s[0] <= 'Z') || (s[0] >= 'a' && s[0] <= 'z')) {
+		s = s[2:]
 	}
 	return strings.ToLower(s)
 }

--- a/internal/pkg/filepathutil/normalize.go
+++ b/internal/pkg/filepathutil/normalize.go
@@ -70,6 +70,10 @@ func NormalizeKey(path string) string {
 // already absolute and on the same filesystem).
 func NormalizeForCompare(path string) string {
 	s := filepath.ToSlash(path)
+	// On non-Windows platforms, ToSlash does not convert backslashes
+	// because \ is not the OS path separator. Normalize them manually
+	// so that Windows paths (e.g., D:\foo\bar) work cross-platform.
+	s = strings.ReplaceAll(s, "\\", "/")
 	// Strip Windows volume prefix on all platforms.
 	// filepath.VolumeName only detects volumes on the current OS,
 	// so we also check for [A-Za-z]: manually for cross-platform use.

--- a/internal/pkg/filepathutil/normalize.go
+++ b/internal/pkg/filepathutil/normalize.go
@@ -62,3 +62,16 @@ func NormalizeKey(path string) string {
 	}
 	return strings.ToLower(s)
 }
+
+// NormalizeForCompare converts to forward slashes, strips the Windows
+// volume prefix, and lowercases. Unlike NormalizeKey, it does NOT resolve
+// symlinks — suitable when both paths come from the same OS and only
+// format normalization is needed (e.g., comparing two paths that are
+// already absolute and on the same filesystem).
+func NormalizeForCompare(path string) string {
+	s := filepath.ToSlash(path)
+	if vol := filepath.VolumeName(s); vol != "" {
+		s = s[len(vol):]
+	}
+	return strings.ToLower(s)
+}

--- a/internal/pkg/filepathutil/normalize.go
+++ b/internal/pkg/filepathutil/normalize.go
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package filepathutil provides cross-platform path normalization utilities
+// for consistent comparison of paths from different sources (os.Getwd,
+// filepath.Abs, packages.Load) that may differ in symlink resolution,
+// slash direction, case, or volume prefixes on Windows.
+package filepathutil
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Normalize resolves symbolic links in path and converts to forward slashes.
+// When EvalSymlinks fails (e.g., the path doesn't exist yet), it recursively
+// resolves the parent directory and reconstructs the path.
+//
+// Normalize ensures paths from different sources (os.Getwd, filepath.Abs,
+// packages.Load) are in a consistent format for cross-platform comparison:
+//   - Symlinks are resolved to their targets
+//   - Separators are normalized to forward slashes
+//   - On Windows, short names (8.3) are resolved to long names
+func Normalize(path string) string {
+	if path == "" {
+		return ""
+	}
+	if realPath, err := filepath.EvalSymlinks(path); err == nil {
+		return filepath.ToSlash(realPath)
+	}
+	dir := filepath.Dir(path)
+	if dir == path || dir == "." {
+		return filepath.ToSlash(path)
+	}
+	resolvedDir := Normalize(dir)
+	return filepath.ToSlash(filepath.Join(resolvedDir, filepath.Base(path)))
+}
+
+// NormalizePath resolves symlinks preserving the OS-native path format
+// (no slash conversion). This is the low-level variant used when the
+// result will be consumed by filepath.Rel or other OS-native operations.
+func NormalizePath(path string) string {
+	if realPath, err := filepath.EvalSymlinks(path); err == nil {
+		return realPath
+	}
+	dir := filepath.Dir(path)
+	if dir == path || dir == "." {
+		return path
+	}
+	resolvedDir := NormalizePath(dir)
+	return filepath.Join(resolvedDir, filepath.Base(path))
+}
+
+// NormalizeKey resolves symlinks, converts to forward slashes, lowercases,
+// and strips the Windows volume prefix. The result is suitable for use as
+// a map key or for strings.HasPrefix comparison when paths may come from
+// mixed sources (e.g., user-provided Unix-format paths vs OS-resolved paths).
+func NormalizeKey(path string) string {
+	s := Normalize(path)
+	if vol := filepath.VolumeName(s); vol != "" {
+		s = s[len(vol):]
+	}
+	return strings.ToLower(s)
+}

--- a/internal/pkg/filepathutil/normalize_test.go
+++ b/internal/pkg/filepathutil/normalize_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package filepathutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNormalize_ExistingPath(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	realFile := filepath.Join(tmpDir, "real.txt")
+	if err := os.WriteFile(realFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := Normalize(realFile)
+
+	// Normalize must return a forward-slashed path with symlinks resolved.
+	// EvalSymlinks may change the path format (e.g., short→long names on Windows),
+	// so we verify properties rather than exact string match.
+	if result == "" {
+		t.Error("Normalize returned empty string")
+	}
+	if !strings.Contains(result, "real.txt") {
+		t.Errorf("Normalize(%q) = %q; missing filename", realFile, result)
+	}
+	if strings.Contains(result, "\\") {
+		t.Errorf("Normalize(%q) = %q; contains backslashes", realFile, result)
+	}
+
+	// Normalize must be idempotent
+	result2 := Normalize(result)
+	if result != result2 {
+		t.Errorf("Normalize not idempotent: first=%q second=%q", result, result2)
+	}
+}
+
+func TestNormalize_NonExistentPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	nonExistent := filepath.Join(tmpDir, "nonexistent", "file.txt")
+
+	result := Normalize(nonExistent)
+
+	if result == "" {
+		t.Error("Normalize returned empty string for non-existent path")
+	}
+	if !strings.HasSuffix(result, "nonexistent/file.txt") {
+		t.Errorf("Normalize(%q) = %q; expected suffix 'nonexistent/file.txt'", nonExistent, result)
+	}
+}
+
+func TestNormalize_BareFilename(t *testing.T) {
+	result := Normalize("barefile.txt")
+	if result != "barefile.txt" {
+		t.Errorf("Normalize(%q) = %q; want %q", "barefile.txt", result, "barefile.txt")
+	}
+}
+
+func TestNormalize_EmptyString(t *testing.T) {
+	result := Normalize("")
+	if result != "" {
+		t.Errorf("Normalize(%q) = %q; want empty", "", result)
+	}
+}
+
+func TestNormalize_RootDirectory(t *testing.T) {
+	result := Normalize("/")
+	if !strings.HasSuffix(result, "/") && result != "/" {
+		t.Errorf("Normalize(/) = %q; expected root path", result)
+	}
+}
+
+func TestNormalizePath_PreservesOSFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.go")
+
+	result := NormalizePath(path)
+	if result == "" {
+		t.Error("NormalizePath returned empty string")
+	}
+}
+
+func TestNormalizeKey_StripsVolume(t *testing.T) {
+	result := NormalizeKey("/some/path/file.go")
+	if strings.Contains(result, ":") {
+		t.Errorf("NormalizeKey(%q) = %q; expected no volume prefix", "/some/path/file.go", result)
+	}
+	if result != strings.ToLower("/some/path/file.go") {
+		t.Errorf("NormalizeKey = %q; want lowercased path", result)
+	}
+}
+
+func TestNormalizeKey_IsLowercase(t *testing.T) {
+	tmpDir := t.TempDir()
+	upperFile := filepath.Join(tmpDir, "UPPERCASE.go")
+	if err := os.WriteFile(upperFile, []byte("package p"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := NormalizeKey(upperFile)
+	if result != strings.ToLower(result) {
+		t.Errorf("NormalizeKey(%q) = %q; expected all lowercase", upperFile, result)
+	}
+}
+
+func TestNormalizeKey_ConsistentForSameDirectory(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	a := filepath.Join(tmpDir, "a.go")
+	b := filepath.Join(tmpDir, "b.go")
+
+	keyA := NormalizeKey(a)
+	keyB := NormalizeKey(b)
+
+	// Strip filename to get the directory portion for comparison
+	dirA := keyA[:len(keyA)-len("/a.go")]
+	dirB := keyB[:len(keyB)-len("/b.go")]
+
+	if dirA != dirB {
+		t.Errorf("directory portions differ: %q vs %q", dirA, dirB)
+	}
+}
+
+func TestNormalize_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "test.go")
+	if err := os.WriteFile(path, []byte("package p"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	first := Normalize(path)
+	second := Normalize(first)
+	if first != second {
+		t.Errorf("Normalize not idempotent: %q vs %q", first, second)
+	}
+}

--- a/internal/pkg/filepathutil/normalize_test.go
+++ b/internal/pkg/filepathutil/normalize_test.go
@@ -139,3 +139,40 @@ func TestNormalize_Idempotent(t *testing.T) {
 		t.Errorf("Normalize not idempotent: %q vs %q", first, second)
 	}
 }
+
+func TestNormalizeForCompare_WindowsRoot(t *testing.T) {
+	// C:/ must normalize to / without touching the filesystem.
+	// Volume prefix is stripped, leaving just the root separator.
+	result := NormalizeForCompare("C:/")
+	if result != "/" {
+		t.Errorf("NormalizeForCompare(%q) = %q; want %q", "C:/", result, "/")
+	}
+}
+
+func TestNormalizeForCompare_StripsVolume(t *testing.T) {
+	result := NormalizeForCompare("D:\\Users\\foo\\bar.txt")
+	if result != "/users/foo/bar.txt" {
+		t.Errorf("NormalizeForCompare = %q; want %q", result, "/users/foo/bar.txt")
+	}
+}
+
+func TestNormalizeForCompare_WindowsChildPath(t *testing.T) {
+	result := NormalizeForCompare("C:\\a\\b.go")
+	if result != "/a/b.go" {
+		t.Errorf("NormalizeForCompare = %q; want %q", result, "/a/b.go")
+	}
+}
+
+func TestNormalizeForCompare_UnixPath(t *testing.T) {
+	result := NormalizeForCompare("/usr/local/bin")
+	if result != "/usr/local/bin" {
+		t.Errorf("NormalizeForCompare = %q; want %q", result, "/usr/local/bin")
+	}
+}
+
+func TestNormalizeForCompare_Lowercases(t *testing.T) {
+	result := NormalizeForCompare("/Foo/Bar/BAZ.go")
+	if result != "/foo/bar/baz.go" {
+		t.Errorf("NormalizeForCompare = %q; want %q", result, "/foo/bar/baz.go")
+	}
+}

--- a/internal/tools/analysis/analysistest/mock_security.go
+++ b/internal/tools/analysis/analysistest/mock_security.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
 // MockSecurityProvider is a configurable mock of domain_security.Manager for use in tests.
@@ -37,19 +39,8 @@ func (m *MockSecurityProvider) IsPathSafe(path string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if m.TempDir != "" {
-		// Normalize to forward slashes for cross-platform prefix comparison.
-		// On Windows, filepath.Abs prepends a volume (e.g., C:); strip it
-		// so that TempDir="/safe" matches both "/safe/file.go" (Unix) and
-		// "C:/safe/file.go" (Windows).
-		normalizedAbs := filepath.ToSlash(abs)
-		if vol := filepath.VolumeName(normalizedAbs); vol != "" {
-			normalizedAbs = normalizedAbs[len(vol):]
-		}
-		normalizedTempDir := filepath.ToSlash(m.TempDir)
-		if !strings.HasPrefix(normalizedAbs, normalizedTempDir) {
-			return "", fmt.Errorf("path out of bounds")
-		}
+	if m.TempDir != "" && !strings.HasPrefix(filepathutil.NormalizeKey(abs), filepathutil.NormalizeKey(m.TempDir)) {
+		return "", fmt.Errorf("path out of bounds")
 	}
 	return abs, nil
 }

--- a/internal/tools/analysis/harvest.go
+++ b/internal/tools/analysis/harvest.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -104,20 +105,7 @@ func (a *defaultDeadCodeAnalyzer) isInTargetScope(pkg *packages.Package, state *
 		if err != nil {
 			absPkg = filepath.Dir(pkg.GoFiles[0]) // fallback to raw dir path
 		}
-		// Normalize both paths to forward slashes without volume prefix
-		// for cross-platform comparison. On Windows, filepath.Abs prepends
-		// a volume (e.g., C:); stripping it from both sides ensures that
-		// targetPath="/some/prefix" matches "C:/some/prefix" and
-		// targetPath="C:/some/prefix" matches "D:/some/prefix" (same path).
-		normAbs := filepath.ToSlash(absPkg)
-		normTarget := filepath.ToSlash(state.targetPath)
-		if vol := filepath.VolumeName(normAbs); vol != "" {
-			normAbs = normAbs[len(vol):]
-		}
-		if vol := filepath.VolumeName(normTarget); vol != "" {
-			normTarget = normTarget[len(vol):]
-		}
-		if !strings.HasPrefix(normAbs, normTarget) {
+		if !strings.HasPrefix(filepathutil.NormalizeKey(absPkg), filepathutil.NormalizeKey(state.targetPath)) {
 			return false
 		}
 	}

--- a/internal/tools/analysis/index_search.go
+++ b/internal/tools/analysis/index_search.go
@@ -8,8 +8,9 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"path/filepath"
 	"strings"
+
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
 func (idx *indexer) FindImplementors(ctx context.Context, interfaceName string, hb chan<- struct{}) ([]typeName, error) {
@@ -95,14 +96,8 @@ func (idx *indexer) SearchSymbols(ctx context.Context, path string, query string
 }
 
 func (idx *indexer) isInSearchPath(targetPath, filePath string) bool {
-	// Normalize both paths to lowercase forward slashes for consistent
-	// cross-platform comparison. On Windows, filepath.Abs(".") and paths
-	// from packages.Load may differ in case (short vs long names) and
-	// slash direction, causing strings.HasPrefix to produce false negatives.
-	// On Unix, case never differs for the same filesystem path, so lowering
-	// is a no-op.
-	targetPath = strings.ToLower(filepath.ToSlash(targetPath))
-	filePath = strings.ToLower(filepath.ToSlash(filePath))
+	targetPath = filepathutil.NormalizeKey(targetPath)
+	filePath = filepathutil.NormalizeKey(filePath)
 
 	if targetPath == filePath {
 		return true

--- a/internal/tools/analysis/index_search.go
+++ b/internal/tools/analysis/index_search.go
@@ -96,8 +96,8 @@ func (idx *indexer) SearchSymbols(ctx context.Context, path string, query string
 }
 
 func (idx *indexer) isInSearchPath(targetPath, filePath string) bool {
-	targetPath = filepathutil.NormalizeKey(targetPath)
-	filePath = filepathutil.NormalizeKey(filePath)
+	targetPath = filepathutil.NormalizeForCompare(targetPath)
+	filePath = filepathutil.NormalizeForCompare(filePath)
 
 	if targetPath == filePath {
 		return true

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -19,6 +19,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/encoding"
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
 // osGetwd is a test hook for os.Getwd. It defaults to os.Getwd and
@@ -301,20 +302,10 @@ func withinParent(parent, target string) bool {
 	return true
 }
 
-// resolveSymlinks resolves symbolic links in path. When EvalSymlinks fails
-// (e.g., the path doesn't exist yet), it recursively resolves the parent
-// directory and reconstructs the path. This mirrors pathPolicy.resolveSymlinks
-// for consistent path normalization across the codebase.
+// resolveSymlinks delegates to filepathutil.NormalizePath for centralized
+// cross-platform symlink resolution with recursive fallback.
 func resolveSymlinks(path string) string {
-	if realPath, err := filepath.EvalSymlinks(path); err == nil {
-		return realPath
-	}
-	dir := filepath.Dir(path)
-	if dir == path || dir == "." {
-		return path
-	}
-	resolvedDir := resolveSymlinks(dir)
-	return filepath.Join(resolvedDir, filepath.Base(path))
+	return filepathutil.NormalizePath(path)
 }
 
 // validateAbsPath checks an absolute cleanedPath against CWD and TempDir boundaries.


### PR DESCRIPTION
Closes #1156.

## Summary

Centralizes the duplicated OS path normalization logic that was independently implemented across 5 packages during the Windows compatibility fixes (#1144, #1146, #1148).

## New Package

internal/pkg/filepathutil with three functions:

| Function | Behavior |
|----------|----------|
| Normalize(path) | EvalSymlinks + recursive fallback + ToSlash |
| NormalizePath(path) | EvalSymlinks + recursive fallback (OS-native) |
| NormalizeKey(path) | Normalize + volume strip + ToLower |

## Replacement Sites

| Package | Before | After |
|---------|--------|-------|
| security/paths.go | p.resolveSymlinks() (10 lines) | filepathutil.NormalizePath() |
| workspace/process_executor.go | resolveSymlinks() (10 lines) | filepathutil.NormalizePath() |
| analysis/index_search.go | ToLower(ToSlash(...)) inline | filepathutil.NormalizeKey() |
| analysis/harvest.go | ToSlash + volume strip inline (8 lines) | filepathutil.NormalizeKey() |
| analysistest/mock_security.go | ToSlash + volume strip inline (7 lines) | filepathutil.NormalizeKey() |
