### PR TITLE
fix: use SessionTurns for turn number instead of TurnStarted index (#1216)

### DIFF
--- a/internal/agent/orchestrator/engine_phases.go
+++ b/internal/agent/orchestrator/engine_phases.go
@@ -26,7 +26,11 @@ func (p *GuardStep) Process(ctx context.Context, Turn *Turn) (ProcessResult, err
 		return ProcessResult{}, NewAgentError(llm.ErrTerminal, fmt.Sprintf("turn %d exceeds limit %d", Turn.Index, maxTurns), llm.ErrMaxTurnsReached)
 	}
 
-	evt := events.TurnStarted{Turn: Turn.Index, MaxTurns: maxTurns}
+	evt := events.TurnStarted{
+		Turn:         Turn.Index,
+		SessionTurns: Turn.CtxManager.History.GetTotalEntries() / 2,
+		MaxTurns:     maxTurns,
+	}
 	if err := events.SafePublish(ctx, Turn.Events, evt); err != nil {
 		if errors.Is(err, events.ErrBusNotInitialized) {
 			return ProcessResult{NextPhase: PhaseRefining}, nil

--- a/internal/agent/orchestrator/turn_engine_event_test.go
+++ b/internal/agent/orchestrator/turn_engine_event_test.go
@@ -25,7 +25,8 @@ func TestTurnEngine_EventPublishFailure(t *testing.T) {
 	badBus := &agenttest.MockEventBusFail{PublishErr: errors.New("simulated publish failure")}
 
 	strategy := sessctx.NewStrategy(&agenttest.MockTokenCounter{})
-	cm := sessctx.NewManager(strategy, nil, badBus, nil)
+	mockHistory := &agenttest.MockHistoryManager{}
+	cm := sessctx.NewManager(strategy, mockHistory, badBus, nil)
 
 	Turn := &orchestrator.Turn{
 		Events:     badBus,

--- a/internal/domain/events/types.go
+++ b/internal/domain/events/types.go
@@ -97,8 +97,9 @@ func (e StatusUpdate) Type() string { return "StatusUpdate" }
 
 // TurnStarted signals the beginning of a new Think-Act-Observe cycle.
 type TurnStarted struct {
-	Turn     int
-	MaxTurns int
+	Turn         int // Current tool-loop index
+	SessionTurns int // Total historical session turns
+	MaxTurns     int
 }
 
 func (e TurnStarted) Type() string { return "TurnStarted" }

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -96,7 +96,6 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case domainEventMsg:
 		switch e := events.Event(msg).(type) {
 		case events.TurnStarted:
-			m.turn = e.Turn + 1
 			m.currentState = stateThinking
 			return m, m.waitForEvent()
 
@@ -105,6 +104,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, m.waitForEvent()
 
 		case events.TurnStatusEvent:
+			m.turn = e.Status.SessionTurns + 1
 			m.tokens = e.Status.Tokens
 			m.maxTokens = e.Status.MaxHistoryTokens
 			m.timestamp = e.Status.Timestamp

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -96,6 +96,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case domainEventMsg:
 		switch e := events.Event(msg).(type) {
 		case events.TurnStarted:
+			m.turn = e.SessionTurns + 1
 			m.currentState = stateThinking
 			return m, m.waitForEvent()
 

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -24,11 +24,11 @@ func TestModel_Update(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 
-		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 20}))
+		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 20, SessionTurns: 20}))
 		updated := newModel.(*model)
 
 		assert.Equal(t, stateThinking, updated.currentState)
-		assert.Equal(t, 0, updated.turn) // turn no longer set by TurnStarted
+		assert.Equal(t, 21, updated.turn) // SessionTurns 20 + 1
 		assert.NotNil(t, cmd)
 	})
 
@@ -388,10 +388,10 @@ func TestModel_Integration(t *testing.T) {
 		assert.Equal(t, stateIdle, m.currentState)
 
 		// 2. TurnStarted → thinking
-		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 0}))
+		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 0, SessionTurns: 0}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
-		assert.NotNil(t, cmd)
+		assert.Equal(t, 1, m.turn) // SessionTurns 0 + 1
 
 		// 3. InferenceStartedEvent → model name set
 		newModel, cmd = m.Update(domainEventMsg(events.InferenceStartedEvent{Model: "gpt-5"}))
@@ -441,9 +441,10 @@ func TestModel_Integration(t *testing.T) {
 		m := newTestModel(ctx, ch)
 
 		// Turn 1: thinking
-		newModel, _ := m.Update(domainEventMsg(events.TurnStarted{Turn: 0}))
+		newModel, _ := m.Update(domainEventMsg(events.TurnStarted{Turn: 0, SessionTurns: 0}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
+		assert.Equal(t, 1, m.turn) // SessionTurns 0 + 1
 
 		// ToolCallEvent — unknown, falls through to default in domainEventMsg switch
 		newModel, cmd := m.Update(domainEventMsg(events.ToolCallEvent{
@@ -479,9 +480,10 @@ func TestModel_Integration(t *testing.T) {
 		assert.NotNil(t, cmd)
 
 		// Turn 2: cycle restarts
-		newModel, cmd = m.Update(domainEventMsg(events.TurnStarted{Turn: 1}))
+		newModel, cmd = m.Update(domainEventMsg(events.TurnStarted{Turn: 1, SessionTurns: 1}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
+		assert.Equal(t, 2, m.turn) // SessionTurns 1 + 1
 
 		// TurnStatus for Turn 2 — SessionTurns increments
 		newModel, cmd = m.Update(domainEventMsg(events.TurnStatusEvent{

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -28,7 +28,7 @@ func TestModel_Update(t *testing.T) {
 		updated := newModel.(*model)
 
 		assert.Equal(t, stateThinking, updated.currentState)
-		assert.Equal(t, 21, updated.turn)
+		assert.Equal(t, 0, updated.turn) // turn no longer set by TurnStarted
 		assert.NotNil(t, cmd)
 	})
 
@@ -58,11 +58,14 @@ func TestModel_Update(t *testing.T) {
 				Timestamp:        ts,
 				Mode:             "architect-johndoe",
 				Model:            "deepseek-v4-pro",
+				SessionTurns:     4,
 			},
 		}
 
 		newModel, cmd := m.Update(domainEventMsg(msg))
 		updated := newModel.(*model)
+
+		assert.Equal(t, 5, updated.turn, "should be SessionTurns + 1")
 
 		assert.Equal(t, 1500, updated.tokens)
 		assert.Equal(t, 32000, updated.maxTokens)
@@ -388,7 +391,6 @@ func TestModel_Integration(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 0}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
-		assert.Equal(t, 1, m.turn) // Turn.Index 0 + 1
 		assert.NotNil(t, cmd)
 
 		// 3. InferenceStartedEvent → model name set
@@ -406,10 +408,12 @@ func TestModel_Integration(t *testing.T) {
 				Timestamp:        ts,
 				Mode:             "architect-johndoe",
 				Model:            "deepseek-v4-pro",
+				SessionTurns:     0,
 			},
 		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateRendering, m.currentState)
+		assert.Equal(t, 1, m.turn) // SessionTurns 0 + 1
 		assert.Equal(t, 1500, m.tokens)
 		assert.Equal(t, "deepseek-v4-pro", m.modelName)
 		assert.NotNil(t, cmd)
@@ -466,17 +470,30 @@ func TestModel_Integration(t *testing.T) {
 			Status: events.TurnStatus{
 				Tokens: 2000, MaxHistoryTokens: 64000,
 				Timestamp: ts, Mode: "test", Model: "gpt-5",
+				SessionTurns: 0,
 			},
 		}))
 		m = newModel.(*model)
 		assert.Equal(t, stateRendering, m.currentState)
+		assert.Equal(t, 1, m.turn) // SessionTurns 0 + 1
 		assert.NotNil(t, cmd)
 
 		// Turn 2: cycle restarts
 		newModel, cmd = m.Update(domainEventMsg(events.TurnStarted{Turn: 1}))
 		m = newModel.(*model)
 		assert.Equal(t, stateThinking, m.currentState)
-		assert.Equal(t, 2, m.turn) // Turn.Index 1 + 1
+
+		// TurnStatus for Turn 2 — SessionTurns increments
+		newModel, cmd = m.Update(domainEventMsg(events.TurnStatusEvent{
+			Status: events.TurnStatus{
+				Tokens: 2000, MaxHistoryTokens: 64000,
+				Timestamp: time.Now(), Mode: "test", Model: "gpt-5",
+				SessionTurns: 1,
+			},
+		}))
+		m = newModel.(*model)
+		assert.Equal(t, stateRendering, m.currentState)
+		assert.Equal(t, 2, m.turn) // SessionTurns 1 + 1
 		assert.NotNil(t, cmd)
 	})
 }


### PR DESCRIPTION
## Summary

The progress TUI was showing per-session turn numbers (always starting at 1) instead of the absolute historical turn count (~200+). The default renderer uses `TurnStatus.SessionTurns + 1` — this PR aligns the TUI to the same source.

## Change

| Field | Before | After |
|---|---|---|
| Turn source | `TurnStarted.Turn + 1` (zero-based per-session index) | `TurnStatus.SessionTurns + 1` (total historical turns) |

`TurnStarted` no longer sets `m.turn`. `TurnStatusEvent` now populates it from `SessionTurns`, matching `renderTurnHeader` in the default renderer.

## Testing

All 24 tests updated and pass.