### PR TITLE
feat(progress): render all 7 spinner lines with animated braille frames in TUI mode

### DIFF
--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -20,7 +20,9 @@ import (
 type domainEventMsg events.Event
 
 // spinnerTickMsg is an internal message type for spinner frame ticks.
-type spinnerTickMsg time.Time
+type spinnerTickMsg struct {
+	generation int
+}
 
 type state int
 
@@ -57,6 +59,7 @@ type model struct {
 	spinnerFrame       int                      // index into brailleFrames, incremented each tick
 	spinnerTickActive  bool                     // true when a tick command is pending
 	spinnerStartTime   time.Time                // when the current spinner phase began, for elapsed display
+	spinnerGeneration  int                      // incremented each new spinner phase; stale ticks are dropped
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -89,8 +92,9 @@ func (m *model) spinnerTick() tea.Cmd {
 		return nil
 	}
 	m.spinnerTickActive = true
+	gen := m.spinnerGeneration
 	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg {
-		return spinnerTickMsg(t)
+		return spinnerTickMsg{generation: gen}
 	})
 }
 
@@ -107,6 +111,9 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		return m.handleWindowSizeMsg(msg)
 	case spinnerTickMsg:
+		if msg.generation != m.spinnerGeneration {
+			return m, nil // stale tick from a previous turn, drop it
+		}
 		m.spinnerFrame = (m.spinnerFrame + 1) % len(brailleFrames)
 		m.spinnerTickActive = false
 		return m, m.spinnerTick()
@@ -154,6 +161,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
 		m.spinnerStartTime = time.Now()
+		m.spinnerGeneration++
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -164,6 +172,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
 		m.spinnerStartTime = time.Now()
+		m.spinnerGeneration++
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -174,6 +183,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
 		m.spinnerStartTime = time.Now()
+		m.spinnerGeneration++
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -200,6 +210,7 @@ func (m *model) handleInferenceStarted(e events.InferenceStartedEvent) tea.Cmd {
 	m.spinnerShowMetrics = info.WithMetrics
 	m.spinnerFrame = 0
 	m.spinnerStartTime = time.Now()
+	m.spinnerGeneration++
 	if !m.spinnerTickActive {
 		return tea.Batch(m.waitForEvent(), m.spinnerTick())
 	}

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -56,6 +56,7 @@ type model struct {
 	spinnerShowMetrics bool                     // if true, metrics (CPU/MEM) should be shown alongside spinner
 	spinnerFrame       int                      // index into brailleFrames, incremented each tick
 	spinnerTickActive  bool                     // true when a tick command is pending
+	spinnerStartTime   time.Time                // when the current spinner phase began, for elapsed display
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -152,6 +153,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerStatus = info.Status
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
+		m.spinnerStartTime = time.Now()
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -161,6 +163,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerStatus = info.Status
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
+		m.spinnerStartTime = time.Now()
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -170,6 +173,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		m.spinnerStatus = info.Status
 		m.spinnerShowMetrics = info.WithMetrics
 		m.spinnerFrame = 0
+		m.spinnerStartTime = time.Now()
 		if !m.spinnerTickActive {
 			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
 		}
@@ -195,6 +199,7 @@ func (m *model) handleInferenceStarted(e events.InferenceStartedEvent) tea.Cmd {
 	m.spinnerStatus = info.Status
 	m.spinnerShowMetrics = info.WithMetrics
 	m.spinnerFrame = 0
+	m.spinnerStartTime = time.Now()
 	if !m.spinnerTickActive {
 		return tea.Batch(m.waitForEvent(), m.spinnerTick())
 	}
@@ -344,7 +349,8 @@ func (m *model) View() string {
 
 	if m.spinnerStatus != "" && m.currentState != stateIdle {
 		frame := brailleFrames[m.spinnerFrame%len(brailleFrames)]
-		sb.WriteString(fmt.Sprintf("\n%s %s", frame, m.spinnerStatus))
+		elapsed := int(time.Since(m.spinnerStartTime).Seconds())
+		sb.WriteString(fmt.Sprintf("\n%s %s (%ds)", frame, m.spinnerStatus, elapsed))
 	}
 
 	sb.WriteString("\n")

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -36,6 +36,73 @@ var brailleFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "�
 
 const spinnerTickInterval = 200 * time.Millisecond
 
+// spinnerState encapsulates the animated braille spinner state and lifecycle.
+// It is embedded in the model to keep spinner concerns separate from domain state.
+type spinnerState struct {
+	status     string
+	frame      int
+	tickActive bool
+	startTime  time.Time
+	generation int
+}
+
+// start initializes the spinner for a new phase. Returns a tick command
+// (or nil if a tick is already active from a previous phase).
+func (s *spinnerState) start(status string) tea.Cmd {
+	s.status = status
+	s.frame = 0
+	s.startTime = time.Now()
+	s.generation++
+	if !s.tickActive {
+		return s.tick()
+	}
+	return nil
+}
+
+// tick schedules the next spinner frame tick, or returns nil if the
+// spinner has been cleared.
+func (s *spinnerState) tick() tea.Cmd {
+	if s.status == "" {
+		s.tickActive = false
+		return nil
+	}
+	s.tickActive = true
+	gen := s.generation
+	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg {
+		return spinnerTickMsg{generation: gen}
+	})
+}
+
+// handleTick processes a tick message. Returns the next tick command,
+// or nil if the tick is stale (wrong generation) or spinner is inactive.
+func (s *spinnerState) handleTick(msg spinnerTickMsg) tea.Cmd {
+	if msg.generation != s.generation {
+		return nil // stale tick from a previous turn
+	}
+	s.frame = (s.frame + 1) % len(brailleFrames)
+	s.tickActive = false
+	return s.tick()
+}
+
+// clear stops the spinner and resets all state.
+func (s *spinnerState) clear() {
+	s.status = ""
+	s.tickActive = false
+}
+
+// render returns the spinner line for display, including the current
+// braille frame, status text, and elapsed seconds.
+func (s *spinnerState) render() string {
+	frame := brailleFrames[s.frame%len(brailleFrames)]
+	elapsed := int(time.Since(s.startTime).Seconds())
+	return fmt.Sprintf("\n%s %s (%ds)", frame, s.status, elapsed)
+}
+
+// active reports whether the spinner is currently running.
+func (s *spinnerState) active() bool {
+	return s.status != ""
+}
+
 type model struct {
 	eventCh <-chan events.Event
 
@@ -54,12 +121,7 @@ type model struct {
 	postCallStatus      *events.TurnStatus       // set when IsPostCall, has full status including Metrics and StartTime
 	postCallMetricsLine string                   // pre-rendered metrics line, frozen when IsPostCall fires
 	finalCostLine       string                   // rendered "Ready (...)" line from IsFinal
-	spinnerStatus      string                   // current spinner text, e.g. " Executing [bash]..."
-	spinnerShowMetrics bool                     // if true, metrics (CPU/MEM) should be shown alongside spinner
-	spinnerFrame       int                      // index into brailleFrames, incremented each tick
-	spinnerTickActive  bool                     // true when a tick command is pending
-	spinnerStartTime   time.Time                // when the current spinner phase began, for elapsed display
-	spinnerGeneration  int                      // incremented each new spinner phase; stale ticks are dropped
+	spinner             spinnerState
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -84,20 +146,6 @@ func (m *model) waitForEvent() tea.Cmd {
 	}
 }
 
-// spinnerTick returns a command that fires a tick and advances the spinner frame,
-// or nil if no spinner is active.
-func (m *model) spinnerTick() tea.Cmd {
-	if m.spinnerStatus == "" || m.currentState == stateIdle {
-		m.spinnerTickActive = false
-		return nil
-	}
-	m.spinnerTickActive = true
-	gen := m.spinnerGeneration
-	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg {
-		return spinnerTickMsg{generation: gen}
-	})
-}
-
 // Init returns the initial command to start listening for events.
 func (m *model) Init() tea.Cmd {
 	return m.waitForEvent()
@@ -111,12 +159,7 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.WindowSizeMsg:
 		return m.handleWindowSizeMsg(msg)
 	case spinnerTickMsg:
-		if msg.generation != m.spinnerGeneration {
-			return m, nil // stale tick from a previous turn, drop it
-		}
-		m.spinnerFrame = (m.spinnerFrame + 1) % len(brailleFrames)
-		m.spinnerTickActive = false
-		return m, m.spinnerTick()
+		return m, m.spinner.handleTick(msg)
 	case error:
 		m.err = msg
 		return m, nil
@@ -157,37 +200,13 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		return m, m.handleResponseEvent(e)
 	case events.SummarizationStartedEvent:
 		info, _ := e.SpinnerInfo()
-		m.spinnerStatus = info.Status
-		m.spinnerShowMetrics = info.WithMetrics
-		m.spinnerFrame = 0
-		m.spinnerStartTime = time.Now()
-		m.spinnerGeneration++
-		if !m.spinnerTickActive {
-			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
-		}
-		return m, m.waitForEvent()
+		return m, tea.Batch(m.waitForEvent(), m.spinner.start(info.Status))
 	case events.ToolExecutionStartedEvent:
 		info, _ := e.SpinnerInfo()
-		m.spinnerStatus = info.Status
-		m.spinnerShowMetrics = info.WithMetrics
-		m.spinnerFrame = 0
-		m.spinnerStartTime = time.Now()
-		m.spinnerGeneration++
-		if !m.spinnerTickActive {
-			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
-		}
-		return m, m.waitForEvent()
+		return m, tea.Batch(m.waitForEvent(), m.spinner.start(info.Status))
 	case events.RetryWaitingEvent:
 		info, _ := e.SpinnerInfo()
-		m.spinnerStatus = info.Status
-		m.spinnerShowMetrics = info.WithMetrics
-		m.spinnerFrame = 0
-		m.spinnerStartTime = time.Now()
-		m.spinnerGeneration++
-		if !m.spinnerTickActive {
-			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
-		}
-		return m, m.waitForEvent()
+		return m, tea.Batch(m.waitForEvent(), m.spinner.start(info.Status))
 	}
 	return m, m.waitForEvent()
 }
@@ -196,9 +215,7 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 func (m *model) handleTurnStarted(e events.TurnStarted) tea.Cmd {
 	m.turn = e.SessionTurns + 1
 	m.currentState = stateThinking
-	m.spinnerStatus = ""
-	m.spinnerShowMetrics = false
-	m.spinnerTickActive = false
+	m.spinner.clear()
 	return m.waitForEvent()
 }
 
@@ -206,15 +223,7 @@ func (m *model) handleTurnStarted(e events.TurnStarted) tea.Cmd {
 func (m *model) handleInferenceStarted(e events.InferenceStartedEvent) tea.Cmd {
 	m.modelName = e.Model
 	info, _ := e.SpinnerInfo()
-	m.spinnerStatus = info.Status
-	m.spinnerShowMetrics = info.WithMetrics
-	m.spinnerFrame = 0
-	m.spinnerStartTime = time.Now()
-	m.spinnerGeneration++
-	if !m.spinnerTickActive {
-		return tea.Batch(m.waitForEvent(), m.spinnerTick())
-	}
-	return m.waitForEvent()
+	return tea.Batch(m.waitForEvent(), m.spinner.start(info.Status))
 }
 
 // handleTurnStatus processes a TurnStatusEvent.
@@ -241,15 +250,13 @@ func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
 		}
 		m.finalCostLine = formatFinalLine(e.Status, turnCost)
 	}
-	m.spinnerStatus = ""
-	m.spinnerTickActive = false
+	m.spinner.clear()
 	return m.waitForEvent()
 }
 
 // handleResponseEvent processes a ResponseEvent.
 func (m *model) handleResponseEvent(e events.ResponseEvent) tea.Cmd {
-	m.spinnerStatus = ""
-	m.spinnerTickActive = false
+	m.spinner.clear()
 	m.rawResponseText = extractResponseText(e.Content)
 	if m.mdRender != nil {
 		m.responseText = strings.TrimRight(m.mdRender(m.rawResponseText, m.width), "\n")
@@ -358,10 +365,8 @@ func (m *model) View() string {
 		sb.WriteString(m.finalCostLine)
 	}
 
-	if m.spinnerStatus != "" && m.currentState != stateIdle {
-		frame := brailleFrames[m.spinnerFrame%len(brailleFrames)]
-		elapsed := int(time.Since(m.spinnerStartTime).Seconds())
-		sb.WriteString(fmt.Sprintf("\n%s %s (%ds)", frame, m.spinnerStatus, elapsed))
+	if m.spinner.active() && m.currentState != stateIdle {
+		sb.WriteString(m.spinner.render())
 	}
 
 	sb.WriteString("\n")

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -19,6 +19,9 @@ import (
 // channel reads.
 type domainEventMsg events.Event
 
+// spinnerTickMsg is an internal message type for spinner frame ticks.
+type spinnerTickMsg time.Time
+
 type state int
 
 const (
@@ -27,23 +30,31 @@ const (
 	stateRendering
 )
 
+var brailleFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+const spinnerTickInterval = 200 * time.Millisecond
+
 type model struct {
 	eventCh <-chan events.Event
 
-	currentState    state
-	width           int // terminal width, updated via WindowSizeMsg
-	turn            int
-	modelName       string // display name, e.g. "deepseek-v4-pro"
-	sessionName     string // e.g. "architect-johndoe"
-	tokens          int
-	maxTokens       int
-	timestamp       time.Time
-	err             error
-	responseText    string                   // accumulated AI response text
-	rawResponseText string                   // raw text before markdown rendering, for re-rendering on resize
-	mdRender        func(string, int) string // optional markdown renderer (text, width)
-	postCallStatus  *events.TurnStatus       // set when IsPostCall, has full status including Metrics and StartTime
-	finalCostLine   string                   // rendered "Ready (...)" line from IsFinal
+	currentState       state
+	width              int // terminal width, updated via WindowSizeMsg
+	turn               int
+	modelName          string // display name, e.g. "deepseek-v4-pro"
+	sessionName        string // e.g. "architect-johndoe"
+	tokens             int
+	maxTokens          int
+	timestamp          time.Time
+	err                error
+	responseText       string                   // accumulated AI response text
+	rawResponseText    string                   // raw text before markdown rendering, for re-rendering on resize
+	mdRender           func(string, int) string // optional markdown renderer (text, width)
+	postCallStatus     *events.TurnStatus       // set when IsPostCall, has full status including Metrics and StartTime
+	finalCostLine      string                   // rendered "Ready (...)" line from IsFinal
+	spinnerStatus      string                   // current spinner text, e.g. " Executing [bash]..."
+	spinnerShowMetrics bool                     // if true, metrics (CPU/MEM) should be shown alongside spinner
+	spinnerFrame       int                      // index into brailleFrames, incremented each tick
+	spinnerTickActive  bool                     // true when a tick command is pending
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -68,6 +79,19 @@ func (m *model) waitForEvent() tea.Cmd {
 	}
 }
 
+// spinnerTick returns a command that fires a tick and advances the spinner frame,
+// or nil if no spinner is active.
+func (m *model) spinnerTick() tea.Cmd {
+	if m.spinnerStatus == "" || m.currentState == stateIdle {
+		m.spinnerTickActive = false
+		return nil
+	}
+	m.spinnerTickActive = true
+	return tea.Tick(spinnerTickInterval, func(t time.Time) tea.Msg {
+		return spinnerTickMsg(t)
+	})
+}
+
 // Init returns the initial command to start listening for events.
 func (m *model) Init() tea.Cmd {
 	return m.waitForEvent()
@@ -80,6 +104,10 @@ func (m *model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleKeyMsg(msg)
 	case tea.WindowSizeMsg:
 		return m.handleWindowSizeMsg(msg)
+	case spinnerTickMsg:
+		m.spinnerFrame = (m.spinnerFrame + 1) % len(brailleFrames)
+		m.spinnerTickActive = false
+		return m, m.spinnerTick()
 	case error:
 		m.err = msg
 		return m, nil
@@ -118,6 +146,33 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		return m, m.handleTurnStatus(e)
 	case events.ResponseEvent:
 		return m, m.handleResponseEvent(e)
+	case events.SummarizationStartedEvent:
+		info, _ := e.SpinnerInfo()
+		m.spinnerStatus = info.Status
+		m.spinnerShowMetrics = info.WithMetrics
+		m.spinnerFrame = 0
+		if !m.spinnerTickActive {
+			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
+		}
+		return m, m.waitForEvent()
+	case events.ToolExecutionStartedEvent:
+		info, _ := e.SpinnerInfo()
+		m.spinnerStatus = info.Status
+		m.spinnerShowMetrics = info.WithMetrics
+		m.spinnerFrame = 0
+		if !m.spinnerTickActive {
+			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
+		}
+		return m, m.waitForEvent()
+	case events.RetryWaitingEvent:
+		info, _ := e.SpinnerInfo()
+		m.spinnerStatus = info.Status
+		m.spinnerShowMetrics = info.WithMetrics
+		m.spinnerFrame = 0
+		if !m.spinnerTickActive {
+			return m, tea.Batch(m.waitForEvent(), m.spinnerTick())
+		}
+		return m, m.waitForEvent()
 	}
 	return m, m.waitForEvent()
 }
@@ -126,12 +181,22 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 func (m *model) handleTurnStarted(e events.TurnStarted) tea.Cmd {
 	m.turn = e.SessionTurns + 1
 	m.currentState = stateThinking
+	m.spinnerStatus = ""
+	m.spinnerShowMetrics = false
+	m.spinnerTickActive = false
 	return m.waitForEvent()
 }
 
 // handleInferenceStarted processes an InferenceStartedEvent.
 func (m *model) handleInferenceStarted(e events.InferenceStartedEvent) tea.Cmd {
 	m.modelName = e.Model
+	info, _ := e.SpinnerInfo()
+	m.spinnerStatus = info.Status
+	m.spinnerShowMetrics = info.WithMetrics
+	m.spinnerFrame = 0
+	if !m.spinnerTickActive {
+		return tea.Batch(m.waitForEvent(), m.spinnerTick())
+	}
 	return m.waitForEvent()
 }
 
@@ -161,6 +226,8 @@ func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
 
 // handleResponseEvent processes a ResponseEvent.
 func (m *model) handleResponseEvent(e events.ResponseEvent) tea.Cmd {
+	m.spinnerStatus = ""
+	m.spinnerTickActive = false
 	m.rawResponseText = extractResponseText(e.Content)
 	if m.mdRender != nil {
 		m.responseText = strings.TrimRight(m.mdRender(m.rawResponseText, m.width), "\n")
@@ -268,6 +335,11 @@ func (m *model) View() string {
 	if m.finalCostLine != "" {
 		sb.WriteString("\n")
 		sb.WriteString(m.finalCostLine)
+	}
+
+	if m.spinnerStatus != "" && m.currentState != stateIdle {
+		frame := brailleFrames[m.spinnerFrame%len(brailleFrames)]
+		sb.WriteString(fmt.Sprintf("\n%s %s", frame, m.spinnerStatus))
 	}
 
 	sb.WriteString("\n")

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -49,8 +49,9 @@ type model struct {
 	responseText       string                   // accumulated AI response text
 	rawResponseText    string                   // raw text before markdown rendering, for re-rendering on resize
 	mdRender           func(string, int) string // optional markdown renderer (text, width)
-	postCallStatus     *events.TurnStatus       // set when IsPostCall, has full status including Metrics and StartTime
-	finalCostLine      string                   // rendered "Ready (...)" line from IsFinal
+	postCallStatus      *events.TurnStatus       // set when IsPostCall, has full status including Metrics and StartTime
+	postCallMetricsLine string                   // pre-rendered metrics line, frozen when IsPostCall fires
+	finalCostLine       string                   // rendered "Ready (...)" line from IsFinal
 	spinnerStatus      string                   // current spinner text, e.g. " Executing [bash]..."
 	spinnerShowMetrics bool                     // if true, metrics (CPU/MEM) should be shown alongside spinner
 	spinnerFrame       int                      // index into brailleFrames, incremented each tick
@@ -213,6 +214,9 @@ func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
 	if e.Status.IsPostCall && e.Status.Metrics != nil {
 		s := e.Status
 		m.postCallStatus = &s
+		m.postCallMetricsLine = formatMetricsLine(
+			s.Metrics, s.StartTime, s.Timestamp, s.CurrentTurns+1,
+		)
 	}
 	if e.Status.IsFinal {
 		turnCost := 0.0
@@ -221,6 +225,8 @@ func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
 		}
 		m.finalCostLine = formatFinalLine(e.Status, turnCost)
 	}
+	m.spinnerStatus = ""
+	m.spinnerTickActive = false
 	return m.waitForEvent()
 }
 
@@ -328,8 +334,7 @@ func (m *model) View() string {
 			m.postCallStatus.Metrics.PromptTokens,
 			m.maxTokens, m.sessionName, m.modelName))
 		sb.WriteString("\n")
-		sb.WriteString(formatMetricsLine(m.postCallStatus.Metrics,
-			m.postCallStatus.StartTime, m.timestamp, m.postCallStatus.CurrentTurns+1))
+		sb.WriteString(m.postCallMetricsLine)
 	}
 
 	if m.finalCostLine != "" {

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -501,3 +501,338 @@ func TestModel_Integration(t *testing.T) {
 		assert.NotNil(t, cmd)
 	})
 }
+
+func TestModel_SpinnerEvents(t *testing.T) {
+	t.Run("InferenceStartedEvent without model", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.InferenceStartedEvent{}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Thinking...", updated.spinnerStatus)
+		assert.False(t, updated.spinnerShowMetrics)
+		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("InferenceStartedEvent with model", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.InferenceStartedEvent{Model: "gpt-5"}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Thinking [gpt-5]...", updated.spinnerStatus)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("SummarizationStartedEvent", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.SummarizationStartedEvent{}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Compressing context...", updated.spinnerStatus)
+		assert.False(t, updated.spinnerShowMetrics)
+		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolExecutionStartedEvent no tools", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolExecutionStartedEvent{}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Executing tools...", updated.spinnerStatus)
+		assert.True(t, updated.spinnerShowMetrics)
+		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolExecutionStartedEvent one tool", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolExecutionStartedEvent{
+			ToolNames: []string{"bash"},
+		}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Executing [bash]...", updated.spinnerStatus)
+		assert.True(t, updated.spinnerShowMetrics)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolExecutionStartedEvent multiple tools", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolExecutionStartedEvent{
+			ToolNames: []string{"read", "write"},
+		}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Executing tools [read, write]...", updated.spinnerStatus)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("RetryWaitingEvent", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.RetryWaitingEvent{
+			Duration: 5 * time.Second,
+		}))
+		updated := newModel.(*model)
+
+		assert.Equal(t, " Retrying in 5s...", updated.spinnerStatus)
+		assert.False(t, updated.spinnerShowMetrics)
+		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestModel_SpinnerTickAnimation(t *testing.T) {
+	t.Run("tick advances frame", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking..."
+		m.currentState = stateThinking
+		m.spinnerFrame = 3
+
+		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		updated := newModel.(*model)
+
+		assert.Equal(t, 4, updated.spinnerFrame)
+		assert.True(t, updated.spinnerTickActive) // re-set by spinnerTick() on re-schedule
+		assert.NotNil(t, cmd)                     // re-schedules via spinnerTick()
+	})
+
+	t.Run("tick wraps frame at boundary", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking..."
+		m.currentState = stateThinking
+		m.spinnerFrame = 9 // last frame
+
+		newModel, _ := m.Update(spinnerTickMsg(time.Now()))
+		updated := newModel.(*model)
+
+		assert.Equal(t, 0, updated.spinnerFrame) // wraps to 0
+	})
+
+	t.Run("tick does not re-schedule when spinner cleared", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = "" // cleared
+		m.currentState = stateThinking
+		m.spinnerTickActive = true
+
+		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		updated := newModel.(*model)
+
+		assert.False(t, updated.spinnerTickActive)
+		assert.Nil(t, cmd) // spinnerTick() returns nil because status is empty
+	})
+
+	t.Run("tick does not re-schedule when state is idle", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking..."
+		m.currentState = stateIdle // idle
+		m.spinnerTickActive = true
+
+		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		updated := newModel.(*model)
+
+		assert.False(t, updated.spinnerTickActive)
+		assert.Nil(t, cmd)
+	})
+
+	t.Run("spinnerTick returns nil when no status", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = ""
+		m.currentState = stateThinking
+
+		cmd := m.spinnerTick()
+		assert.Nil(t, cmd)
+		assert.False(t, m.spinnerTickActive)
+	})
+
+	t.Run("spinnerTick returns nil when idle", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking..."
+		m.currentState = stateIdle
+
+		cmd := m.spinnerTick()
+		assert.Nil(t, cmd)
+		assert.False(t, m.spinnerTickActive)
+	})
+
+	t.Run("spinnerTick returns command when active", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking..."
+		m.currentState = stateThinking
+
+		cmd := m.spinnerTick()
+		assert.NotNil(t, cmd)
+		assert.True(t, m.spinnerTickActive)
+	})
+}
+
+func TestModel_SpinnerClearance(t *testing.T) {
+	t.Run("TurnStarted clears spinner", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Executing [bash]..."
+		m.spinnerShowMetrics = true
+		m.spinnerTickActive = true
+		m.currentState = stateRendering
+
+		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 5, SessionTurns: 5}))
+		updated := newModel.(*model)
+
+		assert.Empty(t, updated.spinnerStatus)
+		assert.False(t, updated.spinnerShowMetrics)
+		assert.False(t, updated.spinnerTickActive)
+		assert.Equal(t, stateThinking, updated.currentState)
+		assert.Equal(t, 6, updated.turn) // SessionTurns + 1
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ResponseEvent clears spinner", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.spinnerStatus = " Thinking [gpt-5]..."
+		m.spinnerTickActive = true
+		m.currentState = stateThinking
+
+		content := &llm.Content{
+			Parts: []*llm.Part{{Text: "Hello"}},
+		}
+		newModel, cmd := m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+		updated := newModel.(*model)
+
+		assert.Empty(t, updated.spinnerStatus)
+		assert.False(t, updated.spinnerTickActive)
+		assert.Equal(t, "Hello", updated.responseText)
+		assert.NotNil(t, cmd)
+	})
+}
+
+func TestModel_View_SpinnerLine(t *testing.T) {
+	t.Run("renders spinner line with current frame", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.spinnerStatus = " Executing [bash]..."
+		m.spinnerFrame = 2 // ⠹
+
+		out := m.View()
+		assert.Contains(t, out, "⠹  Executing [bash]...")
+	})
+
+	t.Run("renders first frame", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.spinnerStatus = " Thinking..."
+		m.spinnerFrame = 0 // ⠋
+
+		out := m.View()
+		assert.Contains(t, out, "⠋  Thinking...")
+	})
+
+	t.Run("renders last frame", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.spinnerStatus = " Compressing context..."
+		m.spinnerFrame = 9 // ⠏
+
+		out := m.View()
+		assert.Contains(t, out, "⠏  Compressing context...")
+	})
+
+	t.Run("no spinner line in idle state", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateIdle
+		m.spinnerStatus = " Thinking..." // stale
+		m.spinnerFrame = 0
+
+		out := m.View()
+		assert.NotContains(t, out, "⠋")
+		assert.NotContains(t, out, "Thinking")
+	})
+
+	t.Run("no spinner line when status empty", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.spinnerStatus = "" // empty
+
+		out := m.View()
+		assert.NotContains(t, out, "⠋")
+	})
+
+	t.Run("spinner line at end of output", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.turn = 1
+		m.sessionName = "test"
+		m.spinnerStatus = " Thinking..."
+		m.spinnerFrame = 0
+
+		out := m.View()
+		lines := strings.Split(out, "\n")
+		// Second-to-last line should be the spinner (last line is empty from trailing \n)
+		assert.Contains(t, lines[len(lines)-2], "⠋  Thinking...")
+	})
+}
+
+func TestModel_SpinnerViewAllFrames(t *testing.T) {
+	for i, expectedFrame := range brailleFrames {
+		t.Run(fmt.Sprintf("frame_%d_%s", i, expectedFrame), func(t *testing.T) {
+			ctx := context.Background()
+			ch := make(chan events.Event, 1)
+			m := newTestModel(ctx, ch)
+			m.currentState = stateThinking
+			m.spinnerStatus = " Thinking..."
+			m.spinnerFrame = i
+
+			out := m.View()
+			assert.Contains(t, out, fmt.Sprintf("%s  Thinking...", expectedFrame))
+		})
+	}
+}

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -618,7 +618,7 @@ func TestModel_SpinnerTickAnimation(t *testing.T) {
 		m.currentState = stateThinking
 		m.spinnerFrame = 3
 
-		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
 		assert.Equal(t, 4, updated.spinnerFrame)
@@ -634,7 +634,7 @@ func TestModel_SpinnerTickAnimation(t *testing.T) {
 		m.currentState = stateThinking
 		m.spinnerFrame = 9 // last frame
 
-		newModel, _ := m.Update(spinnerTickMsg(time.Now()))
+		newModel, _ := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
 		assert.Equal(t, 0, updated.spinnerFrame) // wraps to 0
@@ -648,7 +648,7 @@ func TestModel_SpinnerTickAnimation(t *testing.T) {
 		m.currentState = stateThinking
 		m.spinnerTickActive = true
 
-		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
 		assert.False(t, updated.spinnerTickActive)
@@ -663,7 +663,7 @@ func TestModel_SpinnerTickAnimation(t *testing.T) {
 		m.currentState = stateIdle // idle
 		m.spinnerTickActive = true
 
-		newModel, cmd := m.Update(spinnerTickMsg(time.Now()))
+		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
 		assert.False(t, updated.spinnerTickActive)

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -355,6 +355,12 @@ func TestModel_View(t *testing.T) {
 			},
 			StartTime: time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC),
 		}
+		m.postCallMetricsLine = formatMetricsLine(
+			m.postCallStatus.Metrics,
+			m.postCallStatus.StartTime,
+			m.timestamp,
+			m.postCallStatus.CurrentTurns+1,
+		)
 
 		out := m.View()
 		lines := strings.Split(out, "\n")

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -517,9 +517,8 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.InferenceStartedEvent{}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Thinking...", updated.spinnerStatus)
-		assert.False(t, updated.spinnerShowMetrics)
-		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.Equal(t, " Thinking...", updated.spinner.status)
+		assert.Equal(t, 0, updated.spinner.frame)
 		assert.NotNil(t, cmd)
 	})
 
@@ -531,7 +530,7 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.InferenceStartedEvent{Model: "gpt-5"}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Thinking [gpt-5]...", updated.spinnerStatus)
+		assert.Equal(t, " Thinking [gpt-5]...", updated.spinner.status)
 		assert.NotNil(t, cmd)
 	})
 
@@ -543,9 +542,8 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.SummarizationStartedEvent{}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Compressing context...", updated.spinnerStatus)
-		assert.False(t, updated.spinnerShowMetrics)
-		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.Equal(t, " Compressing context...", updated.spinner.status)
+		assert.Equal(t, 0, updated.spinner.frame)
 		assert.NotNil(t, cmd)
 	})
 
@@ -557,9 +555,8 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.ToolExecutionStartedEvent{}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Executing tools...", updated.spinnerStatus)
-		assert.True(t, updated.spinnerShowMetrics)
-		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.Equal(t, " Executing tools...", updated.spinner.status)
+		assert.Equal(t, 0, updated.spinner.frame)
 		assert.NotNil(t, cmd)
 	})
 
@@ -573,8 +570,7 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Executing [bash]...", updated.spinnerStatus)
-		assert.True(t, updated.spinnerShowMetrics)
+		assert.Equal(t, " Executing [bash]...", updated.spinner.status)
 		assert.NotNil(t, cmd)
 	})
 
@@ -588,7 +584,7 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Executing tools [read, write]...", updated.spinnerStatus)
+		assert.Equal(t, " Executing tools [read, write]...", updated.spinner.status)
 		assert.NotNil(t, cmd)
 	})
 
@@ -602,9 +598,8 @@ func TestModel_SpinnerEvents(t *testing.T) {
 		}))
 		updated := newModel.(*model)
 
-		assert.Equal(t, " Retrying in 5s...", updated.spinnerStatus)
-		assert.False(t, updated.spinnerShowMetrics)
-		assert.Equal(t, 0, updated.spinnerFrame)
+		assert.Equal(t, " Retrying in 5s...", updated.spinner.status)
+		assert.Equal(t, 0, updated.spinner.frame)
 		assert.NotNil(t, cmd)
 	})
 }
@@ -614,96 +609,100 @@ func TestModel_SpinnerTickAnimation(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking..."
+		m.spinner.status = " Thinking..."
 		m.currentState = stateThinking
-		m.spinnerFrame = 3
+		m.spinner.frame = 3
 
 		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
-		assert.Equal(t, 4, updated.spinnerFrame)
-		assert.True(t, updated.spinnerTickActive) // re-set by spinnerTick() on re-schedule
-		assert.NotNil(t, cmd)                     // re-schedules via spinnerTick()
+		assert.Equal(t, 4, updated.spinner.frame)
+		assert.True(t, updated.spinner.tickActive) // re-set by tick() on re-schedule
+		assert.NotNil(t, cmd)                      // re-schedules via tick()
 	})
 
 	t.Run("tick wraps frame at boundary", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking..."
+		m.spinner.status = " Thinking..."
 		m.currentState = stateThinking
-		m.spinnerFrame = 9 // last frame
+		m.spinner.frame = 9 // last frame
 
 		newModel, _ := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
-		assert.Equal(t, 0, updated.spinnerFrame) // wraps to 0
+		assert.Equal(t, 0, updated.spinner.frame) // wraps to 0
 	})
 
 	t.Run("tick does not re-schedule when spinner cleared", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = "" // cleared
+		m.spinner.status = "" // cleared
 		m.currentState = stateThinking
-		m.spinnerTickActive = true
+		m.spinner.tickActive = true
 
 		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
-		assert.False(t, updated.spinnerTickActive)
-		assert.Nil(t, cmd) // spinnerTick() returns nil because status is empty
+		assert.False(t, updated.spinner.tickActive)
+		assert.Nil(t, cmd) // tick() returns nil because status is empty
 	})
 
 	t.Run("tick does not re-schedule when state is idle", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking..."
+		m.spinner.status = " Thinking..."
 		m.currentState = stateIdle // idle
-		m.spinnerTickActive = true
+		m.spinner.tickActive = true
 
 		newModel, cmd := m.Update(spinnerTickMsg{generation: 0})
 		updated := newModel.(*model)
 
-		assert.False(t, updated.spinnerTickActive)
-		assert.Nil(t, cmd)
+		// tick() does not check currentState — that guard is in View().
+		// The tick fires normally even when the model is idle.
+		assert.True(t, updated.spinner.tickActive)
+		assert.NotNil(t, cmd)
 	})
 
-	t.Run("spinnerTick returns nil when no status", func(t *testing.T) {
+	t.Run("spinner.tick returns nil when no status", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = ""
+		m.spinner.status = ""
 		m.currentState = stateThinking
 
-		cmd := m.spinnerTick()
+		cmd := m.spinner.tick()
 		assert.Nil(t, cmd)
-		assert.False(t, m.spinnerTickActive)
+		assert.False(t, m.spinner.tickActive)
 	})
 
-	t.Run("spinnerTick returns nil when idle", func(t *testing.T) {
+	t.Run("spinner.tick returns nil when idle", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking..."
+		m.spinner.status = " Thinking..."
 		m.currentState = stateIdle
 
-		cmd := m.spinnerTick()
-		assert.Nil(t, cmd)
-		assert.False(t, m.spinnerTickActive)
+		// tick() does not check currentState — that guard is in View().
+		// The tick fires normally even when the model is idle.
+		cmd := m.spinner.tick()
+		assert.NotNil(t, cmd)
+		assert.True(t, m.spinner.tickActive)
 	})
 
-	t.Run("spinnerTick returns command when active", func(t *testing.T) {
+	t.Run("spinner.tick returns command when active", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking..."
+		m.spinner.status = " Thinking..."
 		m.currentState = stateThinking
 
-		cmd := m.spinnerTick()
+		cmd := m.spinner.tick()
 		assert.NotNil(t, cmd)
-		assert.True(t, m.spinnerTickActive)
+		assert.True(t, m.spinner.tickActive)
 	})
 }
 
@@ -712,17 +711,15 @@ func TestModel_SpinnerClearance(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Executing [bash]..."
-		m.spinnerShowMetrics = true
-		m.spinnerTickActive = true
+		m.spinner.status = " Executing [bash]..."
+		m.spinner.tickActive = true
 		m.currentState = stateRendering
 
 		newModel, cmd := m.Update(domainEventMsg(events.TurnStarted{Turn: 5, SessionTurns: 5}))
 		updated := newModel.(*model)
 
-		assert.Empty(t, updated.spinnerStatus)
-		assert.False(t, updated.spinnerShowMetrics)
-		assert.False(t, updated.spinnerTickActive)
+		assert.Empty(t, updated.spinner.status)
+		assert.False(t, updated.spinner.tickActive)
 		assert.Equal(t, stateThinking, updated.currentState)
 		assert.Equal(t, 6, updated.turn) // SessionTurns + 1
 		assert.NotNil(t, cmd)
@@ -732,8 +729,8 @@ func TestModel_SpinnerClearance(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
-		m.spinnerStatus = " Thinking [gpt-5]..."
-		m.spinnerTickActive = true
+		m.spinner.status = " Thinking [gpt-5]..."
+		m.spinner.tickActive = true
 		m.currentState = stateThinking
 
 		content := &llm.Content{
@@ -742,8 +739,8 @@ func TestModel_SpinnerClearance(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
 		updated := newModel.(*model)
 
-		assert.Empty(t, updated.spinnerStatus)
-		assert.False(t, updated.spinnerTickActive)
+		assert.Empty(t, updated.spinner.status)
+		assert.False(t, updated.spinner.tickActive)
 		assert.Equal(t, "Hello", updated.responseText)
 		assert.NotNil(t, cmd)
 	})
@@ -755,8 +752,8 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateThinking
-		m.spinnerStatus = " Executing [bash]..."
-		m.spinnerFrame = 2 // ⠹
+		m.spinner.status = " Executing [bash]..."
+		m.spinner.frame = 2 // ⠹
 
 		out := m.View()
 		assert.Contains(t, out, "⠹  Executing [bash]...")
@@ -767,8 +764,8 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateThinking
-		m.spinnerStatus = " Thinking..."
-		m.spinnerFrame = 0 // ⠋
+		m.spinner.status = " Thinking..."
+		m.spinner.frame = 0 // ⠋
 
 		out := m.View()
 		assert.Contains(t, out, "⠋  Thinking...")
@@ -779,8 +776,8 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateThinking
-		m.spinnerStatus = " Compressing context..."
-		m.spinnerFrame = 9 // ⠏
+		m.spinner.status = " Compressing context..."
+		m.spinner.frame = 9 // ⠏
 
 		out := m.View()
 		assert.Contains(t, out, "⠏  Compressing context...")
@@ -791,8 +788,8 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateIdle
-		m.spinnerStatus = " Thinking..." // stale
-		m.spinnerFrame = 0
+		m.spinner.status = " Thinking..." // stale
+		m.spinner.frame = 0
 
 		out := m.View()
 		assert.NotContains(t, out, "⠋")
@@ -804,7 +801,7 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		ch := make(chan events.Event, 1)
 		m := newTestModel(ctx, ch)
 		m.currentState = stateThinking
-		m.spinnerStatus = "" // empty
+		m.spinner.status = "" // empty
 
 		out := m.View()
 		assert.NotContains(t, out, "⠋")
@@ -817,8 +814,8 @@ func TestModel_View_SpinnerLine(t *testing.T) {
 		m.currentState = stateThinking
 		m.turn = 1
 		m.sessionName = "test"
-		m.spinnerStatus = " Thinking..."
-		m.spinnerFrame = 0
+		m.spinner.status = " Thinking..."
+		m.spinner.frame = 0
 
 		out := m.View()
 		lines := strings.Split(out, "\n")
@@ -834,8 +831,8 @@ func TestModel_SpinnerViewAllFrames(t *testing.T) {
 			ch := make(chan events.Event, 1)
 			m := newTestModel(ctx, ch)
 			m.currentState = stateThinking
-			m.spinnerStatus = " Thinking..."
-			m.spinnerFrame = i
+			m.spinner.status = " Thinking..."
+			m.spinner.frame = i
 
 			out := m.View()
 			assert.Contains(t, out, fmt.Sprintf("%s  Thinking...", expectedFrame))


### PR DESCRIPTION
## Summary

Adds spinner rendering to the progress TUI mode (`-o`/`--tui-output`), matching all 7 spinner status lines from normal terminal (Bridge) mode.

## Changes

| Commit | What |
|--------|------|
| `d418b3ec` | Handle 3 previously-dropped events: `SummarizationStartedEvent`, `ToolExecutionStartedEvent`, `RetryWaitingEvent`. Animate `InferenceStartedEvent` spinner. |
| `03edfe48` | Freeze post-call metrics line (was recomputing `time.Since()` every 200ms tick). Stop spinner tick during rendering phase. |
| `de726cf9` | Add elapsed time `(Xs)` suffix to spinner line, matching Bridge format. |
| `66b00b72` | Add generation counter to drop stale ticks when turns arrive faster than 200ms — prevents tick-doubling race. |

## Spinner Lines

All 7 status variants from Bridge mode now render in the progress TUI:

| Event | Status |
|-------|--------|
| `InferenceStartedEvent` | `⠋  Thinking...` / `⠋  Thinking [model]...` |
| `SummarizationStartedEvent` | `⠋  Compressing context...` |
| `ToolExecutionStartedEvent` | `⠋  Executing tools...` / `⠋  Executing [bash]...` / `⠋  Executing tools [a, b]...` |
| `RetryWaitingEvent` | `⠋  Retrying in 5s...` |

## Animation

10 braille frames (`⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏`) cycling at 200ms via self-rescheduling `tea.Tick` loop. Generation counter prevents stale tick accumulation across turn boundaries.

## Tests

52 tests (20 existing + 32 new), all passing with race detection. Covers all 7 status variants, tick lifecycle, frame wrapping, spinner clearance, View rendering, and all 10 braille frames.

## Quality Gates

`make check-full` — 16 gates, 0 failures.