### PR TITLE
fix: show tool call logs immediately from ResponseEvent, before ToolCallEvent (#1233)

### DIFF
--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -124,7 +124,8 @@ type model struct {
 	finalCostLine       string                   // rendered "Ready (...)" line from IsFinal
 	spinner             spinnerState
 
-	toolLogs []string // accumulated tool call/result/output lines, cleared each turn
+	toolLogs    []string        // accumulated tool call/result/output lines, cleared each turn
+	seenCallIDs map[string]bool // dedup tool logs from ResponseEvent vs ToolCallEvent
 }
 
 // NewModel creates a new progress model that consumes events from the given
@@ -134,6 +135,7 @@ func NewModel(_ context.Context, ch <-chan events.Event, mdRender func(string, i
 		eventCh:      ch,
 		currentState: stateIdle,
 		mdRender:     mdRender,
+		seenCallIDs:  make(map[string]bool),
 	}
 }
 
@@ -243,8 +245,25 @@ func (m *model) handleDomainEvent(msg domainEventMsg) (tea.Model, tea.Cmd) {
 		if len(e.Calls) == 0 {
 			return m, m.waitForEvent()
 		}
-		m.appendToolLog("Tool Engine", fmt.Sprintf("Step %d/%d", e.Turn+1, e.MaxTurns))
+		// Count new calls and track which ones need fresh log lines.
+		// Calls already extracted from ResponseEvent are skipped.
+		newCalls := make([]*llm.FunctionCall, 0, len(e.Calls))
 		for _, fc := range e.Calls {
+			id := fc.ID
+			if id == "" {
+				id = fc.Name
+			}
+			if !m.seenCallIDs[id] {
+				m.seenCallIDs[id] = true
+				newCalls = append(newCalls, fc)
+			}
+		}
+		// Only emit Tool Engine if there are new calls not already seen.
+		if len(newCalls) > 0 {
+			m.appendToolLog("Tool Engine", fmt.Sprintf("Step %d/%d", e.Turn+1, e.MaxTurns))
+		}
+		// Only emit reason/action for new calls.
+		for _, fc := range newCalls {
 			if reason, ok := fc.Args["reason"].(string); ok && reason != "" {
 				m.appendToolLog("Tool Reason", reason)
 			}
@@ -319,6 +338,7 @@ func (m *model) handleTurnStarted(e events.TurnStarted) tea.Cmd {
 	m.currentState = stateThinking
 	m.spinner.clear()
 	m.toolLogs = nil
+	m.seenCallIDs = make(map[string]bool)
 	return m.waitForEvent()
 }
 
@@ -365,6 +385,14 @@ func (m *model) handleResponseEvent(e events.ResponseEvent) tea.Cmd {
 	} else {
 		m.responseText = m.rawResponseText
 	}
+
+	// Extract tool call info from ResponseEvent so [Tool Reason]
+	// and [Tool Action] appear immediately — before ToolCallEvent
+	// arrives from the Dispatcher.
+	if e.Content != nil {
+		m.extractToolCallsFromResponse(e.Content)
+	}
+
 	return m.waitForEvent()
 }
 
@@ -380,6 +408,55 @@ func extractResponseText(content *llm.Content) string {
 		}
 	}
 	return sb.String()
+}
+
+// extractToolCallsFromResponse populates toolLogs from FunctionCall parts
+// in the ResponseEvent content. This bridges the visibility gap between
+// ResponseEvent and ToolCallEvent. seenCallIDs prevents duplicates when
+// the real ToolCallEvent arrives later from the Dispatcher.
+func (m *model) extractToolCallsFromResponse(content *llm.Content) {
+	var toolCalls []*llm.FunctionCall
+	for _, part := range content.Parts {
+		if part.FunctionCall != nil {
+			toolCalls = append(toolCalls, part.FunctionCall)
+		}
+	}
+	if len(toolCalls) == 0 {
+		return
+	}
+
+	for _, fc := range toolCalls {
+		id := fc.ID
+		if id == "" {
+			id = fc.Name // fallback for providers that don't set ID
+		}
+		if m.seenCallIDs[id] {
+			continue
+		}
+		m.seenCallIDs[id] = true
+
+		if reason, ok := fc.Args["reason"].(string); ok && reason != "" {
+			m.appendToolLog("Tool Reason", reason)
+		}
+
+		var keys []string
+		for k := range fc.Args {
+			if k != "reason" {
+				keys = append(keys, k)
+			}
+		}
+		sort.Strings(keys)
+
+		var parts []string
+		for _, k := range keys {
+			valStr := fmt.Sprintf("%v", fc.Args[k])
+			if len(valStr) > 189 {
+				valStr = safeTruncate(valStr, 186) + "..."
+			}
+			parts = append(parts, fmt.Sprintf("%s: %s", k, valStr))
+		}
+		m.appendToolLog("Tool Action", fmt.Sprintf("%s(%s)", fc.Name, strings.Join(parts, ", ")))
+	}
 }
 
 // formatMetricsLine renders a single-line post-call metrics summary.

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -267,6 +267,7 @@ func newTestModel(_ context.Context, ch <-chan events.Event) *model {
 	return &model{
 		eventCh:      ch,
 		currentState: stateIdle,
+		seenCallIDs:  make(map[string]bool),
 	}
 }
 
@@ -1151,4 +1152,166 @@ func TestModel_ToolLogs(t *testing.T) {
 		// Response text after tool logs
 		assert.Contains(t, out, "I'll read that file for you.")
 	})
+}
+
+func TestModel_ResponseEvent_ExtractsToolCalls(t *testing.T) {
+	ch := make(chan events.Event, 1)
+	m := newTestModel(t.Context(), ch)
+
+	content := &llm.Content{
+		Role: "model",
+		Parts: []*llm.Part{
+			{Text: "Let me run a test for you."},
+			{FunctionCall: &llm.FunctionCall{
+				ID:   "call_1",
+				Name: "execute_command",
+				Args: map[string]interface{}{
+					"reason":  "Run unit tests",
+					"command": "go test ./...",
+				},
+			}},
+		},
+	}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+
+	foundReason := false
+	foundAction := false
+	for _, log := range m.toolLogs {
+		if strings.Contains(log, "[Tool Reason] Run unit tests") {
+			foundReason = true
+		}
+		if strings.Contains(log, "[Tool Action] execute_command") {
+			foundAction = true
+		}
+	}
+	assert.True(t, foundReason, "expected [Tool Reason] in toolLogs from ResponseEvent")
+	assert.True(t, foundAction, "expected [Tool Action] in toolLogs from ResponseEvent")
+}
+
+func TestModel_ToolCallEvent_DedupsAfterResponseEvent(t *testing.T) {
+	ch := make(chan events.Event, 2)
+	m := newTestModel(t.Context(), ch)
+
+	content := &llm.Content{
+		Role: "model",
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{
+				ID:   "call_1",
+				Name: "execute_command",
+				Args: map[string]interface{}{
+					"reason":  "Run unit tests",
+					"command": "go test ./...",
+				},
+			}},
+		},
+	}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+	logCountAfterResponse := len(m.toolLogs)
+
+	m.Update(domainEventMsg(events.ToolCallEvent{
+		Calls: []*llm.FunctionCall{{
+			ID:   "call_1",
+			Name: "execute_command",
+			Args: map[string]interface{}{
+				"reason":  "Run unit tests",
+				"command": "go test ./...",
+			},
+		}},
+		Turn:     0,
+		MaxTurns: 10,
+	}))
+
+	assert.Equal(t, logCountAfterResponse, len(m.toolLogs),
+		"ToolCallEvent should not add log lines for already-seen calls")
+}
+
+func TestModel_ToolCallEvent_ShowsEngineForPartialNewCalls(t *testing.T) {
+	ch := make(chan events.Event, 2)
+	m := newTestModel(t.Context(), ch)
+
+	content := &llm.Content{
+		Role: "model",
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{
+				ID:   "call_1",
+				Name: "execute_command",
+				Args: map[string]interface{}{"command": "go build"},
+			},
+			}},
+	}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+	logCount := len(m.toolLogs)
+
+	m.Update(domainEventMsg(events.ToolCallEvent{
+		Calls: []*llm.FunctionCall{
+			{
+				ID:   "call_1",
+				Name: "execute_command",
+				Args: map[string]interface{}{"command": "go build"},
+			},
+			{
+				ID:   "call_2",
+				Name: "read_file",
+				Args: map[string]interface{}{"filepath": "main.go"},
+			},
+		},
+		Turn:     0,
+		MaxTurns: 10,
+	}))
+
+	assert.Greater(t, len(m.toolLogs), logCount,
+		"ToolCallEvent should add lines for new calls not already seen")
+
+	foundEngine := false
+	foundReadFile := false
+	for _, log := range m.toolLogs {
+		if strings.Contains(log, "[Tool Engine] Step 1/10") {
+			foundEngine = true
+		}
+		if strings.Contains(log, "[Tool Action] read_file") {
+			foundReadFile = true
+		}
+	}
+	assert.True(t, foundEngine, "expected [Tool Engine] for partially new ToolCallEvent")
+	assert.True(t, foundReadFile, "expected [Tool Action] for new call_2")
+}
+
+func TestModel_TurnStarted_ClearsSeenCallIDs(t *testing.T) {
+	ch := make(chan events.Event, 2)
+	m := newTestModel(t.Context(), ch)
+
+	content := &llm.Content{
+		Role: "model",
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{
+				ID:   "call_1",
+				Name: "execute_command",
+				Args: map[string]interface{}{"command": "go test"},
+			}},
+		},
+	}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+	assert.Len(t, m.seenCallIDs, 1, "seenCallIDs should have 1 entry after ResponseEvent")
+
+	m.Update(domainEventMsg(events.TurnStarted{Turn: 1, SessionTurns: 1, MaxTurns: 10}))
+	assert.Len(t, m.seenCallIDs, 0, "seenCallIDs should be empty after TurnStarted")
+
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+	assert.Len(t, m.seenCallIDs, 1, "seenCallIDs should accept same call ID in new turn")
+}
+
+func TestModel_ResponseEvent_NoToolCalls_NoSpuriousLogs(t *testing.T) {
+	ch := make(chan events.Event, 1)
+	m := newTestModel(t.Context(), ch)
+
+	content := &llm.Content{
+		Role: "model",
+		Parts: []*llm.Part{
+			{Text: "Here is the result of the analysis."},
+		},
+	}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+
+	assert.Len(t, m.toolLogs, 0, "text-only ResponseEvent should not add tool logs")
+	assert.Len(t, m.seenCallIDs, 0, "text-only ResponseEvent should not populate seenCallIDs")
 }


### PR DESCRIPTION
## Summary

Fixes the visibility gap where `[Tool Reason]` and `[Tool Action]` lines were invisible between `ResponseEvent` (step 3) and `ToolCallEvent` (step 5). The `ResponseEvent.Content` already contained `FunctionCall` parts — the UI just wasn't consuming them.

## Approach

**UI-layer only** — zero orchestrator or domain changes. The fix extracts `FunctionCall` data from `ResponseEvent.Content.Parts` immediately after the LLM responds, populating `m.toolLogs` several seconds earlier than before.

A `seenCallIDs` map prevents duplicate lines when the real `ToolCallEvent` later arrives from the `Dispatcher`.

## Changes

| File | Change |
|------|--------|
| `internal/ui/tui/progress/model.go` | +81/−2: `seenCallIDs` field, `extractToolCallsFromResponse` method, dedup-aware `ToolCallEvent` handler, `handleResponseEvent` hook, turn boundary reset |
| `internal/ui/tui/progress/model_test.go` | +161: `newTestModel` init + 5 new tests (extraction, full dedup, partial dedup, turn reset, text-only no-op) |

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- 5 new tests pass
- `go test ./...` — all 75 packages, zero regressions

Closes #1233