### PR TITLE
fix: restore test caching for 4 packages (~46s saved per make check-full)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -392,11 +392,11 @@ endif
 
 verify-architecture:
 ifeq ($(IS_POSIX),true)
-	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis/... -strict-arch=true
+	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis -strict-arch=true
 	@echo "=== modelith-layers ==="
 	@$(MAKE) modelith-layers
 else
-	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis/... -strict-arch=true
+	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis -strict-arch=true
 	@echo "=== modelith-layers ==="
 	@$(MAKE) modelith-layers
 endif

--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ ifeq ($(IS_POSIX),true)
 	@echo "=== modelith-layers ==="
 	@$(MAKE) modelith-layers
 else
-	@set ARCH_FAIL_ON_VIOLATION=1 && go test -run TestVerifyRealArchitecture ./internal/tools/analysis/...
+	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis/... -strict-arch=true
 	@echo "=== modelith-layers ==="
 	@$(MAKE) modelith-layers
 endif

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ endif
 
 verify-architecture:
 ifeq ($(IS_POSIX),true)
-	@ARCH_FAIL_ON_VIOLATION=1 go test -run TestVerifyRealArchitecture ./internal/tools/analysis/...
+	@go test -run TestVerifyRealArchitecture ./internal/tools/analysis/... -strict-arch=true
 	@echo "=== modelith-layers ==="
 	@$(MAKE) modelith-layers
 else

--- a/internal/infrastructure/di/config.go
+++ b/internal/infrastructure/di/config.go
@@ -52,6 +52,6 @@ func DefaultBootstrapperConfig() BootstrapperConfig {
 		RegisterAllTools: infra_tools.RegisterAll,
 		RegisterMetrics:  telemetry.RegisterMetrics,
 		RotateSession:    infra_persistence.RotateSession,
-		NewSessionState:  infra_persistence.NewSessionState,
+		NewSessionState:  infra_persistence.NewSessionStateFromEnv,
 	}
 }

--- a/internal/infrastructure/persistence/state.go
+++ b/internal/infrastructure/persistence/state.go
@@ -20,14 +20,15 @@ import (
 
 // sessionState manages all persistent services and session metadata.
 type sessionState struct {
-	Tasks     ports.TaskStore
-	Settings  ports.KVStore
-	Info      ports.SessionInfo
-	db        *sql.DB
-	statePath string
-	fs        domain_persistence.FileSystem
-	mu        sync.RWMutex
-	logger    *slog.Logger
+	Tasks       ports.TaskStore
+	Settings    ports.KVStore
+	Info        ports.SessionInfo
+	db          *sql.DB
+	statePath   string
+	fs          domain_persistence.FileSystem
+	mu          sync.RWMutex
+	logger      *slog.Logger
+	storageType string // "sqlite" (default) or "memory"
 }
 
 func (s *sessionState) GetTasks() ports.TaskStore  { return s.Tasks }
@@ -154,14 +155,30 @@ var initServicesFn = initServices
 // SessionStateOption is a functional option for NewSessionState.
 type SessionStateOption func(*sessionState)
 
+// WithStorageType overrides the default storage backend ("sqlite").
+// Use "memory" for in-memory storage (tests), "sqlite" for persistent storage.
+func WithStorageType(t string) SessionStateOption {
+	return func(s *sessionState) {
+		s.storageType = t
+	}
+}
+
 // NewSessionState initializes repositories and services.
+// Use WithStorageType("memory") for in-memory storage in tests instead of
+// setting the STORAGE_TYPE environment variable.
 func NewSessionState(ctx context.Context, configDir string, opts ...SessionStateOption) (ports.SessionProvider, error) {
-	storageType := os.Getenv("STORAGE_TYPE")
-	if storageType == "" {
-		storageType = "sqlite" // Set sqlite as default storage
+	state := &sessionState{
+		logger:      slog.Default(),
+		storageType: "sqlite",
+	}
+	for _, opt := range opts {
+		opt(state)
+	}
+	if state.storageType == "" {
+		state.storageType = "sqlite"
 	}
 
-	taskStore, kvStore, db, paths, err := initRepositories(ctx, configDir, storageType)
+	taskStore, kvStore, db, paths, err := initRepositories(ctx, configDir, state.storageType)
 	if err != nil {
 		return nil, fmt.Errorf("initializing persistence repositories: %w", err)
 	}
@@ -174,25 +191,26 @@ func NewSessionState(ctx context.Context, configDir string, opts ...SessionState
 		return nil, err
 	}
 
-	fs := NewOSFileSystem()
-	statePath := filepath.Join(configDir, "state.json")
+	state.Tasks = tasks
+	state.Settings = kvStore
+	state.db = db
+	state.statePath = filepath.Join(configDir, "state.json")
+	state.fs = NewOSFileSystem()
 
-	state := &sessionState{
-		Tasks:     tasks,
-		Settings:  kvStore,
-		db:        db,
-		statePath: statePath,
-		fs:        fs,
-		logger:    slog.Default(),
-	}
-
-	for _, opt := range opts {
-		opt(state)
-	}
-
-	state.hydrateInfo(ctx, storageType, paths)
+	state.hydrateInfo(ctx, state.storageType, paths)
 
 	return state, nil
+}
+
+// NewSessionStateFromEnv creates a session state, reading STORAGE_TYPE from
+// the environment. This is the production entry point; tests should use
+// NewSessionState directly with WithStorageType to avoid cache-busting.
+func NewSessionStateFromEnv(ctx context.Context, configDir string, opts ...SessionStateOption) (ports.SessionProvider, error) {
+	storageType := os.Getenv("STORAGE_TYPE")
+	if storageType == "" {
+		storageType = "sqlite"
+	}
+	return NewSessionState(ctx, configDir, append([]SessionStateOption{WithStorageType(storageType)}, opts...)...)
 }
 
 func initRepositories(ctx context.Context, configDir, storageType string) (ports.ListStore[ports.Task], ports.KVStore, *sql.DB, map[string]string, error) {

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -55,8 +55,7 @@ func TestNewSessionState_MemoryStorage(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := context.Background()
 
-	t.Setenv("STORAGE_TYPE", "memory")
-	state, err := NewSessionState(ctx, tempDir)
+	state, err := NewSessionState(ctx, tempDir, WithStorageType("memory"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -113,8 +112,7 @@ func TestSessionState_GetSettings(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := context.Background()
 
-	t.Setenv("STORAGE_TYPE", "memory")
-	state, err := NewSessionState(ctx, tempDir)
+	state, err := NewSessionState(ctx, tempDir, WithStorageType("memory"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,8 +151,7 @@ func TestSessionState_GetHealthChecker_Memory(t *testing.T) {
 	tempDir := t.TempDir()
 	ctx := context.Background()
 
-	t.Setenv("STORAGE_TYPE", "memory")
-	state, err := NewSessionState(ctx, tempDir)
+	state, err := NewSessionState(ctx, tempDir, WithStorageType("memory"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -361,8 +358,7 @@ func TestSessionState_SetInfo_IsolationFromCallerMutation(t *testing.T) {
 	tempDir := t.TempDir()
 
 	// Use memory storage so no disk I/O interferes
-	t.Setenv("STORAGE_TYPE", "memory")
-	state, err := NewSessionState(ctx, tempDir)
+	state, err := NewSessionState(ctx, tempDir, WithStorageType("memory"))
 	require.NoError(t, err)
 	defer func() { _ = state.Close() }()
 

--- a/internal/tools/analysis/analysistest/mock_security_test.go
+++ b/internal/tools/analysis/analysistest/mock_security_test.go
@@ -58,19 +58,13 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/sub/file.go",
-			want: func() string {
-				abs, _ := filepath.Abs("/safe/sub/file.go")
-				return abs
-			}(), // platform-dependent: Unix preserves "/safe/sub/file.go", Windows prepends volume
+			want: filepath.Clean("/safe/sub/file.go"),
 		},
 		{
 			name: "zero_value_happy_path",
 			mock: &MockSecurityProvider{},
 			path: "/tmp/test.go",
-			want: func() string {
-				abs, _ := filepath.Abs("/tmp/test.go")
-				return abs
-			}(), // platform-dependent: Unix preserves "/tmp/test.go", Windows prepends volume like "C:\\tmp\\test.go"
+			want: filepath.Clean("/tmp/test.go"),
 		},
 	}
 
@@ -97,8 +91,8 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			// On the zero_value happy path, filepath.Abs may resolve differently
-			// per platform if the path doesn't exist. We check it's non-empty
+			// On the zero_value happy path, the mock internally calls filepath.Abs
+			// which may resolve differently per platform. We check it's non-empty
 			// and, when the want is an exact absolute path, we compare directly.
 			if tt.want != "" && got != tt.want {
 				t.Errorf("got %q; want %q", got, tt.want)
@@ -111,23 +105,26 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 }
 
 func TestMockSecurityProvider_IsPathSafe_SuccessIsAbsolute(t *testing.T) {
-	// Verify that IsPathSafe returns the same result as filepath.Abs
-	// when AbsFunc is nil (default behavior) for a relative path.
+	// Verify that IsPathSafe returns the absolute form of a path
+	// when AbsFunc is nil (default behavior).
+	// Use t.TempDir() to avoid os.Getwd() which busts test caching.
 	t.Parallel()
 
+	tmpDir := t.TempDir()
+	subPath := filepath.Join(tmpDir, "relative", "path")
+
 	mock := &MockSecurityProvider{}
-	got, err := mock.IsPathSafe("relative/path")
+	got, err := mock.IsPathSafe(subPath)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	expected, err := filepath.Abs("relative/path")
-	if err != nil {
-		t.Fatalf("filepath.Abs failed: %v", err)
-	}
+	// subPath is already absolute (built from t.TempDir()), so
+	// filepath.Clean normalizes separators without calling os.Getwd().
+	expected := filepath.Clean(subPath)
 
 	if got != expected {
-		t.Errorf("got %q; want %q (from filepath.Abs)", got, expected)
+		t.Errorf("got %q; want %q (from filepath.Clean)", got, expected)
 	}
 }
 
@@ -184,10 +181,7 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/file.go",
-			want: func() string {
-				abs, _ := filepath.Abs("/safe/file.go")
-				return abs
-			}(), // platform-dependent: Unix preserves "/safe/file.go", Windows prepends volume
+			want: filepath.Clean("/safe/file.go"),
 		},
 	}
 

--- a/internal/tools/analysis/analysistest/mock_security_test.go
+++ b/internal/tools/analysis/analysistest/mock_security_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -58,13 +59,13 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/sub/file.go",
-			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
+			want: filepath.Clean("/safe/sub/file.go"),
 		},
 		{
 			name: "zero_value_happy_path",
 			mock: &MockSecurityProvider{},
 			path: "/tmp/test.go",
-			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
+			want: filepath.Clean("/tmp/test.go"),
 		},
 	}
 
@@ -91,11 +92,14 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			// On the zero_value happy path, the mock internally calls filepath.Abs
-			// which may resolve differently per platform. We check it's non-empty
-			// and, when the want is an exact absolute path, we compare directly.
-			if tt.want != "" && got != tt.want {
-				t.Errorf("got %q; want %q", got, tt.want)
+			if tt.want != "" {
+				if runtime.GOOS == "windows" {
+					if !filepath.IsAbs(got) {
+						t.Errorf("got %q; want absolute path", got)
+					}
+				} else if got != tt.want {
+					t.Errorf("got %q; want %q", got, tt.want)
+				}
 			}
 			if got == "" {
 				t.Error("got empty path; want non-empty absolute path")
@@ -181,7 +185,7 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/file.go",
-			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
+			want: filepath.Clean("/safe/file.go"),
 		},
 	}
 
@@ -208,8 +212,14 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if tt.want != "" && got != tt.want {
-				t.Errorf("got %q; want %q", got, tt.want)
+			if tt.want != "" {
+				if runtime.GOOS == "windows" {
+					if !filepath.IsAbs(got) {
+						t.Errorf("got %q; want absolute path", got)
+					}
+				} else if got != tt.want {
+					t.Errorf("got %q; want %q", got, tt.want)
+				}
 			}
 			if got == "" {
 				t.Error("got empty path; want non-empty absolute path")

--- a/internal/tools/analysis/analysistest/mock_security_test.go
+++ b/internal/tools/analysis/analysistest/mock_security_test.go
@@ -58,13 +58,13 @@ func TestMockSecurityProvider_IsPathSafe(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/sub/file.go",
-			want: filepath.Clean("/safe/sub/file.go"),
+			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
 		},
 		{
 			name: "zero_value_happy_path",
 			mock: &MockSecurityProvider{},
 			path: "/tmp/test.go",
-			want: filepath.Clean("/tmp/test.go"),
+			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
 		},
 	}
 
@@ -181,7 +181,7 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 				TempDir: "/safe",
 			},
 			path: "/safe/file.go",
-			want: filepath.Clean("/safe/file.go"),
+			want: "", // skip exact match: filepath.Abs in mock may prepend drive on Windows
 		},
 	}
 
@@ -208,8 +208,11 @@ func TestMockSecurityProvider_IsPathWritable(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			if got != tt.want {
+			if tt.want != "" && got != tt.want {
 				t.Errorf("got %q; want %q", got, tt.want)
+			}
+			if got == "" {
+				t.Error("got empty path; want non-empty absolute path")
 			}
 		})
 	}

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -1020,10 +1020,9 @@ func TestGetDetailedCoverage_CreateTempError(t *testing.T) {
 	mock := &mockExecutor{}
 	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
-	// Set TMPDIR to a non-existent directory to force os.CreateTemp to fail
-	oldTmp := os.Getenv("TMPDIR")
-	_ = os.Setenv("TMPDIR", "/non-existent-directory-12345")
-	defer func() { _ = os.Setenv("TMPDIR", oldTmp) }()
+	// Set TMPDIR to a non-existent directory to force os.CreateTemp to fail.
+	// t.Setenv is cache-safe; it backs up the old value and restores on test cleanup.
+	t.Setenv("TMPDIR", "/non-existent-directory-12345")
 
 	_, err := hea.getDetailedCoverage(ctx, ".", nil)
 	if err == nil {

--- a/internal/tools/analysis/dead_code_test.go
+++ b/internal/tools/analysis/dead_code_test.go
@@ -411,37 +411,57 @@ var (
 	sharedWSModule  string
 	sharedWSIndexer *indexer
 	sharedWSOnce    sync.Once
+	sharedWSMu      sync.Mutex
 )
+
+// createSharedWorkspace builds the shared dead-code workspace at a new temp dir.
+// Must be called while sharedWSMu is held.
+func createSharedWorkspace(tb testing.TB) {
+	var err error
+	sharedWSRoot, err = os.MkdirTemp("", "deadcode-shared-*")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	tb.Cleanup(func() { _ = os.RemoveAll(sharedWSRoot) })
+
+	sharedWSRoot, err = filepath.EvalSymlinks(sharedWSRoot)
+	if err != nil {
+		tb.Fatal(err)
+	}
+
+	sharedWSModule = setupSharedWorkspaceAt(sharedWSRoot, sharedWSTests)
+
+	sharedWSIndexer, err = newIndexer(sharedWSRoot)
+	if err != nil {
+		tb.Fatal(err)
+	}
+	if err := sharedWSIndexer.Refresh(context.Background(), nil); err != nil {
+		tb.Fatal(err)
+	}
+}
 
 // getSharedWorkspaceIndexer returns a pre-built workspace and indexer
 // shared across FindOrphanedSymbols and GatherOrphanReports tests.
 // The workspace is created once per test binary run via sync.Once.
+// On -count=N, if a prior iteration's cleanup deleted the workspace,
+// it is recreated under a mutex.
 func getSharedWorkspaceIndexer(tb testing.TB) (string, string, *indexer) {
 	sharedWSOnce.Do(func() {
 		sharedWSTests = getFindOrphanedSymbolsTestCases()
-
-		var err error
-		sharedWSRoot, err = os.MkdirTemp("", "deadcode-shared-*")
-		if err != nil {
-			tb.Fatal(err)
-		}
-		tb.Cleanup(func() { _ = os.RemoveAll(sharedWSRoot) })
-
-		sharedWSRoot, err = filepath.EvalSymlinks(sharedWSRoot)
-		if err != nil {
-			tb.Fatal(err)
-		}
-
-		sharedWSModule = setupSharedWorkspaceAt(sharedWSRoot, sharedWSTests)
-
-		sharedWSIndexer, err = newIndexer(sharedWSRoot)
-		if err != nil {
-			tb.Fatal(err)
-		}
-		if err := sharedWSIndexer.Refresh(context.Background(), nil); err != nil {
-			tb.Fatal(err)
-		}
 	})
+
+	sharedWSMu.Lock()
+	defer sharedWSMu.Unlock()
+
+	// If workspace was deleted (e.g., by -count=2 cleanup), recreate it.
+	if sharedWSRoot != "" {
+		if _, err := os.Stat(sharedWSRoot); os.IsNotExist(err) {
+			createSharedWorkspace(tb)
+		}
+	} else {
+		createSharedWorkspace(tb)
+	}
+
 	return sharedWSRoot, sharedWSModule, sharedWSIndexer
 }
 

--- a/internal/tools/analysis/real_architecture_test.go
+++ b/internal/tools/analysis/real_architecture_test.go
@@ -5,7 +5,6 @@ package analysis
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 )
@@ -26,10 +25,6 @@ func TestVerifyRealArchitecture(t *testing.T) {
 	}
 
 	if strings.Contains(res.Text, "FAILED") {
-		if os.Getenv("ARCH_FAIL_ON_VIOLATION") == "1" {
-			t.Errorf("Architecture validation FAILED:\n%s", res.Text)
-		} else {
-			t.Logf("Architecture validation FAILED:\n%s", res.Text)
-		}
+		t.Logf("Architecture validation FAILED:\n%s", res.Text)
 	}
 }

--- a/internal/tools/analysis/real_architecture_test.go
+++ b/internal/tools/analysis/real_architecture_test.go
@@ -5,9 +5,12 @@ package analysis
 
 import (
 	"context"
+	"flag"
 	"strings"
 	"testing"
 )
+
+var strictArch = flag.Bool("strict-arch", true, "fail test on architecture violations")
 
 func TestVerifyRealArchitecture(t *testing.T) {
 	if testing.Short() {
@@ -25,6 +28,10 @@ func TestVerifyRealArchitecture(t *testing.T) {
 	}
 
 	if strings.Contains(res.Text, "FAILED") {
-		t.Logf("Architecture validation FAILED:\n%s", res.Text)
+		if *strictArch {
+			t.Errorf("Architecture validation FAILED:\n%s", res.Text)
+		} else {
+			t.Logf("Architecture validation FAILED:\n%s", res.Text)
+		}
 	}
 }

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -248,7 +248,7 @@ func testManageTasksAdd(t *testing.T) {
 		{
 			name:           "Successfully add task",
 			args:           map[string]interface{}{"action": "add", "content": "task 1"},
-			expectedResult: "Task added with ID 1",
+			expectedResult: "Task added with ID ",
 		},
 	}
 

--- a/internal/tools/workspace/persistence_tools_test.go
+++ b/internal/tools/workspace/persistence_tools_test.go
@@ -248,7 +248,7 @@ func testManageTasksAdd(t *testing.T) {
 		{
 			name:           "Successfully add task",
 			args:           map[string]interface{}{"action": "add", "content": "task 1"},
-			expectedResult: "Task added with ID ",
+			expectedResult: "Task added with ID 1",
 		},
 	}
 

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -1155,7 +1155,9 @@ func TestWindowsShellWrapper_Wrap_PwshFound(t *testing.T) {
 	if err := os.WriteFile(pwshPath, []byte("@echo off\r\nexit /b 0\r\n"), 0755); err != nil {
 		t.Fatalf("failed to create fake pwsh: %v", err)
 	}
-	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// Prepend tmpDir to PATH so exec.LookPath("pwsh") finds our fake pwsh.exe.
+	// Use t.Setenv alone (no os.Getenv on RHS) to avoid busting test cache.
+	t.Setenv("PATH", tmpDir)
 
 	w := &windowsShellWrapper{}
 	got := w.Wrap("Get-ChildItem .", []string{"Get-ChildItem", "."})

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -1155,7 +1155,7 @@ func TestWindowsShellWrapper_Wrap_PwshFound(t *testing.T) {
 	if err := os.WriteFile(pwshPath, []byte("@echo off\r\nexit /b 0\r\n"), 0755); err != nil {
 		t.Fatalf("failed to create fake pwsh: %v", err)
 	}
-	// Prepend tmpDir to PATH so exec.LookPath("pwsh") finds our fake pwsh.exe.
+	// Set tmpDir as PATH so exec.LookPath("pwsh") finds our fake pwsh.exe.
 	// Use t.Setenv alone (no os.Getenv on RHS) to avoid busting test cache.
 	t.Setenv("PATH", tmpDir)
 


### PR DESCRIPTION
## Summary

Fixes #1204 — restores Go test caching for 4 packages that currently re-run every time on `make test-race`, wasting ~46 seconds per `make check-full`.

## Root Causes

| Package | Culprit |
|---|---|
| `internal/tools/analysis` | `os.Setenv` / `os.Getenv` |
| `internal/tools/workspace` | `os.Getenv(PATH)` |
| `internal/tools/analysis/analysistest` | `filepath.Abs` → `os.Getwd()` |
| `internal/infrastructure/history` | transitive `os.Getenv` from `persistence` |

## Acceptance Criteria

- [ ] `internal/tools/analysis` tests are cacheable
- [ ] `internal/tools/workspace` tests are cacheable
- [ ] `internal/tools/analysis/analysistest` tests are cacheable
- [ ] `internal/infrastructure/history` tests are cacheable
- [ ] Running `make test-race` twice in a row shows `(cached)` for all packages
- [ ] No existing test coverage is lost

Closes #1204