### PR TITLE
fix: prevent duplicate Turn headers in TUI progress mode (#1229)

### DIFF
--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -49,6 +49,11 @@ type Turn struct {
 	Mode         string
 	Logger       ports.Logger
 
+	// SessionTurnsAtStart is the frozen snapshot of session turns at the moment
+	// this turn began. Captured once by GuardStep before any persistence mutates
+	// history, ensuring all status events within this turn report a stable value.
+	SessionTurnsAtStart int
+
 	// Results/Outputs
 	Stop bool
 }

--- a/internal/agent/orchestrator/engine_phases.go
+++ b/internal/agent/orchestrator/engine_phases.go
@@ -26,9 +26,13 @@ func (p *GuardStep) Process(ctx context.Context, Turn *Turn) (ProcessResult, err
 		return ProcessResult{}, NewAgentError(llm.ErrTerminal, fmt.Sprintf("turn %d exceeds limit %d", Turn.Index, maxTurns), llm.ErrMaxTurnsReached)
 	}
 
+	// Freeze session turn count before persistence mutates history.
+	// This value is used by TurnStatusEvent throughout the turn lifecycle.
+	Turn.SessionTurnsAtStart = Turn.CtxManager.History.GetTotalEntries() / 2
+
 	evt := events.TurnStarted{
 		Turn:         Turn.Index,
-		SessionTurns: Turn.CtxManager.History.GetTotalEntries() / 2,
+		SessionTurns: Turn.SessionTurnsAtStart,
 		MaxTurns:     maxTurns,
 	}
 	if err := events.SafePublish(ctx, Turn.Events, evt); err != nil {

--- a/internal/agent/orchestrator/middleware.go
+++ b/internal/agent/orchestrator/middleware.go
@@ -71,7 +71,7 @@ func (e *Engine) publishTurnStatus(ctx context.Context, Turn *Turn, isPostCall b
 		Status: events.TurnStatus{
 			Timestamp:        Turn.Clock.Now(),
 			CurrentTurns:     Turn.Index,
-			SessionTurns:     Turn.CtxManager.History.GetTotalEntries() / 2,
+			SessionTurns:     Turn.SessionTurnsAtStart,
 			MaxHistoryTurns:  maxHistTurns,
 			Tokens:           Turn.State.Tokens,
 			MaxHistoryTokens: maxTokens,

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -331,7 +331,6 @@ func (m *model) handleInferenceStarted(e events.InferenceStartedEvent) tea.Cmd {
 
 // handleTurnStatus processes a TurnStatusEvent.
 func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
-	m.turn = e.Status.SessionTurns + 1
 	m.tokens = e.Status.Tokens
 	m.maxTokens = e.Status.MaxHistoryTokens
 	m.timestamp = e.Status.Timestamp

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -65,7 +65,7 @@ func TestModel_Update(t *testing.T) {
 		newModel, cmd := m.Update(domainEventMsg(msg))
 		updated := newModel.(*model)
 
-		assert.Equal(t, 5, updated.turn, "should be SessionTurns + 1")
+		assert.Equal(t, 0, updated.turn, "turn should NOT be set by TurnStatusEvent; only TurnStarted sets it")
 
 		assert.Equal(t, 1500, updated.tokens)
 		assert.Equal(t, 32000, updated.maxTokens)


### PR DESCRIPTION
## Summary

Fixes duplicate `╭─ Turn` headers in TUI progress mode (`-o`) where two consecutive turn headers appeared for a single turn.

## Root Cause

Two defects combined to produce the bug:

1. **TUI consumer** — `handleTurnStatus` overwrote `m.turn` using a live/mutable `SessionTurns` value from `TurnStatusEvent`. After `PersistenceStep` saved the response, the same field returned a higher value, causing `m.turn` to be set one too high.

2. **Orchestrator producer** — `publishTurnStatus` read `SessionTurns` live from `History.GetTotalEntries() / 2` on every call, creating a temporal coupling across phase boundaries.

## Fix (Two Layers)

### Layer 1 — Symptom fix (TUI)
- Removed `m.turn = e.Status.SessionTurns + 1` from `handleTurnStatus`. Turn identity is now owned exclusively by `handleTurnStarted` which fires pre-persistence.

### Layer 2 — Root cause fix (Orchestrator)
- Added `Turn.SessionTurnsAtStart` field, frozen once in `GuardStep` before any persistence mutates history.
- `publishTurnStatus` and `TurnStarted` both use the frozen value, eliminating the live read.

## Files Changed

| File | Change |
|------|--------|
| `internal/ui/tui/progress/model.go` | Delete `m.turn = ...` from `handleTurnStatus` |
| `internal/ui/tui/progress/model_test.go` | Update assertion: turn stays 0 after isolated `TurnStatusEvent` |
| `internal/agent/orchestrator/engine.go` | Add `SessionTurnsAtStart` field to `Turn` struct |
| `internal/agent/orchestrator/engine_phases.go` | Capture frozen value in `GuardStep`, reuse for `TurnStarted` |
| `internal/agent/orchestrator/middleware.go` | Use `Turn.SessionTurnsAtStart` instead of live `GetTotalEntries()/2` |

## Verification

- `go build ./...` — clean
- `go test ./...` — all 72 packages pass, zero regressions
- Non-TUI mode unaffected (uses `ui.Bridge`, not the progress model)

Closes #1229