### PR TITLE
fix(orchestrator): document error.Is branch in agentError (#1173)

### DIFF
--- a/internal/agent/orchestrator/errors.go
+++ b/internal/agent/orchestrator/errors.go
@@ -36,6 +36,9 @@ func (e *agentError) Unwrap() error {
 }
 
 func (e *agentError) Is(target error) bool {
+	// Category is typically a simple sentinel (short-circuits via ==),
+	// but may be a wrapped error for future callers; errors.Is handles
+	// the unwrap.
 	return e.Category == target || errors.Is(e.Category, target)
 }
 


### PR DESCRIPTION
Closes #1173.

## Summary
Added a documentation comment to `(*agentError).Is()` in `internal/agent/orchestrator/errors.go` explaining why the `errors.Is(Category, target)` branch exists — it's forward-compatibility for future callers that may pass wrapped errors as Category.

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| Target coverage | N/A (comment-only change) |