### PR TITLE
refactor: remove redundant resolveSymlinks wrappers

### DIFF
--- a/internal/infrastructure/security/paths.go
+++ b/internal/infrastructure/security/paths.go
@@ -339,9 +339,3 @@ func (p *pathPolicy) tryBoundary(absPath, boundary string) bool {
 	}
 	return ok
 }
-
-// resolveSymlinks delegates to filepathutil.NormalizePath for centralized
-// cross-platform symlink resolution with recursive fallback.
-func (p *pathPolicy) resolveSymlinks(path string) string {
-	return filepathutil.NormalizePath(path)
-}

--- a/internal/infrastructure/security/paths_test.go
+++ b/internal/infrastructure/security/paths_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
 func TestPathPolicy_ValidatePath(t *testing.T) {
@@ -551,14 +552,14 @@ func TestCheckDefaultBoundaries_ExtraTempDirs(t *testing.T) {
 
 	// A file in /tmp should be permitted by checkDefaultBoundaries.
 	// Whether via os.TempDir() or getExtraTempDirs() depends on the platform.
-	path := p.resolveSymlinks("/tmp/test-extra-temp-file.txt")
+	path := filepathutil.NormalizePath("/tmp/test-extra-temp-file.txt")
 	ok, err := p.checkDefaultBoundaries(path, false)
 	require.NoError(t, err)
 	assert.True(t, ok, "path in /tmp should pass checkDefaultBoundaries (via os.TempDir or getExtraTempDirs)")
 
 	// macOS-specific: /private/tmp is also covered by getExtraTempDirs
 	if runtime.GOOS == "darwin" {
-		path2 := p.resolveSymlinks("/private/tmp/test-extra-temp-file.txt")
+		path2 := filepathutil.NormalizePath("/private/tmp/test-extra-temp-file.txt")
 		ok2, err2 := p.checkDefaultBoundaries(path2, false)
 		require.NoError(t, err2)
 		assert.True(t, ok2, "path in /private/tmp should pass checkDefaultBoundaries on macOS")
@@ -578,7 +579,7 @@ func TestCheckDefaultBoundaries_ExtraTempDirs(t *testing.T) {
 				if _, statErr := os.Stat(extraDir); statErr != nil {
 					continue
 				}
-				path := p.resolveSymlinks(filepath.Join(extraDir, "test-extra-shortcircuit.txt"))
+				path := filepathutil.NormalizePath(filepath.Join(extraDir, "test-extra-shortcircuit.txt"))
 				ok, err := p.checkBoundary(path, extraDir)
 				require.NoError(t, err)
 				assert.True(t, ok, "path in %s should be within boundary", extraDir)
@@ -1102,7 +1103,6 @@ func TestValidatePath_CustomRuleErrorPropagation(t *testing.T) {
 // resolver. Verification: result is non-empty and preserves the base filename.
 func TestResolveSymlinks_RecursiveFallback(t *testing.T) {
 	t.Parallel()
-	p := newPathPolicy(nil)
 	tmpDir := t.TempDir()
 
 	tests := []struct {
@@ -1134,7 +1134,7 @@ func TestResolveSymlinks_RecursiveFallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := p.resolveSymlinks(tt.path)
+			result := filepathutil.NormalizePath(tt.path)
 			if result == "" {
 				t.Error("resolveSymlinks returned empty string")
 			}

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -289,8 +289,8 @@ func withinParent(parent, target string) bool {
 	// comparison. On Windows, os.Getwd() and filepath.Abs may return paths
 	// with different normalization (short vs long names, case differences)
 	// causing filepath.Rel to fail even for valid parent-child relationships.
-	parent = resolveSymlinks(parent)
-	target = resolveSymlinks(target)
+	parent = filepathutil.NormalizePath(parent)
+	target = filepathutil.NormalizePath(target)
 
 	rel, err := filepath.Rel(parent, target)
 	if err != nil {
@@ -300,12 +300,6 @@ func withinParent(parent, target string) bool {
 		return false
 	}
 	return true
-}
-
-// resolveSymlinks delegates to filepathutil.NormalizePath for centralized
-// cross-platform symlink resolution with recursive fallback.
-func resolveSymlinks(path string) string {
-	return filepathutil.NormalizePath(path)
 }
 
 // validateAbsPath checks an absolute cleanedPath against CWD and TempDir boundaries.


### PR DESCRIPTION
Removes the redundant one-line resolveSymlinks wrappers in both process_executor.go and paths.go. Callers now use filepathutil.NormalizePath directly.

- workspace/process_executor.go: withinParent now calls filepathutil.NormalizePath directly; resolveSymlinks function removed.
- security/paths.go: p.resolveSymlinks wrapper method removed; all 4 test call sites updated to filepathutil.NormalizePath.