### PR TITLE
fix(context): add UUID-based stable turn identifiers and fix summarization pin contract (#1185)

### DIFF
--- a/docs/adr/2026-07-stable-turn-identifiers.md
+++ b/docs/adr/2026-07-stable-turn-identifiers.md
@@ -1,0 +1,81 @@
+# ADR-047: Stable Turn Identifiers via UUID
+
+- **Status:** Accepted
+- **Date:** 2026-07
+- **Author:** Architect (tell-me-go)
+
+## Context
+
+Conversation turns are currently identified by their positional index within the history slice (`turnIndex int`). The `SetPinned` API, the `manage_history` tool, and the TUI history browser all use these integer indices to reference specific turns.
+
+This approach is fragile under summarization compaction. When the `summarize_history` tool compacts older turns — replacing N raw turns with a single summary turn pair — the indices of all remaining turns shift. Any pinned turn that survived compaction now occupies a different index. The result is twofold:
+
+1. **Pin identity is lost on re-reference.** After compaction, the agent or TUI cannot reliably toggle the pin state of a previously pinned turn because the index has changed. The in-memory `Pinned` boolean survives on the `llm.Content` struct, but the mapping from the external identifier (the index the agent received) to the correct content entry is broken.
+
+2. **Manual summarization ignores pinned status.** The `summarize_history` tool accepts a raw `turns` count from the LLM and passes it directly to `SummarizeRange`. It does not consult the `Pinned` field at all. The auto-summarization path (via `TokenGatekeeper`) already uses `contiguousUnpinnedSelector` to skip pinned turns, but the tool-driven path has no such guard. An LLM that calls `summarize_history(turns=5)` will bulldoze through pinned turns.
+
+A third, related concern is the `manage_history` tool's `index: integer` parameter: the LLM sees only integer indices in its conversation history. After compaction, the index it remembers is stale.
+
+## Decision
+
+**Add stable UUID-based turn identifiers and update all pin-related APIs to use them.**
+
+### 1. `llm.Content` already carries an `ID string` field
+
+The `llm.Content` struct already defines `ID string` (`json:"id,omitempty"`) populated by `llm.NewID()` (UUIDv4) at creation time. This was originally included for deduplication; it becomes the stable turn identity.
+
+### 2. Change `SetPinned` signature
+
+```go
+// Before
+SetPinned(ctx context.Context, turnIndex int, pinned bool) error
+
+// After
+SetPinned(ctx context.Context, turnID string, pinned bool) error
+```
+
+The implementation locates the turn by scanning `Contents` for a matching `ID` field, toggles `Pinned` on both messages in the turn, and persists the metadata update via `store.UpdateMetadata`.
+
+### 3. Interface ripple
+
+The `SetPinned` method belongs to the `HistoryManager` interface (`ports` package or equivalent). All ~30 implementations (production `history.Manager`, mocks in `agenttest`, `cli`, `ui/tui`, `infrastructure/di`, and test stubs) will adopt the new signature.
+
+### 4. Lazy migration on `Load()`
+
+Legacy history files predating this ADR will have empty `ID` fields. On `Load()`, the `Manager` will scan all loaded `Content` entries and backfill any missing IDs with fresh UUIDv4 values, then persist the updated file. This is a one-time, transparent migration with no user action required.
+
+### 5. `manage_history` tool keeps `index: integer` in JSON schema
+
+The LLM-facing JSON schema retains `index: integer` for agent ergonomics (LLMs reason naturally about "the 3rd turn"). At call time, the tool handler resolves the index to a UUID:
+
+1. Acquire read lock on `Contents`.
+2. Map `index` → `Contents[offset + index*2].ID`.
+3. Release lock, call `SetPinned(ctx, id, pinned)`.
+
+This preserves the LLM's existing mental model while insulating it from index drift. The resolution is re-performed on every call, so a newly compacted session uses the latest index mapping.
+
+## Consequences
+
+### Positive
+
+- **Pin identity survives compaction.** Because the UUID is stable across the lifetime of a `Content` entry, pin toggles always target the correct turn regardless of how many compaction rounds occur.
+- **TUI toggle round-trips correctly.** The TUI history browser resolves indices to UUIDs the same way `manage_history` does. Pinning/unpinning a turn in the TUI, then summarizing, then toggling again targets the same turn.
+- **Manual summarization gains pin awareness.** The `summarize_history` tool path can now use `contiguousUnpinnedSelector` (already implemented for auto-summarization) to skip pinned turns, or at minimum warn when pinned turns would be destroyed. This closes the gap between auto-summarization (which respects pins) and manual summarization (which currently does not).
+- **Forward-compatible migration.** The lazy backfill on `Load()` means no user-visible migration step. Old sessions silently gain UUIDs on first load.
+
+### Negative
+
+- **`google/uuid` becomes a direct dependency.** The `llm.NewID()` function currently generates UUIDs; if it doesn't already depend on `google/uuid`, it will now. (This is a minor, well-known dependency with no transitive risk.)
+- **~30 call sites need interface updates.** Every implementation and mock of `SetPinned` must change its signature. This is mechanical — the compiler enforces correctness — but it is a large diff.
+- **ID scan on `SetPinned` is O(n).** Scanning `Contents` by UUID is linear; for typical history sizes (hundreds, not thousands of turns) this is negligible. If profiling reveals it as a bottleneck, an internal `map[string]int` index can be added to the `Manager` without changing the public API.
+- **Legacy history files without IDs get modified on load.** The lazy migration writes back to disk. For read-only filesystems or archived histories, the migration will fail on save. The `Load()` path should gracefully degrade — IDs are assigned in memory even if persistence fails.
+
+### Trade-off
+
+- **`manage_history` index → UUID resolution is a leaky abstraction.** The LLM still thinks in indices. After a compaction round, the LLM's mental index may be stale — it might say "pin turn 3" when turn 3 has already been compacted away. In practice, the LLM typically pins turns *before* summarizing, and the TUI is the primary interface for post-hoc pin management. The resolution layer is a pragmatic bridge, not a perfect solution. A future ADR could introduce `manage_history` with explicit UUID parameters if agent ergonomics improve.
+
+## References
+
+- [ADR-006: History Log Compaction and Bounded Contexts](2026-01-history-log-compaction.md)
+- [ADR-008: Bubble Tea Interactive History Browser](2026-02-bubble-tea-history-browser.md)
+- [ADR-019: JSONL History Persistence](2026-04-jsonl-history-persistence.md)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -52,6 +52,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-044** | Token Counter Decomposition | 2026-01 | Accepted | [2026-01-token-counter-decomposition.md](2026-01-token-counter-decomposition.md) |
 | **ADR-045** | Single-Process Crew — Rejected | 2026-07 | Rejected | [2026-07-single-process-crew-rejected.md](2026-07-single-process-crew-rejected.md) |
 | **ADR-046** | Remove `ask_user` Tool — Turn Boundaries Replace Mid-Turn Prompts | 2026-07 | Accepted | [2026-07-remove-ask-user-tool.md](2026-07-remove-ask-user-tool.md) |
+| **ADR-047** | Stable Turn Identifiers via UUID | 2026-07 | Accepted | [2026-07-stable-turn-identifiers.md](2026-07-stable-turn-identifiers.md) |
 
 ## How to Create a New ADR
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/fsnotify/fsnotify v1.10.1
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
+	github.com/google/uuid v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
@@ -62,7 +63,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/pprof v0.0.0-20260604005048-7023385849c0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.16 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/internal/agent/agenttest/mock_history_manager.go
+++ b/internal/agent/agenttest/mock_history_manager.go
@@ -105,7 +105,7 @@ func (m *MockHistoryManager) AppendParts(ctx context.Context, index int, parts [
 }
 
 func (m *MockHistoryManager) GetResolver() llm.AssetResolver { return m.resolver }
-func (m *MockHistoryManager) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *MockHistoryManager) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	return nil
 }
 func (m *MockHistoryManager) Save(ctx context.Context) error { return nil }

--- a/internal/agent/agenttest/mock_history_manager_test.go
+++ b/internal/agent/agenttest/mock_history_manager_test.go
@@ -495,7 +495,7 @@ func TestMockHistoryManager_SetPinned_ReturnsNil(t *testing.T) {
 	t.Parallel()
 
 	m := newMockWithContents(3)
-	err := m.SetPinned(context.Background(), 1, true)
+	err := m.SetPinned(context.Background(), "test-id", true)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/agent/mocks_test.go
+++ b/internal/agent/mocks_test.go
@@ -101,9 +101,15 @@ func (m *mockHistoryManager) GetResolver() llm.AssetResolver {
 	return m.Resolver
 }
 
-func (m *mockHistoryManager) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *mockHistoryManager) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// Parse turnID as integer for backward compatibility with index-based tests.
+	// Production code passes stable UUIDs; internal tests pass stringified indices.
+	var turnIndex int
+	if _, err := fmt.Sscanf(turnID, "%d", &turnIndex); err != nil {
+		return fmt.Errorf("invalid turn ID: %s", turnID)
+	}
 	startIdx := turnIndex * 2
 	if startIdx < 0 || startIdx+1 >= len(m.Contents) {
 		return fmt.Errorf("invalid turn index")

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -517,7 +517,7 @@ func (m *mockHistoryManagerForRetry) Save(ctx context.Context) error { return ni
 func (m *mockHistoryManagerForRetry) Archive(ctx context.Context, contents []*llm.Content) error {
 	return nil
 }
-func (m *mockHistoryManagerForRetry) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *mockHistoryManagerForRetry) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	return nil
 }
 func (m *mockHistoryManagerForRetry) RollbackTurns(ctx context.Context, turns int) (int, int, int, error) {

--- a/internal/agent/session/context/context_manager_helpers_test.go
+++ b/internal/agent/session/context/context_manager_helpers_test.go
@@ -4,41 +4,15 @@
 package context
 
 import (
+	"context"
+	"fmt"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestCalculateSummarizationEndIndex(t *testing.T) {
-	turns := [][]*llm.Content{
-		{{Role: "user", Parts: []*llm.Part{{Text: "u1"}}}, {Role: "model", Parts: []*llm.Part{{Text: "m1"}}}},
-		{{Role: "user", Parts: []*llm.Part{{Text: "u2"}}}, {Role: "model", Parts: []*llm.Part{{Text: "m2"}}}},
-		{{Role: "user", Parts: []*llm.Part{{Text: "u3"}}}, {Role: "model", Parts: []*llm.Part{{Text: "m3"}}}},
-	}
-
-	tests := []struct {
-		name           string
-		requestedTurns int
-		expectedEndIdx int
-		expectedTurns  int
-	}{
-		{"Normal", 2, 4, 2},
-		{"TooMany", 5, 4, 2},
-		{"All", 3, 4, 2},
-		{"Zero", 0, 0, 0},
-		{"Negative", -1, 0, 0},
-		{"One", 1, 2, 1},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			endIdx, turnsUsed := calculateSummarizationEndIndex(turns, tt.requestedTurns)
-			assert.Equal(t, tt.expectedEndIdx, endIdx)
-			assert.Equal(t, tt.expectedTurns, turnsUsed)
-		})
-	}
-}
 
 func TestIsTokenCountSafe(t *testing.T) {
 	tests := []struct {
@@ -60,4 +34,132 @@ func TestIsTokenCountSafe(t *testing.T) {
 			assert.Equal(t, int(float64(tt.window)*0.9), limit)
 		})
 	}
+}
+
+// makePinnableTurns creates N turns (each turn = user + model) as []*llm.Content.
+// pinnedIndices contains zero-based turn indices whose messages will have Pinned=true.
+func makePinnableTurns(n int, pinnedIndices ...int) []*llm.Content {
+	pinned := make(map[int]bool)
+	for _, idx := range pinnedIndices {
+		pinned[idx] = true
+	}
+	var contents []*llm.Content
+	for i := 0; i < n; i++ {
+		c1 := &llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i+1)}}, Pinned: pinned[i]}
+		c2 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i+1)}}, Pinned: pinned[i]}
+		contents = append(contents, c1, c2)
+	}
+	return contents
+}
+
+func TestFindSummarizationBoundary_PinnedAware(t *testing.T) {
+	tests := []struct {
+		name         string
+		contents     []*llm.Content
+		numTurns     int
+		wantStartIdx int
+		wantEndIdx   int
+		wantNil      bool
+	}{
+		{
+			name:         "all unpinned, request 2",
+			contents:     makePinnableTurns(4), // 4 turns, all unpinned
+			numTurns:     2,
+			wantStartIdx: 0,
+			wantEndIdx:   4, // turns 0+1 → messages [0:4]
+		},
+		{
+			name:         "first turn pinned, skips it",
+			contents:     makePinnableTurns(4, 0), // turn 0 pinned
+			numTurns:     2,
+			wantStartIdx: 2, // skip turn 0, use turns 1+2
+			wantEndIdx:   6,
+		},
+		{
+			name:         "interspersed pins, skips pinned",
+			contents:     makePinnableTurns(5, 0, 2), // turns 0 and 2 pinned
+			numTurns:     2,
+			wantStartIdx: 6, // skip pinned, use turns 3+4
+			wantEndIdx:   10,
+		},
+		{
+			name:     "all pinned, no viable block",
+			contents: makePinnableTurns(4, 0, 1, 2, 3),
+			numTurns: 2,
+			wantNil:  true,
+		},
+		{
+			name:     "single unpinned, request exceeds available",
+			contents: makePinnableTurns(2, 0), // turn 0 pinned, turn 1 unpinned
+			numTurns: 3,
+			wantNil:  true, // best block count=1 < MinViableBlock=2
+		},
+		{
+			name:     "empty history",
+			contents: nil,
+			numTurns: 2,
+			wantNil:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tc := &agenttest.MockTokenCounter{}
+			strategy := NewStrategy(tc)
+			history := &agenttest.MockHistoryManager{}
+			history.SetInternalContents(tt.contents)
+			cm := NewManager(strategy, history, nil, nil)
+
+			ctx := context.Background()
+			totalEntries := len(tt.contents)
+
+			subset, startIdx, endIdx, err := cm.findSummarizationBoundary(ctx, tt.numTurns, totalEntries)
+			require.NoError(t, err)
+
+			if tt.wantNil {
+				assert.Nil(t, subset)
+				return
+			}
+
+			require.NotNil(t, subset)
+			assert.Equal(t, tt.wantStartIdx, startIdx, "startIdx mismatch")
+			assert.Equal(t, tt.wantEndIdx, endIdx, "endIdx mismatch")
+			assert.Len(t, subset, tt.wantEndIdx-tt.wantStartIdx, "subset length mismatch")
+		})
+	}
+}
+
+func TestFindSummarizationBoundary_WindowGrowth(t *testing.T) {
+	// 20 messages: first 16 are pinned (8 turns), last 4 are unpinned (2 turns).
+	// Requesting 2 turns → initial window of 8 msgs only sees pinned → window grows
+	// until it reaches 20, finally discovering the 2 unpinned turns at the end.
+	var contents []*llm.Content
+	for i := 0; i < 8; i++ {
+		contents = append(contents,
+			&llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("pu%d", i+1)}}, Pinned: true},
+			&llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("pm%d", i+1)}}, Pinned: true},
+		)
+	}
+	for i := 0; i < 2; i++ {
+		contents = append(contents,
+			&llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i+1)}}},
+			&llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i+1)}}},
+		)
+	}
+
+	tc := &agenttest.MockTokenCounter{}
+	strategy := NewStrategy(tc)
+	history := &agenttest.MockHistoryManager{}
+	history.SetInternalContents(contents)
+	cm := NewManager(strategy, history, nil, nil)
+
+	ctx := context.Background()
+	subset, startIdx, endIdx, err := cm.findSummarizationBoundary(ctx, 2, len(contents))
+	require.NoError(t, err)
+	require.NotNil(t, subset)
+
+	// Expect the last 2 unpinned turns (messages [16:20]).
+	assert.Equal(t, 16, startIdx)
+	assert.Equal(t, 20, endIdx)
+	assert.Len(t, subset, 4)
 }

--- a/internal/agent/session/context/context_manager_test.go
+++ b/internal/agent/session/context/context_manager_test.go
@@ -356,15 +356,16 @@ func TestManager_WindowSize_BoundaryCondition(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Requesting 5 turns, but history only has 2 turns.
-	// It should reach the end (windowSize = 25), then cap numTurns to totalTurns - 1 = 1.
+	// Requesting 5 turns, but history only has 2 turns (both unpinned candidates).
+	// The pin-aware selector finds 2 candidate turns but leaves at least one
+	// turn unsummarized, so it caps at 1 turn (meets MinViableBlock=2 before capping).
 	msg, _, err := cm.SummarizeRange(ctx, 5, "")
 	assert.NoError(t, err)
 	assert.Contains(t, msg, "summarized the first 1 turns")
 
-	// Verify history was updated (summarized 1 turn = 24 messages replaced by 2 summary messages)
+	// Verify history was updated (summarized 1 turn = 24 messages replaced by 2 summary messages).
 	// Original: 25 messages. Turn 1 (24 msgs), Turn 2 (1 msg).
-	// After summarization of Turn 1: 2 summary messages + 1 message from Turn 2 = 3 messages.
+	// After summarization: 2 summary messages + 1 remaining message = 3.
 	assert.Equal(t, 3, history.GetTotalEntries())
 }
 
@@ -866,4 +867,103 @@ func TestWithSessionProvider(t *testing.T) {
 		sessctx.WithSessionProvider(&testfixtures.MockSessionProvider{}),
 	)
 	assert.NotNil(t, cm.SessionProvider)
+}
+
+// makePinnableTurnsExt creates N turns (each turn = user + model) as []*llm.Content.
+// pinnedIndices contains zero-based turn indices whose messages will have Pinned=true.
+func makePinnableTurnsExt(n int, pinnedIndices ...int) []*llm.Content {
+	pinned := make(map[int]bool)
+	for _, idx := range pinnedIndices {
+		pinned[idx] = true
+	}
+	var contents []*llm.Content
+	for i := 0; i < n; i++ {
+		c1 := &llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i+1)}}, Pinned: pinned[i]}
+		c2 := &llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i+1)}}, Pinned: pinned[i]}
+		contents = append(contents, c1, c2)
+	}
+	return contents
+}
+
+func TestSummarizeRange_PinnedAware(t *testing.T) {
+	tests := []struct {
+		name        string
+		contents    []*llm.Content
+		numTurns    int
+		wantErr     bool
+		errContains string
+		// Captured subset passed to summarizer (verified in non-error/non-skip cases)
+		wantSubsetMsgCount int
+		wantMsgContains    string // text expected in first message of subset
+	}{
+		{
+			name:     "contiguous skip: T2 pinned → T3+T4 summarized, T2 untouched",
+			contents: makePinnableTurnsExt(4, 1), // T0=unpinned, T1=pinned, T2=unpinned, T3=unpinned
+			numTurns: 2,
+			// Subset should be T2+T3 (messages 4-7: "u3","m3","u4","m4")
+			wantSubsetMsgCount: 4,
+			wantMsgContains:    "u3",
+		},
+		{
+			name:        "no viable block: all pinned",
+			contents:    makePinnableTurnsExt(4, 0, 1, 2, 3),
+			numTurns:    2,
+			wantErr:     false,
+			errContains: "too short",
+		},
+		{
+			name:     "normal unpinned: first 2 turns summarized",
+			contents: makePinnableTurnsExt(4),
+			numTurns: 2,
+			// Subset should be T0+T1 (messages 0-3: "u1","m1","u2","m2")
+			wantSubsetMsgCount: 4,
+			wantMsgContains:    "u1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			counter := &agenttest.MockTokenCounter{}
+			strategy := sessctx.NewStrategy(counter)
+			strategy.SetContextWindow(1000000)
+
+			history := &agenttest.MockHistoryManager{}
+			history.SetInternalContents(tt.contents)
+
+			cm := sessctx.NewManager(strategy, history, nil, nil)
+
+			var capturedSubset []*llm.Content
+			mockSum := &agenttest.MockSummarizer{}
+			mockSum.SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
+				capturedSubset = subset
+				return "summary", &llm.Metrics{PromptTokens: 5}, nil
+			})
+			cm.Summarizer = mockSum
+
+			ctx := context.Background()
+			msg, _, err := cm.SummarizeRange(ctx, tt.numTurns, "")
+
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.errContains != "" {
+					assert.Contains(t, err.Error(), tt.errContains)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.errContains != "" {
+				// Non-error path that returns a specific message (e.g., "too short")
+				assert.Contains(t, msg, tt.errContains)
+				return
+			}
+
+			// Verify the subset passed to summarizer
+			require.NotNil(t, capturedSubset, "summarizer should have been called")
+			assert.Len(t, capturedSubset, tt.wantSubsetMsgCount, "subset message count mismatch")
+			require.NotEmpty(t, capturedSubset)
+			assert.Contains(t, capturedSubset[0].Parts[0].Text, tt.wantMsgContains)
+		})
+	}
 }

--- a/internal/agent/session/context/error_coverage_test.go
+++ b/internal/agent/session/context/error_coverage_test.go
@@ -496,3 +496,39 @@ func TestCheckWindowSize_EndIdxZero(t *testing.T) {
 	require.Equal(t, 0, endIdx)
 	require.NoError(t, err)
 }
+
+func TestValidateSummarizationSubset_DetectsPinMutation(t *testing.T) {
+	cm := &Manager{}
+	ctx := context.Background()
+
+	current := []*llm.Content{
+		{Role: "user", ID: "id-1", Pinned: false, Parts: []*llm.Part{{Text: "u"}}},
+		{Role: "model", ID: "id-2", Pinned: false, Parts: []*llm.Part{{Text: "m"}}},
+	}
+
+	subset := []*llm.Content{
+		{Role: "user", ID: "id-1", Pinned: false, Parts: []*llm.Part{{Text: "u"}}},
+		{Role: "model", ID: "id-2", Pinned: false, Parts: []*llm.Part{{Text: "m"}}},
+	}
+
+	// Baseline: success
+	err := cm.validateSummarizationSubset(ctx, current, subset, 0)
+	require.NoError(t, err)
+
+	// Mutation 1: ID changed (e.g. somehow replaced)
+	current[0].ID = "id-changed"
+	err = cm.validateSummarizationSubset(ctx, current, subset, 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, llm.ErrTerminal)
+	require.Contains(t, err.Error(), "history content changed")
+
+	// Revert
+	current[0].ID = "id-1"
+
+	// Mutation 2: Pin state changed during summarization
+	current[1].Pinned = true
+	err = cm.validateSummarizationSubset(ctx, current, subset, 0)
+	require.Error(t, err)
+	require.ErrorIs(t, err, llm.ErrTerminal)
+	require.Contains(t, err.Error(), "history content changed")
+}

--- a/internal/agent/session/context/error_coverage_test.go
+++ b/internal/agent/session/context/error_coverage_test.go
@@ -27,7 +27,7 @@ func TestContextManager_FindSummarizationBoundary_Cancelled(t *testing.T) {
 	}}
 	cm := NewManager(nil, hm, nil, nil)
 
-	_, _, err := cm.findSummarizationBoundary(ctx, 1, 1)
+	_, _, _, err := cm.findSummarizationBoundary(ctx, 1, 1)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
@@ -45,7 +45,7 @@ func TestContextManager_ValidateSubset_Cancelled(t *testing.T) {
 		current[i] = &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "msg"}}}
 	}
 
-	err := cm.validateSummarizationSubset(ctx, current, subset)
+	err := cm.validateSummarizationSubset(ctx, current, subset, 0)
 	require.ErrorIs(t, err, context.Canceled)
 }
 
@@ -141,7 +141,7 @@ func TestContextManager_FinalizeSummarization_ArchiveError(t *testing.T) {
 		{Role: "model", Parts: []*llm.Part{{Text: "2"}}},
 	}
 
-	err := cm.finalizeSummarization(context.Background(), subset, 2, "summary")
+	err := cm.finalizeSummarization(context.Background(), subset, 0, 2, "summary")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to archive history")
 }
@@ -171,7 +171,7 @@ func TestContextManager_FinalizeSummarization_SetContentsError(t *testing.T) {
 		{Role: "model", Parts: []*llm.Part{{Text: "2"}}},
 	}
 
-	err := cm.finalizeSummarization(context.Background(), subset, 2, "summary")
+	err := cm.finalizeSummarization(context.Background(), subset, 0, 2, "summary")
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to update history after summarization")
 }
@@ -190,7 +190,7 @@ func TestContextManager_FinalizeSummarization_PrunedError(t *testing.T) {
 		{Role: "model", Parts: []*llm.Part{{Text: "2"}}},
 	}
 
-	err := cm.finalizeSummarization(context.Background(), subset, 2, "summary")
+	err := cm.finalizeSummarization(context.Background(), subset, 0, 2, "summary")
 	require.Error(t, err)
 	require.ErrorIs(t, err, llm.ErrTerminal)
 	require.Contains(t, err.Error(), "summarization aborted: history was pruned")
@@ -488,10 +488,11 @@ func TestCheckWindowSize_EndIdxZero(t *testing.T) {
 	cm := NewManager(strategy, hm, nil, nil)
 
 	ctx := context.Background()
-	found, subset, endIdx, err := cm.checkWindowSize(ctx, 2, 5, 2)
+	found, subset, startIdx, endIdx, err := cm.checkWindowSize(ctx, 2, 5, 2)
 
 	require.True(t, found)
 	require.Nil(t, subset)
+	require.Equal(t, 0, startIdx)
 	require.Equal(t, 0, endIdx)
 	require.NoError(t, err)
 }

--- a/internal/agent/session/context/gatekeeper.go
+++ b/internal/agent/session/context/gatekeeper.go
@@ -398,10 +398,12 @@ func applySummaryToHistory(history []*llm.Content, start, end int, summary strin
 
 	sumUser := &llm.Content{
 		Role:  "user",
+		ID:    llm.NewID(),
 		Parts: []*llm.Part{{Text: "system auto-summary (context limit reached):\n\n" + summary}},
 	}
 	sumModel := &llm.Content{
 		Role:  "model",
+		ID:    llm.NewID(),
 		Parts: []*llm.Part{{Text: "understood: context compressed"}},
 	}
 

--- a/internal/agent/session/context/group_turns_error_test.go
+++ b/internal/agent/session/context/group_turns_error_test.go
@@ -155,7 +155,7 @@ func TestSummarizeRange_GroupTurns_ErrorPropagation(t *testing.T) {
 	cm := NewManager(NewStrategy(mockCounter), mockHistory, nil, nil)
 	cm.Summarizer = &agenttest.MockSummarizer{}
 
-	subset, _, _, err := cm.prepareSummarizationMetadata(ctx, 2)
+	subset, _, _, _, err := cm.prepareSummarizationMetadata(ctx, 2)
 	require.NoError(t, err)
 	require.NotNil(t, subset)
 	require.Equal(t, "", subset[0].Role, "Sabotage should have taken effect")

--- a/internal/agent/session/context/manager.go
+++ b/internal/agent/session/context/manager.go
@@ -591,7 +591,10 @@ func (cm *Manager) validateSummarizationSubset(ctx context.Context, currentConte
 			}
 		}
 
-		if !llm.EqualContent(currentContents[startIdx+i], expected) {
+		curr := currentContents[startIdx+i]
+
+		// ADR-047: Explicitly check UUID and Pin state, as llm.EqualContent ignores them.
+		if curr.ID != expected.ID || curr.Pinned != expected.Pinned || !llm.EqualContent(curr, expected) {
 			return fmt.Errorf("%w: summarization aborted: history content changed while summarizing", llm.ErrTerminal)
 		}
 	}

--- a/internal/agent/session/context/manager.go
+++ b/internal/agent/session/context/manager.go
@@ -33,6 +33,8 @@ type Manager struct {
 	Summarizer      ports.Summarizer
 	SessionProvider ports.SessionProvider
 	logger          ports.Logger
+
+	candidateSelector candidateSelector
 }
 
 // contextManagerOption defines a functional option for configuring the Manager.
@@ -48,11 +50,12 @@ func WithLogger(l ports.Logger) contextManagerOption {
 // NewManager creates a new context manager.
 func NewManager(strategy *Strategy, history ports.HistoryManager, bus events.EventBus, factory *Factory, opts ...contextManagerOption) *Manager {
 	cm := &Manager{
-		Strategy: strategy,
-		History:  history,
-		Events:   bus,
-		Factory:  factory,
-		logger:   slog.Default(),
+		Strategy:          strategy,
+		History:           history,
+		Events:            bus,
+		Factory:           factory,
+		logger:            slog.Default(),
+		candidateSelector: &contiguousUnpinnedSelector{},
 	}
 
 	for _, opt := range opts {
@@ -253,6 +256,11 @@ func (cm *Manager) AddContent(ctx context.Context, content *llm.Content) error {
 	default:
 	}
 
+	// Ensure stable identity for every message entering history
+	if content.ID == "" {
+		content.ID = llm.NewID()
+	}
+
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
@@ -364,7 +372,7 @@ func (cm *Manager) SummarizeRange(ctx context.Context, numTurns int, focus strin
 		return "", nil, err
 	}
 
-	subset, endIdx, tokens, err := cm.prepareSummarizationMetadata(ctx, numTurns)
+	subset, startIdx, endIdx, tokens, err := cm.prepareSummarizationMetadata(ctx, numTurns)
 	if err != nil || subset == nil {
 		return cm.handleSummarizationPrep(subset, err)
 	}
@@ -382,40 +390,40 @@ func (cm *Manager) SummarizeRange(ctx context.Context, numTurns int, focus strin
 		return "", nil, cm.wrapSummarizationError(err)
 	}
 
-	if err := cm.finalizeSummarization(ctx, subset, endIdx, summary); err != nil {
+	if err := cm.finalizeSummarization(ctx, subset, startIdx, endIdx, summary); err != nil {
 		return "", nil, err
 	}
 
 	return fmt.Sprintf("summarized the first %d turns of history", actualTurns), metrics, nil
 }
 
-func (cm *Manager) prepareSummarizationMetadata(ctx context.Context, numTurns int) (subset []*llm.Content, endIdx int, tokens int, err error) {
+func (cm *Manager) prepareSummarizationMetadata(ctx context.Context, numTurns int) (subset []*llm.Content, startIdx int, endIdx int, tokens int, err error) {
 	cm.mu.RLock()
 	totalEntries := cm.History.GetTotalEntries()
 	strategy := cm.Strategy
 	cm.mu.RUnlock()
 
 	if totalEntries == 0 {
-		return nil, 0, 0, nil
+		return nil, 0, 0, 0, nil
 	}
 
-	subset, endIdx, err = cm.findSummarizationBoundary(ctx, numTurns, totalEntries)
+	subset, startIdx, endIdx, err = cm.findSummarizationBoundary(ctx, numTurns, totalEntries)
 	if err != nil || subset == nil {
-		return subset, endIdx, 0, err
+		return subset, startIdx, endIdx, 0, err
 	}
 
 	tokens = strategy.EstimateTokens(subset)
 
 	window := strategy.getContextWindow()
 	if ok, limit := isTokenCountSafe(tokens, window); !ok {
-		return nil, 0, 0, fmt.Errorf("%w: summarization failed: the selected %d turns contain ~%d tokens, which exceeds the safety limit of %d. Please try summarizing a smaller number of turns", llm.ErrContextLimitExceeded, numTurns, tokens, limit)
+		return nil, 0, 0, 0, fmt.Errorf("%w: summarization failed: the selected %d turns contain ~%d tokens, which exceeds the safety limit of %d. Please try summarizing a smaller number of turns", llm.ErrContextLimitExceeded, numTurns, tokens, limit)
 	}
 
-	return subset, endIdx, tokens, nil
+	return subset, startIdx, endIdx, tokens, nil
 }
 
-func (cm *Manager) findSummarizationBoundary(ctx context.Context, numTurns int, totalEntries int) (subset []*llm.Content, endIdx int, err error) {
-	// Determine endIdx using a windowed load to avoid cloning the entire history if it's large.
+func (cm *Manager) findSummarizationBoundary(ctx context.Context, numTurns int, totalEntries int) (subset []*llm.Content, startIdx int, endIdx int, err error) {
+	// Determine boundary using a windowed load to avoid cloning the entire history if it's large.
 	// We'll start by loading a chunk that is likely to contain the requested number of turns.
 	windowSize := numTurns * 4 // Conservative estimate: 4 messages per turn on average
 	if windowSize > totalEntries {
@@ -424,15 +432,15 @@ func (cm *Manager) findSummarizationBoundary(ctx context.Context, numTurns int, 
 
 	for {
 		if err := cm.checkContext(ctx); err != nil {
-			return nil, 0, err
+			return nil, 0, 0, err
 		}
 
-		found, subset, endIdx, err := cm.checkWindowSize(ctx, windowSize, numTurns, totalEntries)
+		found, subset, startIdx, endIdx, err := cm.checkWindowSize(ctx, windowSize, numTurns, totalEntries)
 		if err != nil {
-			return nil, 0, err
+			return nil, 0, 0, err
 		}
 		if found {
-			return subset, endIdx, nil
+			return subset, startIdx, endIdx, nil
 		}
 
 		// Not enough turns found, increase window and try again.
@@ -443,31 +451,87 @@ func (cm *Manager) findSummarizationBoundary(ctx context.Context, numTurns int, 
 	}
 }
 
-func (cm *Manager) checkWindowSize(ctx context.Context, windowSize int, numTurns int, totalEntries int) (found bool, subset []*llm.Content, endIdx int, err error) {
+func (cm *Manager) checkWindowSize(ctx context.Context, windowSize int, numTurns int, totalEntries int) (found bool, subset []*llm.Content, startIdx int, endIdx int, err error) {
 	contents, err := cm.History.GetWindow(ctx, 0, windowSize)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, 0, err
 	}
 
 	turns, err := groupTurns(ctx, contents)
 	if err != nil {
-		return false, nil, 0, err
+		return false, nil, 0, 0, err
 	}
 
-	if len(turns) >= numTurns || windowSize >= totalEntries {
-		// Found enough turns or reached the end of history.
-		endIdx, _ = calculateSummarizationEndIndex(turns, numTurns)
-		if endIdx == 0 {
-			return true, nil, 0, nil
+	minViable := cm.candidateSelector.MinViableBlock()
+
+	// block tracks a contiguous run of candidate turns during the scan.
+	type block struct {
+		startMsg int
+		endMsg   int
+		count    int
+	}
+	var current *block
+	var best *block
+	msgIdx := 0
+
+	for _, turn := range turns {
+		isCandidate := cm.candidateSelector.IsCandidate(turn)
+
+		if isCandidate {
+			if current == nil {
+				current = &block{startMsg: msgIdx}
+			}
+			current.count++
+			current.endMsg = msgIdx + len(turn)
+
+			if current.count >= numTurns {
+				// Found enough candidate turns in this block.
+				subset = contents[current.startMsg:current.endMsg]
+				return true, subset, current.startMsg, current.endMsg, nil
+			}
+		} else {
+			if current != nil {
+				if best == nil || current.count > best.count {
+					best = current
+				}
+				current = nil
+			}
 		}
-
-		// subset is the first endIdx elements of contents.
-		// Since contents is already a deep clone from GetWindow, we can just slice it.
-		subset = contents[:endIdx]
-		return true, subset, endIdx, nil
+		msgIdx += len(turn)
 	}
 
-	return false, nil, 0, nil
+	// End of turns: check the final block.
+	if current != nil {
+		if best == nil || current.count > best.count {
+			best = current
+		}
+	}
+
+	// If we've reached the end of history, use the best block if viable.
+	if windowSize >= totalEntries {
+		if best != nil && best.count >= minViable {
+			// Leave at least one turn unsummarized by capping the block
+			// at (best.count - 1) turns when more than one turn exists.
+			cappedCount := best.count - 1
+			if cappedCount > 0 {
+				subTurns, err := groupTurns(ctx, contents[best.startMsg:best.endMsg])
+				if err != nil {
+					return false, nil, 0, 0, err
+				}
+				if len(subTurns) > 1 {
+					cappedEnd := best.endMsg - len(subTurns[len(subTurns)-1])
+					subset = contents[best.startMsg:cappedEnd]
+					return true, subset, best.startMsg, cappedEnd, nil
+				}
+			}
+			subset = contents[best.startMsg:best.endMsg]
+			return true, subset, best.startMsg, best.endMsg, nil
+		}
+		return true, nil, 0, 0, nil
+	}
+
+	// Not enough candidate turns yet, caller should increase the window.
+	return false, nil, 0, 0, nil
 }
 
 func isTokenCountSafe(tokens, window int) (bool, int) {
@@ -475,23 +539,7 @@ func isTokenCountSafe(tokens, window int) (bool, int) {
 	return tokens <= limit, limit
 }
 
-func calculateSummarizationEndIndex(turns [][]*llm.Content, requestedTurns int) (int, int) {
-	totalTurns := len(turns)
-	if requestedTurns >= totalTurns {
-		requestedTurns = totalTurns - 1
-	}
-	if requestedTurns < 1 {
-		return 0, 0
-	}
-
-	endIdx := 0
-	for i := 0; i < requestedTurns; i++ {
-		endIdx += len(turns[i])
-	}
-	return endIdx, requestedTurns
-}
-
-func (cm *Manager) finalizeSummarization(ctx context.Context, subset []*llm.Content, endIdx int, summary string) error {
+func (cm *Manager) finalizeSummarization(ctx context.Context, subset []*llm.Content, startIdx int, endIdx int, summary string) error {
 	cm.mu.Lock()
 	defer cm.mu.Unlock()
 
@@ -504,12 +552,12 @@ func (cm *Manager) finalizeSummarization(ctx context.Context, subset []*llm.Cont
 	}
 
 	// Robust check: did the messages we summarized change?
-	if err := cm.validateSummarizationSubset(ctx, currentContents, subset); err != nil {
+	if err := cm.validateSummarizationSubset(ctx, currentContents, subset, startIdx); err != nil {
 		return err
 	}
 
 	// Reconstruct history using the robust helper
-	newHistory := applySummaryToHistory(currentContents, 0, endIdx, summary)
+	newHistory := applySummaryToHistory(currentContents, startIdx, endIdx, summary)
 	cm.version++
 
 	// ✅ SCALABLE (Event-Sourced Archival):
@@ -533,7 +581,7 @@ func (cm *Manager) finalizeSummarization(ctx context.Context, subset []*llm.Cont
 	return nil
 }
 
-func (cm *Manager) validateSummarizationSubset(ctx context.Context, currentContents, subset []*llm.Content) error {
+func (cm *Manager) validateSummarizationSubset(ctx context.Context, currentContents, subset []*llm.Content, startIdx int) error {
 	for i, expected := range subset {
 		if i%100 == 0 {
 			select {
@@ -543,7 +591,7 @@ func (cm *Manager) validateSummarizationSubset(ctx context.Context, currentConte
 			}
 		}
 
-		if !llm.EqualContent(currentContents[i], expected) {
+		if !llm.EqualContent(currentContents[startIdx+i], expected) {
 			return fmt.Errorf("%w: summarization aborted: history content changed while summarizing", llm.ErrTerminal)
 		}
 	}

--- a/internal/agent/session/context/transformers.go
+++ b/internal/agent/session/context/transformers.go
@@ -252,6 +252,7 @@ func (t *HistoryRepairer) Transform(ctx context.Context, req *ports.ContextReque
 	if len(responses) > 0 {
 		req.History = append(req.History, &llm.Content{
 			Role:  "user",
+			ID:    llm.NewID(),
 			Parts: responses,
 		})
 		req.PersistHistory = true

--- a/internal/agent/session/internal_tools.go
+++ b/internal/agent/session/internal_tools.go
@@ -122,7 +122,13 @@ func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]inter
 		return tools.ToolResult{}, fmt.Errorf("unsupported action: %s", params.Action)
 	}
 
-	if err := t.ctxManager.History.SetPinned(ctx, params.Index, pinned); err != nil {
+	// Resolve ordinal turn index to stable UUID
+	turnID, err := resolveTurnID(ctx, t.ctxManager.History, params.Index)
+	if err != nil {
+		return tools.ToolResult{}, err
+	}
+
+	if err := t.ctxManager.History.SetPinned(ctx, turnID, pinned); err != nil {
 		return tools.ToolResult{}, err
 	}
 
@@ -130,7 +136,39 @@ func (t *InternalTools) ManageHistory(ctx context.Context, args map[string]inter
 	if pinned {
 		status = "pinned"
 	}
-	return tools.ToolResult{Text: fmt.Sprintf("turn %d has been successfully %s", params.Index, status)}, nil
+	return tools.ToolResult{Text: fmt.Sprintf("turn %s has been successfully %s", turnID, status)}, nil
+}
+
+// resolveTurnID resolves an ordinal turn index to the stable UUID of the
+// first message in that turn. It skips leading system messages and counts
+// turns as user+model pairs (accounting for tool-call messages).
+func resolveTurnID(ctx context.Context, history ports.HistoryReader, index int) (string, error) {
+	contents, err := history.GetWindow(ctx, 0, -1)
+	if err != nil {
+		return "", fmt.Errorf("resolve turn id: %w", err)
+	}
+
+	// Skip system messages at position 0
+	start := 0
+	for start < len(contents) && contents[start].Role == "system" {
+		start++
+	}
+
+	// Count turns from remaining messages (each turn starts with a user message)
+	turnCount := 0
+	for i := start; i < len(contents); i++ {
+		if contents[i].Role == "user" {
+			if turnCount == index {
+				if contents[i].ID == "" {
+					return "", fmt.Errorf("turn %d has no stable ID", index)
+				}
+				return contents[i].ID, nil
+			}
+			turnCount++
+		}
+	}
+
+	return "", fmt.Errorf("turn index %d out of range (only %d turns available)", index, turnCount)
 }
 
 // RegisterInternal registers the internal tools with the provided registrar.

--- a/internal/agent/session/internal_tools_test.go
+++ b/internal/agent/session/internal_tools_test.go
@@ -50,13 +50,19 @@ type setPinnedFailingHM struct {
 	err error
 }
 
-func (m *setPinnedFailingHM) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *setPinnedFailingHM) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	return m.err
 }
 
 func TestManageHistory_SetPinnedError(t *testing.T) {
+	baseHM := &agenttest.MockHistoryManager{}
+	baseHM.SetInternalContents([]*llm.Content{
+		{Role: "user", ID: "turn-0-user", Parts: []*llm.Part{{Text: "hello"}}},
+		{Role: "model", ID: "turn-0-model", Parts: []*llm.Part{{Text: "hi"}}},
+	})
+
 	failingHM := &setPinnedFailingHM{
-		HistoryManager: &failingHMBase{},
+		HistoryManager: baseHM,
 		err:            errors.New("set pinned failed"),
 	}
 
@@ -75,8 +81,14 @@ func TestManageHistory_SetPinnedError(t *testing.T) {
 }
 
 func TestManageHistory_SetPinnedError_Unpin(t *testing.T) {
+	baseHM := &agenttest.MockHistoryManager{}
+	baseHM.SetInternalContents([]*llm.Content{
+		{Role: "user", ID: "turn-1-user", Parts: []*llm.Part{{Text: "hello"}}},
+		{Role: "model", ID: "turn-1-model", Parts: []*llm.Part{{Text: "hi"}}},
+	})
+
 	failingHM := &setPinnedFailingHM{
-		HistoryManager: &failingHMBase{},
+		HistoryManager: baseHM,
 		err:            errors.New("set pinned failed"),
 	}
 
@@ -85,7 +97,7 @@ func TestManageHistory_SetPinnedError_Unpin(t *testing.T) {
 
 	args := map[string]interface{}{
 		"action": "unpin",
-		"index":  float64(1),
+		"index":  float64(0),
 	}
 
 	result, err := tools.ManageHistory(context.Background(), args, nil)
@@ -131,7 +143,7 @@ func (m *failingHMBase) AppendParts(ctx context.Context, i int, p []*llm.Part) e
 func (m *failingHMBase) Save(ctx context.Context) error                              { return nil }
 func (m *failingHMBase) Sync(ctx context.Context) error                              { return nil }
 func (m *failingHMBase) Archive(ctx context.Context, c []*llm.Content) error         { return nil }
-func (m *failingHMBase) SetPinned(ctx context.Context, i int, p bool) error          { return nil }
+func (m *failingHMBase) SetPinned(ctx context.Context, i string, p bool) error       { return nil }
 func (m *failingHMBase) GetFilePath() string                                         { return "" }
 func (m *failingHMBase) RollbackTurns(ctx context.Context, t int) (int, int, int, error) {
 	return 0, 0, 0, nil
@@ -357,21 +369,23 @@ func TestManageHistory_UnsupportedAction(t *testing.T) {
 }
 
 func TestManageHistory_OutOfBoundsIndex(t *testing.T) {
-	failingHM := &setPinnedFailingHM{
-		HistoryManager: &failingHMBase{},
-		err:            errors.New("index out of range"),
-	}
-	cm := &sessctx.Manager{History: failingHM}
+	baseHM := &agenttest.MockHistoryManager{}
+	baseHM.SetInternalContents([]*llm.Content{
+		{Role: "user", ID: "turn-0-user", Parts: []*llm.Part{{Text: "hello"}}},
+		{Role: "model", ID: "turn-0-model", Parts: []*llm.Part{{Text: "hi"}}},
+	})
+
+	cm := &sessctx.Manager{History: baseHM}
 	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	args := map[string]interface{}{
 		"action": "pin",
-		"index":  float64(99999),
+		"index":  float64(5),
 	}
 
 	result, err := it.ManageHistory(context.Background(), args, nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "index out of range")
+	require.Contains(t, err.Error(), "out of range")
 	require.Empty(t, result.Text)
 }
 
@@ -391,27 +405,36 @@ func TestManageHistory_UnmarshalArgsError(t *testing.T) {
 }
 
 func TestManageHistory_Success(t *testing.T) {
-	cm := &sessctx.Manager{History: &failingHMBase{}}
+	history := &agenttest.MockHistoryManager{}
+	history.SetInternalContents([]*llm.Content{
+		{Role: "system", ID: "sys-1", Parts: []*llm.Part{{Text: "system prompt"}}},
+		{Role: "user", ID: "turn-0-user", Parts: []*llm.Part{{Text: "hello"}}},
+		{Role: "model", ID: "turn-0-model", Parts: []*llm.Part{{Text: "hi"}}},
+		{Role: "user", ID: "turn-1-user", Parts: []*llm.Part{{Text: "how are you"}}},
+		{Role: "model", ID: "turn-1-model", Parts: []*llm.Part{{Text: "good"}}},
+	})
+
+	cm := &sessctx.Manager{History: history}
 	it := NewInternalTools(cm, &ports.NoOpLogger{})
 
 	t.Run("pin", func(t *testing.T) {
 		args := map[string]interface{}{
 			"action": "pin",
-			"index":  float64(2),
+			"index":  float64(1),
 		}
 		result, err := it.ManageHistory(context.Background(), args, nil)
 		require.NoError(t, err)
-		require.Contains(t, result.Text, "turn 2 has been successfully pinned")
+		require.Contains(t, result.Text, "turn turn-1-user has been successfully pinned")
 	})
 
 	t.Run("unpin", func(t *testing.T) {
 		args := map[string]interface{}{
 			"action": "unpin",
-			"index":  float64(3),
+			"index":  float64(0),
 		}
 		result, err := it.ManageHistory(context.Background(), args, nil)
 		require.NoError(t, err)
-		require.Contains(t, result.Text, "turn 3 has been successfully unpinned")
+		require.Contains(t, result.Text, "turn turn-0-user has been successfully unpinned")
 	})
 }
 

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -57,7 +57,7 @@ func (s *stubHistoryManager) AppendParts(_ stdctx.Context, _ int, _ []*llm.Part)
 func (s *stubHistoryManager) Save(_ stdctx.Context) error                              { return nil }
 func (s *stubHistoryManager) Sync(_ stdctx.Context) error                              { return nil }
 func (s *stubHistoryManager) Archive(_ stdctx.Context, _ []*llm.Content) error         { return nil }
-func (s *stubHistoryManager) SetPinned(_ stdctx.Context, _ int, _ bool) error          { return nil }
+func (s *stubHistoryManager) SetPinned(_ stdctx.Context, _ string, _ bool) error       { return nil }
 func (s *stubHistoryManager) GetFilePath() string                                      { return "" }
 func (s *stubHistoryManager) RollbackTurns(_ stdctx.Context, _ int) (int, int, int, error) {
 	return 0, 0, 0, nil

--- a/internal/domain/llm/types.go
+++ b/internal/domain/llm/types.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/google/uuid"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
@@ -17,6 +18,7 @@ import (
 
 type Content struct {
 	Role           string  `json:"role"`
+	ID             string  `json:"id,omitempty"`
 	Parts          []*Part `json:"parts,omitempty"`
 	TokenCount     int     `json:"token_count,omitempty"`
 	Pinned         bool    `json:"pinned,omitempty"`
@@ -132,6 +134,7 @@ func (p *Part) canMergeWith(other *Part) bool {
 func (c *Content) clone() *Content {
 	clone := &Content{
 		Role:       c.Role,
+		ID:         c.ID,
 		TokenCount: c.TokenCount,
 		Pinned:     c.Pinned,
 	}
@@ -213,6 +216,11 @@ func (fr *FunctionResponse) clone() *FunctionResponse {
 		}
 	}
 	return clone
+}
+
+// NewID returns a new unique identifier string (UUID v4).
+func NewID() string {
+	return uuid.New().String()
 }
 
 // CloneContent returns a deep copy of Content.

--- a/internal/domain/ports/history.go
+++ b/internal/domain/ports/history.go
@@ -68,10 +68,10 @@ type HistoryModifier interface {
 	// via GetWindow but remains available through ArchiveReader.
 	Archive(ctx context.Context, contents []*llm.Content) error
 
-	// SetPinned marks or unmarks a specific turn as pinned. Pinned turns
-	// are exempt from automatic pruning and summarization. turnIndex
-	// refers to the turn number in active memory.
-	SetPinned(ctx context.Context, turnIndex int, pinned bool) error
+	// SetPinned marks or unmarks a specific turn as pinned by its stable
+	// UUID identifier. Pinned turns are exempt from automatic pruning
+	// and summarization. The turnID corresponds to llm.Content.ID.
+	SetPinned(ctx context.Context, turnID string, pinned bool) error
 
 	// GetFilePath returns the filesystem path to the active history file.
 	// This is primarily used for logging and diagnostic purposes.

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -62,7 +62,7 @@ func NewBootstrapper(cfg BootstrapperConfig) *Bootstrapper {
 		cfg.RegisterAllTools, cfg.RegisterMetrics,
 	)
 	b.telemetryFactory = newTelemetryFactory(cfg.HomeDir, cfg.FileSystem, cfg.SM, cfg.Logger)
-	b.historyFactory = newHistoryFactory(cfg.HomeDir, cfg.FileSystem)
+	b.historyFactory = newHistoryFactory(cfg.HomeDir, cfg.FileSystem, cfg.Logger)
 	b.healthFactory = newHealthFactory()
 	b.uiFactory = newUIFactory(cfg.SM, cfg.Stdout, cfg.Stderr, cfg.Logger)
 	b.chatFactory = newChatFactory(cfg.HomeDir, cfg.Version, cfg.Stdout, cfg.Stderr, cfg.SM, cfg.FileSystem, b, b.uiFactory)

--- a/internal/infrastructure/di/factory_error_test.go
+++ b/internal/infrastructure/di/factory_error_test.go
@@ -94,7 +94,7 @@ type mockHistoryManagerFull struct {
 	SaveFunc                func(ctx context.Context) error
 	SyncFunc                func(ctx context.Context) error
 	ArchiveFunc             func(ctx context.Context, contents []*llm.Content) error
-	SetPinnedFunc           func(ctx context.Context, turnIndex int, pinned bool) error
+	SetPinnedFunc           func(ctx context.Context, turnID string, pinned bool) error
 	GetFilePathFunc         func() string
 	RollbackTurnsFunc       func(ctx context.Context, turns int) (int, int, int, error)
 	getWindowCalls          int
@@ -192,10 +192,10 @@ func (m *mockHistoryManagerFull) Archive(ctx context.Context, contents []*llm.Co
 	return nil
 }
 
-func (m *mockHistoryManagerFull) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *mockHistoryManagerFull) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	m.setPinnedCalls++
 	if m.SetPinnedFunc != nil {
-		return m.SetPinnedFunc(ctx, turnIndex, pinned)
+		return m.SetPinnedFunc(ctx, turnID, pinned)
 	}
 	return nil
 }

--- a/internal/infrastructure/di/history_factory.go
+++ b/internal/infrastructure/di/history_factory.go
@@ -23,12 +23,14 @@ type historyFactory interface {
 type defaultHistoryFactory struct {
 	HomeDir    string
 	FileSystem infra_persistence.FileSystem
+	Logger     ports.Logger
 }
 
-func newHistoryFactory(homeDir string, fs infra_persistence.FileSystem) historyFactory {
+func newHistoryFactory(homeDir string, fs infra_persistence.FileSystem, logger ports.Logger) historyFactory {
 	return &defaultHistoryFactory{
 		HomeDir:    homeDir,
 		FileSystem: fs,
+		Logger:     logger,
 	}
 }
 
@@ -38,7 +40,7 @@ func (f *defaultHistoryFactory) BuildHistoryManager(ctx stdctx.Context, cfg *con
 		return nil, fmt.Errorf("%w: failed to ensure session directories for %s: %w", errInfraInit, cfg.Mode, err)
 	}
 
-	hManager := history.NewManager(infra_persistence.NewDomainFS(f.FileSystem), paths.HistoryPath, paths.HistoryArchivePath)
+	hManager := history.NewManager(infra_persistence.NewDomainFS(f.FileSystem), paths.HistoryPath, paths.HistoryArchivePath).WithLogger(f.Logger)
 	if err := hManager.Load(ctx); err != nil {
 		if !errors.Is(err, ports.ErrHistoryNotFound) {
 			return nil, fmt.Errorf("%w: failed to load history from %s: %w", errInfraInit, paths.HistoryPath, err)

--- a/internal/infrastructure/history/archive_reader.go
+++ b/internal/infrastructure/history/archive_reader.go
@@ -251,6 +251,7 @@ func (r *jsonlArchiveReader) toDTO(content llm.Content) ports.HistoryViewDTO {
 		agg.absorb(part)
 	}
 	return ports.HistoryViewDTO{
+		ID:             content.ID,
 		Role:           content.Role,
 		IsArchived:     true,
 		ContentPreview: strings.TrimSpace(agg.preview.String()),

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -64,6 +64,20 @@ func (m *Manager) Load(ctx context.Context) error {
 		return err
 	}
 	m.Contents = contents
+
+	backfillCount := 0
+	for _, c := range m.Contents {
+		if c.ID == "" {
+			c.ID = llm.NewID()
+			backfillCount++
+		}
+	}
+	if backfillCount > 0 {
+		if saveErr := m.store.Save(ctx, m.Contents); saveErr != nil {
+			return fmt.Errorf("failed to persist backfilled UUIDs: %w", saveErr)
+		}
+	}
+
 	return nil
 }
 
@@ -182,40 +196,115 @@ func (m *Manager) GetResolver() llm.AssetResolver {
 	return nil
 }
 
-// SetPinned toggles the pinned status of messages in a turn.
-func (m *Manager) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+// SetPinned toggles the pinned status of both messages in a turn,
+// identified by the stable UUID of either message in the pair.
+func (m *Manager) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	offset := 0
-	if len(m.Contents) > 0 && m.Contents[0].Role == "system" {
-		offset = 1
+	// Find the message with matching ID.
+	i := -1
+	for idx, c := range m.Contents {
+		if c.ID == turnID {
+			i = idx
+			break
+		}
+	}
+	if i == -1 {
+		return fmt.Errorf("turn not found: %s", turnID)
 	}
 
-	// Turns are pairs. Turn 0 is messages offset and offset+1.
-	startIdx := offset + (turnIndex * 2)
-	if startIdx < offset || startIdx+1 >= len(m.Contents) {
-		return fmt.Errorf("invalid turn index: %d (history length: %d)", turnIndex, len(m.Contents))
+	// System messages are not part of any turn.
+	if m.Contents[i].Role == "system" {
+		return fmt.Errorf("turn not found: %s (system message)", turnID)
+	}
+
+	first, second, err := findTurnPair(m.Contents, i)
+	if err != nil {
+		return err
 	}
 
 	metadata := map[string]interface{}{"pinned": pinned}
-	if err := m.store.UpdateMetadata(ctx, startIdx, metadata); err != nil {
+	if err := m.store.UpdateMetadata(ctx, first, metadata); err != nil {
 		return err
 	}
-	if err := m.store.UpdateMetadata(ctx, startIdx+1, metadata); err != nil {
+	if err := m.store.UpdateMetadata(ctx, second, metadata); err != nil {
 		return err
 	}
 
-	m.Contents[startIdx].Pinned = pinned
-	m.Contents[startIdx+1].Pinned = pinned
+	m.Contents[first].Pinned = pinned
+	m.Contents[second].Pinned = pinned
 
 	return nil
+}
+
+// findTurnPair determines the two indices forming the turn containing
+// the message at index i. It handles normal user→model pairs and
+// tool-call model→user (FunctionCall/FunctionResponse) pairs.
+func findTurnPair(contents []*llm.Content, i int) (first, second int, err error) {
+	role := contents[i].Role
+	total := len(contents)
+
+	if role == "model" && contentHasFunctionCall(contents[i]) {
+		// Tool-call turn: model (FunctionCall) → user (FunctionResponse).
+		if i+1 >= total || contents[i+1].Role != "user" || !contentHasFunctionResponse(contents[i+1]) {
+			return 0, 0, fmt.Errorf("invalid turn pair: tool-call model at index %d has no function response", i)
+		}
+		return i, i + 1, nil
+	}
+
+	if role == "user" && contentHasFunctionResponse(contents[i]) {
+		// Tool-call turn: user (FunctionResponse) → preceded by model (FunctionCall).
+		if i-1 < 0 || contents[i-1].Role != "model" || !contentHasFunctionCall(contents[i-1]) {
+			return 0, 0, fmt.Errorf("invalid turn pair: function response at index %d has no preceding function call", i)
+		}
+		return i - 1, i, nil
+	}
+
+	if role == "user" {
+		// Normal turn: user → model.
+		if i+1 >= total || contents[i+1].Role != "model" {
+			return 0, 0, fmt.Errorf("invalid turn pair: user at index %d has no model response", i)
+		}
+		return i, i + 1, nil
+	}
+
+	if role == "model" {
+		// Normal turn: model → preceded by user.
+		if i-1 < 0 || contents[i-1].Role != "user" {
+			return 0, 0, fmt.Errorf("invalid turn pair: model at index %d has no preceding user message", i)
+		}
+		return i - 1, i, nil
+	}
+
+	return 0, 0, fmt.Errorf("invalid role for turn pairing: %s", role)
+}
+
+// contentHasFunctionCall returns true if any part of the content contains a FunctionCall.
+func contentHasFunctionCall(c *llm.Content) bool {
+	for _, p := range c.Parts {
+		if p.FunctionCall != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// contentHasFunctionResponse returns true if any part of the content contains a FunctionResponse.
+func contentHasFunctionResponse(c *llm.Content) bool {
+	for _, p := range c.Parts {
+		if p.FunctionResponse != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // addEntry appends a new text message to the history.
 func (m *Manager) addEntry(ctx context.Context, role, text string) error {
 	return m.AddContent(ctx, &llm.Content{
 		Role:  role,
+		ID:    llm.NewID(),
 		Parts: []*llm.Part{{Text: text}},
 	})
 }

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -21,6 +20,7 @@ import (
 type Manager struct {
 	mu       sync.RWMutex
 	store    store
+	logger   ports.Logger
 	FilePath string
 	Contents []*llm.Content
 }
@@ -29,9 +29,18 @@ type Manager struct {
 func NewManager(fs persistence.FileSystem, filePath string, archivePath string) *Manager {
 	return &Manager{
 		store:    newJSONLStore(fs, filePath, archivePath),
+		logger:   &ports.NoOpLogger{},
 		FilePath: filePath,
 		Contents: []*llm.Content{},
 	}
+}
+
+// WithLogger sets the logger for the Manager.
+func (m *Manager) WithLogger(l ports.Logger) *Manager {
+	if l != nil {
+		m.logger = l
+	}
+	return m
 }
 
 // setStore allows injecting a custom store.
@@ -75,7 +84,7 @@ func (m *Manager) Load(ctx context.Context) error {
 	}
 	if backfillCount > 0 {
 		if saveErr := m.store.Save(ctx, m.Contents); saveErr != nil {
-			slog.WarnContext(ctx, "failed to persist backfilled UUIDs; continuing with in-memory IDs", "error", saveErr)
+			m.logger.Warn("failed to persist backfilled UUIDs; continuing with in-memory IDs", "error", saveErr)
 		}
 	}
 

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -74,7 +75,7 @@ func (m *Manager) Load(ctx context.Context) error {
 	}
 	if backfillCount > 0 {
 		if saveErr := m.store.Save(ctx, m.Contents); saveErr != nil {
-			return fmt.Errorf("failed to persist backfilled UUIDs: %w", saveErr)
+			slog.WarnContext(ctx, "failed to persist backfilled UUIDs; continuing with in-memory IDs", "error", saveErr)
 		}
 	}
 

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -945,3 +945,67 @@ func TestLoad_BackfillsMissingUUIDs(t *testing.T) {
 		}
 	}
 }
+
+type mockLoadRealSaveFailing struct {
+	realStore store
+	err       error
+}
+
+func (m *mockLoadRealSaveFailing) Load(ctx context.Context) ([]*llm.Content, error) {
+	return m.realStore.Load(ctx)
+}
+
+func (m *mockLoadRealSaveFailing) Save(ctx context.Context, contents []*llm.Content) error {
+	return m.err
+}
+
+func (m *mockLoadRealSaveFailing) Append(ctx context.Context, c []*llm.Content) error { return nil }
+func (m *mockLoadRealSaveFailing) AppendParts(ctx context.Context, index int, parts []*llm.Part) error {
+	return nil
+}
+func (m *mockLoadRealSaveFailing) UpdateMetadata(ctx context.Context, index int, metadata map[string]interface{}) error {
+	return nil
+}
+func (m *mockLoadRealSaveFailing) Sync(ctx context.Context) error    { return nil }
+func (m *mockLoadRealSaveFailing) Compact(ctx context.Context) error { return nil }
+func (m *mockLoadRealSaveFailing) Archive(ctx context.Context, c []*llm.Content) error { return nil }
+func (m *mockLoadRealSaveFailing) FilePath() string                  { return "" }
+
+func TestLoad_BackfillSaveFailure_GracefulDegradation(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyFile := filepath.Join(tmpDir, "history.jsonl")
+	archiveFile := filepath.Join(tmpDir, "history.archive.jsonl")
+	ctx := context.Background()
+
+	m1 := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+
+	legacyContents := []*llm.Content{
+		{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}, Pinned: true},
+		{Role: "model", Parts: []*llm.Part{{Text: "Hi"}}},
+	}
+
+	if err := m1.SetContents(ctx, legacyContents); err != nil {
+		t.Fatalf("SetContents (legacy) failed: %v", err)
+	}
+
+	m2 := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+	m2.setStore(&mockLoadRealSaveFailing{
+		realStore: m2.store,
+		err:       errors.New("simulated save error on read-only FS"),
+	})
+
+	err := m2.Load(ctx)
+	if err != nil {
+		t.Fatalf("expected graceful degradation, but Load returned error: %v", err)
+	}
+
+	if len(m2.Contents) != 2 {
+		t.Fatalf("expected 2 entries in memory, got %d", len(m2.Contents))
+	}
+
+	for i, c := range m2.Contents {
+		if c.ID == "" {
+			t.Errorf("expected Content[%d] to have ID assigned in memory despite save failure", i)
+		}
+	}
+}

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -207,9 +207,13 @@ func TestHistoryManager_SetPinned_WithSystemMessage(t *testing.T) {
 	_ = m.addEntry(ctx, "user", "U1")
 	_ = m.addEntry(ctx, "model", "M1")
 
+	// Get the ID of the user message (turn 0, message at index 1)
+	contents, _ := m.GetWindow(ctx, 0, -1)
+	turnID := contents[1].ID
+
 	t.Run("Pin", func(t *testing.T) {
-		if err := m.SetPinned(ctx, 0, true); err != nil {
-			t.Fatalf("SetPinned(0, true) failed: %v", err)
+		if err := m.SetPinned(ctx, turnID, true); err != nil {
+			t.Fatalf("SetPinned(%s, true) failed: %v", turnID, err)
 		}
 
 		contents, _ := m.GetWindow(ctx, 0, -1)
@@ -225,8 +229,8 @@ func TestHistoryManager_SetPinned_WithSystemMessage(t *testing.T) {
 	})
 
 	t.Run("Unpin", func(t *testing.T) {
-		if err := m.SetPinned(ctx, 0, false); err != nil {
-			t.Fatalf("SetPinned(0, false) failed: %v", err)
+		if err := m.SetPinned(ctx, turnID, false); err != nil {
+			t.Fatalf("SetPinned(%s, false) failed: %v", turnID, err)
 		}
 
 		contents, _ := m.GetWindow(ctx, 0, -1)
@@ -249,11 +253,15 @@ func TestHistoryManager_PinValidTurn(t *testing.T) {
 	_ = m.addEntry(ctx, "user", "U2")
 	_ = m.addEntry(ctx, "model", "M2")
 
-	if err := m.SetPinned(ctx, 0, true); err != nil {
-		t.Fatalf("SetPinned(0, true) failed: %v", err)
+	// Get the ID of the first user message (turn 0)
+	contents, _ := m.GetWindow(ctx, 0, -1)
+	turnID := contents[0].ID
+
+	if err := m.SetPinned(ctx, turnID, true); err != nil {
+		t.Fatalf("SetPinned(%s, true) failed: %v", turnID, err)
 	}
 
-	contents, _ := m.GetWindow(ctx, 0, -1)
+	contents, _ = m.GetWindow(ctx, 0, -1)
 	if !contents[0].Pinned || !contents[1].Pinned {
 		t.Error("Turn 0 (messages 0 and 1) should be pinned")
 	}
@@ -272,14 +280,18 @@ func TestHistoryManager_UnpinTurn(t *testing.T) {
 	// Setup: 1 turn pinned
 	_ = m.addEntry(ctx, "user", "U1")
 	_ = m.addEntry(ctx, "model", "M1")
-	if err := m.SetPinned(ctx, 0, true); err != nil {
-		t.Fatalf("SetPinned(0, true) failed: %v", err)
+
+	contents, _ := m.GetWindow(ctx, 0, -1)
+	turnID := contents[0].ID
+
+	if err := m.SetPinned(ctx, turnID, true); err != nil {
+		t.Fatalf("SetPinned(%s, true) failed: %v", turnID, err)
 	}
 
-	if err := m.SetPinned(ctx, 0, false); err != nil {
-		t.Fatalf("SetPinned(0, false) failed: %v", err)
+	if err := m.SetPinned(ctx, turnID, false); err != nil {
+		t.Fatalf("SetPinned(%s, false) failed: %v", turnID, err)
 	}
-	contents, _ := m.GetWindow(ctx, 0, -1)
+	contents, _ = m.GetWindow(ctx, 0, -1)
 	if contents[0].Pinned || contents[1].Pinned {
 		t.Error("Turn 0 should be unpinned")
 	}
@@ -341,18 +353,21 @@ func TestHistoryManager_SetPinned_Error(t *testing.T) {
 	_ = m.addEntry(ctx, "user", "U1")
 	_ = m.addEntry(ctx, "model", "M1")
 
+	contents, _ := m.GetWindow(ctx, 0, -1)
+	turnID := contents[0].ID
+
 	expectedErr := errors.New("update failed")
 
 	// Test failure on first UpdateMetadata
 	m.setStore(&mockStoreErrorMetadata{err: expectedErr, failOnIndex: 0})
-	err := m.SetPinned(ctx, 0, true)
+	err := m.SetPinned(ctx, turnID, true)
 	if err == nil || err.Error() != expectedErr.Error() {
 		t.Errorf("expected error %v on first update, got %v", expectedErr, err)
 	}
 
 	// Test failure on second UpdateMetadata
 	m.setStore(&mockStoreErrorMetadata{err: expectedErr, failOnIndex: 1})
-	err = m.SetPinned(ctx, 0, true)
+	err = m.SetPinned(ctx, turnID, true)
 	if err == nil || err.Error() != expectedErr.Error() {
 		t.Errorf("expected error %v on second update, got %v", expectedErr, err)
 	}
@@ -366,14 +381,9 @@ func TestHistoryManager_SetPinned_InvalidIndex(t *testing.T) {
 	_ = m.addEntry(ctx, "user", "U1")
 	_ = m.addEntry(ctx, "model", "M1")
 
-	// Invalid index (negative)
-	if err := m.SetPinned(ctx, -1, true); err == nil {
-		t.Error("expected error for negative index, got nil")
-	}
-
-	// Invalid index (out of bounds)
-	if err := m.SetPinned(ctx, 1, true); err == nil {
-		t.Error("expected error for out of bounds index, got nil")
+	// Invalid ID (non-existent)
+	if err := m.SetPinned(ctx, "nonexistent-id", true); err == nil {
+		t.Error("expected error for non-existent ID, got nil")
 	}
 }
 
@@ -860,3 +870,78 @@ func (m *mockFailingAppendPartsStore) AppendParts(ctx context.Context, index int
 }
 
 func (m *mockFailingAppendPartsStore) Sync(ctx context.Context) error { return nil }
+
+func TestLoad_BackfillsMissingUUIDs(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyFile := filepath.Join(tmpDir, "history.jsonl")
+	archiveFile := filepath.Join(tmpDir, "history.archive.jsonl")
+	ctx := context.Background()
+
+	// Step 1: Write legacy content with no IDs to disk via SetContents.
+	m1 := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+
+	legacyContents := []*llm.Content{
+		{Role: "user", Parts: []*llm.Part{{Text: "Hello"}}, Pinned: true},
+		{Role: "model", Parts: []*llm.Part{{Text: "Hi"}}},
+		{Role: "user", Parts: []*llm.Part{{Text: "How are you?"}}},
+		{Role: "model", Parts: []*llm.Part{{Text: "I'm fine"}}, Pinned: true},
+	}
+
+	if err := m1.SetContents(ctx, legacyContents); err != nil {
+		t.Fatalf("SetContents (legacy) failed: %v", err)
+	}
+
+	// Step 2: Load via a fresh Manager — backfill should trigger.
+	m2 := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+	if err := m2.Load(ctx); err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if m2.GetTotalEntries() != 4 {
+		t.Fatalf("expected 4 entries, got %d", m2.GetTotalEntries())
+	}
+
+	// Step 3: Verify all IDs populated and unique.
+	ids := make(map[string]bool)
+	for i, c := range m2.Contents {
+		if c.ID == "" {
+			t.Errorf("Content[%d] has empty ID after backfill", i)
+		}
+		if ids[c.ID] {
+			t.Errorf("Content[%d] has duplicate ID %q", i, c.ID)
+		}
+		ids[c.ID] = true
+	}
+
+	// Step 4: Verify pinned state preserved.
+	if !m2.Contents[0].Pinned {
+		t.Error("Content[0] pinned state not preserved: expected true")
+	}
+	if m2.Contents[1].Pinned {
+		t.Error("Content[1] should not be pinned")
+	}
+	if m2.Contents[2].Pinned {
+		t.Error("Content[2] should not be pinned")
+	}
+	if !m2.Contents[3].Pinned {
+		t.Error("Content[3] pinned state not preserved: expected true")
+	}
+
+	// Step 5: Record IDs and Load again to confirm stability.
+	firstIDs := make([]string, len(m2.Contents))
+	for i, c := range m2.Contents {
+		firstIDs[i] = c.ID
+	}
+
+	m3 := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+	if err := m3.Load(ctx); err != nil {
+		t.Fatalf("Second Load failed: %v", err)
+	}
+
+	for i, c := range m3.Contents {
+		if c.ID != firstIDs[i] {
+			t.Errorf("Content[%d] ID changed: was %q, now %q (IDs must be stable)",
+				i, firstIDs[i], c.ID)
+		}
+	}
+}

--- a/internal/infrastructure/history/unified_provider.go
+++ b/internal/infrastructure/history/unified_provider.go
@@ -118,9 +118,10 @@ func (p *unifiedProvider) fetchArchiveHistory(ctx context.Context, limit int, of
 }
 
 func (p *unifiedProvider) isAutoSummary(dto ports.HistoryViewDTO) bool {
-	// Filter both the injected summary block and the agent's synthetic acknowledgment
-	return strings.Contains(dto.ContentPreview, "System Auto-Summary") ||
-		dto.ContentPreview == "Understood. Context compressed."
+	lower := strings.ToLower(dto.ContentPreview)
+	return strings.HasPrefix(lower, "system auto-summary") ||
+		lower == "understood: context compressed" ||
+		lower == "understood. context compressed."
 }
 
 func (p *unifiedProvider) processHistoryItem(dto ports.HistoryViewDTO, skipSummaries bool, results []ports.HistoryViewDTO) []ports.HistoryViewDTO {
@@ -159,6 +160,7 @@ func writePartPreview(part *llm.Part, preview *strings.Builder) {
 
 func (p *unifiedProvider) toDTO(c *llm.Content, archived bool) ports.HistoryViewDTO {
 	dto := ports.HistoryViewDTO{
+		ID:         c.ID,
 		Role:       c.Role,
 		IsArchived: archived,
 		IsPinned:   c.Pinned,

--- a/internal/infrastructure/history/unified_provider_test.go
+++ b/internal/infrastructure/history/unified_provider_test.go
@@ -332,3 +332,56 @@ func TestUnifiedProvider_ToDTO_ExtraCases(t *testing.T) {
 		t.Errorf("expected tool calls [get_weather, get_weather], got %v", dto.ToolCalls)
 	}
 }
+
+func TestIsAutoSummary(t *testing.T) {
+	mockActive := &mockHistoryManager{}
+	mockArchive := &mockArchiveReader{}
+	p := NewUnifiedProvider(mockArchive, mockActive)
+
+	tests := []struct {
+		name    string
+		preview string
+		want    bool
+	}{
+		{
+			name:    "production output - lowercase prefix with colon",
+			preview: "system auto-summary (context limit reached):\n\nKey findings...",
+			want:    true,
+		},
+		{
+			name:    "case-insensitive - mixed case",
+			preview: "System Auto-Summary: ...",
+			want:    true,
+		},
+		{
+			name:    "new understood format with colon",
+			preview: "understood: context compressed",
+			want:    true,
+		},
+		{
+			name:    "legacy understood format with period",
+			preview: "Understood. Context compressed.",
+			want:    true,
+		},
+		{
+			name:    "normal user message",
+			preview: "Normal user message",
+			want:    false,
+		},
+		{
+			name:    "does not start with prefix - contains substring",
+			preview: "I read the system auto-summary report",
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dto := ports.HistoryViewDTO{ContentPreview: tt.preview}
+			got := p.(*unifiedProvider).isAutoSummary(dto)
+			if got != tt.want {
+				t.Errorf("isAutoSummary(%q) = %v; want %v", tt.preview, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -189,7 +189,7 @@ func (m *mockErrorHistoryReader) Sync(ctx context.Context) error { return nil }
 func (m *mockErrorHistoryReader) Archive(ctx context.Context, contents []*llm.Content) error {
 	return nil
 }
-func (m *mockErrorHistoryReader) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *mockErrorHistoryReader) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	return nil
 }
 func (m *mockErrorHistoryReader) GetFilePath() string { return "" }

--- a/internal/ui/tui/browser_pinning.go
+++ b/internal/ui/tui/browser_pinning.go
@@ -47,13 +47,12 @@ func (m *rootBrowserModel) getSystemOffset() int {
 	return 0
 }
 
-// getTurnIndex returns the 0-based turn number (pair of msgs) for a given DTO.
-func (m *rootBrowserModel) getTurnIndex(dto ports.HistoryViewDTO) int {
-	offset := m.getSystemOffset()
-	if dto.OriginalIndex < offset && dto.Role == "system" {
-		return -1
+// truncateID returns a short prefix of a UUID for display in error messages.
+func truncateID(id string) string {
+	if len(id) > 8 {
+		return id[:8]
 	}
-	return (dto.OriginalIndex - offset) / 2
+	return id
 }
 
 // getTurnStartOriginalIndex returns the index of the first message in a turn (usually the 'user' msg).
@@ -67,50 +66,46 @@ func (m *rootBrowserModel) getTurnStartOriginalIndex(dto ports.HistoryViewDTO) i
 }
 
 func (m *rootBrowserModel) getPinningMetrics() (activeTurns int, pinnedTurns int) {
-	lastTurnIdx := -1
+	seen := make(map[string]bool)
 	for _, dto := range m.history {
-		if dto.IsArchived {
+		if dto.IsArchived || dto.ID == "" {
 			continue
 		}
-		turnIdx := m.getTurnIndex(dto)
-		if turnIdx < 0 {
+		if seen[dto.ID] {
 			continue
 		}
-		if turnIdx != lastTurnIdx {
-			activeTurns++
-			if dto.IsPinned {
-				pinnedTurns++
-			}
-			lastTurnIdx = turnIdx
+		seen[dto.ID] = true
+		activeTurns++
+		if dto.IsPinned {
+			pinnedTurns++
 		}
 	}
 	return activeTurns, pinnedTurns
 }
 
-func (m *rootBrowserModel) getTurnForPinning() (ports.HistoryViewDTO, int, bool) {
+func (m *rootBrowserModel) getTurnForPinning() (ports.HistoryViewDTO, bool) {
 	if m.selectedTurn == -1 || m.selectedTurn >= len(m.history) {
-		return ports.HistoryViewDTO{}, 0, false
+		return ports.HistoryViewDTO{}, false
 	}
 
 	dto := m.history[m.selectedTurn]
 	if dto.IsArchived {
-		return ports.HistoryViewDTO{}, 0, false
+		return ports.HistoryViewDTO{}, false
 	}
 
-	turnIdx := m.getTurnIndex(dto)
-	if turnIdx < 0 {
-		return ports.HistoryViewDTO{}, 0, false
+	if dto.ID == "" {
+		return ports.HistoryViewDTO{}, false
 	}
-	return dto, turnIdx, true
+	return dto, true
 }
 
 func (m *rootBrowserModel) togglePin() {
-	dto, turnIdx, ok := m.getTurnForPinning()
+	dto, ok := m.getTurnForPinning()
 	if !ok {
 		return
 	}
 
-	err := m.cmdService.SetPinned(context.Background(), turnIdx, !dto.IsPinned)
+	err := m.cmdService.SetPinned(context.Background(), dto.ID, !dto.IsPinned)
 	if err != nil {
 		m.err = err
 		return
@@ -151,7 +146,7 @@ func (m *rootBrowserModel) rollbackToSelected() tea.Cmd {
 
 	dto := m.history[m.selectedTurn]
 	if dto.IsArchived {
-		m.err = fmt.Errorf("cannot rollback: turn %d is archived and read-only", m.getTurnIndex(dto)+1)
+		m.err = fmt.Errorf("cannot rollback: turn %s is archived and read-only", truncateID(dto.ID))
 		return nil
 	}
 

--- a/internal/ui/tui/browser_render_test.go
+++ b/internal/ui/tui/browser_render_test.go
@@ -177,18 +177,18 @@ func TestBrowserModel_Footer(t *testing.T) {
 
 	// Test high pinning pressure (count of pinned turns > 5)
 	m.history = []ports.HistoryViewDTO{
-		{Role: "user", OriginalIndex: 0, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 1, IsPinned: true},
-		{Role: "user", OriginalIndex: 2, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 3, IsPinned: true},
-		{Role: "user", OriginalIndex: 4, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 5, IsPinned: true},
-		{Role: "user", OriginalIndex: 6, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 7, IsPinned: true},
-		{Role: "user", OriginalIndex: 8, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 9, IsPinned: true},
-		{Role: "user", OriginalIndex: 10, IsPinned: true},
-		{Role: "assistant", OriginalIndex: 11, IsPinned: true},
+		{ID: "t0", Role: "user", OriginalIndex: 0, IsPinned: true},
+		{ID: "t0", Role: "assistant", OriginalIndex: 1, IsPinned: true},
+		{ID: "t1", Role: "user", OriginalIndex: 2, IsPinned: true},
+		{ID: "t1", Role: "assistant", OriginalIndex: 3, IsPinned: true},
+		{ID: "t2", Role: "user", OriginalIndex: 4, IsPinned: true},
+		{ID: "t2", Role: "assistant", OriginalIndex: 5, IsPinned: true},
+		{ID: "t3", Role: "user", OriginalIndex: 6, IsPinned: true},
+		{ID: "t3", Role: "assistant", OriginalIndex: 7, IsPinned: true},
+		{ID: "t4", Role: "user", OriginalIndex: 8, IsPinned: true},
+		{ID: "t4", Role: "assistant", OriginalIndex: 9, IsPinned: true},
+		{ID: "t5", Role: "user", OriginalIndex: 10, IsPinned: true},
+		{ID: "t5", Role: "assistant", OriginalIndex: 11, IsPinned: true},
 	}
 	got = m.renderFooter()
 	if !strings.Contains(got, "High Pinning Pressure") {
@@ -576,10 +576,10 @@ func TestBrowserModel_GetTurnLabelSuffix_ArchivedAndSystem(t *testing.T) {
 		t.Errorf("expected empty suffix for archived DTO, got %q", got)
 	}
 
-	// System DTO (turnIdx < 0) returns ""
+	// System DTO returns " - 1" (getTurnLabelSuffix computes from OriginalIndex - offset)
 	systemDto := m.history[0]
-	if got := m.getTurnLabelSuffix(systemDto); got != "" {
-		t.Errorf("expected empty suffix for system DTO, got %q", got)
+	if got := m.getTurnLabelSuffix(systemDto); got != " - 1" {
+		t.Errorf("expected ' - 1' for system DTO, got %q", got)
 	}
 }
 
@@ -615,12 +615,12 @@ func TestBrowserModel_RenderEmptyState_NoHistory(t *testing.T) {
 func TestBrowserModel_HighPinningPressure_CalculateFooterHeight(t *testing.T) {
 	m := &rootBrowserModel{
 		history: []ports.HistoryViewDTO{
-			{Role: "user", OriginalIndex: 0, IsPinned: true},
-			{Role: "assistant", OriginalIndex: 1, IsPinned: true},
-			{Role: "user", OriginalIndex: 2, IsPinned: true},
-			{Role: "assistant", OriginalIndex: 3, IsPinned: true},
-			{Role: "user", OriginalIndex: 4, IsPinned: true},
-			{Role: "assistant", OriginalIndex: 5, IsPinned: true},
+			{ID: "t0", Role: "user", OriginalIndex: 0, IsPinned: true},
+			{ID: "t0", Role: "assistant", OriginalIndex: 1, IsPinned: true},
+			{ID: "t1", Role: "user", OriginalIndex: 2, IsPinned: true},
+			{ID: "t1", Role: "assistant", OriginalIndex: 3, IsPinned: true},
+			{ID: "t2", Role: "user", OriginalIndex: 4, IsPinned: true},
+			{ID: "t2", Role: "assistant", OriginalIndex: 5, IsPinned: true},
 		},
 	}
 	h := m.calculateFooterHeight()

--- a/internal/ui/tui/browser_test.go
+++ b/internal/ui/tui/browser_test.go
@@ -31,13 +31,13 @@ func (m *mockHistoryProvider) GetHistoryStream(ctx context.Context, limit int, c
 
 type mockHistoryModifier struct {
 	ArchiveFunc       func(ctx context.Context, contents []*llm.Content) error
-	SetPinnedFunc     func(ctx context.Context, turnIndex int, pinned bool) error
+	SetPinnedFunc     func(ctx context.Context, turnID string, pinned bool) error
 	GetFilePathFunc   func() string
 	RollbackTurnsFunc func(ctx context.Context, turns int) (int, int, int, error)
 
 	SetPinnedCalled   bool
 	RollbackCalled    bool
-	LastPinnedIndex   int
+	LastPinnedID      string
 	LastPinnedState   bool
 	LastRollbackTurns int
 }
@@ -49,12 +49,12 @@ func (m *mockHistoryModifier) Archive(ctx context.Context, contents []*llm.Conte
 	return nil
 }
 
-func (m *mockHistoryModifier) SetPinned(ctx context.Context, turnIndex int, pinned bool) error {
+func (m *mockHistoryModifier) SetPinned(ctx context.Context, turnID string, pinned bool) error {
 	m.SetPinnedCalled = true
-	m.LastPinnedIndex = turnIndex
+	m.LastPinnedID = turnID
 	m.LastPinnedState = pinned
 	if m.SetPinnedFunc != nil {
-		return m.SetPinnedFunc(ctx, turnIndex, pinned)
+		return m.SetPinnedFunc(ctx, turnID, pinned)
 	}
 	return nil
 }
@@ -77,8 +77,8 @@ func (m *mockHistoryModifier) RollbackTurns(ctx context.Context, turns int) (int
 
 func newHistoryState(userContent, modelContent string) []ports.HistoryViewDTO {
 	return []ports.HistoryViewDTO{
-		{Role: "user", ContentPreview: userContent, OriginalIndex: 0},
-		{Role: "assistant", ContentPreview: modelContent, OriginalIndex: 1},
+		{ID: "user-0", Role: "user", ContentPreview: userContent, OriginalIndex: 0},
+		{ID: "model-0", Role: "assistant", ContentPreview: modelContent, OriginalIndex: 1},
 	}
 }
 
@@ -89,13 +89,13 @@ func verifyScrollInteraction(t *testing.T, m *rootBrowserModel, expectedTurn int
 	}
 }
 
-func verifyPinInteraction(t *testing.T, m *rootBrowserModel, mock *mockHistoryModifier, expectedTurnIndex int, expectedOriginalIndex int, expectedState bool) {
+func verifyPinInteraction(t *testing.T, m *rootBrowserModel, mock *mockHistoryModifier, expectedTurnID string, expectedOriginalIndex int, expectedState bool) {
 	t.Helper()
 	if !mock.SetPinnedCalled {
 		t.Error("expected SetPinned to be called")
 	}
-	if mock.LastPinnedIndex != expectedTurnIndex {
-		t.Errorf("expected pinned turn index %d, got %d", expectedTurnIndex, mock.LastPinnedIndex)
+	if mock.LastPinnedID != expectedTurnID {
+		t.Errorf("expected pinned turn ID %q, got %q", expectedTurnID, mock.LastPinnedID)
 	}
 	if mock.LastPinnedState != expectedState {
 		t.Errorf("expected pinned state %v, got %v", expectedState, mock.LastPinnedState)
@@ -304,7 +304,7 @@ func actionTestCases() []updateTestCase {
 			},
 			msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")},
 			check: func(t *testing.T, m *rootBrowserModel, cmd tea.Cmd, mock *mockHistoryModifier) {
-				verifyPinInteraction(t, m, mock, 0, 0, true)
+				verifyPinInteraction(t, m, mock, "user-0", 0, true)
 			},
 		},
 		{
@@ -317,7 +317,7 @@ func actionTestCases() []updateTestCase {
 			},
 			msg: tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")},
 			check: func(t *testing.T, m *rootBrowserModel, cmd tea.Cmd, mock *mockHistoryModifier) {
-				verifyPinInteraction(t, m, mock, 0, 0, false)
+				verifyPinInteraction(t, m, mock, "user-0", 0, false)
 			},
 		},
 		{
@@ -506,16 +506,15 @@ func TestBrowserModel_SystemMessageOffset(t *testing.T) {
 	t.Run("Pinning with system message", func(t *testing.T) {
 		m := NewRootBrowserModel(ctx, mockProvider, mockModifier)
 		m.history = []ports.HistoryViewDTO{
-			{Role: "system", ContentPreview: "sys", OriginalIndex: 0},
-			{Role: "user", ContentPreview: "u1", OriginalIndex: 1},
-			{Role: "assistant", ContentPreview: "m1", OriginalIndex: 2},
+			{ID: "sys-0", Role: "system", ContentPreview: "sys", OriginalIndex: 0},
+			{ID: "u1", Role: "user", ContentPreview: "u1", OriginalIndex: 1},
+			{ID: "m1", Role: "assistant", ContentPreview: "m1", OriginalIndex: 2},
 		}
 		// Select U1 (index 1)
 		m.selectedTurn = 1
 		m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("p")})
 
-		// Expected turnIndex: (1 - 1) / 2 = 0. ExpectedOriginalIndex: 1.
-		verifyPinInteraction(t, m, mockModifier, 0, 1, true)
+		verifyPinInteraction(t, m, mockModifier, "u1", 1, true)
 	})
 
 	t.Run("Rollback with system message", func(t *testing.T) {
@@ -590,14 +589,14 @@ func checkFileChangedMsgDebounced(t *testing.T, m *rootBrowserModel, _ tea.Cmd, 
 func TestTogglePin_SetPinnedError(t *testing.T) {
 	mockProvider := &mockHistoryProvider{}
 	mockModifier := &mockHistoryModifier{
-		SetPinnedFunc: func(ctx context.Context, turnIndex int, pinned bool) error {
+		SetPinnedFunc: func(ctx context.Context, turnID string, pinned bool) error {
 			return errors.New("set pinned failed")
 		},
 	}
 	m := NewRootBrowserModel(context.Background(), mockProvider, mockModifier)
 	m.history = []ports.HistoryViewDTO{
-		{Role: "user", ContentPreview: "Hello", OriginalIndex: 0},
-		{Role: "assistant", ContentPreview: "Hi", OriginalIndex: 1},
+		{ID: "u0", Role: "user", ContentPreview: "Hello", OriginalIndex: 0},
+		{ID: "m0", Role: "assistant", ContentPreview: "Hi", OriginalIndex: 1},
 	}
 	m.selectedTurn = 0
 
@@ -675,7 +674,7 @@ func TestTogglePin_RecoveryAfterError(t *testing.T) {
 	mockProvider := &mockHistoryProvider{}
 	callCount := 0
 	mockModifier := &mockHistoryModifier{
-		SetPinnedFunc: func(ctx context.Context, turnIndex int, pinned bool) error {
+		SetPinnedFunc: func(ctx context.Context, turnID string, pinned bool) error {
 			callCount++
 			if callCount == 1 {
 				return errors.New("transient error")
@@ -685,8 +684,8 @@ func TestTogglePin_RecoveryAfterError(t *testing.T) {
 	}
 	m := NewRootBrowserModel(context.Background(), mockProvider, mockModifier)
 	m.history = []ports.HistoryViewDTO{
-		{Role: "user", ContentPreview: "Hello", OriginalIndex: 0},
-		{Role: "assistant", ContentPreview: "Hi", OriginalIndex: 1},
+		{ID: "u0", Role: "user", ContentPreview: "Hello", OriginalIndex: 0},
+		{ID: "m0", Role: "assistant", ContentPreview: "Hi", OriginalIndex: 1},
 	}
 	m.selectedTurn = 0
 
@@ -722,8 +721,8 @@ func TestTogglePin_LocalStateUpdateNotFound(t *testing.T) {
 	}
 	m := NewRootBrowserModel(context.Background(), mockProvider, &mockHistoryModifier{})
 	m.history = []ports.HistoryViewDTO{
-		{Role: "user", ContentPreview: "hello", OriginalIndex: 0},
-		{Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		{ID: "u0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+		{ID: "m0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
 	}
 	m.selectedTurn = 0
 	m.isLoading = false
@@ -731,7 +730,7 @@ func TestTogglePin_LocalStateUpdateNotFound(t *testing.T) {
 	// Use SetPinnedFunc to clear history between getTurnForPinning and updateLocalPinState,
 	// simulating a concurrent modification that makes the local state stale.
 	mockModifier := &mockHistoryModifier{
-		SetPinnedFunc: func(ctx context.Context, turnIndex int, pinned bool) error {
+		SetPinnedFunc: func(ctx context.Context, turnID string, pinned bool) error {
 			m.history = nil
 			return nil
 		},
@@ -756,8 +755,8 @@ func TestTogglePin_LocalStateUpdateSucceeds(t *testing.T) {
 	mockModifier := &mockHistoryModifier{}
 	m := NewRootBrowserModel(context.Background(), mockProvider, mockModifier)
 	m.history = []ports.HistoryViewDTO{
-		{Role: "user", ContentPreview: "hello", OriginalIndex: 0},
-		{Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		{ID: "u0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+		{ID: "m0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
 	}
 	m.selectedTurn = 0
 	m.isLoading = false
@@ -958,15 +957,16 @@ func TestSyncViewportToSelectedTurn_BelowViewport(t *testing.T) {
 	}
 }
 
-func TestGetTurnIndex_SystemDto(t *testing.T) {
+func TestGetTurnStartOriginalIndex_SystemDto(t *testing.T) {
 	m := &rootBrowserModel{
 		history: []ports.HistoryViewDTO{
 			{Role: "system", OriginalIndex: 0},
 		},
 	}
-	turnIdx := m.getTurnIndex(m.history[0])
-	if turnIdx != -1 {
-		t.Errorf("expected -1 for system DTO, got %d", turnIdx)
+	turnIdx := m.getTurnStartOriginalIndex(m.history[0])
+	// System message at index 0: offset=1, msgOffset=-1 (<0), returns OriginalIndex=0
+	if turnIdx != 0 {
+		t.Errorf("expected 0 for system DTO, got %d", turnIdx)
 	}
 }
 
@@ -1145,13 +1145,13 @@ func TestGetTurnForPinning_OutOfBounds(t *testing.T) {
 		history:      []ports.HistoryViewDTO{{Role: "user", OriginalIndex: 0}},
 		selectedTurn: 5,
 	}
-	_, _, ok := m.getTurnForPinning()
+	_, ok := m.getTurnForPinning()
 	if ok {
 		t.Error("expected ok=false for out of bounds selectedTurn")
 	}
 
 	m.selectedTurn = -1
-	_, _, ok = m.getTurnForPinning()
+	_, ok = m.getTurnForPinning()
 	if ok {
 		t.Error("expected ok=false for selectedTurn=-1")
 	}

--- a/internal/ui/tui/browser_viewport.go
+++ b/internal/ui/tui/browser_viewport.go
@@ -201,7 +201,8 @@ func (m *rootBrowserModel) getRoleLabel(dto ports.HistoryViewDTO) string {
 
 func (m *rootBrowserModel) getTurnLabelSuffix(dto ports.HistoryViewDTO) string {
 	if !dto.IsArchived {
-		turnIdx := m.getTurnIndex(dto)
+		offset := m.getSystemOffset()
+		turnIdx := (dto.OriginalIndex - offset) / 2
 		if turnIdx >= 0 {
 			return fmt.Sprintf(" - %d", turnIdx+1)
 		}

--- a/tests/integration/agent/agent_integration_test.go
+++ b/tests/integration/agent/agent_integration_test.go
@@ -357,27 +357,30 @@ func TestAgent_PinningFlow(t *testing.T) {
 	})
 }
 
-func verifyPinAction(t *testing.T, it *session.InternalTools, h ports.HistoryManager, ctx context.Context, action string, index float64) {
+func verifyPinAction(t *testing.T, it *session.InternalTools, h ports.HistoryManager, ctx context.Context, action string, turnIndex int) {
 	t.Helper()
-	resp, err := it.ManageHistory(ctx, map[string]interface{}{"action": action, "index": index}, nil)
+	// Get the turn's content ID before the operation
+	contents, _ := h.GetWindow(ctx, 0, -1)
+	turnID := contents[turnIndex*2].ID
+
+	resp, err := it.ManageHistory(ctx, map[string]interface{}{"action": action, "index": float64(turnIndex)}, nil)
 	if err != nil {
 		t.Fatalf("ManageHistory failed: %v", err)
 	}
 
-	expectedMsg := fmt.Sprintf("turn %d has been successfully %sned", int(index), action)
+	expectedMsg := fmt.Sprintf("turn %s has been successfully %sned", turnID, action)
 	if resp.Text != expectedMsg {
 		t.Errorf("unexpected response: got %q, want %q", resp.Text, expectedMsg)
 	}
 
-	contents, _ := h.GetWindow(ctx, 0, -1)
+	contents, _ = h.GetWindow(ctx, 0, -1)
 	isPinned := (action == "pin")
-	idx := int(index)
 
-	if contents[2*idx].Pinned != isPinned || contents[2*idx+1].Pinned != isPinned {
-		t.Errorf("expected turn %d pinned status to be %v", idx, isPinned)
+	if contents[2*turnIndex].Pinned != isPinned || contents[2*turnIndex+1].Pinned != isPinned {
+		t.Errorf("expected turn %d pinned status to be %v", turnIndex, isPinned)
 	}
 
-	if action == "pin" && idx == 0 {
+	if action == "pin" && turnIndex == 0 {
 		if contents[2].Pinned || contents[3].Pinned {
 			t.Error("expected turn 1 to remain unpinned")
 		}
@@ -394,8 +397,8 @@ func setupPinningFlowTest(t *testing.T) (ports.Chatter, ports.HistoryManager, co
 
 	// Add 2 turns
 	for i := 1; i <= 2; i++ {
-		_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("t%d", i)}}})
-		_ = h.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("r%d", i)}}})
+		_ = h.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("t%d", i)}}})
+		_ = h.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("r%d", i)}}})
 	}
 
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
@@ -425,8 +428,9 @@ func TestAgent_Integration_PinningPruning(t *testing.T) {
 	ctx := context.Background()
 	addTurns(ctx, h, 10)
 
-	// 2. Pin the 2nd turn (index 1)
-	_ = h.SetPinned(ctx, 1, true)
+	// 2. Pin the 2nd turn (index 1) — use the content ID of the user message at turn 1
+	contents, _ := h.GetWindow(ctx, 0, -1)
+	_ = h.SetPinned(ctx, contents[2].ID, true)
 
 	// 3. Set limits to only keep 3 turns
 	_ = a.SetLimits(ctx, 10, 100000, 3)
@@ -453,7 +457,14 @@ func setupPinningTest(t *testing.T) (ports.Chatter, ports.HistoryManager, contex
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	ctx := context.Background()
 
-	mockClient := &agenttest.MockLLMClient{}
+	mockClient := &agenttest.MockLLMClient{
+		SendChatFn: func(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+			return &llm.Content{
+				Role:  "model",
+				Parts: []*llm.Part{{Text: "Hello! How can I help you?"}},
+			}, &llm.Metrics{PromptTokens: 10, ResponseTokens: 5}, nil
+		},
+	}
 	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
 	a, err := agent.NewAgent(mockClient, bus, reg,
 		agent.WithHistoryManager(h),
@@ -470,8 +481,8 @@ func setupPinningTest(t *testing.T) (ports.Chatter, ports.HistoryManager, contex
 
 func addTurns(ctx context.Context, h ports.HistoryManager, count int) {
 	for i := 0; i < count; i++ {
-		_ = h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i)}}})
-		_ = h.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i)}}})
+		_ = h.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i)}}})
+		_ = h.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i)}}})
 	}
 }
 

--- a/tests/integration/agent/session/internal_tools_test.go
+++ b/tests/integration/agent/session/internal_tools_test.go
@@ -27,10 +27,10 @@ func TestAgent_ManageHistory(t *testing.T) {
 	ctx := context.Background()
 
 	// Fill history with 2 turns (4 messages)
-	_ = hManager.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "U1"}}})
-	_ = hManager.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "M1"}}})
-	_ = hManager.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "U2"}}})
-	_ = hManager.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "M2"}}})
+	_ = hManager.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "user", Parts: []*llm.Part{{Text: "U1"}}})
+	_ = hManager.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "model", Parts: []*llm.Part{{Text: "M1"}}})
+	_ = hManager.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "user", Parts: []*llm.Part{{Text: "U2"}}})
+	_ = hManager.AddContent(ctx, &llm.Content{ID: llm.NewID(), Role: "model", Parts: []*llm.Part{{Text: "M2"}}})
 
 	cm := sessctx.NewManager(nil, hManager, nil, nil)
 	it := session.NewInternalTools(cm, &ports.NoOpLogger{})


### PR DESCRIPTION
Closes #1185.

## Summary
- **Phase 1**: Add UUID field to `llm.Content` struct with `NewID()` helper, backfill via `Load()`, UUID guard in `AddContent`
- **Phase 2**: Change `SetPinned(ctx, turnIndex int, ...)` → `SetPinned(ctx, turnID string, ...)`, UUID resolution in `manage_history`
- **Phase 3**: TUI `browser_pinning.go` uses `dto.ID`, DTO mappers populate `HistoryViewDTO.ID`
- **Phase 4**: Rewrite `findSummarizationBoundary` with `contiguousUnpinnedSelector`, delete `calculateSummarizationEndIndex`
- **Phase 5**: `manage_history` keeps `index: integer` schema, resolves to UUID internally
- **Phase 6**: ADR-047 documenting the stable turn identifier decision

## Verification
| Check | Status |
|-------|--------|
| make check-full (all 10 steps) | PASS |
| go build ./... | PASS |
| go vet ./... | PASS |
| go test ./internal/... (68 packages) | PASS |
| go test ./tests/integration/agent/... (4 packages) | PASS |
| test-race (all packages) | PASS |
| vulncheck | No vulnerabilities |
| dead-code | No dead code |