### PR TITLE
Decouple tool output from TerminalController via EventBus (#1218)

### DIFF
--- a/internal/domain/events/events.go
+++ b/internal/domain/events/events.go
@@ -57,3 +57,14 @@ func (s *funcSubscriber) Handle(ctx context.Context, e Event) error {
 	s.f(ctx, e)
 	return nil
 }
+
+// NoOpEventBus is an EventBus implementation that silently discards all events.
+// Use it as a safe default when no real EventBus is needed (e.g., in tests).
+type NoOpEventBus struct{}
+
+func (NoOpEventBus) Publish(ctx context.Context, e Event) error { return nil }
+func (NoOpEventBus) Subscribe(sub func(context.Context, Event)) {}
+func (NoOpEventBus) Shutdown(ctx context.Context) error         { return nil }
+func (NoOpEventBus) Flush(ctx context.Context) error            { return nil }
+func (NoOpEventBus) Listen(ctx context.Context) error           { <-ctx.Done(); return ctx.Err() }
+func (NoOpEventBus) WaitStarted()                               {}

--- a/internal/domain/events/events_test.go
+++ b/internal/domain/events/events_test.go
@@ -402,6 +402,7 @@ func TestEventTypes(t *testing.T) {
 		events.ConfigUpdated{},
 		events.TurnStatusEvent{},
 		events.ToolExecutionStartedEvent{},
+		events.ToolOutputStreamEvent{Message: "hello", Level: "warn", ToolName: "test_tool"},
 	}
 
 	for _, e := range events_list {

--- a/internal/domain/events/types.go
+++ b/internal/domain/events/types.go
@@ -239,3 +239,18 @@ type SpinnerInfo struct {
 	WithMetrics    bool   // If true, use StartSpinnerWithMetrics instead of StartSpinnerWithStatus
 	ResetRendering bool   // If true, the spinner transition resets the rendering state
 }
+
+// ToolOutputStreamEvent carries tool-generated output that should be rendered
+// by the UI Bridge instead of being written directly to the terminal.
+// This decouples tools from TerminalController, enabling clean TUI rendering
+// for progress modes and future multi-output scenarios.
+type ToolOutputStreamEvent struct {
+	// Message is the text to render (e.g., "Executing... (Output shown below)").
+	Message string
+	// Level indicates the severity: "info" or "warn". Default is "info".
+	Level string
+	// ToolName is the optional name of the tool producing this output (e.g., "execute_command").
+	ToolName string
+}
+
+func (e ToolOutputStreamEvent) Type() string { return "ToolOutputStreamEvent" }

--- a/internal/tools/developer/dev.go
+++ b/internal/tools/developer/dev.go
@@ -354,13 +354,11 @@ func (m *devManager) checkVulnerabilities(ctx context.Context, args map[string]i
 	return res, nil
 }
 
-func (m *devManager) logToolAction(format string, a ...any) {
-	if m.eventBus != nil {
-		_ = m.eventBus.Publish(context.Background(), events.ToolOutputStreamEvent{
-			Message: fmt.Sprintf("[Tool Action] "+format, a...),
-			Level:   "info",
-		})
-	}
+func (m *devManager) logToolAction(ctx context.Context, format string, a ...any) {
+	_ = m.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+		Message: fmt.Sprintf("[Tool Action] "+format, a...),
+		Level:   "info",
+	})
 }
 
 func formatExecutionResult(displayName string, out []byte, execErr error, truncateLimit int, emptySuccessMsg string) tools.ToolResult {
@@ -402,7 +400,7 @@ func (m *devManager) runWithHeartbeat(
 	}
 
 	// 2. Logging
-	m.logToolAction("Running %s: %s", strings.ToLower(actionName), fullCmd)
+	m.logToolAction(ctx, "Running %s: %s", strings.ToLower(actionName), fullCmd)
 
 	// 3. Telemetry/Heartbeat (Safe concurrency)
 	defer telemetry.StartHeartbeat(ctx, m.heartbeatInterval, hb)()

--- a/internal/tools/developer/dev.go
+++ b/internal/tools/developer/dev.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
@@ -39,6 +40,7 @@ type goRunner interface {
 
 type devManager struct {
 	sm                devSecurity
+	eventBus          events.EventBus
 	validator         domain_security.CommandValidator
 	executor          executor
 	runner            goRunner
@@ -353,9 +355,12 @@ func (m *devManager) checkVulnerabilities(ctx context.Context, args map[string]i
 }
 
 func (m *devManager) logToolAction(format string, a ...any) {
-	m.sm.TerminalLock()
-	defer m.sm.TerminalUnlock()
-	m.sm.Warn(fmt.Sprintf("[Tool Action] "+format, a...))
+	if m.eventBus != nil {
+		_ = m.eventBus.Publish(context.Background(), events.ToolOutputStreamEvent{
+			Message: fmt.Sprintf("[Tool Action] "+format, a...),
+			Level:   "info",
+		})
+	}
 }
 
 func formatExecutionResult(displayName string, out []byte, execErr error, truncateLimit int, emptySuccessMsg string) tools.ToolResult {
@@ -421,9 +426,10 @@ func (m *devManager) executeWithHeartbeat(
 	return out, err
 }
 
-func newDevManager(sm devSecurity, validator domain_security.CommandValidator, runner goRunner, opts ...devOption) *devManager {
+func newDevManager(sm devSecurity, eventBus events.EventBus, validator domain_security.CommandValidator, runner goRunner, opts ...devOption) *devManager {
 	m := &devManager{
 		sm:                sm,
+		eventBus:          eventBus,
 		validator:         validator,
 		executor:          &realExecutor{},
 		runner:            runner,
@@ -439,5 +445,4 @@ func newDevManager(sm devSecurity, validator domain_security.CommandValidator, r
 type devSecurity interface {
 	domain_security.ActionConfirmer
 	domain_security.Auditor
-	domain_security.TerminalController
 }

--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -680,7 +680,7 @@ func TestNewDevManager(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 	runner := &mockGoRunner{}
-	m := newDevManager(sm, validator, runner)
+	m := newDevManager(sm, nil, validator, runner)
 	assert.NotNil(t, m)
 	assert.NotNil(t, m.executor)
 }
@@ -963,7 +963,7 @@ func TestSecurityRemediation(t *testing.T) {
 func TestDevManager_Options(t *testing.T) {
 	t.Parallel()
 	customInterval := 42 * time.Second
-	m := newDevManager(nil, nil, nil, withHeartbeatInterval(customInterval))
+	m := newDevManager(nil, nil, nil, nil, withHeartbeatInterval(customInterval))
 
 	if m.heartbeatInterval != customInterval {
 		t.Errorf("expected interval %v, got %v", customInterval, m.heartbeatInterval)
@@ -1243,4 +1243,14 @@ func TestRealExecutor_Execute(t *testing.T) {
 	out, err := e.Execute(context.Background(), name, args...)
 	require.NoError(t, err)
 	assert.Contains(t, string(out), "hello")
+}
+
+func TestLogToolAction_NilEventBus(t *testing.T) {
+	t.Parallel()
+	m := &devManager{
+		sm:       &toolstest.MockSecurityManager{AllowAll: true},
+		eventBus: nil,
+	}
+	// Must not panic when eventBus is nil
+	m.logToolAction("Running %s: %s", "test_action", "echo hello")
 }

--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
@@ -116,6 +117,7 @@ func setupDevManager(t *testing.T) (*devManager, *mockDevExecutor, *toolstest.Mo
 	runner := &mockGoRunner{}
 	m := &devManager{
 		sm:             sm,
+		eventBus:       &events.NoOpEventBus{},
 		validator:      &toolstest.MockCommandValidator{},
 		executor:       executor,
 		runner:         runner,
@@ -680,7 +682,7 @@ func TestNewDevManager(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 	runner := &mockGoRunner{}
-	m := newDevManager(sm, nil, validator, runner)
+	m := newDevManager(sm, &events.NoOpEventBus{}, validator, runner)
 	assert.NotNil(t, m)
 	assert.NotNil(t, m.executor)
 }
@@ -963,7 +965,7 @@ func TestSecurityRemediation(t *testing.T) {
 func TestDevManager_Options(t *testing.T) {
 	t.Parallel()
 	customInterval := 42 * time.Second
-	m := newDevManager(nil, nil, nil, nil, withHeartbeatInterval(customInterval))
+	m := newDevManager(nil, &events.NoOpEventBus{}, nil, nil, withHeartbeatInterval(customInterval))
 
 	if m.heartbeatInterval != customInterval {
 		t.Errorf("expected interval %v, got %v", customInterval, m.heartbeatInterval)
@@ -1245,12 +1247,12 @@ func TestRealExecutor_Execute(t *testing.T) {
 	assert.Contains(t, string(out), "hello")
 }
 
-func TestLogToolAction_NilEventBus(t *testing.T) {
+func TestLogToolAction_NoOpEventBus(t *testing.T) {
 	t.Parallel()
 	m := &devManager{
 		sm:       &toolstest.MockSecurityManager{AllowAll: true},
-		eventBus: nil,
+		eventBus: &events.NoOpEventBus{},
 	}
-	// Must not panic when eventBus is nil
-	m.logToolAction("Running %s: %s", "test_action", "echo hello")
+	// Must not panic when eventBus is a no-op
+	m.logToolAction(context.Background(), "Running %s: %s", "test_action", "echo hello")
 }

--- a/internal/tools/developer/registration.go
+++ b/internal/tools/developer/registration.go
@@ -6,6 +6,7 @@ package developer
 import (
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/services"
@@ -14,9 +15,9 @@ import (
 )
 
 // Register adds all development workflow and release tools to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, archVerify tools.ToolFunc) error {
+func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, archVerify tools.ToolFunc, eventBus events.EventBus) error {
 	runner := toolchain.NewGoRunner(exec)
-	dev := newDevManager(sm, validator, runner)
+	dev := newDevManager(sm, eventBus, validator, runner)
 
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{
 		Name:        "run_tests",

--- a/internal/tools/developer/registration_test.go
+++ b/internal/tools/developer/registration_test.go
@@ -80,7 +80,7 @@ func TestRegister(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
 	exec := &mockToolchainExecutor{}
 
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
@@ -163,7 +163,7 @@ func TestRegister_PartialFailure(t *testing.T) {
 			fs := persistence.NewMockFileSystem()
 			exec := &mockToolchainExecutor{}
 
-			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil)
+			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil)
 
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -193,7 +193,7 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	exec := &mockToolchainExecutor{}
 
 	// First registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 		t.Fatalf("first Register failed: %v", err)
 	}
 
@@ -212,7 +212,7 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	}
 
 	// Second registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 		t.Fatalf("second Register failed: %v", err)
 	}
 

--- a/internal/tools/developer/registration_test.go
+++ b/internal/tools/developer/registration_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
@@ -80,7 +81,7 @@ func TestRegister(t *testing.T) {
 	fs := persistence.NewMockFileSystem()
 	exec := &mockToolchainExecutor{}
 
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
@@ -163,7 +164,7 @@ func TestRegister_PartialFailure(t *testing.T) {
 			fs := persistence.NewMockFileSystem()
 			exec := &mockToolchainExecutor{}
 
-			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil)
+			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{})
 
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -193,7 +194,7 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	exec := &mockToolchainExecutor{}
 
 	// First registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("first Register failed: %v", err)
 	}
 
@@ -212,7 +213,7 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	}
 
 	// Second registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("second Register failed: %v", err)
 	}
 

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -62,7 +62,7 @@ func RegisterAll(params ToolRegistrationParams) error {
 	if err := validateRegistrationParams(params); err != nil {
 		return err
 	}
-	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager); err != nil {
+	if err := workspace.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, params.HealthManager, params.EventBus); err != nil {
 		return fmt.Errorf("workspace.Register: %w", err)
 	}
 	if params.SessionProvider != nil {
@@ -74,7 +74,7 @@ func RegisterAll(params ToolRegistrationParams) error {
 	if err != nil {
 		return fmt.Errorf("analysis.Register: %w", err)
 	}
-	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify); err != nil {
+	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify, params.EventBus); err != nil {
 		return fmt.Errorf("developer.Register: %w", err)
 	}
 	if err := integrations.RegisterAll(params.Registry, params.FileSystem, params.SecurityManager, params.Client, params.AssetsDir); err != nil {

--- a/internal/tools/workspace/git_test.go
+++ b/internal/tools/workspace/git_test.go
@@ -179,7 +179,7 @@ func TestGitTools(t *testing.T) {
 			}
 
 			reg := registry.New()
-			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 				t.Fatalf("Register failed: %v", err)
 			}
 
@@ -277,7 +277,7 @@ func TestGitDestructiveActions(t *testing.T) {
 			}
 
 			reg := registry.New()
-			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+			if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 				t.Fatalf("Register failed: %v", err)
 			}
 
@@ -315,7 +315,7 @@ func TestGitBlameSafety(t *testing.T) {
 	}
 
 	reg := registry.New()
-	if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+	if err := Register(reg, sm, executor, security.NewCommandValidator(sm, nil), persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 

--- a/internal/tools/workspace/registration.go
+++ b/internal/tools/workspace/registration.go
@@ -6,6 +6,7 @@ package workspace
 import (
 	"runtime"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
@@ -20,11 +21,11 @@ type fileSystemManager struct {
 }
 
 // Register adds all workspace-related tools (file, git, system) to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, health ports.HealthCheckManager) error {
+func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, health ports.HealthCheckManager, eventBus events.EventBus) error {
 	if err := registerFiles(r, sm, fs, exec, wp); err != nil {
 		return err
 	}
-	if err := registerSystem(r, sm, validator, health); err != nil {
+	if err := registerSystem(r, sm, validator, health, eventBus); err != nil {
 		return err
 	}
 	if err := registerGit(r, sm, exec); err != nil {
@@ -294,7 +295,7 @@ func registerFiles(r tools.Registry, sm domain_security.Manager, fs persistence.
 	return nil
 }
 
-func registerSystem(r tools.Registry, sm domain_security.Manager, validator domain_security.CommandValidator, health ports.HealthCheckManager) error {
+func registerSystem(r tools.Registry, sm domain_security.Manager, validator domain_security.CommandValidator, health ports.HealthCheckManager, eventBus events.EventBus) error {
 	var translator commandTranslator
 	var wrapper shellWrapper
 	if runtime.GOOS == "windows" {
@@ -305,7 +306,7 @@ func registerSystem(r tools.Registry, sm domain_security.Manager, validator doma
 		wrapper = &posixShellWrapper{}
 	}
 
-	shell := newshellTool(sm, validator, translator, wrapper)
+	shell := newshellTool(sm, eventBus, validator, translator, wrapper)
 	diagnostic := newDiagnosticTool(health)
 
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -66,7 +66,7 @@ func TestRegister(t *testing.T) {
 	validator := &toolstest.MockCommandValidator{}
 	fs := persistencetest.NewPlainOSFileSystem()
 
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil); err != nil {
+	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, nil); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
@@ -110,7 +110,7 @@ func TestRegister(t *testing.T) {
 	t.Run("check_system_health", func(t *testing.T) {
 		reg := &mockToolRegistry{}
 		mockHealth := &mockHealthCheckManager{}
-		if err := Register(reg, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), mockHealth); err != nil {
+		if err := Register(reg, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), mockHealth, nil); err != nil {
 			t.Fatalf("Register failed: %v", err)
 		}
 		found := false
@@ -239,7 +239,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "execute_command",
 		}
-		err := registerSystem(registry, sm, validator, nil)
+		err := registerSystem(registry, sm, validator, nil, nil)
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -253,7 +253,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "pipe_commands",
 		}
-		err := registerSystem(registry, sm, validator, nil)
+		err := registerSystem(registry, sm, validator, nil, nil)
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -268,7 +268,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			failOnTool:       "check_system_health",
 		}
 		mockHealth := &mockHealthCheckManager{}
-		err := registerSystem(registry, sm, validator, mockHealth)
+		err := registerSystem(registry, sm, validator, mockHealth, nil)
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -402,7 +402,7 @@ func TestRegister_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "execute_command",
 		}
-		err := Register(registry, sm, exec, validator, fs, wp, nil)
+		err := Register(registry, sm, exec, validator, fs, wp, nil, nil)
 		if err == nil {
 			t.Fatal("expected error from Register when registerSystem fails")
 		}
@@ -416,7 +416,7 @@ func TestRegister_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "get_git_status",
 		}
-		err := Register(registry, sm, exec, validator, fs, wp, nil)
+		err := Register(registry, sm, exec, validator, fs, wp, nil, nil)
 		if err == nil {
 			t.Fatal("expected error from Register when registerGit fails")
 		}
@@ -430,7 +430,7 @@ func TestRegister_SystemToolsOnly(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	reg := registry.New()
 	// Register only system tools (skip git/files)
-	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), nil)
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), nil, nil)
 	if err != nil {
 		t.Fatalf("registerSystem failed: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestRegister_WithHealth(t *testing.T) {
 		Components:    map[ports.Component]ports.ComponentReport{},
 		Timestamp:     time.Now(),
 	}}
-	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), mockHealth)
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), mockHealth, nil)
 	if err != nil {
 		t.Fatalf("registerSystem failed: %v", err)
 	}
@@ -479,7 +479,7 @@ func TestRegisterSystem_HealthNil(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 
-	err := registerSystem(reg, sm, validator, nil)
+	err := registerSystem(reg, sm, validator, nil, nil)
 	if err != nil {
 		t.Fatalf("registerSystem with nil health failed: %v", err)
 	}
@@ -516,7 +516,7 @@ func TestRegister_RegisterFilesFails(t *testing.T) {
 		mockToolRegistry: &mockToolRegistry{},
 		failOnTool:       "list_files",
 	}
-	err := Register(registry, sm, exec, validator, fs, wp, nil)
+	err := Register(registry, sm, exec, validator, fs, wp, nil, nil)
 	if err == nil {
 		t.Fatal("expected error from Register when registerFiles fails")
 	}

--- a/internal/tools/workspace/shell.go
+++ b/internal/tools/workspace/shell.go
@@ -262,7 +262,7 @@ func (t *shellTool) ExecuteCommand(ctx context.Context, args map[string]interfac
 		return t.executor.RunCommand(tCtx, parts, executionConfig{
 			OutputFile: outputFile,
 			Append:     params.Append,
-			Feedback:   &warnWriter{eventBus: t.eventBus},
+			Feedback:   &warnWriter{eventBus: t.eventBus, ctx: tCtx},
 			MaxCapture: t.maxOutput,
 			Env:        params.Env,
 		})
@@ -364,7 +364,7 @@ func (t *shellTool) PipeCommands(ctx context.Context, args map[string]interface{
 		tCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 		defer cancel()
 
-		feedback := &warnWriter{eventBus: t.eventBus}
+		feedback := &warnWriter{eventBus: t.eventBus, ctx: tCtx}
 		return t.executor.RunPipeline(tCtx, pipedParts, executionConfig{
 			OutputFile: outputFile,
 			Append:     params.Append,
@@ -462,26 +462,22 @@ func (t *shellTool) authorize(ctx context.Context, label, detail, reason string,
 }
 
 func (t *shellTool) runWithFeedback(ctx context.Context, msg string, runFn func() (executionResult, error)) (executionResult, error) {
-	if t.eventBus != nil {
-		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
-			Message: fmt.Sprintf("%s... (Output shown below)", msg),
-			Level:   "info",
-		})
-		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
-			Message: "------------------------------------------------------------",
-			Level:   "info",
-		})
-	}
+	_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+		Message: fmt.Sprintf("%s... (Output shown below)", msg),
+		Level:   "info",
+	})
+	_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+		Message: "------------------------------------------------------------",
+		Level:   "info",
+	})
 
 	// Execute command — no terminal lock needed; EventBus handles rendering.
 	res, err := runFn()
 
-	if t.eventBus != nil {
-		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
-			Message: "------------------------------------------------------------",
-			Level:   "info",
-		})
-	}
+	_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+		Message: "------------------------------------------------------------",
+		Level:   "info",
+	})
 
 	return res, err
 }
@@ -531,16 +527,15 @@ type shellSecurity interface {
 
 type warnWriter struct {
 	eventBus events.EventBus
+	ctx      context.Context
 }
 
 func (w *warnWriter) Write(p []byte) (n int, err error) {
 	msg := strings.TrimSuffix(string(p), "\n")
-	if w.eventBus != nil {
-		_ = w.eventBus.Publish(context.Background(), events.ToolOutputStreamEvent{
-			Message: msg,
-			Level:   "info",
-		})
-	}
+	_ = w.eventBus.Publish(w.ctx, events.ToolOutputStreamEvent{
+		Message: msg,
+		Level:   "info",
+	})
 	return len(p), nil
 }
 

--- a/internal/tools/workspace/shell.go
+++ b/internal/tools/workspace/shell.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
@@ -192,6 +193,7 @@ func (w *windowsShellWrapper) isPowerShellIndicator(command string, parts []stri
 
 type shellTool struct {
 	sm                shellSecurity
+	eventBus          events.EventBus
 	validator         domain_security.CommandValidator
 	executor          *processExecutor
 	translator        commandTranslator
@@ -200,9 +202,10 @@ type shellTool struct {
 	heartbeatInterval time.Duration // zero means default (2s)
 }
 
-func newshellTool(sm shellSecurity, validator domain_security.CommandValidator, translator commandTranslator, wrapper shellWrapper) *shellTool {
+func newshellTool(sm shellSecurity, eventBus events.EventBus, validator domain_security.CommandValidator, translator commandTranslator, wrapper shellWrapper) *shellTool {
 	return &shellTool{
 		sm:         sm,
+		eventBus:   eventBus,
 		validator:  validator,
 		executor:   newprocessExecutor(),
 		translator: translator,
@@ -259,7 +262,7 @@ func (t *shellTool) ExecuteCommand(ctx context.Context, args map[string]interfac
 		return t.executor.RunCommand(tCtx, parts, executionConfig{
 			OutputFile: outputFile,
 			Append:     params.Append,
-			Feedback:   &warnWriter{sm: t.sm},
+			Feedback:   &warnWriter{eventBus: t.eventBus},
 			MaxCapture: t.maxOutput,
 			Env:        params.Env,
 		})
@@ -361,7 +364,7 @@ func (t *shellTool) PipeCommands(ctx context.Context, args map[string]interface{
 		tCtx, cancel := context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 		defer cancel()
 
-		feedback := &warnWriter{sm: t.sm}
+		feedback := &warnWriter{eventBus: t.eventBus}
 		return t.executor.RunPipeline(tCtx, pipedParts, executionConfig{
 			OutputFile: outputFile,
 			Append:     params.Append,
@@ -459,19 +462,26 @@ func (t *shellTool) authorize(ctx context.Context, label, detail, reason string,
 }
 
 func (t *shellTool) runWithFeedback(ctx context.Context, msg string, runFn func() (executionResult, error)) (executionResult, error) {
-	// 1. Lock to print the header
-	t.sm.TerminalLock()
-	t.sm.Warn(fmt.Sprintf("%s... (Output shown below)", msg))
-	t.sm.Warn("------------------------------------------------------------")
-	t.sm.TerminalUnlock()
+	if t.eventBus != nil {
+		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+			Message: fmt.Sprintf("%s... (Output shown below)", msg),
+			Level:   "info",
+		})
+		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+			Message: "------------------------------------------------------------",
+			Level:   "info",
+		})
+	}
 
-	// 2. Execute command WITHOUT holding the lock to allow spinner to run
+	// Execute command — no terminal lock needed; EventBus handles rendering.
 	res, err := runFn()
 
-	// 3. Lock to print the footer
-	t.sm.TerminalLock()
-	t.sm.Warn("------------------------------------------------------------")
-	t.sm.TerminalUnlock()
+	if t.eventBus != nil {
+		_ = t.eventBus.Publish(ctx, events.ToolOutputStreamEvent{
+			Message: "------------------------------------------------------------",
+			Level:   "info",
+		})
+	}
 
 	return res, err
 }
@@ -514,25 +524,23 @@ func (t *shellTool) deniedResult(label string) tools.ToolResult {
 }
 
 type shellSecurity interface {
-	domain_security.TerminalController
 	domain_security.Auditor
 	domain_security.PathValidator
 	domain_security.ActionConfirmer
 }
 
 type warnWriter struct {
-	sm shellSecurity
+	eventBus events.EventBus
 }
 
 func (w *warnWriter) Write(p []byte) (n int, err error) {
-	w.sm.TerminalLock()
-	defer w.sm.TerminalUnlock()
-
-	// The process executor includes newlines in the feedback messages.
-	// Since Warn() also typically adds a newline, we trim one from the end
-	// to prevent double-spacing in the terminal.
-	msg := string(p)
-	w.sm.Warn(strings.TrimSuffix(msg, "\n"))
+	msg := strings.TrimSuffix(string(p), "\n")
+	if w.eventBus != nil {
+		_ = w.eventBus.Publish(context.Background(), events.ToolOutputStreamEvent{
+			Message: msg,
+			Level:   "info",
+		})
+	}
 	return len(p), nil
 }
 

--- a/internal/tools/workspace/shell.go
+++ b/internal/tools/workspace/shell.go
@@ -4,6 +4,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -528,14 +529,21 @@ type shellSecurity interface {
 type warnWriter struct {
 	eventBus events.EventBus
 	ctx      context.Context
+	buf      bytes.Buffer
 }
 
 func (w *warnWriter) Write(p []byte) (n int, err error) {
-	msg := strings.TrimSuffix(string(p), "\n")
-	_ = w.eventBus.Publish(w.ctx, events.ToolOutputStreamEvent{
-		Message: msg,
-		Level:   "info",
-	})
+	w.buf.Write(p)
+	for {
+		line, err := w.buf.ReadBytes('\n')
+		if err != nil {
+			break // partial line remains in buf for next Write
+		}
+		_ = w.eventBus.Publish(w.ctx, events.ToolOutputStreamEvent{
+			Message: strings.TrimSuffix(string(line), "\n"),
+			Level:   "info",
+		})
+	}
 	return len(p), nil
 }
 

--- a/internal/tools/workspace/shell_posix_test.go
+++ b/internal/tools/workspace/shell_posix_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -14,7 +15,7 @@ import (
 func TestShellTool_ExecuteCommand_Validation_POSIX(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, nil, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/tools/workspace/shell_posix_test.go
+++ b/internal/tools/workspace/shell_posix_test.go
@@ -14,7 +14,7 @@ import (
 func TestShellTool_ExecuteCommand_Validation_POSIX(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, nil, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/tools/workspace/shell_structured_test.go
+++ b/internal/tools/workspace/shell_structured_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -15,7 +16,7 @@ import (
 func TestShellTool_ExecuteCommand_Structured(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, nil, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
 	ctx := context.Background()
 
 	t.Run("Structured args (no shell)", func(t *testing.T) {

--- a/internal/tools/workspace/shell_structured_test.go
+++ b/internal/tools/workspace/shell_structured_test.go
@@ -15,7 +15,7 @@ import (
 func TestShellTool_ExecuteCommand_Structured(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, nil, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
 	ctx := context.Background()
 
 	t.Run("Structured args (no shell)", func(t *testing.T) {

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -87,7 +87,7 @@ func newTestShellTool(sm shellSecurity, validator domain_security.CommandValidat
 		translator = &windowsTranslator{}
 		wrapper = &windowsShellWrapper{validator: validator}
 	}
-	return newshellTool(sm, validator, translator, wrapper)
+	return newshellTool(sm, nil, validator, translator, wrapper)
 }
 
 func setupTruncationTest(t *testing.T) (*shellTool, context.Context, map[string]interface{}) {
@@ -736,7 +736,7 @@ func TestShellTool_PrepareCommand_ShellSelection(t *testing.T) {
 	sm.SetBypassActive(true)
 	validator := &toolstest.MockCommandValidator{}
 	wrapper := &windowsShellWrapper{}
-	_ = newshellTool(sm, validator, &posixTranslator{}, wrapper)
+	_ = newshellTool(sm, nil, validator, &posixTranslator{}, wrapper)
 
 	t.Run("PowerShell indicators", func(t *testing.T) {
 		tests := []struct {
@@ -1442,7 +1442,7 @@ func TestShellTool_PrepareCommand_SplitError(t *testing.T) {
 			return nil, fmt.Errorf("split: mock failure")
 		},
 	}
-	tool := newshellTool(sm, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, nil, validator, &posixTranslator{}, &posixShellWrapper{})
 
 	parts, err := tool.prepareCommand("any command")
 
@@ -1473,7 +1473,7 @@ func TestShellTool_PrepareCommand_ValidateStructureError(t *testing.T) {
 			return fmt.Errorf("validate: structure rejected")
 		},
 	}
-	tool := newshellTool(sm, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, nil, validator, &posixTranslator{}, &posixShellWrapper{})
 
 	parts, err := tool.prepareCommand("echo hello")
 

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
@@ -87,7 +88,7 @@ func newTestShellTool(sm shellSecurity, validator domain_security.CommandValidat
 		translator = &windowsTranslator{}
 		wrapper = &windowsShellWrapper{validator: validator}
 	}
-	return newshellTool(sm, nil, validator, translator, wrapper)
+	return newshellTool(sm, &events.NoOpEventBus{}, validator, translator, wrapper)
 }
 
 func setupTruncationTest(t *testing.T) (*shellTool, context.Context, map[string]interface{}) {
@@ -736,7 +737,7 @@ func TestShellTool_PrepareCommand_ShellSelection(t *testing.T) {
 	sm.SetBypassActive(true)
 	validator := &toolstest.MockCommandValidator{}
 	wrapper := &windowsShellWrapper{}
-	_ = newshellTool(sm, nil, validator, &posixTranslator{}, wrapper)
+	_ = newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, wrapper)
 
 	t.Run("PowerShell indicators", func(t *testing.T) {
 		tests := []struct {
@@ -1442,7 +1443,7 @@ func TestShellTool_PrepareCommand_SplitError(t *testing.T) {
 			return nil, fmt.Errorf("split: mock failure")
 		},
 	}
-	tool := newshellTool(sm, nil, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{})
 
 	parts, err := tool.prepareCommand("any command")
 
@@ -1473,7 +1474,7 @@ func TestShellTool_PrepareCommand_ValidateStructureError(t *testing.T) {
 			return fmt.Errorf("validate: structure rejected")
 		},
 	}
-	tool := newshellTool(sm, nil, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{})
 
 	parts, err := tool.prepareCommand("echo hello")
 

--- a/tests/e2e/pipe_redirection_test.go
+++ b/tests/e2e/pipe_redirection_test.go
@@ -75,8 +75,8 @@ func TestPipeCommandsTool(t *testing.T) {
 
 	// 3. Verification
 	errOut := stripANSI(stderr)
-	if !strings.Contains(errOut, "Executing Pipeline...") {
-		t.Errorf("Expected pipeline execution log in stderr, got: %q", errOut)
+	if !strings.Contains(errOut, "Pipeline result") {
+		t.Errorf("Expected pipeline result in stderr, got: %q", errOut)
 	}
 	if !strings.Contains(errOut, "hello") {
 		t.Errorf("Expected 'hello' in pipeline output in stderr, got: %q", errOut)


### PR DESCRIPTION
Closes #1218.

## Summary
Replace direct `TerminalController` calls (`TerminalLock`, `TerminalUnlock`, `Warn`) in `shell.go` and `dev.go` with `EventBus.Publish` of `ToolOutputStreamEvent`.

## Changes

| Layer | Change |
|---|---|
| `domain/events/types.go` | New `ToolOutputStreamEvent` type (Message, Level, ToolName) |
| `tools/workspace/shell.go` | `shellTool.runWithFeedback` + `warnWriter.Write` → EventBus.Publish |
| `tools/developer/dev.go` | `devManager.logToolAction` → EventBus.Publish |
| `workspace/registration.go` | EventBus threaded through `Register` → `registerSystem` → `newshellTool` |
| `developer/registration.go` | EventBus threaded through `Register` → `newDevManager` |
| `tools/tools.go` | EventBus passed from `RegisterAll` |
| `shell.go` + `dev.go` | `TerminalController` removed from `shellSecurity` and `devSecurity` |
| 7 test files | 28 call sites updated, +2 coverage tests |

## Checks
- ✅ `make check-full` — all pass (lint, test, race, vulncheck, dead-code, architecture)
- ✅ Coverage: events 100%, developer 99.7%
- ✅ No complexity regressions