### PR TITLE
perf: Reduce workspace test suite runtime from ~10.7s to ~3.4s

### DIFF
--- a/internal/tools/workspace/git.go
+++ b/internal/tools/workspace/git.go
@@ -14,8 +14,9 @@ import (
 )
 
 type gitManager struct {
-	sm   gitSecurity
-	Exec tools.CommandExecutor
+	sm                gitSecurity
+	Exec              tools.CommandExecutor
+	heartbeatInterval time.Duration // zero means default (2s)
 }
 
 func (m *gitManager) getGitStatus(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -159,7 +160,11 @@ func (m *gitManager) runGitCommand(ctx context.Context, hb chan<- struct{}, args
 	// Heartbeat while git is running
 	done := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(2 * time.Second)
+		interval := m.heartbeatInterval
+		if interval <= 0 {
+			interval = 2 * time.Second
+		}
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/internal/tools/workspace/git_test.go
+++ b/internal/tools/workspace/git_test.go
@@ -413,6 +413,7 @@ func TestRunGitCommand_HeartbeatTickerFires(t *testing.T) {
 	unblock := make(chan struct{})
 
 	m := &gitManager{
+		heartbeatInterval: 1 * time.Millisecond,
 		Exec: &mockGitExecutor{
 			handler: func(ctx context.Context, name string, args ...string) ([]byte, error) {
 				select {
@@ -445,7 +446,7 @@ func TestRunGitCommand_HeartbeatTickerFires(t *testing.T) {
 		close(unblock)
 	case <-done:
 		t.Fatal("runGitCommand returned before ticker fired")
-	case <-time.After(5 * time.Second):
+	case <-time.After(500 * time.Millisecond):
 		t.Fatal("timed out waiting for heartbeat ticker to fire")
 	}
 

--- a/internal/tools/workspace/process_executor_posix_test.go
+++ b/internal/tools/workspace/process_executor_posix_test.go
@@ -13,12 +13,12 @@ import (
 
 func TestTimeoutKillsProcessTree(t *testing.T) {
 	e := newprocessExecutor()
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	defer cancel()
 
 	start := time.Now()
-	_, _ = e.RunCommand(ctx, []string{"sh", "-c", "echo started; sleep 6 & wait"}, executionConfig{})
-	if elapsed := time.Since(start); elapsed > 3*time.Second {
-		t.Errorf("RunCommand blocked %v past the 1s deadline (orphaned grandchild held the pipe)", elapsed)
+	_, _ = e.RunCommand(ctx, []string{"sh", "-c", "echo started; sleep 2 & wait"}, executionConfig{})
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Errorf("RunCommand blocked %v past the 100ms deadline (orphaned grandchild held the pipe)", elapsed)
 	}
 }

--- a/internal/tools/workspace/process_executor_test.go
+++ b/internal/tools/workspace/process_executor_test.go
@@ -71,10 +71,10 @@ func TestRunPipeline_TableDriven(t *testing.T) {
 		{
 			name: "context timeout",
 			pipedParts: [][]string{
-				{helperPath, "sleep", "2"},
+				{helperPath, "sleep", "0.2"},
 				{helperPath, "cat"},
 			},
-			timeout:          500 * time.Millisecond,
+			timeout:          100 * time.Millisecond,
 			wantErr:          true,
 			expectedExitCode: -1, // non-zero
 		},

--- a/internal/tools/workspace/shell.go
+++ b/internal/tools/workspace/shell.go
@@ -191,12 +191,13 @@ func (w *windowsShellWrapper) isPowerShellIndicator(command string, parts []stri
 }
 
 type shellTool struct {
-	sm         shellSecurity
-	validator  domain_security.CommandValidator
-	executor   *processExecutor
-	translator commandTranslator
-	wrapper    shellWrapper
-	maxOutput  int
+	sm                shellSecurity
+	validator         domain_security.CommandValidator
+	executor          *processExecutor
+	translator        commandTranslator
+	wrapper           shellWrapper
+	maxOutput         int
+	heartbeatInterval time.Duration // zero means default (2s)
 }
 
 func newshellTool(sm shellSecurity, validator domain_security.CommandValidator, translator commandTranslator, wrapper shellWrapper) *shellTool {
@@ -557,7 +558,11 @@ func (t *shellTool) prepareCommand(command string) ([]string, error) {
 func (t *shellTool) startHeartbeat(hb chan<- struct{}) (stop func()) {
 	done := make(chan struct{})
 	go func() {
-		ticker := time.NewTicker(2 * time.Second)
+		interval := t.heartbeatInterval
+		if interval <= 0 {
+			interval = 2 * time.Second
+		}
+		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
@@ -633,14 +634,15 @@ func TestShellTool_StartHeartbeat_TickFires(t *testing.T) {
 	sm.SetBypassActive(true)
 	validator := &toolstest.MockCommandValidator{}
 	tool := newTestShellTool(sm, validator)
+	tool.heartbeatInterval = 1 * time.Millisecond
 	ctx := context.Background()
 
 	hb := make(chan struct{}, 1)
 	helperSlash := filepath.ToSlash(helperPath)
 
-	// Sleep long enough for the 2-second heartbeat ticker to fire at least once
+	// Sleep just long enough for the 1ms heartbeat ticker to fire at least once
 	res, err := tool.ExecuteCommand(ctx, map[string]interface{}{
-		"command": fmt.Sprintf("%s sleep 3", helperSlash),
+		"command": fmt.Sprintf("%s sleep 0.05", helperSlash),
 		"reason":  "test heartbeat tick fires",
 		"timeout": 10,
 	}, hb)
@@ -869,9 +871,9 @@ func TestShellTool_TimeoutEnforcement(t *testing.T) {
 	helperSlash := filepath.ToSlash(helperPath)
 
 	t.Run("ExecuteCommand timeout enforcement", func(t *testing.T) {
-		// Sleep for 2 seconds with a 1 second timeout
+		// Sleep for 1.1 seconds with a 1 second timeout
 		args := map[string]interface{}{
-			"command": fmt.Sprintf("%s sleep 2", helperSlash),
+			"command": fmt.Sprintf("%s sleep 1.1", helperSlash),
 			"reason":  "testing timeout enforcement",
 			"timeout": 1,
 		}
@@ -885,9 +887,9 @@ func TestShellTool_TimeoutEnforcement(t *testing.T) {
 	})
 
 	t.Run("PipeCommands timeout enforcement", func(t *testing.T) {
-		// Sleep for 2 seconds with a 1 second timeout
+		// Sleep for 1.1 seconds with a 1 second timeout
 		args := map[string]interface{}{
-			"commands": []interface{}{fmt.Sprintf("%s sleep 2", helperSlash), fmt.Sprintf("%s echo done", helperSlash)},
+			"commands": []interface{}{fmt.Sprintf("%s sleep 1.1", helperSlash), fmt.Sprintf("%s echo done", helperSlash)},
 			"reason":   "testing pipe timeout enforcement",
 			"timeout":  1,
 		}


### PR DESCRIPTION
## Summary

Reduces `internal/tools/workspace` test suite runtime by **68%** (~10.7s → ~3.4s).

Closes [#1213](https://github.com/gosharplite/tell-me-go/issues/1213).

## Changes

### Category 1: Sleep/timeout value reductions (~2.4s saved)

| Test | Before | After |
|---|---|---|
| `TestShellTool_TimeoutEnforcement` (2 subtests) | `sleep 2` | `sleep 1.1` |
| `TestTimeoutKillsProcessTree` | 1s timeout, `sleep 6` | 100ms timeout, `sleep 2` |
| `TestRunPipeline_TableDriven/context_timeout` | 500ms timeout, `sleep 2` | 100ms timeout, `sleep 0.2` |

### Category 2: Injectable heartbeat ticker (~5s saved)

Added `heartbeatInterval time.Duration` field to both `shellTool` and `gitManager` structs. Zero-value defaults to `2 * time.Second` (unchanged production behavior). Tests set `1 * time.Millisecond`.

| Test | Before | After |
|---|---|---|
| `TestShellTool_StartHeartbeat_TickFires` | 2s ticker + `sleep 3` | 1ms ticker + `sleep 0.05` |
| `TestRunGitCommand_HeartbeatTickerFires` | 2s ticker + 5s safety timeout | 1ms ticker + 500ms safety timeout |

## Safety

- Both `newshellTool` and `registerGit` create structs without setting `heartbeatInterval`, so it stays at zero → `<= 0` guard → 2s default.
- All existing tests pass.
- No API or behavior changes in production code paths.