### PR TITLE
feat(progress): render tool logs and system messages in TUI mode

### DIFF
--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -6,6 +6,7 @@ package progress
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -154,6 +155,46 @@ func (m *model) appendToolLog(tag, message string) {
 	m.toolLogs = append(m.toolLogs, fmt.Sprintf("[%s] [%s] %s", ts, tag, message))
 }
 
+// appendLevelEventLog appends a timestamped log line with a level-mapped
+// prefix. Used by ToolOutputStreamEvent, SystemMessageEvent, and StatusUpdate.
+func (m *model) appendLevelEventLog(level, message string) {
+	prefix := "System"
+	switch level {
+	case "error":
+		prefix = "Error"
+	case "warn":
+		prefix = "Warning"
+	case "output":
+		prefix = "Tool Output"
+	case "info":
+		prefix = "Info"
+	}
+	m.appendToolLog(prefix, message)
+}
+
+// safeTruncate truncates s to at most maxLen bytes, ensuring the cut
+// never lands in the middle of a multi-byte UTF-8 character.
+// If s is already shorter than maxLen, it is returned unchanged.
+func safeTruncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	// Walk runes to find the byte index of the (maxLen)th rune.
+	var count, byteIdx int
+	for i := range s {
+		if count == maxLen {
+			byteIdx = i
+			break
+		}
+		count++
+	}
+	if byteIdx > 0 {
+		return s[:byteIdx]
+	}
+	// maxLen is 0 or s starts with a multi-byte rune exceeding maxLen.
+	return ""
+}
+
 // Init returns the initial command to start listening for events.
 func (m *model) Init() tea.Cmd {
 	return m.waitForEvent()
@@ -199,7 +240,7 @@ func (m *model) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) 
 func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 	switch e := events.Event(msg).(type) {
 	case events.ToolCallEvent:
-		if e.Calls == nil {
+		if len(e.Calls) == 0 {
 			return m, m.waitForEvent()
 		}
 		m.appendToolLog("Tool Engine", fmt.Sprintf("Step %d/%d", e.Turn+1, e.MaxTurns))
@@ -207,14 +248,19 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 			if reason, ok := fc.Args["reason"].(string); ok && reason != "" {
 				m.appendToolLog("Tool Reason", reason)
 			}
-			var parts []string
-			for k, v := range fc.Args {
-				if k == "reason" {
-					continue
+			var keys []string
+			for k := range fc.Args {
+				if k != "reason" {
+					keys = append(keys, k)
 				}
-				valStr := fmt.Sprintf("%v", v)
+			}
+			sort.Strings(keys)
+
+			var parts []string
+			for _, k := range keys {
+				valStr := fmt.Sprintf("%v", fc.Args[k])
 				if len(valStr) > 189 {
-					valStr = valStr[:186] + "..."
+					valStr = safeTruncate(valStr, 186) + "..."
 				}
 				parts = append(parts, fmt.Sprintf("%s: %s", k, valStr))
 			}
@@ -228,49 +274,20 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		if e.Result.Text != "" {
 			snippet := e.Result.Text
 			if len(snippet) > 200 {
-				snippet = snippet[:197] + "..."
+				snippet = safeTruncate(snippet, 197) + "..."
 			}
 			snippet = strings.ReplaceAll(snippet, "\n", " ")
 			m.appendToolLog("Tool Result", fmt.Sprintf("%s: %s", e.Name, snippet))
 		}
 		return m, m.waitForEvent()
 	case events.ToolOutputStreamEvent:
-		prefix := "System"
-		switch e.Level {
-		case "error":
-			prefix = "Error"
-		case "warn":
-			prefix = "Warning"
-		case "output":
-			prefix = "Tool Output"
-		case "info":
-			prefix = "Info"
-		}
-		m.appendToolLog(prefix, e.Message)
+		m.appendLevelEventLog(e.Level, e.Message)
 		return m, m.waitForEvent()
 	case events.SystemMessageEvent:
-		prefix := "System"
-		switch e.Level {
-		case "error":
-			prefix = "Error"
-		case "warn":
-			prefix = "Warning"
-		case "info":
-			prefix = "Info"
-		}
-		m.appendToolLog(prefix, e.Message)
+		m.appendLevelEventLog(e.Level, e.Message)
 		return m, m.waitForEvent()
 	case events.StatusUpdate:
-		prefix := "System"
-		switch e.Level {
-		case "error":
-			prefix = "Error"
-		case "warn":
-			prefix = "Warning"
-		case "info":
-			prefix = "Info"
-		}
-		m.appendToolLog(prefix, e.Message)
+		m.appendLevelEventLog(e.Level, e.Message)
 		return m, m.waitForEvent()
 	case events.TurnStarted:
 		return m, m.handleTurnStarted(e)

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -122,6 +122,8 @@ type model struct {
 	postCallMetricsLine string                   // pre-rendered metrics line, frozen when IsPostCall fires
 	finalCostLine       string                   // rendered "Ready (...)" line from IsFinal
 	spinner             spinnerState
+
+	toolLogs []string // accumulated tool call/result/output lines, cleared each turn
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -144,6 +146,12 @@ func (m *model) waitForEvent() tea.Cmd {
 		}
 		return domainEventMsg(e)
 	}
+}
+
+// appendToolLog appends a timestamped log line for tool events.
+func (m *model) appendToolLog(tag, message string) {
+	ts := time.Now().Format("15:04:05")
+	m.toolLogs = append(m.toolLogs, fmt.Sprintf("[%s] [%s] %s", ts, tag, message))
 }
 
 // Init returns the initial command to start listening for events.
@@ -190,6 +198,56 @@ func (m *model) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) 
 // handleDomainEvent dispatches a domain event to the appropriate handler.
 func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 	switch e := events.Event(msg).(type) {
+	case events.ToolCallEvent:
+		if e.Calls == nil {
+			return m, m.waitForEvent()
+		}
+		m.appendToolLog("Tool Engine", fmt.Sprintf("Step %d/%d", e.Turn+1, e.MaxTurns))
+		for _, fc := range e.Calls {
+			if reason, ok := fc.Args["reason"].(string); ok && reason != "" {
+				m.appendToolLog("Tool Reason", reason)
+			}
+			var parts []string
+			for k, v := range fc.Args {
+				if k == "reason" {
+					continue
+				}
+				valStr := fmt.Sprintf("%v", v)
+				if len(valStr) > 189 {
+					valStr = valStr[:186] + "..."
+				}
+				parts = append(parts, fmt.Sprintf("%s: %s", k, valStr))
+			}
+			m.appendToolLog("Tool Action", fmt.Sprintf("%s(%s)", fc.Name, strings.Join(parts, ", ")))
+		}
+		return m, m.waitForEvent()
+	case events.ToolResultEvent:
+		if e.Name == "" {
+			return m, m.waitForEvent()
+		}
+		if e.Result.Text != "" {
+			snippet := e.Result.Text
+			if len(snippet) > 200 {
+				snippet = snippet[:197] + "..."
+			}
+			snippet = strings.ReplaceAll(snippet, "\n", " ")
+			m.appendToolLog("Tool Result", fmt.Sprintf("%s: %s", e.Name, snippet))
+		}
+		return m, m.waitForEvent()
+	case events.ToolOutputStreamEvent:
+		prefix := "System"
+		switch e.Level {
+		case "error":
+			prefix = "Error"
+		case "warn":
+			prefix = "Warning"
+		case "output":
+			prefix = "Tool Output"
+		case "info":
+			prefix = "Info"
+		}
+		m.appendToolLog(prefix, e.Message)
+		return m, m.waitForEvent()
 	case events.TurnStarted:
 		return m, m.handleTurnStarted(e)
 	case events.InferenceStartedEvent:
@@ -216,6 +274,7 @@ func (m *model) handleTurnStarted(e events.TurnStarted) tea.Cmd {
 	m.turn = e.SessionTurns + 1
 	m.currentState = stateThinking
 	m.spinner.clear()
+	m.toolLogs = nil
 	return m.waitForEvent()
 }
 
@@ -344,6 +403,13 @@ func (m *model) View() string {
 	sb.WriteString(fmt.Sprintf("╭─ Turn %d - %s\n", m.turn, m.sessionName))
 	sb.WriteString(fmt.Sprintf("[%s] Payload: ~%d/%d tokens - %s - %s",
 		ts, m.tokens, m.maxTokens, m.sessionName, m.modelName))
+
+	if len(m.toolLogs) > 0 {
+		for _, log := range m.toolLogs {
+			sb.WriteString("\n")
+			sb.WriteString(log)
+		}
+	}
 
 	if m.responseText != "" {
 		sb.WriteString("\n")

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -248,6 +248,30 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		}
 		m.appendToolLog(prefix, e.Message)
 		return m, m.waitForEvent()
+	case events.SystemMessageEvent:
+		prefix := "System"
+		switch e.Level {
+		case "error":
+			prefix = "Error"
+		case "warn":
+			prefix = "Warning"
+		case "info":
+			prefix = "Info"
+		}
+		m.appendToolLog(prefix, e.Message)
+		return m, m.waitForEvent()
+	case events.StatusUpdate:
+		prefix := "System"
+		switch e.Level {
+		case "error":
+			prefix = "Error"
+		case "warn":
+			prefix = "Warning"
+		case "info":
+			prefix = "Info"
+		}
+		m.appendToolLog(prefix, e.Message)
+		return m, m.waitForEvent()
 	case events.TurnStarted:
 		return m, m.handleTurnStarted(e)
 	case events.InferenceStartedEvent:

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -1041,6 +1041,81 @@ func TestModel_ToolLogs(t *testing.T) {
 		assert.Contains(t, updated.toolLogs[0], "[System] some message")
 	})
 
+	t.Run("SystemMessageEvent error level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.SystemMessageEvent{
+			Message: "failed to connect to API",
+			Level:   "error",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Error] failed to connect to API")
+	})
+
+	t.Run("SystemMessageEvent info level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.SystemMessageEvent{
+			Message: "context window expanded to 128k",
+			Level:   "info",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Info] context window expanded to 128k")
+	})
+
+	t.Run("SystemMessageEvent default level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.SystemMessageEvent{
+			Message: "agent state changed",
+			Level:   "debug",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[System] agent state changed")
+	})
+
+	t.Run("StatusUpdate error level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.StatusUpdate{
+			Message: "context limit exceeded",
+			Level:   "error",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Error] context limit exceeded")
+	})
+
+	t.Run("StatusUpdate warn level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.StatusUpdate{
+			Message: "retry attempt 2 of 3",
+			Level:   "warn",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Warning] retry attempt 2 of 3")
+	})
+
 	t.Run("TurnStarted clears toolLogs", func(t *testing.T) {
 		ctx := context.Background()
 		ch := make(chan events.Event, 1)

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -839,3 +839,242 @@ func TestModel_SpinnerViewAllFrames(t *testing.T) {
 		})
 	}
 }
+
+func TestModel_ToolLogs(t *testing.T) {
+	t.Run("ToolCallEvent renders Step, Reason, and Action", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolCallEvent{
+			Turn:     0,
+			MaxTurns: 5,
+			Calls: []*llm.FunctionCall{
+				{
+					Name: "execute_command",
+					Args: map[string]interface{}{
+						"reason":  "Stage the formatting fix for commit",
+						"command": "git add internal/ui/tui/progress/model.go",
+					},
+				},
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 3)
+		assert.Contains(t, updated.toolLogs[0], "[Tool Engine] Step 1/5")
+		assert.Contains(t, updated.toolLogs[1], "[Tool Reason] Stage the formatting fix for commit")
+		assert.Contains(t, updated.toolLogs[2], "[Tool Action] execute_command(command: git add internal/ui/tui/progress/model.go)")
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolCallEvent with nil Calls is no-op", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolCallEvent{
+			Turn:  0,
+			Calls: nil,
+		}))
+		updated := newModel.(*model)
+
+		assert.Nil(t, updated.toolLogs)
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolCallEvent skips empty reason", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolCallEvent{
+			Turn:     0,
+			MaxTurns: 3,
+			Calls: []*llm.FunctionCall{
+				{
+					Name: "read_file",
+					Args: map[string]interface{}{
+						"reason":   "",
+						"filepath": "/tmp/test.go",
+					},
+				},
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 2) // Step + Action only, no Reason
+		assert.Contains(t, updated.toolLogs[0], "[Tool Engine]")
+		assert.Contains(t, updated.toolLogs[1], "[Tool Action] read_file(filepath: /tmp/test.go)")
+	})
+
+	t.Run("ToolResultEvent renders snippet", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, cmd := m.Update(domainEventMsg(events.ToolResultEvent{
+			Name: "execute_command",
+			Result: tools.ToolResult{
+				Text: "Exit Code: 0 Output: (empty)",
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Tool Result] execute_command: Exit Code: 0 Output: (empty)")
+		assert.NotNil(t, cmd)
+	})
+
+	t.Run("ToolResultEvent truncates long text", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		longText := strings.Repeat("x", 250)
+		newModel, _ := m.Update(domainEventMsg(events.ToolResultEvent{
+			Name: "read_file",
+			Result: tools.ToolResult{
+				Text: longText,
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		snippet := updated.toolLogs[0]
+		// Should be truncated at 200 chars of text: timestamp(11) + tag(14) + "read_file: "(12) + 200 = ~237
+		assert.Less(t, len(snippet), 240)
+		assert.True(t, strings.HasSuffix(snippet, "..."))
+	})
+
+	t.Run("ToolResultEvent collapses newlines", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolResultEvent{
+			Name: "read_file",
+			Result: tools.ToolResult{
+				Text: "line1\nline2\nline3",
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.NotContains(t, updated.toolLogs[0], "\n")
+		assert.Contains(t, updated.toolLogs[0], "line1 line2 line3")
+	})
+
+	t.Run("ToolResultEvent with empty Name is no-op", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolResultEvent{
+			Name: "",
+			Result: tools.ToolResult{
+				Text: "some text",
+			},
+		}))
+		updated := newModel.(*model)
+
+		assert.Nil(t, updated.toolLogs)
+	})
+
+	t.Run("ToolOutputStreamEvent error level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolOutputStreamEvent{
+			Message: "command not found",
+			Level:   "error",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Error] command not found")
+	})
+
+	t.Run("ToolOutputStreamEvent warn level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolOutputStreamEvent{
+			Message: "deprecated flag used",
+			Level:   "warn",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Warning] deprecated flag used")
+	})
+
+	t.Run("ToolOutputStreamEvent output level", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolOutputStreamEvent{
+			Message: "Executing... (Output shown below)",
+			Level:   "output",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[Tool Output] Executing...")
+	})
+
+	t.Run("ToolOutputStreamEvent unknown level defaults to System", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+
+		newModel, _ := m.Update(domainEventMsg(events.ToolOutputStreamEvent{
+			Message: "some message",
+			Level:   "debug",
+		}))
+		updated := newModel.(*model)
+
+		assert.Len(t, updated.toolLogs, 1)
+		assert.Contains(t, updated.toolLogs[0], "[System] some message")
+	})
+
+	t.Run("TurnStarted clears toolLogs", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.toolLogs = []string{"[12:00:00] [Tool Engine] Step 1/5"}
+
+		newModel, _ := m.Update(domainEventMsg(events.TurnStarted{Turn: 0, SessionTurns: 0}))
+		updated := newModel.(*model)
+
+		assert.Nil(t, updated.toolLogs)
+	})
+
+	t.Run("View renders toolLogs between header and response", func(t *testing.T) {
+		ctx := context.Background()
+		ch := make(chan events.Event, 1)
+		m := newTestModel(ctx, ch)
+		m.currentState = stateThinking
+		m.turn = 1
+		m.sessionName = "test"
+		m.timestamp = time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC)
+		m.toolLogs = []string{
+			"[14:30:00] [Tool Engine] Step 1/3",
+			"[14:30:00] [Tool Reason] read the file",
+		}
+		m.responseText = "I'll read that file for you."
+
+		out := m.View()
+		lines := strings.Split(out, "\n")
+
+		// Header (line 0), token line (line 1), then tool logs
+		assert.Contains(t, lines[0], "╭─ Turn 1 - test")
+		assert.Contains(t, lines[2], "[Tool Engine] Step 1/3")
+		assert.Contains(t, lines[3], "[Tool Reason] read the file")
+		// Response text after tool logs
+		assert.Contains(t, out, "I'll read that file for you.")
+	})
+}


### PR DESCRIPTION
## Summary

Adds rendering of 5 previously-dropped event types to the progress TUI mode (`-o`/`--tui-output`), matching Bridge mode output format.

## Events Added

| Event | Example output |
|-------|---------------|
| `ToolCallEvent` | `[13:32:13] [Tool Engine] Step 1/3` |
| | `[13:32:13] [Tool Reason] Stage the formatting fix` |
| | `[13:32:13] [Tool Action] execute_command(command: git add ...)` |
| `ToolResultEvent` | `[13:32:13] [Tool Result] execute_command: Exit Code: 0` |
| `ToolOutputStreamEvent` | `[13:32:13] [Tool Output] Executing...` |
| `SystemMessageEvent` | `[13:32:13] [Error] failed to connect to API` |
| `StatusUpdate` | `[13:32:13] [Warning] retry attempt 2 of 3` |

## Implementation

- `toolLogs []string` field on model, accumulated per turn
- `appendToolLog(tag, message)` helper with timestamp formatting
- Truncation: Tool Result text capped at 200 chars, newlines collapsed
- Level mapping (shared by 3 event types): `error`→Error, `warn`→Warning, `info`→Info, `output`→Tool Output, default→System
- Cleared on `TurnStarted`, rendered in `View()` between header and response text

## Tests

58 tests (53 existing + 5 new), all passing. Covers all event types, truncation, newline collapse, nil guards, and `TurnStarted` clearance.