### PR TITLE
perf: reduce e2e test suite from ~17s to ~9.4s (44% faster)

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -65,12 +65,26 @@ func TestMain(m *testing.M) {
 	projectRoot = filepath.Dir(filepath.Dir(wd))
 	mainPath := filepath.Join(projectRoot, "cmd", "tell-me-go", "main.go")
 
-	fmt.Printf("Building binary: %s from %s\n", binPath, mainPath)
-	build := exec.Command("go", "build", "-o", binPath, mainPath)
-	if out, err := build.CombinedOutput(); err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to build binary: %v\nOutput: %s\n", err, string(out))
-		_ = os.RemoveAll(tempDir)
-		os.Exit(1)
+	// Skip rebuild if the binary is already up-to-date (faster incremental runs).
+	needsBuild := true
+	if binInfo, err := os.Stat(binPath); err == nil {
+		if srcInfo, err := os.Stat(mainPath); err == nil {
+			if binInfo.ModTime().After(srcInfo.ModTime()) {
+				needsBuild = false
+			}
+		}
+	}
+
+	if needsBuild {
+		fmt.Printf("Building binary: %s from %s\n", binPath, mainPath)
+		build := exec.Command("go", "build", "-o", binPath, mainPath)
+		if out, err := build.CombinedOutput(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to build binary: %v\nOutput: %s\n", err, string(out))
+			_ = os.RemoveAll(tempDir)
+			os.Exit(1)
+		}
+	} else {
+		fmt.Printf("Using cached binary: %s\n", binPath)
 	}
 
 	code := m.Run()
@@ -357,12 +371,22 @@ func TestStdinPiping(t *testing.T) {
 		t.Skip("skipping slow E2E test in short mode")
 	}
 
+	// Setup a minimal mock server so the binary does not attempt a real
+	// network connection. The test only needs to verify stdin piping logs.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
 	homeDir := t.TempDir()
-	env := []string{"TELL_ME_HOME=" + homeDir}
+	configPath := createTempConfig(t, "google", server.URL)
+	env := []string{
+		"TELL_ME_HOME=" + homeDir,
+		"TELL_ME_MOCK_URL=" + server.URL,
+	}
 
 	stdinContent := "This is from stdin"
-	// We check if the stderr shows "Input captured" which is a log in main.go
-	_, stderr, _ := runCommandWithEnv(env, stdinContent, "Prompt from arg")
+	_, stderr, _ := runCommandWithEnvInDir(homeDir, env, stdinContent, "-c", configPath, "Prompt from arg")
 
 	out := stripANSI(stderr)
 	if !strings.Contains(out, "Input captured") {

--- a/tests/e2e/history_flags_test.go
+++ b/tests/e2e/history_flags_test.go
@@ -57,7 +57,7 @@ func newHistoryNavEnv(t *testing.T) *historyNavEnv {
 			t.Fatalf("Failed to send prompt %q: %v", p, err)
 		}
 		forceReconcileHistory(t, histPath)
-		time.Sleep(1000 * time.Millisecond)
+		waitForHistoryStable(t, histPath, 2*time.Second)
 	}
 
 	return &historyNavEnv{
@@ -65,6 +65,27 @@ func newHistoryNavEnv(t *testing.T) *historyNavEnv {
 		configPath: configPath,
 		histPath:   histPath,
 	}
+}
+
+// waitForHistoryStable polls the history file until its size stabilizes
+// (two consecutive reads return the same size), or until timeout.
+func waitForHistoryStable(t *testing.T, path string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	var lastSize int64 = -1
+	for time.Now().Before(deadline) {
+		fi, err := os.Stat(path)
+		if err != nil {
+			time.Sleep(10 * time.Millisecond)
+			continue
+		}
+		if fi.Size() == lastSize {
+			return // stable (size 0 is terminal — the binary may have failed)
+		}
+		lastSize = fi.Size()
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Logf("history file %s did not stabilize within %v (final size: %d)", path, timeout, lastSize)
 }
 
 // forceReconcileHistory ensures the history file is fully flushed and visible on Windows.
@@ -119,7 +140,7 @@ func TestHistoryNavigationFlags_GoBack(t *testing.T) {
 		t.Fatalf("CLI -b 1 failed: %v\nStderr: %s", err, stderr)
 	}
 	forceReconcileHistory(t, env.histPath)
-	time.Sleep(1000 * time.Millisecond)
+	waitForHistoryStable(t, env.histPath, 2*time.Second)
 
 	stdout, stderr, err := runCommandWithEnv(env.env, "", "-c="+env.configPath, "-l", "4")
 	if err != nil {
@@ -153,7 +174,7 @@ func TestHistoryNavigationFlags_Retry(t *testing.T) {
 		t.Fatalf("CLI -b 1 (prerequisite for retry) failed: %v\nStderr: %s", err, stderr)
 	}
 	forceReconcileHistory(t, env.histPath)
-	time.Sleep(1000 * time.Millisecond)
+	waitForHistoryStable(t, env.histPath, 2*time.Second)
 
 	// Test --retry
 	stdout, stderr, err := runCommandWithEnv(env.env, "", "-c="+env.configPath, "--retry")
@@ -161,7 +182,7 @@ func TestHistoryNavigationFlags_Retry(t *testing.T) {
 		t.Fatalf("CLI --retry failed: %v\nStderr: %s", err, stderr)
 	}
 	forceReconcileHistory(t, env.histPath)
-	time.Sleep(1000 * time.Millisecond)
+	waitForHistoryStable(t, env.histPath, 2*time.Second)
 
 	out := stripANSI(stdout)
 	if !strings.Contains(out, "Response to your prompt") {
@@ -204,7 +225,7 @@ func TestHistoryOnlyExit(t *testing.T) {
 
 	_, _, _ = runCommandWithEnv(env, "", "-c="+configPath, "initial message")
 	forceReconcileHistory(t, histPath)
-	time.Sleep(500 * time.Millisecond)
+	waitForHistoryStable(t, histPath, 2*time.Second)
 
 	t.Run("ShowHistoryAndExit", func(t *testing.T) {
 		stdout, stderr, err := runCommandWithEnv(env, "", "-c="+configPath, "-l")
@@ -223,7 +244,7 @@ func TestHistoryOnlyExit(t *testing.T) {
 			t.Fatalf("CLI -b 1 failed: %v\nStderr: %s", err, stderr)
 		}
 		forceReconcileHistory(t, histPath)
-		time.Sleep(500 * time.Millisecond)
+		waitForHistoryStable(t, histPath, 2*time.Second)
 
 		if !strings.Contains(stdout, "Rolled back 1 turns") {
 			t.Error("Expected stdout to contain rollback confirmation")


### PR DESCRIPTION
## Summary

Closes #1211.

Reduces `go test ./tests/e2e/...` from **~16.7s → ~9.4s** (44% faster) by fixing three bottlenecks identified in the investigation.

## Changes

### 1. Fix `TestStdinPiping` — missing mock server (19.4s → 0.22s)
The test had no `TELL_ME_MOCK_URL`, causing the binary to attempt a real network connection and block on TCP timeout. Added a minimal `httptest.Server` and explicit temp config via `runCommandWithEnvInDir`.

### 2. Replace all `time.Sleep` with polling in history tests
Added `waitForHistoryStable()` helper that polls `os.Stat` at 10ms intervals until the history file size stabilizes. Replaced 6 `time.Sleep` calls across `newHistoryNavEnv`, `TestHistoryNavigationFlags_GoBack`, `TestHistoryNavigationFlags_Retry`, and `TestHistoryOnlyExit`.

### 3. Cache binary build in `TestMain`
Skip `go build` when the binary already exists and is newer than `main.go`, using `ModTime` comparison.

## Per-test impact

| Test | Before | After |
|---|---|---|
| `TestStdinPiping` | 19.4s | 0.22s |
| `TestHistoryNavigationFlags_Retry` | 5.5s | 0.65s |
| `TestHistoryNavigationFlags_GoBack` | 4.5s | 0.56s |
| `TestHistoryNavigationFlags_LastNMessages` | 3.4s | 0.51s |
| `TestHistoryOnlyExit` | 1.3s | 0.37s |

## Remaining

~4.6s is the one-time binary build in `TestMain` (temp dir scoping prevents cross-invocation caching). ~2.8s is `TestBypassArchiving`/`TestSessionArchiving` subprocess spawns for the `--new` archiving path — converting these to in-process DI tests (like `golden_path_test.go`) is a potential follow-up.