### PR TITLE
llm: add Kimi file upload, document extraction, and per-turn cleanup

### DIFF
--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -235,19 +235,20 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 		applyPreparedParts(history, prepared)
 	}
 
+	// Register cleanup for all exit paths. Per-turn files are useless
+	// after this call — the orchestrator retries by rebuilding from
+	// scratch, triggering fresh uploads.
+	if ta != nil {
+		defer ta.release(context.Background(), c)
+	}
+
 	reqPayload, err := c.prepareChatRequest(ctx, history, toolDecls, ta)
 	if err != nil {
-		if ta != nil {
-			ta.release(context.Background(), c)
-		}
 		return nil, nil, err
 	}
 	endpoint := c.resolveEndpoint(reqPayload)
 	req, err := c.createHTTPRequest(ctx, reqPayload)
 	if err != nil {
-		if ta != nil {
-			ta.release(context.Background(), c)
-		}
 		return nil, nil, err
 	}
 
@@ -256,19 +257,11 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 	ttfb := time.Since(startTime) // Time To First Byte
 
 	if err != nil {
-		if ta != nil {
-			ta.release(context.Background(), c)
-		}
 		return nil, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-
-	// Defer cleanup on success
-	if ta != nil {
-		defer ta.release(context.Background(), c)
-	}
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 	llmerr "github.com/gosharplite/tell-me-go/internal/infrastructure/llm/llmerr"
 )
 
@@ -209,26 +208,11 @@ func (c *client) createHTTPRequest(ctx context.Context, payload *chatRequest) (*
 	}
 
 	endpoint := c.resolveEndpoint(payload)
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+endpoint, bytes.NewBuffer(body))
+	req, err := c.newAuthenticatedRequest(ctx, "POST", c.baseURL+endpoint, bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
-
 	req.Header.Set("Content-Type", "application/json")
-
-	// Apply custom headers
-	for k, v := range c.headers {
-		req.Header.Set(k, v)
-	}
-
-	// Apply authentication
-	authReq := &auth.Request{Headers: make(map[string]string)}
-	if err := c.authenticator.Apply(ctx, authReq); err != nil {
-		return nil, err
-	}
-	for k, v := range authReq.Headers {
-		req.Header.Set(k, v)
-	}
 
 	return req, nil
 }

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -270,10 +270,16 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 		}
 	}
 
-	if endpoint == "/responses" {
-		return c.decodeResponsesAPIResponse(resp, startTime, ttfb, endpoint)
+	content, metrics, err := func() (*llm.Content, *llm.Metrics, error) {
+		if endpoint == "/responses" {
+			return c.decodeResponsesAPIResponse(resp, startTime, ttfb, endpoint)
+		}
+		return c.decodeStandardResponse(resp, startTime, ttfb, endpoint)
+	}()
+	if err == nil {
+		c.cleanupUploadedFiles(ctx)
 	}
-	return c.decodeStandardResponse(resp, startTime, ttfb, endpoint)
+	return content, metrics, err
 }
 
 // decodeStandardResponse decodes a /chat/completions JSON response from

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -67,12 +67,12 @@ func (s *standardSink) AddToolResponse(id, response string) {
 // Chat Completions input conversion
 // ---------------------------------------------------------------------------
 
-func (c *client) toStandardMessages(ctx context.Context, history []*llm.Content, resolver llm.AssetResolver) ([]message, error) {
+func (c *client) toStandardMessages(ctx context.Context, history []*llm.Content, ta *turnAssets) ([]message, error) {
 	sink := &standardSink{}
 	personaInjected := c.maybeInjectInitialPersona(sink)
 
 	for _, h := range history {
-		if err := c.appendMessagesFromHistoryItem(ctx, sink, h, resolver, &personaInjected); err != nil {
+		if err := c.appendMessagesFromHistoryItem(ctx, sink, h, ta, &personaInjected); err != nil {
 			return nil, err
 		}
 	}
@@ -121,21 +121,21 @@ func (c *client) resolveOutputBudget() int {
 // buildRequestBody assembles the chat request payload, populating
 // either Input (for /responses) or Messages (for /chat/completions)
 // depending on the selected API strategy.
-func (c *client) buildRequestBody(ctx context.Context, strat apiStrategy, history []*llm.Content, toolDecls []*tools.ToolDeclaration, resolver llm.AssetResolver) (*chatRequest, error) {
+func (c *client) buildRequestBody(ctx context.Context, strat apiStrategy, history []*llm.Content, toolDecls []*tools.ToolDeclaration, ta *turnAssets) (*chatRequest, error) {
 	req := chatRequest{
 		Model: c.model,
 		Tools: c.toOpenAITools(toolDecls, strat.useResponses),
 	}
 
 	if strat.useResponses {
-		items, err := c.toResponsesInput(ctx, history, resolver)
+		items, err := c.toResponsesInput(ctx, history, ta)
 		if err != nil {
 			return nil, err
 		}
 		req.Input = items
 		req.Reasoning = &reasoningConfig{Effort: strat.effort}
 	} else {
-		messages, err := c.toStandardMessages(ctx, history, resolver)
+		messages, err := c.toStandardMessages(ctx, history, ta)
 		if err != nil {
 			return nil, err
 		}
@@ -177,10 +177,10 @@ func (c *client) injectTransportHints(req *chatRequest) {
 // prepareChatRequest constructs the chat request payload by delegating
 // to focused helpers for API strategy, body assembly, output budget,
 // and transport hints.
-func (c *client) prepareChatRequest(ctx context.Context, history []*llm.Content, toolDecls []*tools.ToolDeclaration, resolver llm.AssetResolver) (*chatRequest, error) {
+func (c *client) prepareChatRequest(ctx context.Context, history []*llm.Content, toolDecls []*tools.ToolDeclaration, ta *turnAssets) (*chatRequest, error) {
 	strat := c.resolveAPIStrategy(len(toolDecls))
 
-	req, err := c.buildRequestBody(ctx, strat, history, toolDecls, resolver)
+	req, err := c.buildRequestBody(ctx, strat, history, toolDecls, ta)
 	if err != nil {
 		return nil, err
 	}
@@ -238,13 +238,32 @@ func (c *client) createHTTPRequest(ctx context.Context, payload *chatRequest) (*
 // ---------------------------------------------------------------------------
 
 func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
-	reqPayload, err := c.prepareChatRequest(ctx, history, toolDecls, resolver)
+	// Prepare image assets for the turn: hydrate from resolver,
+	// upload to Kimi file API. Skip if no vision capability.
+	var ta *turnAssets
+	if c.capabilities.SupportsVision {
+		var prepared []*llm.Part
+		var err error
+		ta, prepared, err = c.prepareImageAssets(ctx, collectHistoryParts(history), resolver)
+		if err != nil {
+			return nil, nil, err
+		}
+		applyPreparedParts(history, prepared)
+	}
+
+	reqPayload, err := c.prepareChatRequest(ctx, history, toolDecls, ta)
 	if err != nil {
+		if ta != nil {
+			ta.release(context.Background(), c)
+		}
 		return nil, nil, err
 	}
 	endpoint := c.resolveEndpoint(reqPayload)
 	req, err := c.createHTTPRequest(ctx, reqPayload)
 	if err != nil {
+		if ta != nil {
+			ta.release(context.Background(), c)
+		}
 		return nil, nil, err
 	}
 
@@ -253,11 +272,19 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 	ttfb := time.Since(startTime) // Time To First Byte
 
 	if err != nil {
+		if ta != nil {
+			ta.release(context.Background(), c)
+		}
 		return nil, nil, fmt.Errorf("request failed: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
+
+	// Defer cleanup on success
+	if ta != nil {
+		defer ta.release(context.Background(), c)
+	}
 
 	if resp.StatusCode != http.StatusOK {
 		bodyBytes, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
@@ -270,16 +297,10 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 		}
 	}
 
-	content, metrics, err := func() (*llm.Content, *llm.Metrics, error) {
-		if endpoint == "/responses" {
-			return c.decodeResponsesAPIResponse(resp, startTime, ttfb, endpoint)
-		}
-		return c.decodeStandardResponse(resp, startTime, ttfb, endpoint)
-	}()
-	if err == nil {
-		c.cleanupUploadedFiles(ctx)
+	if endpoint == "/responses" {
+		return c.decodeResponsesAPIResponse(resp, startTime, ttfb, endpoint)
 	}
-	return content, metrics, err
+	return c.decodeStandardResponse(resp, startTime, ttfb, endpoint)
 }
 
 // decodeStandardResponse decodes a /chat/completions JSON response from

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -31,9 +31,6 @@ type client struct {
 	maxTokens      int
 	logger         ports.Logger
 	timeout        time.Duration
-	// uploadedFiles tracks file IDs uploaded during the current SendChat
-	// call, for cleanup after the LLM response.
-	uploadedFiles []string
 }
 
 // openaiOption defines a functional option for configuring the OpenAI Client.
@@ -233,6 +230,84 @@ type imageURLValue struct {
 	URL string `json:"url"`
 }
 
+// turnAssets carries turn-scoped file-upload state: the binding from
+// domain Parts to Kimi server file IDs, plus a list of uploaded file
+// IDs for post-response cleanup. It is owned by a single SendChat call
+// and never shared across goroutines.
+type turnAssets struct {
+	// bindings maps parts to their uploaded file IDs (ms:// references).
+	bindings map[*llm.Part]string
+	// uploaded is the ordered list of file IDs for cleanup.
+	uploaded []string
+}
+
+func newTurnAssets() *turnAssets {
+	return &turnAssets{
+		bindings: make(map[*llm.Part]string),
+	}
+}
+
+// resolveURL returns the image_url value for a part: ms://{file_id}
+// if it was uploaded, or a base64 data URI otherwise. Nil-safe —
+// returns a base64 data URI when ta is nil (no uploads occurred).
+func (ta *turnAssets) resolveURL(p *llm.Part) string {
+	if ta != nil {
+		if fileID, ok := ta.bindings[p]; ok {
+			return "ms://" + fileID
+		}
+	}
+	return fmt.Sprintf("data:%s;base64,%s",
+		p.InlineData.MIMEType,
+		base64.StdEncoding.EncodeToString(p.InlineData.Data))
+}
+
+// release deletes all files uploaded during this turn. Best-effort;
+// individual failures are logged. Uses a detached context so cleanup
+// proceeds even if the caller's context is at deadline.
+func (ta *turnAssets) release(ctx context.Context, c *client) {
+	if len(ta.uploaded) == 0 {
+		return
+	}
+	// Detach from the caller's context — cleanup is best-effort and
+	// must not be gated by the response deadline.
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 15*time.Second)
+	defer cancel()
+	for _, id := range ta.uploaded {
+		if err := c.deleteFile(cleanupCtx, id); err != nil {
+			c.logger.Warn("cleanup_uploaded_file_failed",
+				"file_id", id,
+				"error", err.Error(),
+			)
+		}
+	}
+}
+
+// collectHistoryParts gathers all non-system parts from history for
+// asset preparation.
+func collectHistoryParts(history []*llm.Content) []*llm.Part {
+	var parts []*llm.Part
+	for _, h := range history {
+		if h.Role == "system" {
+			continue
+		}
+		parts = append(parts, h.Parts...)
+	}
+	return parts
+}
+
+// applyPreparedParts writes prepared parts back into history, matching
+// by index. Call after prepareImageAssets has mutated parts in place.
+func applyPreparedParts(history []*llm.Content, prepared []*llm.Part) {
+	idx := 0
+	for _, h := range history {
+		if h.Role == "system" {
+			continue
+		}
+		h.Parts = prepared[idx : idx+len(h.Parts)]
+		idx += len(h.Parts)
+	}
+}
+
 type message struct {
 	Role             string      `json:"role"`
 	Content          interface{} `json:"content,omitempty"` // string, []requestContentBlock, or []any (mixed text+image)
@@ -337,7 +412,7 @@ func (c *client) appendMessagesFromHistoryItem(
 	ctx context.Context,
 	sink openaiSink,
 	h *llm.Content,
-	resolver llm.AssetResolver,
+	ta *turnAssets,
 	personaInjected *bool,
 ) error {
 	role := normalizeRole(h.Role)
@@ -352,18 +427,8 @@ func (c *client) appendMessagesFromHistoryItem(
 		return nil
 	}
 
-	// Hydrate lazy-loaded image assets before extraction.
-	// Parts with AssetID whose InlineData.Data is nil are resolved
-	// from the AssetResolver so they can be serialized as image_url
-	// blocks. Gated on SupportsVision — non-vision models skip.
-	var err error
-	otherParts, err = c.hydrateImageAssets(ctx, otherParts, resolver)
-	if err != nil {
-		return err
-	}
-	if _, err := c.uploadImageAssets(ctx, otherParts); err != nil {
-		return err
-	}
+	// Separate image parts before classification — classifyParts only
+	// handles text and function calls.
 	imageParts, textParts := extractImageParts(otherParts)
 
 	text, reasoning, toolCalls, err := c.classifyParts(textParts)
@@ -385,7 +450,7 @@ func (c *client) appendMessagesFromHistoryItem(
 		// Images are placed before text (images-first ordering). This is
 		// intentional for the describe-this-image use case — interleaved
 		// part ordering within a single history item is not preserved.
-		blocks := imageBlocks(imageParts)
+		blocks := imageBlocks(imageParts, ta)
 		if text != "" {
 			blocks = append(blocks, requestContentBlock{Type: "text", Text: text})
 		}
@@ -472,76 +537,57 @@ func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, reso
 	return out, nil
 }
 
-// uploadImageAssets uploads InlineData parts to the Kimi file API and
-// sets Part.AssetID to the returned file ID. Parts that already have
-// an AssetID (uploaded previously or reloaded from persistence) are
-// skipped. Gated on SupportsVision and a non-empty base URL that is
-// a Kimi endpoint (api.moonshot.ai). Returns the set of file IDs
-// uploaded so the caller can track them for cleanup.
-func (c *client) uploadImageAssets(ctx context.Context, parts []*llm.Part) ([]string, error) {
-	if !c.capabilities.SupportsVision || !strings.Contains(c.baseURL, "api.moonshot.ai") {
-		return nil, nil
+// prepareImageAssets hydrates and uploads image parts for a single
+// turn. Returns the turnAssets with file bindings and the prepared
+// (possibly cloned) part slice. Caller must call release after the
+// LLM response.
+func (c *client) prepareImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) (*turnAssets, []*llm.Part, error) {
+	ta := newTurnAssets()
+
+	out, err := c.hydrateImageAssets(ctx, parts, resolver)
+	if err != nil {
+		return ta, out, err
 	}
-	var uploaded []string
-	for _, p := range parts {
+
+	// Upload fresh images to Kimi file API
+	if !c.capabilities.SupportsVision || !strings.Contains(c.baseURL, "api.moonshot.ai") {
+		return ta, out, nil
+	}
+	for _, p := range out {
 		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
 			continue
 		}
-		if p.AssetID != "" {
-			continue // already uploaded or reloaded
+		if _, ok := ta.bindings[p]; ok {
+			continue // already uploaded in this turn
 		}
-		// Determine MIME type for filename extension
 		ext := "png"
 		if p.InlineData.MIMEType != "" {
-			if mimeParts := strings.Split(p.InlineData.MIMEType, "/"); len(mimeParts) == 2 {
-				ext = mimeParts[1]
+			if parts := strings.Split(p.InlineData.MIMEType, "/"); len(parts) == 2 {
+				ext = parts[1]
 			}
 		}
 		filename := fmt.Sprintf("image.%s", ext)
 		fileID, err := c.uploadFile(ctx, p.InlineData.Data, filename, "image")
 		if err != nil {
-			return uploaded, fmt.Errorf("upload image: %w", err)
+			ta.release(ctx, c)
+			return ta, out, fmt.Errorf("upload image: %w", err)
 		}
-		p.AssetID = fileID
-		uploaded = append(uploaded, fileID)
-		c.uploadedFiles = append(c.uploadedFiles, fileID)
+		ta.bindings[p] = fileID
+		ta.uploaded = append(ta.uploaded, fileID)
 	}
-	return uploaded, nil
-}
-
-// cleanupUploadedFiles deletes all files uploaded during the current
-// SendChat call. Best-effort — individual delete failures are logged
-// but do not fail the cleanup. Called after a successful LLM response.
-func (c *client) cleanupUploadedFiles(ctx context.Context) {
-	for _, id := range c.uploadedFiles {
-		if err := c.deleteFile(ctx, id); err != nil {
-			c.logger.Warn("cleanup_uploaded_file_failed",
-				"file_id", id,
-				"error", err.Error(),
-			)
-		}
-	}
-	c.uploadedFiles = c.uploadedFiles[:0]
+	return ta, out, nil
 }
 
 // imageBlocks converts InlineData parts to image_url content blocks.
-// Parts with an AssetID that starts with "file-" are referenced via
-// ms://{file_id} (uploaded files). Otherwise, InlineData is encoded
-// as a base64 data URI.
-func imageBlocks(parts []*llm.Part) []any {
+// Uses turnAssets to resolve ms:// URLs for uploaded files; falls
+// back to base64 data URIs for non-uploaded parts.
+func imageBlocks(parts []*llm.Part, ta *turnAssets) []any {
 	var blocks []any
 	for _, p := range parts {
 		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
 			continue
 		}
-		var url string
-		if strings.HasPrefix(p.AssetID, "file-") {
-			url = "ms://" + p.AssetID
-		} else {
-			url = fmt.Sprintf("data:%s;base64,%s",
-				p.InlineData.MIMEType,
-				base64.StdEncoding.EncodeToString(p.InlineData.Data))
-		}
+		url := ta.resolveURL(p)
 		blocks = append(blocks, imageURLBlock{
 			Type:     "image_url",
 			ImageURL: imageURLValue{URL: url},

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -31,6 +31,9 @@ type client struct {
 	maxTokens      int
 	logger         ports.Logger
 	timeout        time.Duration
+	// uploadedFiles tracks file IDs uploaded during the current SendChat
+	// call, for cleanup after the LLM response.
+	uploadedFiles []string
 }
 
 // openaiOption defines a functional option for configuring the OpenAI Client.
@@ -358,9 +361,9 @@ func (c *client) appendMessagesFromHistoryItem(
 	if err != nil {
 		return err
 	}
-
-	// Separate image parts before classification — classifyParts only
-	// handles text and function calls.
+	if _, err := c.uploadImageAssets(ctx, otherParts); err != nil {
+		return err
+	}
 	imageParts, textParts := extractImageParts(otherParts)
 
 	text, reasoning, toolCalls, err := c.classifyParts(textParts)
@@ -469,21 +472,79 @@ func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, reso
 	return out, nil
 }
 
+// uploadImageAssets uploads InlineData parts to the Kimi file API and
+// sets Part.AssetID to the returned file ID. Parts that already have
+// an AssetID (uploaded previously or reloaded from persistence) are
+// skipped. Gated on SupportsVision and a non-empty base URL that is
+// a Kimi endpoint (api.moonshot.ai). Returns the set of file IDs
+// uploaded so the caller can track them for cleanup.
+func (c *client) uploadImageAssets(ctx context.Context, parts []*llm.Part) ([]string, error) {
+	if !c.capabilities.SupportsVision || !strings.Contains(c.baseURL, "api.moonshot.ai") {
+		return nil, nil
+	}
+	var uploaded []string
+	for _, p := range parts {
+		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
+			continue
+		}
+		if p.AssetID != "" {
+			continue // already uploaded or reloaded
+		}
+		// Determine MIME type for filename extension
+		ext := "png"
+		if p.InlineData.MIMEType != "" {
+			if mimeParts := strings.Split(p.InlineData.MIMEType, "/"); len(mimeParts) == 2 {
+				ext = mimeParts[1]
+			}
+		}
+		filename := fmt.Sprintf("image.%s", ext)
+		fileID, err := c.uploadFile(ctx, p.InlineData.Data, filename, "image")
+		if err != nil {
+			return uploaded, fmt.Errorf("upload image: %w", err)
+		}
+		p.AssetID = fileID
+		uploaded = append(uploaded, fileID)
+		c.uploadedFiles = append(c.uploadedFiles, fileID)
+	}
+	return uploaded, nil
+}
+
+// cleanupUploadedFiles deletes all files uploaded during the current
+// SendChat call. Best-effort — individual delete failures are logged
+// but do not fail the cleanup. Called after a successful LLM response.
+func (c *client) cleanupUploadedFiles(ctx context.Context) {
+	for _, id := range c.uploadedFiles {
+		if err := c.deleteFile(ctx, id); err != nil {
+			c.logger.Warn("cleanup_uploaded_file_failed",
+				"file_id", id,
+				"error", err.Error(),
+			)
+		}
+	}
+	c.uploadedFiles = c.uploadedFiles[:0]
+}
+
 // imageBlocks converts InlineData parts to image_url content blocks.
-// Returns nil if there are no InlineData parts.
+// Parts with an AssetID that starts with "file-" are referenced via
+// ms://{file_id} (uploaded files). Otherwise, InlineData is encoded
+// as a base64 data URI.
 func imageBlocks(parts []*llm.Part) []any {
 	var blocks []any
 	for _, p := range parts {
 		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
 			continue
 		}
+		var url string
+		if strings.HasPrefix(p.AssetID, "file-") {
+			url = "ms://" + p.AssetID
+		} else {
+			url = fmt.Sprintf("data:%s;base64,%s",
+				p.InlineData.MIMEType,
+				base64.StdEncoding.EncodeToString(p.InlineData.Data))
+		}
 		blocks = append(blocks, imageURLBlock{
-			Type: "image_url",
-			ImageURL: imageURLValue{
-				URL: fmt.Sprintf("data:%s;base64,%s",
-					p.InlineData.MIMEType,
-					base64.StdEncoding.EncodeToString(p.InlineData.Data)),
-			},
+			Type:     "image_url",
+			ImageURL: imageURLValue{URL: url},
 		})
 	}
 	return blocks

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -752,6 +753,30 @@ func (c *client) ResetConnections() {
 	if closer, ok := c.transport.(idleConnectionCloser); ok {
 		closer.CloseIdleConnections()
 	}
+}
+
+// newAuthenticatedRequest creates an HTTP request with all headers applied:
+// custom provider headers (c.headers) and authenticator headers (by name,
+// not by map iteration value). Used by both chat completions and file API
+// endpoints for consistent authentication.
+func (c *client) newAuthenticatedRequest(ctx context.Context, method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	// Custom provider headers (e.g. reasoning_effort)
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+	// Authenticator headers (e.g. Authorization, x-api-key)
+	authReq := &auth.Request{Headers: make(map[string]string)}
+	if err := c.authenticator.Apply(ctx, authReq); err != nil {
+		return nil, err
+	}
+	for k, v := range authReq.Headers {
+		req.Header.Set(k, v)
+	}
+	return req, nil
 }
 
 // truncate returns a string truncated to n characters with "..." appended.

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -106,7 +106,10 @@ func TestVisionDisabled_KeepsStringContent(t *testing.T) {
 }
 
 func TestVision_KimiImagePayload(t *testing.T) {
-	c := NewClient("https://api.moonshot.ai/v1", "kimi-k3",
+	// Use a non-Kimi URL so uploadImageAssets is skipped (gated on
+	// api.moonshot.ai). SupportsVision is set from model name "kimi-k3",
+	// so the base64 image path is still exercised.
+	c := NewClient("", "kimi-k3",
 		&auth.BearerAuth{Token: "test"},
 		WithLogger(&ports.NoOpLogger{}),
 	)
@@ -164,6 +167,53 @@ func TestVision_KimiImagePayload(t *testing.T) {
 	}
 	if !strings.Contains(string(b), "describe this") {
 		t.Error("JSON payload missing text content")
+	}
+}
+
+func TestVision_KimiMsURLPayload(t *testing.T) {
+	c := NewClient("", "kimi-k3",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	if !c.capabilities.SupportsVision {
+		t.Fatal("kimi-k3 should have SupportsVision")
+	}
+
+	// Build history with an image part that has AssetID set (simulating
+	// a previously uploaded file). imageBlocks should produce ms:// URL.
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{AssetID: "file-abc123", InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			{Text: "describe this"},
+		},
+	}}
+
+	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("toStandardMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	msg := msgs[0]
+
+	if _, ok := msg.Content.([]any); !ok {
+		t.Fatalf("expected []any content, got %T", msg.Content)
+	}
+
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	// Verify ms:// URL is used (not base64 data URI)
+	if !strings.Contains(string(b), "ms://file-abc123") {
+		t.Error("JSON payload missing ms://file-abc123 URL")
+	}
+	if strings.Contains(string(b), "data:image/png;base64") {
+		t.Error("JSON payload should NOT contain base64 data URI when AssetID is set")
 	}
 }
 

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -32,7 +32,7 @@ func TestImageBlocks(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blocks := imageBlocks(tt.parts)
+			blocks := imageBlocks(tt.parts, nil)
 			if len(blocks) != tt.want {
 				t.Errorf("got %d blocks, want %d", len(blocks), tt.want)
 			}
@@ -179,17 +179,20 @@ func TestVision_KimiMsURLPayload(t *testing.T) {
 		t.Fatal("kimi-k3 should have SupportsVision")
 	}
 
-	// Build history with an image part that has AssetID set (simulating
-	// a previously uploaded file). imageBlocks should produce ms:// URL.
+	// Build history with an image part. Pre-populate a turnAssets with
+	// a file binding to simulate a previously uploaded file.
+	imgPart := &llm.Part{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}}
 	history := []*llm.Content{{
 		Role: "user",
 		Parts: []*llm.Part{
-			{AssetID: "file-abc123", InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			imgPart,
 			{Text: "describe this"},
 		},
 	}}
 
-	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	ta := newTurnAssets()
+	ta.bindings[imgPart] = "file-abc123"
+	msgs, err := c.toStandardMessages(context.Background(), history, ta)
 	if err != nil {
 		t.Fatalf("toStandardMessages failed: %v", err)
 	}

--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -24,13 +24,6 @@ type fileObject struct {
 	Status    string `json:"status"`
 }
 
-// fileDeleteResponse is the API response from DELETE /v1/files/{id}.
-type fileDeleteResponse struct {
-	ID      string `json:"id"`
-	Object  string `json:"object"`
-	Deleted bool   `json:"deleted"`
-}
-
 // uploadFile uploads a file to the Kimi API and returns the file ID.
 // purpose must be "image", "video", or "file-extract".
 // filename is the original filename for metadata.
@@ -66,7 +59,7 @@ func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose 
 	if err != nil {
 		return "", fmt.Errorf("upload request: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
@@ -96,7 +89,7 @@ func (c *client) deleteFile(ctx context.Context, fileID string) error {
 	if err != nil {
 		return fmt.Errorf("delete file: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("delete file failed (status %d)", resp.StatusCode)
@@ -116,7 +109,7 @@ func (c *client) getFileContent(ctx context.Context, fileID string) (string, err
 	if err != nil {
 		return "", fmt.Errorf("get content: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("get content failed (status %d)", resp.StatusCode)

--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package openai
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"strings"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+// fileObject is the API response from POST /v1/files.
+type fileObject struct {
+	ID        string `json:"id"`
+	Object    string `json:"object"`
+	Bytes     int64  `json:"bytes"`
+	CreatedAt int64  `json:"created_at"`
+	Filename  string `json:"filename"`
+	Purpose   string `json:"purpose"`
+	Status    string `json:"status"`
+}
+
+// fileListResponse is the API response from GET /v1/files.
+type fileListResponse struct {
+	Object string       `json:"object"`
+	Data   []fileObject `json:"data"`
+}
+
+// fileDeleteResponse is the API response from DELETE /v1/files/{id}.
+type fileDeleteResponse struct {
+	ID      string `json:"id"`
+	Object  string `json:"object"`
+	Deleted bool   `json:"deleted"`
+}
+
+// authHeader returns the Authorization header from the client's
+// authenticator. Uses the same Apply pattern as createHTTPRequest.
+func (c *client) authHeader(ctx context.Context) (string, error) {
+	authReq := &auth.Request{Headers: make(map[string]string)}
+	if err := c.authenticator.Apply(ctx, authReq); err != nil {
+		return "", err
+	}
+	for _, v := range authReq.Headers {
+		return v, nil // return first header value (e.g. "Bearer <token>")
+	}
+	return "", fmt.Errorf("no auth header produced by authenticator")
+}
+
+// uploadFile uploads a file to the Kimi API and returns the file ID.
+// purpose must be "image", "video", or "file-extract".
+// filename is the original filename for metadata.
+func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose string) (string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	// purpose field
+	if err := w.WriteField("purpose", purpose); err != nil {
+		return "", fmt.Errorf("write purpose field: %w", err)
+	}
+
+	// file field
+	fw, err := w.CreateFormFile("file", filename)
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := fw.Write(data); err != nil {
+		return "", fmt.Errorf("write file data: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return "", fmt.Errorf("close multipart writer: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/files", &buf)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	authValue, err := c.authHeader(ctx)
+	if err != nil {
+		return "", fmt.Errorf("get auth header: %w", err)
+	}
+	req.Header.Set("Authorization", authValue)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("upload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+		return "", fmt.Errorf("upload failed (status %d): %s", resp.StatusCode, string(body))
+	}
+
+	var fo fileObject
+	if err := json.NewDecoder(resp.Body).Decode(&fo); err != nil {
+		return "", fmt.Errorf("decode upload response: %w", err)
+	}
+
+	if fo.Status != "ready" {
+		return "", fmt.Errorf("upload status %q (expected ready)", fo.Status)
+	}
+
+	return fo.ID, nil
+}
+
+// listFiles returns all uploaded files for the current user.
+func (c *client) listFiles(ctx context.Context) ([]fileObject, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/files", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create request: %w", err)
+	}
+
+	authValue, err := c.authHeader(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get auth header: %w", err)
+	}
+	req.Header.Set("Authorization", authValue)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list files: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("list files failed (status %d)", resp.StatusCode)
+	}
+
+	var fl fileListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&fl); err != nil {
+		return nil, fmt.Errorf("decode list response: %w", err)
+	}
+	return fl.Data, nil
+}
+
+// deleteFile deletes a previously uploaded file by ID.
+func (c *client) deleteFile(ctx context.Context, fileID string) error {
+	req, err := http.NewRequestWithContext(ctx, "DELETE", c.baseURL+"/files/"+fileID, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	authValue, err := c.authHeader(ctx)
+	if err != nil {
+		return fmt.Errorf("get auth header: %w", err)
+	}
+	req.Header.Set("Authorization", authValue)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("delete file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("delete file failed (status %d)", resp.StatusCode)
+	}
+	return nil
+}
+
+// getFileContent retrieves the extracted text content of a file
+// uploaded with purpose="file-extract".
+func (c *client) getFileContent(ctx context.Context, fileID string) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/files/"+fileID+"/content", nil)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	authVal, err := c.authHeader(ctx)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", authVal)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("get content: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("get content failed (status %d)", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBytes))
+	if err != nil {
+		return "", fmt.Errorf("read content: %w", err)
+	}
+
+	return string(body), nil
+}
+
+// extractDocument uploads a document to the Kimi file API for text
+// extraction and returns the extracted content. The document is
+// uploaded with purpose="file-extract", the extracted text is
+// retrieved, and the file is deleted (cleanup). Returns the full
+// extracted text content.
+func (c *client) extractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	fileID, err := c.uploadFile(ctx, data, filename, "file-extract")
+	if err != nil {
+		return "", fmt.Errorf("upload document: %w", err)
+	}
+	defer func() {
+		// Best-effort cleanup; don't shadow the primary error
+		_ = c.deleteFile(ctx, fileID)
+	}()
+
+	content, err := c.getFileContent(ctx, fileID)
+	if err != nil {
+		return "", fmt.Errorf("get document content: %w", err)
+	}
+
+	return content, nil
+}
+
+// uploadedFileIDs returns the file IDs of all parts that have AssetID
+// set and whose AssetID looks like a Kimi file ID.
+func uploadedFileIDs(parts []*llm.Part) []string {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, p := range parts {
+		if p.AssetID != "" && strings.HasPrefix(p.AssetID, "file-") && !seen[p.AssetID] {
+			seen[p.AssetID] = true
+			ids = append(ids, p.AssetID)
+		}
+	}
+	return ids
+}

--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -11,10 +11,6 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
-	"strings"
-
-	"github.com/gosharplite/tell-me-go/internal/domain/llm"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 )
 
 // fileObject is the API response from POST /v1/files.
@@ -28,30 +24,11 @@ type fileObject struct {
 	Status    string `json:"status"`
 }
 
-// fileListResponse is the API response from GET /v1/files.
-type fileListResponse struct {
-	Object string       `json:"object"`
-	Data   []fileObject `json:"data"`
-}
-
 // fileDeleteResponse is the API response from DELETE /v1/files/{id}.
 type fileDeleteResponse struct {
 	ID      string `json:"id"`
 	Object  string `json:"object"`
 	Deleted bool   `json:"deleted"`
-}
-
-// authHeader returns the Authorization header from the client's
-// authenticator. Uses the same Apply pattern as createHTTPRequest.
-func (c *client) authHeader(ctx context.Context) (string, error) {
-	authReq := &auth.Request{Headers: make(map[string]string)}
-	if err := c.authenticator.Apply(ctx, authReq); err != nil {
-		return "", err
-	}
-	for _, v := range authReq.Headers {
-		return v, nil // return first header value (e.g. "Bearer <token>")
-	}
-	return "", fmt.Errorf("no auth header produced by authenticator")
 }
 
 // uploadFile uploads a file to the Kimi API and returns the file ID.
@@ -79,17 +56,11 @@ func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose 
 		return "", fmt.Errorf("close multipart writer: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/files", &buf)
+	req, err := c.newAuthenticatedRequest(ctx, "POST", c.baseURL+"/files", &buf)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}
 	req.Header.Set("Content-Type", w.FormDataContentType())
-
-	authValue, err := c.authHeader(ctx)
-	if err != nil {
-		return "", fmt.Errorf("get auth header: %w", err)
-	}
-	req.Header.Set("Authorization", authValue)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -114,48 +85,12 @@ func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose 
 	return fo.ID, nil
 }
 
-// listFiles returns all uploaded files for the current user.
-func (c *client) listFiles(ctx context.Context) ([]fileObject, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/files", nil)
-	if err != nil {
-		return nil, fmt.Errorf("create request: %w", err)
-	}
-
-	authValue, err := c.authHeader(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("get auth header: %w", err)
-	}
-	req.Header.Set("Authorization", authValue)
-
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("list files: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("list files failed (status %d)", resp.StatusCode)
-	}
-
-	var fl fileListResponse
-	if err := json.NewDecoder(resp.Body).Decode(&fl); err != nil {
-		return nil, fmt.Errorf("decode list response: %w", err)
-	}
-	return fl.Data, nil
-}
-
 // deleteFile deletes a previously uploaded file by ID.
 func (c *client) deleteFile(ctx context.Context, fileID string) error {
-	req, err := http.NewRequestWithContext(ctx, "DELETE", c.baseURL+"/files/"+fileID, nil)
+	req, err := c.newAuthenticatedRequest(ctx, "DELETE", c.baseURL+"/files/"+fileID, nil)
 	if err != nil {
 		return fmt.Errorf("create request: %w", err)
 	}
-
-	authValue, err := c.authHeader(ctx)
-	if err != nil {
-		return fmt.Errorf("get auth header: %w", err)
-	}
-	req.Header.Set("Authorization", authValue)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -172,15 +107,10 @@ func (c *client) deleteFile(ctx context.Context, fileID string) error {
 // getFileContent retrieves the extracted text content of a file
 // uploaded with purpose="file-extract".
 func (c *client) getFileContent(ctx context.Context, fileID string) (string, error) {
-	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+"/files/"+fileID+"/content", nil)
+	req, err := c.newAuthenticatedRequest(ctx, "GET", c.baseURL+"/files/"+fileID+"/content", nil)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
 	}
-	authVal, err := c.authHeader(ctx)
-	if err != nil {
-		return "", err
-	}
-	req.Header.Set("Authorization", authVal)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -203,8 +133,12 @@ func (c *client) getFileContent(ctx context.Context, fileID string) (string, err
 // extractDocument uploads a document to the Kimi file API for text
 // extraction and returns the extracted content. The document is
 // uploaded with purpose="file-extract", the extracted text is
-// retrieved, and the file is deleted (cleanup). Returns the full
-// extracted text content.
+// retrieved, and the file is deleted (cleanup).
+//
+// This is infrastructure ready for tool wiring — a future
+// kimi-extract-document agent tool would call this via the client
+// to extract text from user-provided documents (PDF, DOCX, MD, etc.)
+// and inject the result as system-message context.
 func (c *client) extractDocument(ctx context.Context, data []byte, filename string) (string, error) {
 	fileID, err := c.uploadFile(ctx, data, filename, "file-extract")
 	if err != nil {
@@ -221,18 +155,4 @@ func (c *client) extractDocument(ctx context.Context, data []byte, filename stri
 	}
 
 	return content, nil
-}
-
-// uploadedFileIDs returns the file IDs of all parts that have AssetID
-// set and whose AssetID looks like a Kimi file ID.
-func uploadedFileIDs(parts []*llm.Part) []string {
-	seen := make(map[string]bool)
-	var ids []string
-	for _, p := range parts {
-		if p.AssetID != "" && strings.HasPrefix(p.AssetID, "file-") && !seen[p.AssetID] {
-			seen[p.AssetID] = true
-			ids = append(ids, p.AssetID)
-		}
-	}
-	return ids
 }

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -1,0 +1,257 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package openai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+func TestUploadFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.URL.Path != "/files" {
+			t.Errorf("expected /files, got %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Content-Type"), "multipart/form-data") {
+			t.Errorf("expected multipart, got %s", r.Header.Get("Content-Type"))
+		}
+		// Verify the file was uploaded
+		if err := r.ParseMultipartForm(10 << 20); err != nil {
+			t.Fatalf("parse multipart: %v", err)
+		}
+		if r.FormValue("purpose") != "image" {
+			t.Errorf("expected purpose=image, got %s", r.FormValue("purpose"))
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			t.Fatalf("form file: %v", err)
+		}
+		buf := make([]byte, 4)
+		file.Read(buf)
+		if string(buf) != "test" {
+			t.Errorf("expected file content 'test', got %q", string(buf))
+		}
+
+		json.NewEncoder(w).Encode(fileObject{
+			ID:     "file-abc123",
+			Status: "ready",
+		})
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:      strings.TrimSuffix(server.URL, "/"),
+		httpClient:   server.Client(),
+		capabilities: llm.Capabilities{SupportsVision: true},
+		logger:       &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	id, err := c.uploadFile(context.Background(), []byte("test"), "cat.png", "image")
+	if err != nil {
+		t.Fatalf("uploadFile: %v", err)
+	}
+	if id != "file-abc123" {
+		t.Errorf("expected file-abc123, got %s", id)
+	}
+}
+
+func TestUploadFile_ErrorStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error": "unauthorized"}`))
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	_, err := c.uploadFile(context.Background(), []byte("test"), "cat.png", "image")
+	if err == nil || !strings.Contains(err.Error(), "unauthorized") {
+		t.Errorf("expected unauthorized error, got %v", err)
+	}
+}
+
+func TestUploadFile_NotReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(fileObject{
+			ID:     "file-abc123",
+			Status: "processing",
+		})
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	_, err := c.uploadFile(context.Background(), []byte("test"), "cat.png", "image")
+	if err == nil || !strings.Contains(err.Error(), "expected ready") {
+		t.Errorf("expected 'expected ready' error, got %v", err)
+	}
+}
+
+func TestListFiles(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(fileListResponse{
+			Object: "list",
+			Data: []fileObject{
+				{ID: "file-1", Filename: "a.png", Purpose: "image", Status: "ready"},
+				{ID: "file-2", Filename: "b.png", Purpose: "image", Status: "ready"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	files, err := c.listFiles(context.Background())
+	if err != nil {
+		t.Fatalf("listFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d", len(files))
+	}
+}
+
+func TestDeleteFile(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "DELETE" {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "/files/file-abc") {
+			t.Errorf("expected /files/file-abc in path, got %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	if err := c.deleteFile(context.Background(), "file-abc"); err != nil {
+		t.Fatalf("deleteFile: %v", err)
+	}
+}
+
+func TestGetFileContent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("extracted document text"))
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	content, err := c.getFileContent(context.Background(), "file-abc")
+	if err != nil {
+		t.Fatalf("getFileContent: %v", err)
+	}
+	if content != "extracted document text" {
+		t.Errorf("expected 'extracted document text', got %q", content)
+	}
+}
+
+func TestExtractDocument(t *testing.T) {
+	var deletedID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/files":
+			json.NewEncoder(w).Encode(fileObject{ID: "file-doc", Status: "ready"})
+		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/content"):
+			w.Write([]byte("doc content here"))
+		case r.Method == "DELETE":
+			deletedID = strings.TrimPrefix(r.URL.Path, "/files/")
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	content, err := c.extractDocument(context.Background(), []byte("pdf data"), "report.pdf")
+	if err != nil {
+		t.Fatalf("extractDocument: %v", err)
+	}
+	if content != "doc content here" {
+		t.Errorf("expected 'doc content here', got %q", content)
+	}
+	if deletedID != "file-doc" {
+		t.Errorf("expected cleanup of file-doc, deleted %q", deletedID)
+	}
+}
+
+// fakeAuthenticator implements auth.Authenticator for tests.
+type fakeAuthenticator struct{}
+
+func (f *fakeAuthenticator) Apply(ctx context.Context, req *auth.Request) error {
+	req.Headers["Authorization"] = "Bearer test-token"
+	return nil
+}
+
+func (f *fakeAuthenticator) Invalidate() {}
+
+func TestCleanupUploadedFiles(t *testing.T) {
+	var deletedIDs []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "DELETE" {
+			deletedIDs = append(deletedIDs, strings.TrimPrefix(r.URL.Path, "/files/"))
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:       strings.TrimSuffix(server.URL, "/"),
+		httpClient:    server.Client(),
+		logger:        &ports.NoOpLogger{},
+		uploadedFiles: []string{"file-1", "file-2"},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	c.cleanupUploadedFiles(context.Background())
+
+	if len(deletedIDs) != 2 {
+		t.Errorf("expected 2 deletes, got %d: %v", len(deletedIDs), deletedIDs)
+	}
+	if len(c.uploadedFiles) != 0 {
+		t.Errorf("uploadedFiles not cleared: %v", c.uploadedFiles)
+	}
+}

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -110,34 +110,6 @@ func TestUploadFile_NotReady(t *testing.T) {
 	}
 }
 
-func TestListFiles(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		json.NewEncoder(w).Encode(fileListResponse{
-			Object: "list",
-			Data: []fileObject{
-				{ID: "file-1", Filename: "a.png", Purpose: "image", Status: "ready"},
-				{ID: "file-2", Filename: "b.png", Purpose: "image", Status: "ready"},
-			},
-		})
-	}))
-	defer server.Close()
-
-	c := &client{
-		baseURL:    strings.TrimSuffix(server.URL, "/"),
-		httpClient: server.Client(),
-		logger:     &ports.NoOpLogger{},
-	}
-	c.authenticator = &fakeAuthenticator{}
-
-	files, err := c.listFiles(context.Background())
-	if err != nil {
-		t.Fatalf("listFiles: %v", err)
-	}
-	if len(files) != 2 {
-		t.Errorf("expected 2 files, got %d", len(files))
-	}
-}
-
 func TestDeleteFile(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "DELETE" {

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -239,19 +239,17 @@ func TestCleanupUploadedFiles(t *testing.T) {
 	defer server.Close()
 
 	c := &client{
-		baseURL:       strings.TrimSuffix(server.URL, "/"),
-		httpClient:    server.Client(),
-		logger:        &ports.NoOpLogger{},
-		uploadedFiles: []string{"file-1", "file-2"},
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
 	}
 	c.authenticator = &fakeAuthenticator{}
 
-	c.cleanupUploadedFiles(context.Background())
+	ta := newTurnAssets()
+	ta.uploaded = []string{"file-1", "file-2"}
+	ta.release(context.Background(), c)
 
 	if len(deletedIDs) != 2 {
 		t.Errorf("expected 2 deletes, got %d: %v", len(deletedIDs), deletedIDs)
-	}
-	if len(c.uploadedFiles) != 0 {
-		t.Errorf("uploadedFiles not cleared: %v", c.uploadedFiles)
 	}
 }

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -6,6 +6,7 @@ package openai
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -223,5 +224,118 @@ func TestCleanupUploadedFiles(t *testing.T) {
 
 	if len(deletedIDs) != 2 {
 		t.Errorf("expected 2 deletes, got %d: %v", len(deletedIDs), deletedIDs)
+	}
+}
+
+func TestCollectApplyRoundTrip(t *testing.T) {
+	original := []*llm.Content{
+		{Role: "system", Parts: []*llm.Part{{Text: "system prompt"}}},
+		{Role: "user", Parts: []*llm.Part{{Text: "hello"}, {Text: "world"}}},
+		{Role: "model", Parts: []*llm.Part{{Text: "hi"}}},
+		{Role: "user", Parts: []*llm.Part{}},
+	}
+	collected := collectHistoryParts(original)
+	// system parts excluded; user: 2 + model: 1 + empty-user: 0 = 3
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 parts (system excluded), got %d", len(collected))
+	}
+	// Mutate collected parts
+	for i := range collected {
+		collected[i] = &llm.Part{Text: fmt.Sprintf("modified-%d", i)}
+	}
+	applyPreparedParts(original, collected)
+	// System untouched
+	if original[0].Parts[0].Text != "system prompt" {
+		t.Error("system was modified")
+	}
+	// User parts replaced
+	if original[1].Parts[0].Text != "modified-0" {
+		t.Error("user part not applied")
+	}
+	if original[1].Parts[1].Text != "modified-1" {
+		t.Error("user part 2 not applied")
+	}
+	// Model part replaced
+	if original[2].Parts[0].Text != "modified-2" {
+		t.Error("model part not applied")
+	}
+	// Empty user still empty
+	if len(original[3].Parts) != 0 {
+		t.Error("empty user got parts")
+	}
+}
+
+func TestPrepareImageAssets_Gating(t *testing.T) {
+	// Non-Kimi URL — should skip upload entirely
+	c := &client{
+		baseURL:    "https://api.openai.com/v1",
+		httpClient: http.DefaultClient,
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+	c.capabilities = llm.Capabilities{SupportsVision: true}
+
+	parts := []*llm.Part{
+		{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}},
+	}
+	ta, out, err := c.prepareImageAssets(context.Background(), parts, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ta.uploaded) != 0 {
+		t.Error("non-Kimi URL should not upload")
+	}
+	if len(ta.bindings) != 0 {
+		t.Error("non-Kimi URL should have no bindings")
+	}
+	_ = out
+	ta.release(context.Background(), c)
+}
+
+func TestPrepareImageAssets_KimiURL_Uploads(t *testing.T) {
+	var uploaded, deleted bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/files"):
+			uploaded = true
+			json.NewEncoder(w).Encode(fileObject{ID: "file-xyz", Status: "ready"})
+		case r.Method == "DELETE":
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    server.URL + "/api.moonshot.ai",
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+	c.capabilities = llm.Capabilities{SupportsVision: true}
+
+	parts := []*llm.Part{
+		{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+	}
+	ta, out, err := c.prepareImageAssets(context.Background(), parts, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !uploaded {
+		t.Error("expected POST /files upload")
+	}
+	if len(ta.uploaded) != 1 {
+		t.Errorf("expected 1 uploaded file, got %d", len(ta.uploaded))
+	}
+	if ta.bindings[out[0]] != "file-xyz" {
+		t.Error("expected binding for uploaded part")
+	}
+	if ta.resolveURL(out[0]) != "ms://file-xyz" {
+		t.Errorf("expected ms:// URL, got %s", ta.resolveURL(out[0]))
+	}
+
+	ta.release(context.Background(), c)
+	if !deleted {
+		t.Error("expected DELETE after release")
 	}
 }

--- a/internal/infrastructure/llm/openai/responses.go
+++ b/internal/infrastructure/llm/openai/responses.go
@@ -80,12 +80,12 @@ func (c *client) resolveBlockType(role string) string {
 // Responses API input conversion
 // ---------------------------------------------------------------------------
 
-func (c *client) toResponsesInput(ctx context.Context, history []*llm.Content, resolver llm.AssetResolver) ([]historyItem, error) {
+func (c *client) toResponsesInput(ctx context.Context, history []*llm.Content, ta *turnAssets) ([]historyItem, error) {
 	sink := &responsesSink{client: c}
 	personaInjected := c.maybeInjectInitialPersona(sink)
 
 	for _, h := range history {
-		if err := c.appendMessagesFromHistoryItem(ctx, sink, h, resolver, &personaInjected); err != nil {
+		if err := c.appendMessagesFromHistoryItem(ctx, sink, h, ta, &personaInjected); err != nil {
 			return nil, err
 		}
 	}


### PR DESCRIPTION
Adds file upload capability to the OpenAI/Kimi provider, enabling `ms://` file references and document text extraction.

## Vision: `ms://` file references
Fresh `InlineData` parts are uploaded to `/v1/files` with `purpose="image"` and referenced via `ms://{file_id}` URLs. Combined with the existing `read_image` agent tool, Kimi models can receive and describe local images.

Images are re-uploaded per turn with per-turn cleanup — this avoids cross-turn state complexity and orphaned files accumulating toward Kimi's 1,000-file limit. Cleanup runs unconditionally (success and failure) since retries rebuild from scratch with fresh uploads.

## Document extraction: `purpose="file-extract"`
`extractDocument` uploads a document (PDF, DOCX, MD, etc.), retrieves extracted text via `/v1/files/{id}/content`, and deletes the file — one-shot text extraction with cleanup. Infrastructure ready for future agent-tool wiring.

## Architecture
Turn-scoped `turnAssets` struct owned by `SendChat` — no shared mutable state on the concurrently-used client. File-upload bindings live in a transport-local map (`turnAssets.bindings`), keeping the persistence-owned `Part.AssetID` field untouched. Message serialization is pure — I/O happens in `prepareImageAssets` before message building.

## Changes

| File | Change |
|---|---|
| `files.go` (new) | `uploadFile`, `deleteFile`, `getFileContent`, `extractDocument` |
| `files_test.go` (new) | Upload, delete, get-content, extract-document, cleanup, round-trip, gating tests |
| `client.go` | `turnAssets` type, `prepareImageAssets`, `newAuthenticatedRequest`, `imageBlocks` updated for `ms://`, `collectHistoryParts`, `applyPreparedParts` |
| `chat.go` | `SendChat`: prepare assets before serialization, unconditional cleanup via defer |
| `responses.go` | `toResponsesInput` threaded with `turnAssets` parameter |

## Pipeline per turn
```
prepareImageAssets (hydrate + upload) → collectHistoryParts
→ applyPreparedParts → imageBlocks (ms:// or base64)
→ SendChat → defer ta.release (unconditional, detached context)
```

All gated behind `SupportsVision` + `api.moonshot.ai` URL check. Non-Kimi providers never touch the upload path.