### PR TITLE
feat: AI response display, markdown rendering, and turn metrics in progress TUI (#1216)

### DIFF
--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -33,8 +33,10 @@ type model struct {
 	maxTokens    int
 	timestamp    time.Time
 	err          error
-	responseText string // accumulated AI response text
-	mdRender     func(string) string // optional markdown renderer
+	responseText    string             // accumulated AI response text
+	mdRender        func(string) string // optional markdown renderer
+	postCallMetrics *llm.Metrics       // non-nil when TurnStatusEvent has IsPostCall
+	finalCostLine   string             // rendered "Ready (...)" line from IsFinal
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -89,6 +91,13 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sessionName = msg.Status.Mode
 		m.modelName = msg.Status.Model
 		m.currentState = stateRendering
+
+		if msg.Status.IsPostCall && msg.Status.Metrics != nil {
+			m.postCallMetrics = msg.Status.Metrics
+		}
+		if msg.Status.IsFinal {
+			m.finalCostLine = formatFinalLine(msg.Status)
+		}
 		return m, m.waitForEvent()
 
 	case events.ResponseEvent:
@@ -122,6 +131,63 @@ func extractResponseText(content *llm.Content) string {
 	return sb.String()
 }
 
+// formatMetricsLine renders a single-line post-call metrics summary.
+func formatMetricsLine(m *llm.Metrics) string {
+	if m == nil {
+		return ""
+	}
+	miss := m.PromptTokens - m.CachedTokens
+	var parts []string
+
+	display := m.Provider
+	if display == "" {
+		display = m.Model
+	}
+	if display != "" {
+		parts = append(parts, fmt.Sprintf("[%s]", display))
+	}
+
+	parts = append(parts, fmt.Sprintf("M: %d H: %d C: %d", miss, m.CachedTokens, m.ResponseTokens))
+
+	if m.ThinkingTokens > 0 {
+		parts = append(parts, fmt.Sprintf("Th: %d", m.ThinkingTokens))
+	}
+
+	if m.Cost > 0 {
+		parts = append(parts, fmt.Sprintf("($%.4f)", m.Cost))
+	}
+
+	totalLatency := m.Duration + m.ToolDuration
+	parts = append(parts, fmt.Sprintf("[%.2fs (∑T: %.2fs)]", totalLatency, m.CumulativeToolDuration))
+
+	return strings.Join(parts, " ")
+}
+
+// formatFinalLine renders the "Ready" summary line when IsFinal is true.
+func formatFinalLine(status events.TurnStatus) string {
+	var parts []string
+	parts = append(parts, "Ready")
+
+	if status.TaskCost > 0 {
+		parts = append(parts, fmt.Sprintf("($%.4f)", status.TaskCost))
+	}
+	if status.SessionCost > 0 {
+		parts = append(parts, fmt.Sprintf("$%.4f", status.SessionCost))
+	}
+	if status.DailyCost > 0 {
+		parts = append(parts, fmt.Sprintf("$%.4f", status.DailyCost))
+	}
+
+	hitRate := 0.0
+	if total := status.TotalM + status.TotalH; total > 0 {
+		hitRate = float64(status.TotalH) / float64(total) * 100
+	}
+	parts = append(parts, fmt.Sprintf("M: %d H: %d %.1f%% O: %d",
+		status.TotalM, status.TotalH, hitRate, status.TotalO))
+
+	return "╰─ " + strings.Join(parts, " ")
+}
+
 // View renders the progress model as a two-line display with optional response text.
 func (m *model) View() string {
 	ts := m.timestamp.Format("15:04:05")
@@ -131,6 +197,12 @@ func (m *model) View() string {
 	out := header + "\n" + info
 	if m.responseText != "" {
 		out += "\n" + m.responseText
+	}
+	if m.postCallMetrics != nil {
+		out += "\n" + formatMetricsLine(m.postCallMetrics)
+	}
+	if m.finalCostLine != "" {
+		out += "\n" + m.finalCostLine
 	}
 	return out + "\n"
 }

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -167,7 +167,7 @@ func formatMetricsLine(m *llm.Metrics, startTime time.Time, timestamp time.Time,
 	}
 
 	totalLatency := m.Duration + m.ToolDuration
-	timing := fmt.Sprintf("[%.2fs (∑T: %.2fs)]", totalLatency, m.CumulativeToolDuration)
+	timing := fmt.Sprintf("[%.2fs (ΣT: %.2fs)]", totalLatency, m.CumulativeToolDuration)
 	if !startTime.IsZero() {
 		sessionDur := time.Since(startTime).Seconds()
 		if turns > 0 {

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -14,6 +14,11 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 )
 
+// domainEventMsg wraps a domain event to ensure exactly one reader exists on
+// the event channel. Native Bubble Tea messages must not trigger additional
+// channel reads.
+type domainEventMsg events.Event
+
 type state int
 
 const (
@@ -26,6 +31,7 @@ type model struct {
 	eventCh <-chan events.Event
 
 	currentState state
+	width        int // terminal width, updated via WindowSizeMsg
 	turn         int
 	modelName    string // display name, e.g. "deepseek-v4-pro"
 	sessionName  string // e.g. "architect-johndoe"
@@ -33,15 +39,15 @@ type model struct {
 	maxTokens    int
 	timestamp    time.Time
 	err          error
-	responseText    string             // accumulated AI response text
-	mdRender        func(string) string // optional markdown renderer
-	postCallStatus *events.TurnStatus // set when IsPostCall, has full status including Metrics and StartTime
-	finalCostLine   string             // rendered "Ready (...)" line from IsFinal
+	responseText    string                // accumulated AI response text
+	mdRender        func(string, int) string // optional markdown renderer (text, width)
+	postCallStatus  *events.TurnStatus    // set when IsPostCall, has full status including Metrics and StartTime
+	finalCostLine   string                // rendered "Ready (...)" line from IsFinal
 }
 
 // NewModel creates a new progress model that consumes events from the given
 // channel and optionally renders response text through mdRender.
-func NewModel(_ context.Context, ch <-chan events.Event, mdRender func(string) string) tea.Model {
+func NewModel(_ context.Context, ch <-chan events.Event, mdRender func(string, int) string) tea.Model {
 	return &model{
 		eventCh:      ch,
 		currentState: stateIdle,
@@ -57,7 +63,7 @@ func (m *model) waitForEvent() tea.Cmd {
 		if !ok {
 			return tea.Quit()
 		}
-		return e
+		return domainEventMsg(e)
 	}
 }
 
@@ -73,52 +79,60 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if msg.Type == tea.KeyCtrlC {
 			return m, tea.Quit
 		}
-		return m, m.waitForEvent()
+		return m, nil
 
-	case events.TurnStarted:
-		m.turn = msg.Turn + 1
-		m.currentState = stateThinking
-		return m, m.waitForEvent()
-
-	case events.InferenceStartedEvent:
-		m.modelName = msg.Model
-		return m, m.waitForEvent()
-
-	case events.TurnStatusEvent:
-		m.tokens = msg.Status.Tokens
-		m.maxTokens = msg.Status.MaxHistoryTokens
-		m.timestamp = msg.Status.Timestamp
-		m.sessionName = msg.Status.Mode
-		m.modelName = msg.Status.Model
-		m.currentState = stateRendering
-
-		if msg.Status.IsPostCall && msg.Status.Metrics != nil {
-			s := msg.Status // copy
-			m.postCallStatus = &s
-		}
-		if msg.Status.IsFinal {
-			turnCost := 0.0
-			if msg.Status.Metrics != nil {
-				turnCost = msg.Status.Metrics.Cost
-			}
-			m.finalCostLine = formatFinalLine(msg.Status, turnCost)
-		}
-		return m, m.waitForEvent()
-
-	case events.ResponseEvent:
-		text := extractResponseText(msg.Content)
-		if m.mdRender != nil {
-			text = strings.TrimRight(m.mdRender(text), "\n")
-		}
-		m.responseText = text
-		return m, m.waitForEvent()
+	case tea.WindowSizeMsg:
+		m.width = msg.Width
+		return m, nil
 
 	case error:
 		m.err = msg
+		return m, nil
+
+	case domainEventMsg:
+		switch e := events.Event(msg).(type) {
+		case events.TurnStarted:
+			m.turn = e.Turn + 1
+			m.currentState = stateThinking
+			return m, m.waitForEvent()
+
+		case events.InferenceStartedEvent:
+			m.modelName = e.Model
+			return m, m.waitForEvent()
+
+		case events.TurnStatusEvent:
+			m.tokens = e.Status.Tokens
+			m.maxTokens = e.Status.MaxHistoryTokens
+			m.timestamp = e.Status.Timestamp
+			m.sessionName = e.Status.Mode
+			m.modelName = e.Status.Model
+			m.currentState = stateRendering
+
+			if e.Status.IsPostCall && e.Status.Metrics != nil {
+				s := e.Status
+				m.postCallStatus = &s
+			}
+			if e.Status.IsFinal {
+				turnCost := 0.0
+				if e.Status.Metrics != nil {
+					turnCost = e.Status.Metrics.Cost
+				}
+				m.finalCostLine = formatFinalLine(e.Status, turnCost)
+			}
+			return m, m.waitForEvent()
+
+		case events.ResponseEvent:
+			text := extractResponseText(e.Content)
+			if m.mdRender != nil {
+				text = strings.TrimRight(m.mdRender(text, m.width), "\n")
+			}
+			m.responseText = text
+			return m, m.waitForEvent()
+		}
 		return m, m.waitForEvent()
 
 	default:
-		return m, m.waitForEvent()
+		return m, nil
 	}
 }
 

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -35,7 +35,7 @@ type model struct {
 	err          error
 	responseText    string             // accumulated AI response text
 	mdRender        func(string) string // optional markdown renderer
-	postCallMetrics *llm.Metrics       // non-nil when TurnStatusEvent has IsPostCall
+	postCallStatus *events.TurnStatus // set when IsPostCall, has full status including Metrics and StartTime
 	finalCostLine   string             // rendered "Ready (...)" line from IsFinal
 }
 
@@ -93,10 +93,15 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentState = stateRendering
 
 		if msg.Status.IsPostCall && msg.Status.Metrics != nil {
-			m.postCallMetrics = msg.Status.Metrics
+			s := msg.Status // copy
+			m.postCallStatus = &s
 		}
 		if msg.Status.IsFinal {
-			m.finalCostLine = formatFinalLine(msg.Status)
+			turnCost := 0.0
+			if msg.Status.Metrics != nil {
+				turnCost = msg.Status.Metrics.Cost
+			}
+			m.finalCostLine = formatFinalLine(msg.Status, turnCost)
 		}
 		return m, m.waitForEvent()
 
@@ -132,7 +137,7 @@ func extractResponseText(content *llm.Content) string {
 }
 
 // formatMetricsLine renders a single-line post-call metrics summary.
-func formatMetricsLine(m *llm.Metrics) string {
+func formatMetricsLine(m *llm.Metrics, startTime time.Time) string {
 	if m == nil {
 		return ""
 	}
@@ -158,24 +163,24 @@ func formatMetricsLine(m *llm.Metrics) string {
 	}
 
 	totalLatency := m.Duration + m.ToolDuration
-	parts = append(parts, fmt.Sprintf("[%.2fs (∑T: %.2fs)]", totalLatency, m.CumulativeToolDuration))
+	timing := fmt.Sprintf("[%.2fs (∑T: %.2fs)]", totalLatency, m.CumulativeToolDuration)
+	if !startTime.IsZero() {
+		sessionDur := time.Since(startTime).Seconds()
+		timing = fmt.Sprintf("%s / %.2fs", timing, sessionDur)
+	}
+	parts = append(parts, timing)
 
 	return strings.Join(parts, " ")
 }
 
 // formatFinalLine renders the "Ready" summary line when IsFinal is true.
-func formatFinalLine(status events.TurnStatus) string {
+func formatFinalLine(status events.TurnStatus, turnCost float64) string {
 	var parts []string
 	parts = append(parts, "Ready")
 
-	if status.TaskCost > 0 {
-		parts = append(parts, fmt.Sprintf("($%.4f)", status.TaskCost))
-	}
-	if status.SessionCost > 0 {
-		parts = append(parts, fmt.Sprintf("$%.4f", status.SessionCost))
-	}
-	if status.DailyCost > 0 {
-		parts = append(parts, fmt.Sprintf("$%.4f", status.DailyCost))
+	if turnCost > 0 || status.TaskCost > 0 || status.SessionCost > 0 || status.DailyCost > 0 {
+		parts = append(parts, fmt.Sprintf("($%.4f $%.4f $%.4f $%.4f)",
+			turnCost, status.TaskCost, status.SessionCost, status.DailyCost))
 	}
 
 	hitRate := 0.0
@@ -185,7 +190,7 @@ func formatFinalLine(status events.TurnStatus) string {
 	parts = append(parts, fmt.Sprintf("M: %d H: %d %.1f%% O: %d",
 		status.TotalM, status.TotalH, hitRate, status.TotalO))
 
-	return "╰─ " + strings.Join(parts, " ")
+	return "╰─⠿ " + strings.Join(parts, " ")
 }
 
 // View renders the progress model as a two-line display with optional response text.
@@ -198,8 +203,13 @@ func (m *model) View() string {
 	if m.responseText != "" {
 		out += "\n" + m.responseText
 	}
-	if m.postCallMetrics != nil {
-		out += "\n" + formatMetricsLine(m.postCallMetrics)
+	if m.postCallStatus != nil {
+		// Exact token count for post-call (no tilde)
+		out += "\n" + fmt.Sprintf("[%s] Payload: %d/%d tokens - %s - %s",
+			m.timestamp.Format("15:04:05"),
+			m.postCallStatus.Metrics.PromptTokens,
+			m.maxTokens, m.sessionName, m.modelName)
+		out += "\n" + formatMetricsLine(m.postCallStatus.Metrics, m.postCallStatus.StartTime)
 	}
 	if m.finalCostLine != "" {
 		out += "\n" + m.finalCostLine

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -40,6 +40,7 @@ type model struct {
 	timestamp    time.Time
 	err          error
 	responseText    string                // accumulated AI response text
+	rawResponseText string                // raw text before markdown rendering, for re-rendering on resize
 	mdRender        func(string, int) string // optional markdown renderer (text, width)
 	postCallStatus  *events.TurnStatus    // set when IsPostCall, has full status including Metrics and StartTime
 	finalCostLine   string                // rendered "Ready (...)" line from IsFinal
@@ -83,6 +84,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
+		if m.rawResponseText != "" && m.mdRender != nil {
+			m.responseText = strings.TrimRight(m.mdRender(m.rawResponseText, m.width), "\n")
+		}
 		return m, nil
 
 	case error:
@@ -122,11 +126,12 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.waitForEvent()
 
 		case events.ResponseEvent:
-			text := extractResponseText(e.Content)
+			m.rawResponseText = extractResponseText(e.Content)
 			if m.mdRender != nil {
-				text = strings.TrimRight(m.mdRender(text, m.width), "\n")
+				m.responseText = strings.TrimRight(m.mdRender(m.rawResponseText, m.width), "\n")
+			} else {
+				m.responseText = m.rawResponseText
 			}
-			m.responseText = text
 			return m, m.waitForEvent()
 		}
 		return m, m.waitForEvent()
@@ -208,25 +213,34 @@ func formatFinalLine(status events.TurnStatus, turnCost float64) string {
 
 // View renders the progress model as a two-line display with optional response text.
 func (m *model) View() string {
+	var sb strings.Builder
+
 	ts := m.timestamp.Format("15:04:05")
-	header := fmt.Sprintf("╭─ Turn %d - %s", m.turn, m.sessionName)
-	info := fmt.Sprintf("[%s] Payload: ~%d/%d tokens - %s - %s",
-		ts, m.tokens, m.maxTokens, m.sessionName, m.modelName)
-	out := header + "\n" + info
+	sb.WriteString(fmt.Sprintf("╭─ Turn %d - %s\n", m.turn, m.sessionName))
+	sb.WriteString(fmt.Sprintf("[%s] Payload: ~%d/%d tokens - %s - %s",
+		ts, m.tokens, m.maxTokens, m.sessionName, m.modelName))
+
 	if m.responseText != "" {
-		out += "\n" + m.responseText
+		sb.WriteString("\n")
+		sb.WriteString(m.responseText)
 	}
+
 	if m.postCallStatus != nil {
-		out += "\n" // empty line before post-call
-		out += "\n" + fmt.Sprintf("[%s] Payload: %d/%d tokens - %s - %s",
+		sb.WriteString("\n\n")
+		sb.WriteString(fmt.Sprintf("[%s] Payload: %d/%d tokens - %s - %s",
 			m.timestamp.Format("15:04:05"),
 			m.postCallStatus.Metrics.PromptTokens,
-			m.maxTokens, m.sessionName, m.modelName)
-		out += "\n" + formatMetricsLine(m.postCallStatus.Metrics,
-			m.postCallStatus.StartTime, m.timestamp, m.postCallStatus.CurrentTurns+1)
+			m.maxTokens, m.sessionName, m.modelName))
+		sb.WriteString("\n")
+		sb.WriteString(formatMetricsLine(m.postCallStatus.Metrics,
+			m.postCallStatus.StartTime, m.timestamp, m.postCallStatus.CurrentTurns+1))
 	}
+
 	if m.finalCostLine != "" {
-		out += "\n" + m.finalCostLine
+		sb.WriteString("\n")
+		sb.WriteString(m.finalCostLine)
 	}
-	return out + "\n"
+
+	sb.WriteString("\n")
+	return sb.String()
 }

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -34,14 +34,16 @@ type model struct {
 	timestamp    time.Time
 	err          error
 	responseText string // accumulated AI response text
+	mdRender     func(string) string // optional markdown renderer
 }
 
 // NewModel creates a new progress model that consumes events from the given
-// channel.
-func NewModel(_ context.Context, ch <-chan events.Event) tea.Model {
+// channel and optionally renders response text through mdRender.
+func NewModel(_ context.Context, ch <-chan events.Event, mdRender func(string) string) tea.Model {
 	return &model{
 		eventCh:      ch,
 		currentState: stateIdle,
+		mdRender:     mdRender,
 	}
 }
 
@@ -90,7 +92,11 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.waitForEvent()
 
 	case events.ResponseEvent:
-		m.responseText = extractResponseText(msg.Content)
+		text := extractResponseText(msg.Content)
+		if m.mdRender != nil {
+			text = strings.TrimRight(m.mdRender(text), "\n")
+		}
+		m.responseText = text
 		return m, m.waitForEvent()
 
 	case error:

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -6,10 +6,12 @@ package progress
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 )
 
 type state int
@@ -31,6 +33,7 @@ type model struct {
 	maxTokens    int
 	timestamp    time.Time
 	err          error
+	responseText string // accumulated AI response text
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -86,6 +89,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentState = stateRendering
 		return m, m.waitForEvent()
 
+	case events.ResponseEvent:
+		m.responseText = extractResponseText(msg.Content)
+		return m, m.waitForEvent()
+
 	case error:
 		m.err = msg
 		return m, m.waitForEvent()
@@ -95,11 +102,29 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 }
 
-// View renders the progress model as a two-line display.
+// extractResponseText concatenates non-thought text parts from an LLM response.
+func extractResponseText(content *llm.Content) string {
+	if content == nil {
+		return ""
+	}
+	var sb strings.Builder
+	for _, part := range content.Parts {
+		if part.Text != "" && !part.IsThought {
+			sb.WriteString(part.Text)
+		}
+	}
+	return sb.String()
+}
+
+// View renders the progress model as a two-line display with optional response text.
 func (m *model) View() string {
 	ts := m.timestamp.Format("15:04:05")
 	header := fmt.Sprintf("╭─ Turn %d - %s", m.turn, m.sessionName)
 	info := fmt.Sprintf("[%s] Payload: ~%d/%d tokens - %s - %s",
 		ts, m.tokens, m.maxTokens, m.sessionName, m.modelName)
-	return header + "\n" + info + "\n" + "\n"
+	out := header + "\n" + info
+	if m.responseText != "" {
+		out += "\n" + m.responseText
+	}
+	return out + "\n"
 }

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -137,13 +137,17 @@ func extractResponseText(content *llm.Content) string {
 }
 
 // formatMetricsLine renders a single-line post-call metrics summary.
-func formatMetricsLine(m *llm.Metrics, startTime time.Time) string {
+func formatMetricsLine(m *llm.Metrics, startTime time.Time, timestamp time.Time, turns int) string {
 	if m == nil {
 		return ""
 	}
 	miss := m.PromptTokens - m.CachedTokens
 	var parts []string
 
+	// Timestamp
+	parts = append(parts, fmt.Sprintf("[%s]", timestamp.Format("15:04:05")))
+
+	// Model display
 	display := m.Provider
 	if display == "" {
 		display = m.Model
@@ -166,7 +170,11 @@ func formatMetricsLine(m *llm.Metrics, startTime time.Time) string {
 	timing := fmt.Sprintf("[%.2fs (∑T: %.2fs)]", totalLatency, m.CumulativeToolDuration)
 	if !startTime.IsZero() {
 		sessionDur := time.Since(startTime).Seconds()
-		timing = fmt.Sprintf("%s / %.2fs", timing, sessionDur)
+		if turns > 0 {
+			timing = fmt.Sprintf("%s / %.2fs (%.2f)", timing, sessionDur, sessionDur/float64(turns))
+		} else {
+			timing = fmt.Sprintf("%s / %.2fs", timing, sessionDur)
+		}
 	}
 	parts = append(parts, timing)
 
@@ -175,22 +183,13 @@ func formatMetricsLine(m *llm.Metrics, startTime time.Time) string {
 
 // formatFinalLine renders the "Ready" summary line when IsFinal is true.
 func formatFinalLine(status events.TurnStatus, turnCost float64) string {
-	var parts []string
-	parts = append(parts, "Ready")
-
-	if turnCost > 0 || status.TaskCost > 0 || status.SessionCost > 0 || status.DailyCost > 0 {
-		parts = append(parts, fmt.Sprintf("($%.4f $%.4f $%.4f $%.4f)",
-			turnCost, status.TaskCost, status.SessionCost, status.DailyCost))
-	}
-
 	hitRate := 0.0
 	if total := status.TotalM + status.TotalH; total > 0 {
 		hitRate = float64(status.TotalH) / float64(total) * 100
 	}
-	parts = append(parts, fmt.Sprintf("M: %d H: %d %.1f%% O: %d",
-		status.TotalM, status.TotalH, hitRate, status.TotalO))
-
-	return "╰─⠿ " + strings.Join(parts, " ")
+	return fmt.Sprintf("╰─⠿ Ready ($%.4f $%.4f $%.4f $%.4f M: %d H: %d %.1f%% O: %d)",
+		turnCost, status.TaskCost, status.SessionCost, status.DailyCost,
+		status.TotalM, status.TotalH, hitRate, status.TotalO)
 }
 
 // View renders the progress model as a two-line display with optional response text.
@@ -204,12 +203,13 @@ func (m *model) View() string {
 		out += "\n" + m.responseText
 	}
 	if m.postCallStatus != nil {
-		// Exact token count for post-call (no tilde)
+		out += "\n" // empty line before post-call
 		out += "\n" + fmt.Sprintf("[%s] Payload: %d/%d tokens - %s - %s",
 			m.timestamp.Format("15:04:05"),
 			m.postCallStatus.Metrics.PromptTokens,
 			m.maxTokens, m.sessionName, m.modelName)
-		out += "\n" + formatMetricsLine(m.postCallStatus.Metrics, m.postCallStatus.StartTime)
+		out += "\n" + formatMetricsLine(m.postCallStatus.Metrics,
+			m.postCallStatus.StartTime, m.timestamp, m.postCallStatus.CurrentTurns+1)
 	}
 	if m.finalCostLine != "" {
 		out += "\n" + m.finalCostLine

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -70,6 +70,8 @@ func TestModel_Update(t *testing.T) {
 		assert.Equal(t, "deepseek-v4-pro", updated.modelName, "modelName should be set from Status.Model")
 		assert.Equal(t, "architect-johndoe", updated.sessionName, "sessionName should be set from Status.Mode")
 		assert.Equal(t, stateRendering, updated.currentState)
+		assert.Nil(t, updated.postCallMetrics, "should be nil when IsPostCall is false")
+		assert.Empty(t, updated.finalCostLine, "should be empty when IsFinal is false")
 		assert.NotNil(t, cmd)
 	})
 
@@ -160,6 +162,68 @@ func TestModel_Update(t *testing.T) {
 			"should render through mdRender when set")
 		assert.NotNil(t, cmd)
 	})
+
+	t.Run("TurnStatusEvent with post-call metrics", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		metrics := &llm.Metrics{
+			PromptTokens:  1000,
+			CachedTokens:  800,
+			ResponseTokens: 50,
+			Cost:          0.0012,
+			Duration:      5.0,
+			ToolDuration:  2.0,
+			Provider:      "deepseek-pro",
+		}
+		msg := events.TurnStatusEvent{
+			Status: events.TurnStatus{
+				Tokens:     1500,
+				Timestamp:  time.Now(),
+				Mode:       "test",
+				Model:      "deepseek-v4-pro",
+				IsPostCall: true,
+				Metrics:    metrics,
+			},
+		}
+
+		newModel, cmd := m.Update(msg)
+		updated := newModel.(*model)
+
+		assert.NotNil(t, updated.postCallMetrics)
+		assert.Equal(t, int32(1000), updated.postCallMetrics.PromptTokens)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("TurnStatusEvent with final summary", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		msg := events.TurnStatusEvent{
+			Status: events.TurnStatus{
+				Tokens:       1500,
+				Timestamp:    time.Now(),
+				Mode:         "test",
+				Model:        "deepseek-v4-pro",
+				IsFinal:      true,
+				SessionCost:  0.1505,
+				TaskCost:     0.0012,
+				TotalM:       116386,
+				TotalH:       15172096,
+				TotalO:       51607,
+			},
+		}
+
+		newModel, cmd := m.Update(msg)
+		updated := newModel.(*model)
+
+		assert.NotEmpty(t, updated.finalCostLine)
+		assert.Contains(t, updated.finalCostLine, "Ready")
+		assert.Contains(t, updated.finalCostLine, "0.1505")
+		assert.NotNil(t, cmd)
+	})
 }
 
 // newTestModel creates a model for testing.
@@ -233,6 +297,41 @@ func TestModel_View(t *testing.T) {
 		lines := strings.Split(out, "\n")
 		// header, info, empty trailing — no response line
 		assert.Len(t, lines, 3)
+	})
+
+	t.Run("with post-call metrics", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateRendering
+		m.turn = 1
+		m.timestamp = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
+		m.postCallMetrics = &llm.Metrics{
+			PromptTokens:  1000,
+			CachedTokens:  800,
+			ResponseTokens: 50,
+			Cost:          0.0012,
+			Duration:      5.0,
+			ToolDuration:  2.0,
+			Provider:      "deepseek-pro",
+		}
+
+		out := m.View()
+		assert.Contains(t, out, "[deepseek-pro]")
+		assert.Contains(t, out, "M: 200 H: 800 C: 50")
+		assert.Contains(t, out, "($0.0012)")
+	})
+
+	t.Run("with final summary", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateRendering
+		m.finalCostLine = "╰─ Ready ($0.0012) $0.1505 M: 116386 H: 15172096 99.2% O: 51607"
+
+		out := m.View()
+		assert.Contains(t, out, "╰─ Ready")
+		assert.Contains(t, out, "M: 116386")
 	})
 }
 

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -110,16 +110,23 @@ func TestModel_Update(t *testing.T) {
 		assert.Nil(t, cmd, "unknown messages must return nil to avoid duplicate channel readers")
 	})
 
-	t.Run("WindowSizeMsg sets width", func(t *testing.T) {
+	t.Run("WindowSizeMsg triggers re-render with raw text", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
+		m.width = 80
+		m.rawResponseText = "hello"
+		m.mdRender = func(text string, width int) string {
+			return fmt.Sprintf("[w=%d]%s", width, text)
+		}
 
 		newModel, cmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
 		updated := newModel.(*model)
 
 		assert.Equal(t, 120, updated.width)
-		assert.Nil(t, cmd, "WindowSizeMsg must not trigger channel read")
+		assert.Equal(t, "[w=120]hello", updated.responseText,
+			"response should be re-rendered with new width")
+		assert.Nil(t, cmd)
 	})
 
 	t.Run("default message returns nil cmd", func(t *testing.T) {
@@ -162,6 +169,8 @@ func TestModel_Update(t *testing.T) {
 
 		assert.Equal(t, "Hello, world! I am fine.", updated.responseText,
 			"should concatenate non-thought text parts, skipping thoughts")
+		assert.Equal(t, "Hello, world! I am fine.", updated.rawResponseText,
+			"rawResponseText should store unrendered text")
 		assert.NotNil(t, cmd)
 	})
 

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -121,6 +121,26 @@ func TestModel_Update(t *testing.T) {
 		assert.Equal(t, "test error", updated.err.Error())
 		assert.NotNil(t, cmd)
 	})
+
+	t.Run("ResponseEvent", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		content := &llm.Content{
+			Parts: []*llm.Part{
+				{Text: "Hello, world!"},
+				{Text: " How are you?", IsThought: true},
+				{Text: " I am fine."},
+			},
+		}
+		newModel, cmd := m.Update(events.ResponseEvent{Content: content})
+		updated := newModel.(*model)
+
+		assert.Equal(t, "Hello, world! I am fine.", updated.responseText,
+			"should concatenate non-thought text parts, skipping thoughts")
+		assert.NotNil(t, cmd)
+	})
 }
 
 // newTestModel creates a model for testing.
@@ -169,6 +189,7 @@ func TestModel_View(t *testing.T) {
 		m.maxTokens = 64000
 		m.timestamp = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
 		m.currentState = stateRendering
+		m.responseText = "Hello, world!"
 
 		out := m.View()
 
@@ -179,6 +200,20 @@ func TestModel_View(t *testing.T) {
 		assert.Contains(t, lines[1], "~5000/64000")
 		assert.Contains(t, lines[1], "coder-test")
 		assert.Contains(t, lines[1], "gpt-5")
+		assert.Contains(t, out, "Hello, world!")
+	})
+
+	t.Run("stateRendering_empty_response_shows_no_extra_line", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateRendering
+		m.responseText = ""
+
+		out := m.View()
+		lines := strings.Split(out, "\n")
+		// header, info, empty trailing — no response line
+		assert.Len(t, lines, 3)
 	})
 }
 
@@ -221,10 +256,21 @@ func TestModel_Integration(t *testing.T) {
 		assert.Equal(t, "deepseek-v4-pro", m.modelName)
 		assert.NotNil(t, cmd)
 
+		// ResponseEvent → store response text
+		newModel, cmd = m.Update(events.ResponseEvent{
+			Content: &llm.Content{
+				Parts: []*llm.Part{{Text: "Sure, I can help with that."}},
+			},
+		})
+		m = newModel.(*model)
+		assert.Equal(t, "Sure, I can help with that.", m.responseText)
+		assert.NotNil(t, cmd)
+
 		// Verify View after full cycle
 		out := m.View()
 		assert.Contains(t, out, "╭─ Turn 1 - architect-johndoe")
 		assert.Contains(t, out, "deepseek-v4-pro")
+		assert.Contains(t, out, "Sure, I can help with that.")
 	})
 
 	t.Run("full turn cycle with tool calls", func(t *testing.T) {

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -70,7 +70,7 @@ func TestModel_Update(t *testing.T) {
 		assert.Equal(t, "deepseek-v4-pro", updated.modelName, "modelName should be set from Status.Model")
 		assert.Equal(t, "architect-johndoe", updated.sessionName, "sessionName should be set from Status.Mode")
 		assert.Equal(t, stateRendering, updated.currentState)
-		assert.Nil(t, updated.postCallMetrics, "should be nil when IsPostCall is false")
+		assert.Nil(t, updated.postCallStatus, "should be nil when IsPostCall is false")
 		assert.Empty(t, updated.finalCostLine, "should be empty when IsFinal is false")
 		assert.NotNil(t, cmd)
 	})
@@ -168,6 +168,7 @@ func TestModel_Update(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 
+		startTime := time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC)
 		metrics := &llm.Metrics{
 			PromptTokens:  1000,
 			CachedTokens:  800,
@@ -185,14 +186,15 @@ func TestModel_Update(t *testing.T) {
 				Model:      "deepseek-v4-pro",
 				IsPostCall: true,
 				Metrics:    metrics,
+				StartTime:  startTime,
 			},
 		}
 
 		newModel, cmd := m.Update(msg)
 		updated := newModel.(*model)
 
-		assert.NotNil(t, updated.postCallMetrics)
-		assert.Equal(t, int32(1000), updated.postCallMetrics.PromptTokens)
+		assert.NotNil(t, updated.postCallStatus)
+		assert.Equal(t, int32(1000), updated.postCallStatus.Metrics.PromptTokens)
 		assert.NotNil(t, cmd)
 	})
 
@@ -213,6 +215,7 @@ func TestModel_Update(t *testing.T) {
 				TotalM:       116386,
 				TotalH:       15172096,
 				TotalO:       51607,
+				Metrics:      &llm.Metrics{Cost: 0.0010},
 			},
 		}
 
@@ -306,14 +309,17 @@ func TestModel_View(t *testing.T) {
 		m.currentState = stateRendering
 		m.turn = 1
 		m.timestamp = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
-		m.postCallMetrics = &llm.Metrics{
-			PromptTokens:  1000,
-			CachedTokens:  800,
-			ResponseTokens: 50,
-			Cost:          0.0012,
-			Duration:      5.0,
-			ToolDuration:  2.0,
-			Provider:      "deepseek-pro",
+		m.postCallStatus = &events.TurnStatus{
+			Metrics: &llm.Metrics{
+				PromptTokens:  1000,
+				CachedTokens:  800,
+				ResponseTokens: 50,
+				Cost:          0.0012,
+				Duration:      5.0,
+				ToolDuration:  2.0,
+				Provider:      "deepseek-pro",
+			},
+			StartTime: time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC),
 		}
 
 		out := m.View()
@@ -327,10 +333,10 @@ func TestModel_View(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateRendering
-		m.finalCostLine = "╰─ Ready ($0.0012) $0.1505 M: 116386 H: 15172096 99.2% O: 51607"
+		m.finalCostLine = "╰─⠿ Ready ($0.0010 $0.0012 $0.1505 $0.0000) M: 116386 H: 15172096 99.2% O: 51607"
 
 		out := m.View()
-		assert.Contains(t, out, "╰─ Ready")
+		assert.Contains(t, out, "╰─⠿ Ready")
 		assert.Contains(t, out, "M: 116386")
 	})
 }

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -224,7 +224,7 @@ func TestModel_Update(t *testing.T) {
 
 		assert.NotEmpty(t, updated.finalCostLine)
 		assert.Contains(t, updated.finalCostLine, "Ready")
-		assert.Contains(t, updated.finalCostLine, "0.1505")
+		assert.Contains(t, updated.finalCostLine, "($0.0010 $0.0012 $0.1505 $0.0000 M: 116386 H: 15172096")
 		assert.NotNil(t, cmd)
 	})
 }
@@ -310,6 +310,7 @@ func TestModel_View(t *testing.T) {
 		m.turn = 1
 		m.timestamp = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
 		m.postCallStatus = &events.TurnStatus{
+			CurrentTurns: 0,
 			Metrics: &llm.Metrics{
 				PromptTokens:  1000,
 				CachedTokens:  800,
@@ -323,9 +324,11 @@ func TestModel_View(t *testing.T) {
 		}
 
 		out := m.View()
-		assert.Contains(t, out, "[deepseek-pro]")
-		assert.Contains(t, out, "M: 200 H: 800 C: 50")
-		assert.Contains(t, out, "($0.0012)")
+		lines := strings.Split(out, "\n")
+		// line 0: header, line 1: info, line 2: empty, line 3: token line, line 4: metrics line
+		assert.Contains(t, lines[4], "[14:30:00]")
+		assert.Contains(t, lines[4], "[deepseek-pro]")
+		assert.Contains(t, lines[4], "M: 200 H: 800 C: 50")
 	})
 
 	t.Run("with final summary", func(t *testing.T) {
@@ -333,11 +336,12 @@ func TestModel_View(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateRendering
-		m.finalCostLine = "╰─⠿ Ready ($0.0010 $0.0012 $0.1505 $0.0000) M: 116386 H: 15172096 99.2% O: 51607"
+		m.finalCostLine = "╰─⠿ Ready ($0.0010 $0.0012 $0.1505 $0.0000 M: 116386 H: 15172096 99.2% O: 51607)"
 
 		out := m.View()
 		assert.Contains(t, out, "╰─⠿ Ready")
 		assert.Contains(t, out, "M: 116386")
+		assert.Contains(t, out, "($0.0010 $0.0012 $0.1505 $0.0000 M: 116386 H: 15172096")
 	})
 }
 

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -24,7 +24,7 @@ func TestModel_Update(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 
-		newModel, cmd := m.Update(events.TurnStarted{Turn: 20})
+		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 20}))
 		updated := newModel.(*model)
 
 		assert.Equal(t, stateThinking, updated.currentState)
@@ -37,7 +37,7 @@ func TestModel_Update(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 
-		newModel, cmd := m.Update(events.InferenceStartedEvent{Model: "gpt-5"})
+		newModel, cmd := m.Update(domainEventMsg(events.InferenceStartedEvent{Model: "gpt-5"}))
 		updated := newModel.(*model)
 
 		assert.Equal(t, "gpt-5", updated.modelName)
@@ -61,7 +61,7 @@ func TestModel_Update(t *testing.T) {
 			},
 		}
 
-		newModel, cmd := m.Update(msg)
+		newModel, cmd := m.Update(domainEventMsg(msg))
 		updated := newModel.(*model)
 
 		assert.Equal(t, 1500, updated.tokens)
@@ -96,7 +96,7 @@ func TestModel_Update(t *testing.T) {
 		assert.IsType(t, tea.QuitMsg{}, msg)
 	})
 
-	t.Run("unknown message", func(t *testing.T) {
+	t.Run("unknown message returns nil cmd", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
@@ -107,7 +107,28 @@ func TestModel_Update(t *testing.T) {
 		assert.Equal(t, stateIdle, updated.currentState, "state should be unchanged")
 		assert.Equal(t, 0, updated.turn, "turn should be zero value")
 		assert.Empty(t, updated.modelName, "modelName should be empty")
-		assert.NotNil(t, cmd)
+		assert.Nil(t, cmd, "unknown messages must return nil to avoid duplicate channel readers")
+	})
+
+	t.Run("WindowSizeMsg sets width", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+		updated := newModel.(*model)
+
+		assert.Equal(t, 120, updated.width)
+		assert.Nil(t, cmd, "WindowSizeMsg must not trigger channel read")
+	})
+
+	t.Run("default message returns nil cmd", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		_, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
+		assert.Nil(t, cmd, "non-domain messages must return nil to avoid duplicate channel readers")
 	})
 
 	t.Run("error message", func(t *testing.T) {
@@ -121,7 +142,7 @@ func TestModel_Update(t *testing.T) {
 
 		require.NotNil(t, updated.err)
 		assert.Equal(t, "test error", updated.err.Error())
-		assert.NotNil(t, cmd)
+		assert.Nil(t, cmd, "internal errors must not trigger channel read")
 	})
 
 	t.Run("ResponseEvent", func(t *testing.T) {
@@ -136,7 +157,7 @@ func TestModel_Update(t *testing.T) {
 				{Text: " I am fine."},
 			},
 		}
-		newModel, cmd := m.Update(events.ResponseEvent{Content: content})
+		newModel, cmd := m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
 		updated := newModel.(*model)
 
 		assert.Equal(t, "Hello, world! I am fine.", updated.responseText,
@@ -148,14 +169,14 @@ func TestModel_Update(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.mdRender = func(text string) string {
+		m.mdRender = func(text string, width int) string {
 			return "**" + text + "**"
 		}
 
 		content := &llm.Content{
 			Parts: []*llm.Part{{Text: "Hello"}},
 		}
-		newModel, cmd := m.Update(events.ResponseEvent{Content: content})
+		newModel, cmd := m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
 		updated := newModel.(*model)
 
 		assert.Equal(t, "**Hello**", updated.responseText,
@@ -170,13 +191,13 @@ func TestModel_Update(t *testing.T) {
 
 		startTime := time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC)
 		metrics := &llm.Metrics{
-			PromptTokens:  1000,
-			CachedTokens:  800,
+			PromptTokens:   1000,
+			CachedTokens:   800,
 			ResponseTokens: 50,
-			Cost:          0.0012,
-			Duration:      5.0,
-			ToolDuration:  2.0,
-			Provider:      "deepseek-pro",
+			Cost:           0.0012,
+			Duration:       5.0,
+			ToolDuration:   2.0,
+			Provider:       "deepseek-pro",
 		}
 		msg := events.TurnStatusEvent{
 			Status: events.TurnStatus{
@@ -190,7 +211,7 @@ func TestModel_Update(t *testing.T) {
 			},
 		}
 
-		newModel, cmd := m.Update(msg)
+		newModel, cmd := m.Update(domainEventMsg(msg))
 		updated := newModel.(*model)
 
 		assert.NotNil(t, updated.postCallStatus)
@@ -219,7 +240,7 @@ func TestModel_Update(t *testing.T) {
 			},
 		}
 
-		newModel, cmd := m.Update(msg)
+		newModel, cmd := m.Update(domainEventMsg(msg))
 		updated := newModel.(*model)
 
 		assert.NotEmpty(t, updated.finalCostLine)
@@ -312,13 +333,13 @@ func TestModel_View(t *testing.T) {
 		m.postCallStatus = &events.TurnStatus{
 			CurrentTurns: 0,
 			Metrics: &llm.Metrics{
-				PromptTokens:  1000,
-				CachedTokens:  800,
+				PromptTokens:   1000,
+				CachedTokens:   800,
 				ResponseTokens: 50,
-				Cost:          0.0012,
-				Duration:      5.0,
-				ToolDuration:  2.0,
-				Provider:      "deepseek-pro",
+				Cost:           0.0012,
+				Duration:       5.0,
+				ToolDuration:   2.0,
+				Provider:       "deepseek-pro",
 			},
 			StartTime: time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC),
 		}
@@ -355,21 +376,21 @@ func TestModel_Integration(t *testing.T) {
 		assert.Equal(t, stateIdle, m.currentState)
 
 		// 2. TurnStarted → thinking
-		newModel, cmd := m.Update(events.TurnStarted{Turn: 0})
+		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 0}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
 		assert.Equal(t, 1, m.turn) // Turn.Index 0 + 1
 		assert.NotNil(t, cmd)
 
 		// 3. InferenceStartedEvent → model name set
-		newModel, cmd = m.Update(events.InferenceStartedEvent{Model: "gpt-5"})
+		newModel, cmd = m.Update(domainEventMsg(events.InferenceStartedEvent{Model: "gpt-5"}))
 		m = newModel.(*model)
 		assert.Equal(t, "gpt-5", m.modelName)
 		assert.NotNil(t, cmd)
 
 		// 4. TurnStatusEvent → rendering with all fields
 		ts := time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
-		newModel, cmd = m.Update(events.TurnStatusEvent{
+		newModel, cmd = m.Update(domainEventMsg(events.TurnStatusEvent{
 			Status: events.TurnStatus{
 				Tokens:           1500,
 				MaxHistoryTokens: 32000,
@@ -377,7 +398,7 @@ func TestModel_Integration(t *testing.T) {
 				Mode:             "architect-johndoe",
 				Model:            "deepseek-v4-pro",
 			},
-		})
+		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateRendering, m.currentState)
 		assert.Equal(t, 1500, m.tokens)
@@ -385,11 +406,11 @@ func TestModel_Integration(t *testing.T) {
 		assert.NotNil(t, cmd)
 
 		// ResponseEvent → store response text
-		newModel, cmd = m.Update(events.ResponseEvent{
+		newModel, cmd = m.Update(domainEventMsg(events.ResponseEvent{
 			Content: &llm.Content{
 				Parts: []*llm.Part{{Text: "Sure, I can help with that."}},
 			},
-		})
+		}))
 		m = newModel.(*model)
 		assert.Equal(t, "Sure, I can help with that.", m.responseText)
 		assert.NotNil(t, cmd)
@@ -407,43 +428,43 @@ func TestModel_Integration(t *testing.T) {
 		m := newTestModel(ctx, ch)
 
 		// Turn 1: thinking
-		newModel, _ := m.Update(events.TurnStarted{Turn: 0})
+		newModel, _ := m.Update(domainEventMsg(events.TurnStarted{Turn: 0}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
 
-		// ToolCallEvent — currently a no-op, should not change state
-		newModel, cmd := m.Update(events.ToolCallEvent{
+		// ToolCallEvent — unknown, falls through to default in domainEventMsg switch
+		newModel, cmd := m.Update(domainEventMsg(events.ToolCallEvent{
 			Calls:    []*llm.FunctionCall{{Name: "read_file"}},
 			Turn:     1,
 			MaxTurns: 5,
-		})
+		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState, "ToolCallEvent should not change state")
 		assert.NotNil(t, cmd)
 
-		// ToolResultEvent — also no-op
-		newModel, cmd = m.Update(events.ToolResultEvent{
-			Name: "read_file",
+		// ToolResultEvent — also unknown
+		newModel, cmd = m.Update(domainEventMsg(events.ToolResultEvent{
+			Name:   "read_file",
 			Result: tools.ToolResult{Text: "file contents"},
-		})
+		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState, "ToolResultEvent should not change state")
 		assert.NotNil(t, cmd)
 
 		// TurnStatus → rendering
 		ts := time.Now()
-		newModel, cmd = m.Update(events.TurnStatusEvent{
+		newModel, cmd = m.Update(domainEventMsg(events.TurnStatusEvent{
 			Status: events.TurnStatus{
 				Tokens: 2000, MaxHistoryTokens: 64000,
 				Timestamp: ts, Mode: "test", Model: "gpt-5",
 			},
-		})
+		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateRendering, m.currentState)
 		assert.NotNil(t, cmd)
 
 		// Turn 2: cycle restarts
-		newModel, cmd = m.Update(events.TurnStarted{Turn: 1})
+		newModel, cmd = m.Update(domainEventMsg(events.TurnStarted{Turn: 1}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
 		assert.Equal(t, 2, m.turn) // Turn.Index 1 + 1

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -141,6 +141,25 @@ func TestModel_Update(t *testing.T) {
 			"should concatenate non-thought text parts, skipping thoughts")
 		assert.NotNil(t, cmd)
 	})
+
+	t.Run("ResponseEvent with markdown renderer", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.mdRender = func(text string) string {
+			return "**" + text + "**"
+		}
+
+		content := &llm.Content{
+			Parts: []*llm.Part{{Text: "Hello"}},
+		}
+		newModel, cmd := m.Update(events.ResponseEvent{Content: content})
+		updated := newModel.(*model)
+
+		assert.Equal(t, "**Hello**", updated.responseText,
+			"should render through mdRender when set")
+		assert.NotNil(t, cmd)
+	})
 }
 
 // newTestModel creates a model for testing.

--- a/internal/ui/tui/progress/renderer.go
+++ b/internal/ui/tui/progress/renderer.go
@@ -25,7 +25,7 @@ func (r *renderer) Run(ctx context.Context, source ports.EventSubscriber) func()
 
 	source.Subscribe(func(ctx context.Context, e events.Event) {
 		switch e.(type) {
-		case events.TurnStarted, events.TurnStatusEvent:
+		case events.TurnStarted, events.TurnStatusEvent, events.ResponseEvent:
 			select {
 			case ch <- e:
 			case <-time.After(100 * time.Millisecond):
@@ -39,9 +39,17 @@ func (r *renderer) Run(ctx context.Context, source ports.EventSubscriber) func()
 	})
 
 	tr, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
-	mdRender := func(text string) string {
+	mdRender := func(text string, width int) string {
 		if err != nil || tr == nil {
 			return text
+		}
+		if width > 0 {
+			out, renderErr := tr.Render(text)
+			_ = width
+			if renderErr != nil {
+				return text
+			}
+			return out
 		}
 		out, renderErr := tr.Render(text)
 		if renderErr != nil {

--- a/internal/ui/tui/progress/renderer.go
+++ b/internal/ui/tui/progress/renderer.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/glamour"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 )
@@ -37,7 +38,18 @@ func (r *renderer) Run(ctx context.Context, source ports.EventSubscriber) func()
 		}
 	})
 
-	m := NewModel(ctx, ch)
+	tr, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
+	mdRender := func(text string) string {
+		if err != nil || tr == nil {
+			return text
+		}
+		out, renderErr := tr.Render(text)
+		if renderErr != nil {
+			return text
+		}
+		return out
+	}
+	m := NewModel(ctx, ch, mdRender)
 	p := tea.NewProgram(m, tea.WithInput(nil))
 	go func() {
 		_, _ = p.Run()

--- a/internal/ui/tui/progress/renderer.go
+++ b/internal/ui/tui/progress/renderer.go
@@ -38,20 +38,23 @@ func (r *renderer) Run(ctx context.Context, source ports.EventSubscriber) func()
 		}
 	})
 
-	tr, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
+	var cachedRenderer *glamour.TermRenderer
+	var lastWidth int
+
 	mdRender := func(text string, width int) string {
-		if err != nil || tr == nil {
-			return text
-		}
-		if width > 0 {
-			out, renderErr := tr.Render(text)
-			_ = width
+		if width != lastWidth || cachedRenderer == nil {
+			opts := []glamour.TermRendererOption{glamour.WithAutoStyle()}
+			if width > 0 {
+				opts = append(opts, glamour.WithWordWrap(width))
+			}
+			tr, renderErr := glamour.NewTermRenderer(opts...)
 			if renderErr != nil {
 				return text
 			}
-			return out
+			cachedRenderer = tr
+			lastWidth = width
 		}
-		out, renderErr := tr.Render(text)
+		out, renderErr := cachedRenderer.Render(text)
 		if renderErr != nil {
 			return text
 		}


### PR DESCRIPTION
## Summary

Extends the `-o` progress TUI dashboard to display AI response text, rendered through glamour markdown, plus post-call token/metrics lines matching the default linear renderer exactly.

## Changes

| Commit | What |
|---|---|
| `0b8d6cd` | Response text display — `ResponseEvent` text stored and rendered below header |
| `075d048` | Markdown rendering — glamour `TermRenderer` injected via `mdRender func(string)string` |
| `23f3666` | Post-call metrics + final summary — `IsPostCall`/`IsFinal` branches with `formatMetricsLine` and `formatFinalLine` |
| `e3a6d20` | Formatting parity — ⠿ prefix, exact token count, session timing, 4-cost format |
| `3bb8e56` | More parity — timestamp on metrics line, per-turn average, single closing paren, separator |
| `fdc288f` | Σ character fix |

## Output parity with default renderer

```
╭─ Turn 3 - architect-johndoe
[08:43:10] Payload: ~192657/1000000 tokens - architect-johndoe - deepseek-v4-pro

  Pushed. 5 commits:                                                          
  ... (markdown-rendered response)

[08:43:10] Payload: 192657/1000000 tokens - architect-johndoe - deepseek-v4-pro
[08:43:10] [deepseek-pro] M: 145 H: 192512 C: 109 ($0.0009) [2.92s (ΣT: 0.00s)] / 11.84s (3.95)
╰─⠿ Ready ($0.0009 $0.0025 $0.1781 $4.6068 M: 131333 H: 18503680 99.3% O: 61917)
```

## Architecture

- `mdRender func(string)string` injected from `renderer.go` — no glamour in `model.go`
- `postCallStatus *events.TurnStatus` stored for metrics line
- `formatMetricsLine` / `formatFinalLine` helpers for clean View composition

## Testing

22 tests across 3 layers (Update, View, Integration) — all pass.