### PR TITLE
fix: add Chmod to infra FileSystem, fix AbsError via function injection (#1163)

### DIFF
--- a/internal/domain/persistence/mock_fs.go
+++ b/internal/domain/persistence/mock_fs.go
@@ -143,6 +143,10 @@ func (m *mockFileSystem) MkdirAll(ctx context.Context, path string, perm os.File
 	return nil
 }
 
+func (m *mockFileSystem) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+	return nil
+}
+
 func (m *mockFileSystem) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/infrastructure/persistence/mock_fs_test.go
+++ b/internal/infrastructure/persistence/mock_fs_test.go
@@ -130,6 +130,10 @@ func (m *mockFileSystem) MkdirAll(ctx context.Context, path string, perm os.File
 	return nil
 }
 
+func (m *mockFileSystem) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+	return nil
+}
+
 func (m *mockFileSystem) CreateTemp(ctx context.Context, dir, pattern string) (File, error) {
 	if m.CreateTempFunc != nil {
 		return m.CreateTempFunc(ctx, dir, pattern)

--- a/internal/infrastructure/persistence/os_fs.go
+++ b/internal/infrastructure/persistence/os_fs.go
@@ -26,6 +26,7 @@ type File interface {
 // FileSystem defines the interface for filesystem operations to allow mocking.
 type FileSystem interface {
 	MkdirAll(ctx context.Context, path string, perm os.FileMode) error
+	Chmod(ctx context.Context, name string, mode os.FileMode) error
 	CreateTemp(ctx context.Context, dir, pattern string) (File, error)
 	Rename(ctx context.Context, oldpath, newpath string) error
 	Remove(ctx context.Context, name string) error
@@ -43,6 +44,12 @@ type OSFileSystem struct{}
 func (f *OSFileSystem) MkdirAll(ctx context.Context, path string, perm os.FileMode) error {
 	return fsRetry(ctx, func() error {
 		return os.MkdirAll(path, perm)
+	})
+}
+
+func (f *OSFileSystem) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+	return fsRetry(ctx, func() error {
+		return os.Chmod(name, mode)
 	})
 }
 
@@ -147,6 +154,10 @@ func (f *domainFS) AtomicWrite(ctx context.Context, name string, data []byte, pe
 
 func (f *domainFS) MkdirAll(ctx context.Context, path string, perm os.FileMode) error {
 	return f.fs.MkdirAll(ctx, path, perm)
+}
+
+func (f *domainFS) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+	return f.fs.Chmod(ctx, name, mode)
 }
 
 func (f *domainFS) Stat(ctx context.Context, name string) (os.FileInfo, error) {

--- a/internal/infrastructure/persistence/persistencetest/plain_os_fs.go
+++ b/internal/infrastructure/persistence/persistencetest/plain_os_fs.go
@@ -127,6 +127,10 @@ func (m *plainOSFS) MkdirAll(ctx context.Context, path string, perm os.FileMode)
 	return os.MkdirAll(path, perm)
 }
 
+func (m *plainOSFS) Chmod(ctx context.Context, name string, mode os.FileMode) error {
+	return os.Chmod(name, mode)
+}
+
 func (m *plainOSFS) Stat(ctx context.Context, name string) (os.FileInfo, error) {
 	return os.Stat(name)
 }

--- a/internal/tools/analysis/dead_code.go
+++ b/internal/tools/analysis/dead_code.go
@@ -11,6 +11,7 @@ import (
 	"go/types"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -25,8 +26,9 @@ const deepVerifiedDead = " [DEEP: verified no cross-package callers; text-search
 
 // defaultDeadCodeAnalyzer holds the configuration for identifying technical debt via orphaned symbols.
 type defaultDeadCodeAnalyzer struct {
-	SP  security.PathValidator
-	idx symbolIndex
+	SP          security.PathValidator
+	idx         symbolIndex
+	resolvePath func(string) (string, error) // default: filepath.Abs
 }
 
 // OrphanReport represents a single finding of dead or effectively private code.
@@ -71,7 +73,7 @@ type scanState struct {
 }
 
 func newDeadCodeAnalyzer(sp security.PathValidator, idx symbolIndex) *defaultDeadCodeAnalyzer {
-	return &defaultDeadCodeAnalyzer{SP: sp, idx: idx}
+	return &defaultDeadCodeAnalyzer{SP: sp, idx: idx, resolvePath: filepath.Abs}
 }
 
 // NewDeadCodeAnalyzerForCLI creates a DeadCodeAnalyzer wired for CLI use.

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -12,7 +12,6 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -1774,29 +1773,17 @@ func TestResolveCrossPackage_NilTypesInfo(t *testing.T) {
 
 // =============================================================================
 // Gap: harvestPackageSymbols filepath.Abs error fallback (L104-106).
-// Covered by deleting the current working directory so os.Getwd() fails,
-// which causes filepath.Abs to return an error.
-// This test must NOT use t.Parallel() because it temporarily changes CWD.
+// Covered by injecting a resolvePath function that returns an error,
+// which causes the fallback to filepath.Dir("relative.go") = ".".
 // =============================================================================
 func TestHarvestPackageSymbols_AbsError(t *testing.T) {
-	// NOT parallel — changes working directory
-	if runtime.GOOS == "windows" {
-		t.Skip("deleted-CWD technique cannot restore directory on Windows; file handles prevent cleanup")
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{
+		resolvePath: func(string) (string, error) {
+			return "", fmt.Errorf("simulated Abs failure")
+		},
 	}
-
-	origDir, err := os.Getwd()
-	require.NoError(t, err)
-
-	tmpDir := t.TempDir()
-	require.NoError(t, os.Chdir(tmpDir))
-	require.NoError(t, os.RemoveAll(tmpDir)) // CWD is now a deleted directory
-
-	t.Cleanup(func() {
-		// Restore original CWD
-		_ = os.Chdir(origDir)
-	})
-
-	analyzer := &defaultDeadCodeAnalyzer{}
 
 	state := &scanState{
 		targetModule: "example.com/mod",
@@ -1814,7 +1801,7 @@ func TestHarvestPackageSymbols_AbsError(t *testing.T) {
 		Types:   types.NewPackage("example.com/mod/pkg", "pkg"),
 	}
 
-	// Must not panic; filepath.Abs should fail because CWD is deleted,
+	// Must not panic; resolvePath returns an error,
 	// falling back to filepath.Dir("relative.go") = "."
 	analyzer.harvestPackageSymbols(pkg, state)
 }

--- a/internal/tools/analysis/harvest.go
+++ b/internal/tools/analysis/harvest.go
@@ -101,7 +101,11 @@ func (a *defaultDeadCodeAnalyzer) isInTargetScope(pkg *packages.Package, state *
 	}
 
 	if state.targetPath != "" && len(pkg.GoFiles) > 0 {
-		absPkg, err := filepath.Abs(filepath.Dir(pkg.GoFiles[0]))
+		resolvePath := a.resolvePath
+		if resolvePath == nil {
+			resolvePath = filepath.Abs
+		}
+		absPkg, err := resolvePath(filepath.Dir(pkg.GoFiles[0]))
 		if err != nil {
 			absPkg = filepath.Dir(pkg.GoFiles[0]) // fallback to raw dir path
 		}


### PR DESCRIPTION
Partial fix for #1163.

## Changes

### Chmod on infra FileSystem
- Added Chmod to infra FileSystem interface, OSFileSystem, plainOSFS, domainFS bridge, and both mock implementations (domain and infra).

### TestHarvestPackageSymbols_AbsError — function injection
- Added resolvePath func field to defaultDeadCodeAnalyzer (default: filepath.Abs)
- isInTargetScope now uses a.resolvePath instead of filepath.Abs directly
- Test updated to inject an error-returning function instead of deleted-CWD technique
- Removed t.Skip on Windows — test now passes on all platforms

## Remaining (5 tests, for future PR)
The other 5 tests need deeper FileSystem injection through production code (Walk, MkdirAll, OpenFile) and will be addressed in a follow-up.