### PR TITLE
llm: add vision support for Kimi models via base64 inline images

### DIFF
--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -67,6 +67,13 @@ type Capabilities struct {
 	// Set for all models known to use reasoning_content natively:
 	// deepseek-* and kimi-* model families.
 	SupportsReasoningContent bool
+	// SupportsVision indicates the model natively understands images via
+	// image_url content parts in the messages array. When true, InlineData
+	// parts are serialized as base64 image_url blocks rather than being
+	// silently dropped.
+	//
+	// Set for: kimi-* models (K3, K2.7, K2.6).
+	SupportsVision bool
 	// RequiresVertexThinkingKwargs indicates that the transport silently
 	// disables DeepSeek thinking mode unless the non-standard parameter
 	// chat_template_kwargs.thinking=true is included in the request body.
@@ -167,6 +174,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 
 	if isKimiModel(model) {
 		caps.SupportsReasoningContent = true
+		caps.SupportsVision = true
 		if isKimiK3Model(model) {
 			caps.SupportsReasoningEffort = true
 		}

--- a/internal/domain/llm/capabilities_test.go
+++ b/internal/domain/llm/capabilities_test.go
@@ -18,6 +18,7 @@ func TestResolveCapabilities(t *testing.T) {
 		maxTokensField               MaxTokensField
 		isDeepSeek                   bool
 		supportsReasoningContent     bool
+		supportsVision               bool
 		requiresVertexThinkingKwargs bool
 	}{
 		{
@@ -28,6 +29,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "o1-mini",
@@ -37,6 +39,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldCompletion,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "gpt-5",
@@ -46,6 +49,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldCompletion,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			name:                     "gpt-5.3 does not require responses API (minor < 4)",
@@ -56,6 +60,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldCompletion,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			name:                     "gpt-4.5 does not require responses API (major < 5)",
@@ -66,6 +71,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "gpt-5.4",
@@ -75,6 +81,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldOutput,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "gpt-6",
@@ -84,6 +91,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldOutput,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "gpt-7",
@@ -93,6 +101,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldOutput,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			name:                     "gpt-7.0 requires responses API (major>5, n>=2)",
@@ -103,6 +112,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldOutput,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			name:                     "gpt-10.1 requires responses API (major>5, n>=2, two-digit major)",
@@ -113,6 +123,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldOutput,
 			isDeepSeek:               false,
 			supportsReasoningContent: false,
+			supportsVision:           false,
 		},
 		{
 			model:                    "deepseek-reasoner",
@@ -122,6 +133,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsVision:           false,
 		},
 		{
 			model:                    "deepseek-ai/deepseek-r1-0528-maas",
@@ -131,6 +143,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsVision:           false,
 		},
 		{
 			model:                    "deepseek-r1",
@@ -140,6 +153,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsVision:           false,
 		},
 		{
 			model:                    "deepseek-v3",
@@ -149,6 +163,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsVision:           false,
 		},
 		{
 			model:                    "deepseek-ai/deepseek-v3",
@@ -158,6 +173,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsVision:           false,
 		},
 		{
 			name:                         "vertex deepseek requires thinking kwargs",
@@ -166,6 +182,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsVision:               false,
 			requiresVertexThinkingKwargs: true,
 		},
 		{
@@ -175,6 +192,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsVision:               false,
 			requiresVertexThinkingKwargs: false,
 		},
 		{
@@ -184,6 +202,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   false,
 			supportsReasoningContent:     false,
+			supportsVision:               false,
 			requiresVertexThinkingKwargs: false,
 		},
 		{
@@ -193,6 +212,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsVision:               false,
 			requiresVertexThinkingKwargs: false,
 		},
 		{
@@ -201,6 +221,7 @@ func TestResolveCapabilities(t *testing.T) {
 			baseURL:                  "",
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  true,
+			supportsVision:           true,
 			maxTokensField:           MaxTokensFieldCompletion,
 		},
 		{
@@ -209,6 +230,7 @@ func TestResolveCapabilities(t *testing.T) {
 			baseURL:                  "",
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  true,
+			supportsVision:           true,
 			maxTokensField:           MaxTokensFieldCompletion,
 		},
 		{
@@ -217,6 +239,7 @@ func TestResolveCapabilities(t *testing.T) {
 			baseURL:                  "",
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  false,
+			supportsVision:           true,
 			maxTokensField:           MaxTokensFieldLegacy,
 		},
 		{
@@ -225,6 +248,7 @@ func TestResolveCapabilities(t *testing.T) {
 			baseURL:                  "",
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  false,
+			supportsVision:           true,
 			maxTokensField:           MaxTokensFieldLegacy,
 		},
 	}
@@ -253,6 +277,9 @@ func TestResolveCapabilities(t *testing.T) {
 			}
 			if caps.SupportsReasoningContent != tt.supportsReasoningContent {
 				t.Errorf("expected SupportsReasoningContent %v, got %v", tt.supportsReasoningContent, caps.SupportsReasoningContent)
+			}
+			if caps.SupportsVision != tt.supportsVision {
+				t.Errorf("expected SupportsVision %v, got %v", tt.supportsVision, caps.SupportsVision)
 			}
 			if caps.RequiresVertexThinkingKwargs != tt.requiresVertexThinkingKwargs {
 				t.Errorf("expected RequiresVertexThinkingKwargs %v, got %v", tt.requiresVertexThinkingKwargs, caps.RequiresVertexThinkingKwargs)

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -46,10 +46,10 @@ type standardSink struct {
 	messages []message
 }
 
-func (s *standardSink) AddMessage(role, text string, reasoning *string, toolCalls []toolCall) {
+func (s *standardSink) AddMessage(role string, content any, reasoning *string, toolCalls []toolCall) {
 	s.messages = append(s.messages, message{
 		Role:             role,
-		Content:          text,
+		Content:          content,
 		ReasoningContent: reasoning,
 		ToolCalls:        toolCalls,
 	})

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -5,6 +5,7 @@ package openai
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -218,9 +219,20 @@ type requestContentBlock struct {
 	Text string `json:"text"` // Required field for input_text / output_text
 }
 
+// imageURLBlock represents an image_url content part for vision-capable models.
+type imageURLBlock struct {
+	Type     string        `json:"type"`
+	ImageURL imageURLValue `json:"image_url"`
+}
+
+// imageURLValue holds the URL payload for an image_url block.
+type imageURLValue struct {
+	URL string `json:"url"`
+}
+
 type message struct {
 	Role             string      `json:"role"`
-	Content          interface{} `json:"content,omitempty"` // string or []requestContentBlock
+	Content          interface{} `json:"content,omitempty"` // string, []requestContentBlock, or []any (mixed text+image)
 	ToolCalls        []toolCall  `json:"tool_calls,omitempty"`
 	ToolCallID       string      `json:"tool_call_id,omitempty"`
 	ReasoningContent *string     `json:"reasoning_content,omitempty"`
@@ -304,7 +316,9 @@ type completionTokensDetails struct {
 }
 
 type openaiSink interface {
-	AddMessage(role, text string, reasoning *string, toolCalls []toolCall)
+	// AddMessage adds a message to the sink. content is either a string
+	// (text-only) or []any (mixed text+image blocks for vision models).
+	AddMessage(role string, content any, reasoning *string, toolCalls []toolCall)
 	AddToolResponse(id, response string)
 }
 
@@ -335,7 +349,11 @@ func (c *client) appendMessagesFromHistoryItem(
 		return nil
 	}
 
-	text, reasoning, toolCalls, err := c.classifyParts(otherParts)
+	// Separate image parts before classification — classifyParts only
+	// handles text and function calls.
+	imageParts, textParts := extractImageParts(otherParts)
+
+	text, reasoning, toolCalls, err := c.classifyParts(textParts)
 	if err != nil {
 		return err
 	}
@@ -347,7 +365,18 @@ func (c *client) appendMessagesFromHistoryItem(
 		reasoningPtr = &reasoning
 	}
 
-	sink.AddMessage(role, text, reasoningPtr, toolCalls)
+	// Build content: array format when images present AND vision supported,
+	// string format otherwise.
+	var content any = text
+	if c.capabilities.SupportsVision && len(imageParts) > 0 {
+		blocks := imageBlocks(imageParts)
+		if text != "" {
+			blocks = append(blocks, requestContentBlock{Type: "text", Text: text})
+		}
+		content = blocks
+	}
+
+	sink.AddMessage(role, content, reasoningPtr, toolCalls)
 
 	return nil
 }
@@ -370,6 +399,38 @@ func partitionParts(parts []*llm.Part) (toolResponseParts []*llm.Part, otherPart
 		}
 	}
 	return
+}
+
+// extractImageParts separates InlineData parts from a part slice.
+// Returns the image parts and the remaining non-image, non-tool-response parts.
+func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part) {
+	for _, p := range parts {
+		if p.InlineData != nil && len(p.InlineData.Data) > 0 {
+			images = append(images, p)
+		} else {
+			rest = append(rest, p)
+		}
+	}
+	return
+}
+
+// imageBlocks converts InlineData parts to image_url content blocks.
+// Returns nil if there are no InlineData parts.
+func imageBlocks(parts []*llm.Part) []any {
+	var blocks []any
+	for _, p := range parts {
+		if p.InlineData != nil && len(p.InlineData.Data) > 0 {
+			blocks = append(blocks, imageURLBlock{
+				Type: "image_url",
+				ImageURL: imageURLValue{
+					URL: fmt.Sprintf("data:%s;base64,%s",
+						p.InlineData.MIMEType,
+						base64.StdEncoding.EncodeToString(p.InlineData.Data)),
+				},
+			})
+		}
+	}
+	return blocks
 }
 
 func (c *client) appendToolResponseMessages(sink openaiSink, toolResponseParts []*llm.Part) error {

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -350,8 +350,9 @@ func (c *client) appendMessagesFromHistoryItem(
 	}
 
 	// Hydrate lazy-loaded image assets before extraction.
-	// Parts with AssetID but no InlineData are resolved from the
-	// AssetResolver so they can be serialized as image_url blocks.
+	// Parts with AssetID whose InlineData.Data is nil are resolved
+	// from the AssetResolver so they can be serialized as image_url
+	// blocks. Gated on SupportsVision — non-vision models skip.
 	var err error
 	otherParts, err = c.hydrateImageAssets(ctx, otherParts, resolver)
 	if err != nil {

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -352,7 +352,9 @@ func (c *client) appendMessagesFromHistoryItem(
 	// Hydrate lazy-loaded image assets before extraction.
 	// Parts with AssetID but no InlineData are resolved from the
 	// AssetResolver so they can be serialized as image_url blocks.
-	if err := hydrateImageAssets(ctx, otherParts, resolver); err != nil {
+	var err error
+	otherParts, err = c.hydrateImageAssets(ctx, otherParts, resolver)
+	if err != nil {
 		return err
 	}
 
@@ -424,27 +426,46 @@ func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part)
 	return
 }
 
-// hydrateImageAssets resolves AssetID references on parts that lack
-// InlineData, populating them from the AssetResolver. Parts that
-// already have InlineData.Data or have no AssetID are unchanged.
-// Returns an error if resolution fails.
-func hydrateImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) error {
-	if resolver == nil {
-		return nil
+// hydrateImageAssets resolves AssetID references on parts whose
+// InlineData.Data is nil (lazy-hydration pattern from session reload).
+// It uses copy-on-write — the returned slice is independent of the
+// input — to avoid mutating shared session history. Preserves MIMEType
+// from any existing InlineData blob. Gated on SupportsVision; non-vision
+// models return the input unchanged. Resolve errors are propagated:
+// a corrupt asset store should fail the session loudly.
+func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) ([]*llm.Part, error) {
+	if resolver == nil || !c.capabilities.SupportsVision {
+		return parts, nil
 	}
-	for _, p := range parts {
-		if p.AssetID == "" || p.InlineData != nil {
+	out := parts
+	cloned := false
+	for i, p := range parts {
+		if p.AssetID == "" || (p.InlineData != nil && len(p.InlineData.Data) > 0) {
 			continue
 		}
 		data, err := resolver.Resolve(ctx, p.AssetID)
 		if err != nil {
-			return fmt.Errorf("resolve asset %s: %w", p.AssetID, err)
+			return nil, fmt.Errorf("resolve asset %s: %w", p.AssetID, err)
 		}
-		p.InlineData = &llm.Blob{
-			Data: data,
+		// Copy-on-write: clone the full slice once on first mutation
+		if !cloned {
+			out = make([]*llm.Part, len(parts))
+			copy(out, parts)
+			cloned = true
 		}
+		// Clone the part to avoid mutating shared session history
+		pc := *p
+		if p.InlineData != nil {
+			// Preserve MIMEType from the existing blob (set during AddImage)
+			blob := *p.InlineData
+			blob.Data = data
+			pc.InlineData = &blob
+		} else {
+			pc.InlineData = &llm.Blob{Data: data}
+		}
+		out[i] = &pc
 	}
-	return nil
+	return out, nil
 }
 
 // imageBlocks converts InlineData parts to image_url content blocks.

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -369,6 +369,9 @@ func (c *client) appendMessagesFromHistoryItem(
 	// string format otherwise.
 	var content any = text
 	if c.capabilities.SupportsVision && len(imageParts) > 0 {
+		// Images are placed before text (images-first ordering). This is
+		// intentional for the describe-this-image use case — interleaved
+		// part ordering within a single history item is not preserved.
 		blocks := imageBlocks(imageParts)
 		if text != "" {
 			blocks = append(blocks, requestContentBlock{Type: "text", Text: text})
@@ -419,16 +422,17 @@ func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part)
 func imageBlocks(parts []*llm.Part) []any {
 	var blocks []any
 	for _, p := range parts {
-		if p.InlineData != nil && len(p.InlineData.Data) > 0 {
-			blocks = append(blocks, imageURLBlock{
-				Type: "image_url",
-				ImageURL: imageURLValue{
-					URL: fmt.Sprintf("data:%s;base64,%s",
-						p.InlineData.MIMEType,
-						base64.StdEncoding.EncodeToString(p.InlineData.Data)),
-				},
-			})
+		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
+			continue
 		}
+		blocks = append(blocks, imageURLBlock{
+			Type: "image_url",
+			ImageURL: imageURLValue{
+				URL: fmt.Sprintf("data:%s;base64,%s",
+					p.InlineData.MIMEType,
+					base64.StdEncoding.EncodeToString(p.InlineData.Data)),
+			},
+		})
 	}
 	return blocks
 }

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -349,6 +349,13 @@ func (c *client) appendMessagesFromHistoryItem(
 		return nil
 	}
 
+	// Hydrate lazy-loaded image assets before extraction.
+	// Parts with AssetID but no InlineData are resolved from the
+	// AssetResolver so they can be serialized as image_url blocks.
+	if err := hydrateImageAssets(ctx, otherParts, resolver); err != nil {
+		return err
+	}
+
 	// Separate image parts before classification — classifyParts only
 	// handles text and function calls.
 	imageParts, textParts := extractImageParts(otherParts)
@@ -415,6 +422,29 @@ func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part)
 		}
 	}
 	return
+}
+
+// hydrateImageAssets resolves AssetID references on parts that lack
+// InlineData, populating them from the AssetResolver. Parts that
+// already have InlineData.Data or have no AssetID are unchanged.
+// Returns an error if resolution fails.
+func hydrateImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) error {
+	if resolver == nil {
+		return nil
+	}
+	for _, p := range parts {
+		if p.AssetID == "" || p.InlineData != nil {
+			continue
+		}
+		data, err := resolver.Resolve(ctx, p.AssetID)
+		if err != nil {
+			return fmt.Errorf("resolve asset %s: %w", p.AssetID, err)
+		}
+		p.InlineData = &llm.Blob{
+			Data: data,
+		}
+	}
+	return nil
 }
 
 // imageBlocks converts InlineData parts to image_url content blocks.

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+func TestImageBlocks(t *testing.T) {
+	tests := []struct {
+		name  string
+		parts []*llm.Part
+		want  int // expected number of blocks
+	}{
+		{"single image", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4E, 0x47}}}}, 1},
+		{"multiple images", []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}},
+			{InlineData: &llm.Blob{MIMEType: "image/jpeg", Data: []byte{2}}},
+		}, 2},
+		{"no images", []*llm.Part{{Text: "hello"}}, 0},
+		{"nil InlineData", []*llm.Part{{InlineData: nil}}, 0},
+		{"empty data", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: nil}}}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := imageBlocks(tt.parts)
+			if len(blocks) != tt.want {
+				t.Errorf("got %d blocks, want %d", len(blocks), tt.want)
+			}
+			// Verify base64 URL format for image blocks
+			for _, b := range blocks {
+				ib, ok := b.(imageURLBlock)
+				if !ok {
+					t.Fatal("block is not imageURLBlock")
+				}
+				if ib.Type != "image_url" {
+					t.Errorf("type = %q, want image_url", ib.Type)
+				}
+				if !strings.HasPrefix(ib.ImageURL.URL, "data:") {
+					t.Errorf("URL doesn't start with data: %q", ib.ImageURL.URL)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractImageParts(t *testing.T) {
+	img := &llm.Part{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}}
+	txt := &llm.Part{Text: "hello"}
+	parts := []*llm.Part{img, txt}
+	images, rest := extractImageParts(parts)
+	if len(images) != 1 || len(rest) != 1 {
+		t.Errorf("got %d images, %d rest; want 1,1", len(images), len(rest))
+	}
+}
+
+func TestVisionDisabled_KeepsStringContent(t *testing.T) {
+	// Create a client with SupportsVision=false (default for deepseek)
+	c := NewClient("https://api.deepseek.com", "deepseek-v4-flash",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	// Verify SupportsVision is false
+	if c.capabilities.SupportsVision {
+		t.Fatal("deepseek should not have SupportsVision")
+	}
+
+	// Build history with an image part — image should be dropped,
+	// content stays as string.
+	sink := &standardSink{}
+	h := &llm.Content{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			{Text: "describe this"},
+		},
+	}
+	var personaInjected bool
+	err := c.appendMessagesFromHistoryItem(context.Background(), sink, h, nil, &personaInjected)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(sink.messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(sink.messages))
+	}
+	msg := sink.messages[0]
+
+	// Content should be a plain string (image was dropped)
+	strContent, ok := msg.Content.(string)
+	if !ok {
+		t.Fatalf("expected string content, got %T", msg.Content)
+	}
+	if strContent != "describe this" {
+		t.Errorf("expected 'describe this', got %q", strContent)
+	}
+}
+
+func TestVision_KimiImagePayload(t *testing.T) {
+	c := NewClient("https://api.moonshot.ai/v1", "kimi-k3",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	if !c.capabilities.SupportsVision {
+		t.Fatal("kimi-k3 should have SupportsVision")
+	}
+
+	// Build history with an image part
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			{Text: "describe this"},
+		},
+	}}
+
+	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("toStandardMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+
+	// Content must be []any (array), not string
+	arr, ok := msg.Content.([]any)
+	if !ok {
+		t.Fatalf("expected []any content, got %T", msg.Content)
+	}
+	if len(arr) != 2 {
+		t.Fatalf("expected 2 content blocks (image + text), got %d", len(arr))
+	}
+
+	// Marshal to JSON and verify exact shape
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	// Verify image_url block is present
+	if !strings.Contains(string(b), `"image_url"`) {
+		t.Error("JSON payload missing image_url")
+	}
+	if !strings.Contains(string(b), `"type":"image_url"`) {
+		t.Error("JSON payload missing type:image_url")
+	}
+	// Verify data URI
+	if !strings.Contains(string(b), "data:image/png;base64") {
+		t.Error("JSON payload missing data:image/png;base64 URI")
+	}
+	if !strings.Contains(string(b), `"type":"text"`) {
+		t.Error("JSON payload missing text block")
+	}
+	if !strings.Contains(string(b), "describe this") {
+		t.Error("JSON payload missing text content")
+	}
+}

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -250,8 +250,7 @@ func TestHydrateImageAssets(t *testing.T) {
 				return
 			}
 			if tt.wantSameSlice && &got[0] != &tt.parts[0] {
-				// For no-mutation cases, the returned slice should be the same pointer
-				// (copy-on-write didn't trigger)
+				t.Error("expected no copy-on-write: input slice returned unchanged")
 			}
 			if !tt.wantSameSlice && &got[0] == &tt.parts[0] {
 				t.Error("expected copy-on-write: returned slice should be independent")

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -174,54 +174,95 @@ func TestHydrateImageAssets(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name     string
-		parts    []*llm.Part
-		resolver llm.AssetResolver
-		wantData bool
-		wantErr  bool
+		name          string
+		parts         []*llm.Part
+		resolver      llm.AssetResolver
+		visionCap     bool
+		wantMIME      string
+		wantData      bool
+		wantSameSlice bool // true when no mutation expected (copy-on-write)
+		wantErr       bool
 	}{
 		{
-			name:     "hydrates AssetID with no InlineData",
-			parts:    []*llm.Part{{AssetID: "asset-1"}},
-			resolver: resolver,
-			wantData: true,
+			name:      "hydrates AssetID with nil InlineData (test shape)",
+			parts:     []*llm.Part{{AssetID: "asset-1"}},
+			resolver:  resolver,
+			visionCap: true,
+			wantData:  true,
 		},
 		{
-			name:     "skips part with existing InlineData",
-			parts:    []*llm.Part{{AssetID: "asset-1", InlineData: &llm.Blob{Data: []byte{1}}}},
-			resolver: resolver,
-			wantData: true, // keeps existing data
+			name:      "hydrates reload shape: InlineData present, Data nil — preserves MIMEType",
+			parts:     []*llm.Part{{AssetID: "asset-1", InlineData: &llm.Blob{MIMEType: "image/png"}}},
+			resolver:  resolver,
+			visionCap: true,
+			wantMIME:  "image/png",
+			wantData:  true,
 		},
 		{
-			name:     "skips part with no AssetID",
-			parts:    []*llm.Part{{Text: "hello"}},
-			resolver: resolver,
-			wantData: false,
+			name:          "skips part with existing InlineData.Data (already hydrated)",
+			parts:         []*llm.Part{{AssetID: "asset-1", InlineData: &llm.Blob{MIMEType: "image/jpeg", Data: []byte{1}}}},
+			resolver:      resolver,
+			visionCap:     true,
+			wantMIME:      "image/jpeg",
+			wantData:      true,
+			wantSameSlice: true,
 		},
 		{
-			name:     "nil resolver is no-op",
-			parts:    []*llm.Part{{AssetID: "asset-1"}},
-			resolver: nil,
-			wantData: false,
+			name:          "skips part with no AssetID",
+			parts:         []*llm.Part{{Text: "hello"}},
+			resolver:      resolver,
+			visionCap:     true,
+			wantSameSlice: true,
 		},
 		{
-			name:     "resolve error propagates",
-			parts:    []*llm.Part{{AssetID: "missing"}},
-			resolver: resolver,
-			wantErr:  true,
+			name:          "nil resolver is no-op",
+			parts:         []*llm.Part{{AssetID: "asset-1"}},
+			resolver:      nil,
+			visionCap:     true,
+			wantSameSlice: true,
+		},
+		{
+			name:          "vision-disabled returns input unchanged",
+			parts:         []*llm.Part{{AssetID: "asset-1"}},
+			resolver:      resolver,
+			visionCap:     false,
+			wantSameSlice: true,
+		},
+		{
+			name:      "resolve error propagates",
+			parts:     []*llm.Part{{AssetID: "missing"}},
+			resolver:  resolver,
+			visionCap: true,
+			wantErr:   true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := hydrateImageAssets(context.Background(), tt.parts, tt.resolver)
+			c := &client{
+				capabilities: llm.Capabilities{SupportsVision: tt.visionCap},
+				logger:       &ports.NoOpLogger{},
+			}
+			got, err := c.hydrateImageAssets(context.Background(), tt.parts, tt.resolver)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
 			}
 			if err != nil {
 				return
 			}
-			if tt.wantData && tt.parts[0].InlineData == nil {
-				t.Error("expected InlineData to be populated")
+			if tt.wantSameSlice && &got[0] != &tt.parts[0] {
+				// For no-mutation cases, the returned slice should be the same pointer
+				// (copy-on-write didn't trigger)
+			}
+			if !tt.wantSameSlice && &got[0] == &tt.parts[0] {
+				t.Error("expected copy-on-write: returned slice should be independent")
+			}
+			if tt.wantData {
+				if got[0].InlineData == nil || len(got[0].InlineData.Data) == 0 {
+					t.Error("expected InlineData.Data to be populated")
+				}
+			}
+			if tt.wantMIME != "" && got[0].InlineData.MIMEType != tt.wantMIME {
+				t.Errorf("MIMEType = %q, want %q", got[0].InlineData.MIMEType, tt.wantMIME)
 			}
 		})
 	}

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -6,6 +6,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -164,4 +165,76 @@ func TestVision_KimiImagePayload(t *testing.T) {
 	if !strings.Contains(string(b), "describe this") {
 		t.Error("JSON payload missing text content")
 	}
+}
+
+func TestHydrateImageAssets(t *testing.T) {
+	resolver := &testAssetResolver{
+		data: map[string][]byte{
+			"asset-1": []byte{0x89, 0x50, 0x4E, 0x47},
+		},
+	}
+	tests := []struct {
+		name     string
+		parts    []*llm.Part
+		resolver llm.AssetResolver
+		wantData bool
+		wantErr  bool
+	}{
+		{
+			name:     "hydrates AssetID with no InlineData",
+			parts:    []*llm.Part{{AssetID: "asset-1"}},
+			resolver: resolver,
+			wantData: true,
+		},
+		{
+			name:     "skips part with existing InlineData",
+			parts:    []*llm.Part{{AssetID: "asset-1", InlineData: &llm.Blob{Data: []byte{1}}}},
+			resolver: resolver,
+			wantData: true, // keeps existing data
+		},
+		{
+			name:     "skips part with no AssetID",
+			parts:    []*llm.Part{{Text: "hello"}},
+			resolver: resolver,
+			wantData: false,
+		},
+		{
+			name:     "nil resolver is no-op",
+			parts:    []*llm.Part{{AssetID: "asset-1"}},
+			resolver: nil,
+			wantData: false,
+		},
+		{
+			name:     "resolve error propagates",
+			parts:    []*llm.Part{{AssetID: "missing"}},
+			resolver: resolver,
+			wantErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := hydrateImageAssets(context.Background(), tt.parts, tt.resolver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+			if err != nil {
+				return
+			}
+			if tt.wantData && tt.parts[0].InlineData == nil {
+				t.Error("expected InlineData to be populated")
+			}
+		})
+	}
+}
+
+type testAssetResolver struct {
+	data map[string][]byte
+}
+
+func (r *testAssetResolver) Resolve(ctx context.Context, assetID string) ([]byte, error) {
+	d, ok := r.data[assetID]
+	if !ok {
+		return nil, fmt.Errorf("asset not found: %s", assetID)
+	}
+	return d, nil
 }

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -28,8 +28,15 @@ func (s *responsesSink) AddMessage(role string, content any, reasoning *string, 
 	r := role
 	// content is either a string (text-only) or []any (mixed text+image blocks).
 	// Vision-capable models use the standard sink; the responses sink only
-	// sees string content. Cast accordingly.
-	text, _ := content.(string)
+	// sees string content. Log a warning if non-string content arrives —
+	// no model has both SupportsVision + RequiresResponsesAPI today.
+	text, ok := content.(string)
+	if !ok {
+		s.client.logger.Warn("responses_sink_non_string_content",
+			"model", s.client.model,
+			"note", "images in content dropped — /responses API not used with vision models")
+		return
+	}
 	s.items = append(s.items, historyItem{
 		Type:    "message",
 		Role:    &r,

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -24,8 +24,12 @@ type responsesSink struct {
 	items  []historyItem
 }
 
-func (s *responsesSink) AddMessage(role, text string, reasoning *string, toolCalls []toolCall) {
+func (s *responsesSink) AddMessage(role string, content any, reasoning *string, toolCalls []toolCall) {
 	r := role
+	// content is either a string (text-only) or []any (mixed text+image blocks).
+	// Vision-capable models use the standard sink; the responses sink only
+	// sees string content. Cast accordingly.
+	text, _ := content.(string)
 	s.items = append(s.items, historyItem{
 		Type:    "message",
 		Role:    &r,


### PR DESCRIPTION
Enables Kimi models (K3, K2.7, K2.6) to receive and describe images via base64-encoded `image_url` content parts.

## Changes

- **capabilities.go**: `SupportsVision` flag, set `true` for all `kimi-*` models
- **capabilities_test.go**: `supportsVision` column across all 23 entries + assertion
- **openai/client.go**: `imageURLBlock`/`imageURLValue` types, `imageBlocks` and `extractImageParts` helpers, `openaiSink` `content` parameter generalized from `string` to `any`, image handling in `appendMessagesFromHistoryItem`
- **openai/chat.go**, **openai/responses.go**: sink signatures updated

## Design

Gated behind `SupportsVision` — only Kimi models get `true`. When `InlineData` parts are present and the flag is on, the client builds `[]any` content blocks with base64 `image_url` parts alongside text. DeepSeek and other text-only models are unaffected — the default content format remains a plain string.

Uses the existing domain types (`Part.InlineData` / `Blob` with MIMEType + Data) — same infrastructure Gemini uses for `genai.Blob`.

## Related

Follows the text-only Kimi integration (PR #1251).
See: https://platform.kimi.ai/docs/guide/use-kimi-vision-model