### PR TITLE
fix(persistence): stores return ErrTaskNotFound on missing ID, service drops full-scan (#1170)

### DIFF
--- a/internal/domain/services/task_service.go
+++ b/internal/domain/services/task_service.go
@@ -5,6 +5,7 @@ package services
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -97,7 +98,8 @@ func (s *taskService) AppendTask(ctx context.Context, task ports.Task) error {
 
 // UpdateTask updates an existing task.
 func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status string) (ports.Task, error) {
-	// Fetch existing tasks from store to validate existence
+	// Fetch existing task for merge — empty content/status means "keep current value".
+	// TODO(#1170): Replace Query full-scan with GetByID when added to ListStore.
 	tasks, err := s.store.Query(ctx, ports.ListFilter{}, 0, 0)
 	if err != nil {
 		return ports.Task{}, err
@@ -123,7 +125,12 @@ func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status 
 		t.Status = status
 	}
 
+	// Delegate existence check to store — store.Update now returns ErrTaskNotFound
+	// when the ID doesn't exist (race-condition safety between Query and Update).
 	if err := s.store.Update(ctx, id, t); err != nil {
+		if errors.Is(err, ports.ErrTaskNotFound) {
+			return ports.Task{}, fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
+		}
 		return ports.Task{}, err
 	}
 
@@ -132,22 +139,13 @@ func (s *taskService) UpdateTask(ctx context.Context, id int64, content, status 
 
 // DeleteTask removes a task.
 func (s *taskService) DeleteTask(ctx context.Context, id int64) error {
-	// Pre-check existence
-	tasks, err := s.store.Query(ctx, ports.ListFilter{}, 0, 0)
-	if err != nil {
+	if err := s.store.Delete(ctx, id); err != nil {
+		if errors.Is(err, ports.ErrTaskNotFound) {
+			return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
+		}
 		return err
 	}
-	found := false
-	for _, t := range tasks {
-		if t.ID == id {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
-	}
-	return s.store.Delete(ctx, id)
+	return nil
 }
 
 // ListTasks returns all tasks, optionally filtered by status, bounded by limit and offset.

--- a/internal/domain/services/task_service_test.go
+++ b/internal/domain/services/task_service_test.go
@@ -37,7 +37,7 @@ func (m *mockTaskRepo) Update(ctx context.Context, id int64, task ports.Task) er
 			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 }
 
 func (m *mockTaskRepo) Delete(ctx context.Context, id int64) error {
@@ -46,11 +46,17 @@ func (m *mockTaskRepo) Delete(ctx context.Context, id int64) error {
 	if m.writeErr != nil {
 		return m.writeErr
 	}
+	found := false
 	var next []ports.Task
 	for _, t := range m.tasks {
 		if t.ID != id {
 			next = append(next, t)
+		} else {
+			found = true
 		}
+	}
+	if !found {
+		return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 	}
 	m.tasks = next
 	return nil
@@ -319,6 +325,9 @@ func TestTaskService_UpdateTask_NotFound(t *testing.T) {
 	if err == nil {
 		t.Error("expected not found error")
 	}
+	if !errors.Is(err, ports.ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
+	}
 }
 
 func TestTaskService_UpdateTask_QueryError(t *testing.T) {
@@ -372,35 +381,8 @@ func TestTaskService_DeleteTask_NotFound(t *testing.T) {
 	if err == nil {
 		t.Error("expected not found error")
 	}
-}
-
-func TestTaskService_DeleteTask_QueryError(t *testing.T) {
-	t.Parallel()
-	ctx := context.Background()
-	sentinel := errors.New("store query failed")
-	s, repo := setupTaskServiceWithError(t, nil, nil)
-
-	// Add a task so it exists in the store (no read error yet)
-	task, err := s.AddTask(ctx, "task to delete")
-	if err != nil {
-		t.Fatalf("setup AddTask failed: %v", err)
-	}
-
-	// Now inject the read error
-	repo.readErr = sentinel
-
-	// Attempt delete — should fail at Query, not reach the not-found or delete logic
-	err = s.DeleteTask(ctx, task.ID)
-	if err == nil {
-		t.Fatalf("expected error, got nil")
-	}
-	if !errors.Is(err, sentinel) {
-		t.Errorf("expected sentinel error, got %v", err)
-	}
-
-	// Verify the task still exists (delete didn't happen)
-	if len(repo.tasks) != 1 {
-		t.Errorf("expected task to still exist, got %d tasks", len(repo.tasks))
+	if !errors.Is(err, ports.ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got %v", err)
 	}
 }
 

--- a/internal/infrastructure/persistence/memory_store.go
+++ b/internal/infrastructure/persistence/memory_store.go
@@ -5,6 +5,7 @@ package persistence
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"sync"
 	"time"
@@ -214,7 +215,7 @@ func (s *memoryListStore[T]) Update(ctx context.Context, id int64, item T) error
 			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 }
 
 func (s *memoryListStore[T]) Delete(ctx context.Context, id int64) error {
@@ -226,7 +227,7 @@ func (s *memoryListStore[T]) Delete(ctx context.Context, id int64) error {
 			return nil
 		}
 	}
-	return nil
+	return fmt.Errorf("id %d: %w", id, ports.ErrTaskNotFound)
 }
 
 func (s *memoryListStore[T]) DeleteAll(ctx context.Context) error {

--- a/internal/infrastructure/persistence/memory_store_test.go
+++ b/internal/infrastructure/persistence/memory_store_test.go
@@ -5,6 +5,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 	"sync"
@@ -276,7 +277,7 @@ func TestMemoryListStore_GetID_NonStruct(t *testing.T) {
 }
 
 // =============================================================================
-// Update with non-existent ID — no-op, returns nil
+// Update with non-existent ID — returns ErrTaskNotFound
 // =============================================================================
 
 func TestMemoryListStore_Update_NotFound(t *testing.T) {
@@ -288,8 +289,10 @@ func TestMemoryListStore_Update_NotFound(t *testing.T) {
 	_ = store.Append(ctx, ports.Task{ID: 1, Content: "existing"})
 
 	err := store.Update(ctx, 999, ports.Task{ID: 999, Content: "not found"})
-	if err != nil {
-		t.Errorf("Update for non-existent ID should not error, got: %v", err)
+	if err == nil {
+		t.Error("Update for non-existent ID should return an error")
+	} else if !errors.Is(err, ports.ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got: %v", err)
 	}
 
 	// Verify existing data is unchanged
@@ -300,7 +303,7 @@ func TestMemoryListStore_Update_NotFound(t *testing.T) {
 }
 
 // =============================================================================
-// Delete with non-existent ID — no-op, returns nil
+// Delete with non-existent ID — returns ErrTaskNotFound
 // =============================================================================
 
 func TestMemoryListStore_Delete_NotFound(t *testing.T) {
@@ -311,8 +314,10 @@ func TestMemoryListStore_Delete_NotFound(t *testing.T) {
 	_ = store.Append(ctx, ports.Task{ID: 1, Content: "existing"})
 
 	err := store.Delete(ctx, 999)
-	if err != nil {
-		t.Errorf("Delete for non-existent ID should not error, got: %v", err)
+	if err == nil {
+		t.Error("Delete for non-existent ID should return an error")
+	} else if !errors.Is(err, ports.ErrTaskNotFound) {
+		t.Errorf("expected ErrTaskNotFound, got: %v", err)
 	}
 
 	// Verify existing data is unchanged

--- a/internal/infrastructure/persistence/sqlite_store.go
+++ b/internal/infrastructure/persistence/sqlite_store.go
@@ -171,18 +171,32 @@ func (s *sqliteTaskStore) Count(ctx context.Context) (int, error) {
 }
 
 func (s *sqliteTaskStore) Update(ctx context.Context, id int64, item ports.Task) error {
-	_, err := s.db.ExecContext(ctx, "UPDATE tasks SET content = ?, status = ? WHERE id = ?",
+	result, err := s.db.ExecContext(ctx, "UPDATE tasks SET content = ?, status = ? WHERE id = ?",
 		item.Content, item.Status, id)
 	if err != nil {
 		return fmt.Errorf("updating task %d: %w", id, err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("updating task %d: %w", id, err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("task %d: %w", id, ports.ErrTaskNotFound)
 	}
 	return nil
 }
 
 func (s *sqliteTaskStore) Delete(ctx context.Context, id int64) error {
-	_, err := s.db.ExecContext(ctx, "DELETE FROM tasks WHERE id = ?", id)
+	result, err := s.db.ExecContext(ctx, "DELETE FROM tasks WHERE id = ?", id)
 	if err != nil {
 		return fmt.Errorf("deleting task %d: %w", id, err)
+	}
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("deleting task %d: %w", id, err)
+	}
+	if rowsAffected == 0 {
+		return fmt.Errorf("task %d: %w", id, ports.ErrTaskNotFound)
 	}
 	return nil
 }

--- a/internal/infrastructure/persistence/sqlite_store_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_test.go
@@ -52,6 +52,7 @@ func TestSQLiteTaskStore(t *testing.T) {
 	t.Run("Update Task", testTaskStoreUpdate)
 	t.Run("Delete Task", testTaskStoreDelete)
 	t.Run("Delete All Tasks", testTaskStoreDeleteAll)
+	t.Run("Update/Delete NotFound", TestSQLiteTaskStore_UpdateDelete_NotFound)
 }
 
 func testTaskStoreReadEmpty(t *testing.T) {
@@ -162,6 +163,34 @@ func testTaskStoreDeleteAll(t *testing.T) {
 	if len(tasks) != 0 {
 		t.Errorf("DeleteAll failed, remaining tasks: %d", len(tasks))
 	}
+}
+
+func TestSQLiteTaskStore_UpdateDelete_NotFound(t *testing.T) {
+	t.Parallel()
+	db := setupSQLite(t)
+	store := newSQLiteTaskStore(db)
+	ctx := context.Background()
+
+	// Append one real task so the store is non-empty
+	now := time.Now().Truncate(time.Millisecond)
+	task := ports.Task{ID: 1, Content: "real", Status: "pending", CreatedAt: now}
+	require.NoError(t, store.Append(ctx, task))
+
+	// Update non-existent ID
+	err := store.Update(ctx, 999, ports.Task{ID: 999, Content: "ghost", Status: "completed"})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ports.ErrTaskNotFound), "expected ErrTaskNotFound, got %v", err)
+
+	// Delete non-existent ID
+	err = store.Delete(ctx, 999)
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ports.ErrTaskNotFound), "expected ErrTaskNotFound, got %v", err)
+
+	// Verify real data untouched
+	tasks, err := store.ReadAll(ctx)
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+	assert.Equal(t, "real", tasks[0].Content)
 }
 
 func TestStoreErrors(t *testing.T) {


### PR DESCRIPTION
Closes #1170.

## Summary
Fixes the pattern where `taskService.UpdateTask` and `taskService.DeleteTask` load every row from the store solely to check if an ID exists. Root cause: neither `sqliteTaskStore` nor `memoryListStore` returned `ports.ErrTaskNotFound` on missing IDs.

### Changes
- **sqlite_store.go**: `Update`/`Delete` check `RowsAffected()`, return `ErrTaskNotFound` when zero
- **memory_store.go**: `Update`/`Delete` return `ErrTaskNotFound` when ID not found in scan
- **task_service.go**: `DeleteTask` drops full-scan `Query` pre-scan; `UpdateTask` uses `errors.Is` on `store.Update` result while preserving merge semantics
- **Mock + tests**: `mockTaskRepo` returns `ErrTaskNotFound`, obsolete tests removed, new not-found assertions added

## Verification
| Check | Status |
|-------|--------|
| make check-full | PASS |
| lint | 0 issues |
| vulncheck | No vulnerabilities |
| race detection | PASS |
| dead code | None |