### PR TITLE
llm: add ExtractDocument to LLMClient + read_document agent tool

### DIFF
--- a/internal/domain/llm/types.go
+++ b/internal/domain/llm/types.go
@@ -81,6 +81,10 @@ type AssetResolver interface {
 type LLMClient interface {
 	SendChat(ctx context.Context, history []*Content, tools []*tools.ToolDeclaration, resolver AssetResolver) (*Content, *Metrics, error)
 	GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error)
+	// ExtractDocument extracts text content from a document (PDF, DOCX, MD, etc.)
+	// by uploading it to the provider's file extraction API. Returns the extracted
+	// text. Providers that don't support document extraction return ErrNotImplemented.
+	ExtractDocument(ctx context.Context, data []byte, filename string) (string, error)
 	RefreshAuth() error
 }
 
@@ -96,6 +100,11 @@ var (
 
 	// ErrMaxTurnsReached is returned when the model reaches the turn limit.
 	ErrMaxTurnsReached = errors.New("maximum tool execution turns reached")
+
+	// ErrNotImplemented is returned by provider methods that are not supported
+	// by a particular provider (e.g., GenerateImages on OpenAI, ExtractDocument
+	// on Anthropic/Gemini).
+	ErrNotImplemented = errors.New("not implemented for this provider")
 
 	// errBudgetExceeded is returned when the session cost exceeds the configured budget.
 	errBudgetExceeded = errors.New("session budget exceeded")

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -76,6 +76,10 @@ func (m *mockLLMClient) RefreshAuth() error {
 	return nil
 }
 
+func (m *mockLLMClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 func (m *mockLLMClient) Generate(ctx context.Context, input []*llm.Content, toolDecls []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
 	m.generateCalls++
 	if m.GenerateFunc != nil {

--- a/internal/infrastructure/di/golden_path_integration_test.go
+++ b/internal/infrastructure/di/golden_path_integration_test.go
@@ -41,6 +41,10 @@ func (m *goldenPathMockClient) GenerateImages(ctx context.Context, model, prompt
 
 func (m *goldenPathMockClient) RefreshAuth() error { return nil }
 
+func (m *goldenPathMockClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 // TestGoldenPath_ConfigToShutdown exercises the full vertical:
 // DI bootstrap → agent init → chat → graceful shutdown.
 // It runs in-process under -short and -race.

--- a/internal/infrastructure/di/lazy_client.go
+++ b/internal/infrastructure/di/lazy_client.go
@@ -61,5 +61,13 @@ func (lc *lazyClient) RefreshAuth() error {
 	return lc.client.RefreshAuth()
 }
 
+func (lc *lazyClient) ExtractDocument(ctx stdctx.Context, data []byte, filename string) (string, error) {
+	lc.init()
+	if lc.err != nil {
+		return "", fmt.Errorf("LLM provider initialization failed: %w", lc.err)
+	}
+	return lc.client.ExtractDocument(ctx, data, filename)
+}
+
 // Ensure LazyClient satisfies llm.ExtendedClient at compile time.
 var _ llm.ExtendedClient = (*lazyClient)(nil)

--- a/internal/infrastructure/di/lazy_test.go
+++ b/internal/infrastructure/di/lazy_test.go
@@ -251,6 +251,10 @@ func (m *mockExtendedClient) RefreshAuth() error {
 	return nil
 }
 
+func (m *mockExtendedClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 func (m *mockExtendedClient) Close() error {
 	m.closeCalls++
 	if m.CloseFunc != nil {

--- a/internal/infrastructure/llm/anthropic/client.go
+++ b/internal/infrastructure/llm/anthropic/client.go
@@ -313,6 +313,10 @@ func (c *client) GenerateImages(ctx context.Context, model, prompt string, mimeT
 	return nil, fmt.Errorf("GenerateImages not implemented for Anthropic")
 }
 
+func (c *client) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 func (c *client) RefreshAuth() error {
 	c.authenticator.Invalidate()
 	return nil

--- a/internal/infrastructure/llm/anthropic/client.go
+++ b/internal/infrastructure/llm/anthropic/client.go
@@ -310,7 +310,7 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 }
 
 func (c *client) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
-	return nil, fmt.Errorf("GenerateImages not implemented for Anthropic")
+	return nil, llm.ErrNotImplemented
 }
 
 func (c *client) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {

--- a/internal/infrastructure/llm/failover.go
+++ b/internal/infrastructure/llm/failover.go
@@ -19,8 +19,8 @@ type namedClient struct {
 
 // FailoverGateway implements llm.ExtendedClient by iterating through an ordered
 // list of provider clients on Generate, falling through on transient errors.
-// Non-Generate methods (SendChat, GenerateImages, RefreshAuth) delegate to the
-// primary (first) client.
+// Non-Generate methods (SendChat, GenerateImages, ExtractDocument, RefreshAuth)
+// delegate to the primary (first) client.
 //
 // Separation of concerns:
 //

--- a/internal/infrastructure/llm/failover.go
+++ b/internal/infrastructure/llm/failover.go
@@ -113,3 +113,8 @@ func (fg *failoverGateway) GenerateImages(ctx context.Context, model, prompt str
 func (fg *failoverGateway) RefreshAuth() error {
 	return fg.clients[0].Client.RefreshAuth()
 }
+
+// ExtractDocument delegates to the primary client.
+func (fg *failoverGateway) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return fg.clients[0].Client.ExtractDocument(ctx, data, filename)
+}

--- a/internal/infrastructure/llm/failover_integration_test.go
+++ b/internal/infrastructure/llm/failover_integration_test.go
@@ -31,6 +31,10 @@ func (m *primaryMockClient) GenerateImages(ctx context.Context, model, prompt, m
 
 func (m *primaryMockClient) RefreshAuth() error { return nil }
 
+func (m *primaryMockClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", domain_llm.ErrNotImplemented
+}
+
 // secondaryMockClient returns a success response.
 type secondaryMockClient struct{ callCount *int32 }
 
@@ -51,6 +55,10 @@ func (m *secondaryMockClient) GenerateImages(ctx context.Context, model, prompt,
 }
 
 func (m *secondaryMockClient) RefreshAuth() error { return nil }
+
+func (m *secondaryMockClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", domain_llm.ErrNotImplemented
+}
 
 // TestFailover_PrimaryTransient_SecondarySucceeds verifies that when the
 // primary client returns a transient error, the FailoverGateway falls

--- a/internal/infrastructure/llm/failover_test.go
+++ b/internal/infrastructure/llm/failover_test.go
@@ -65,6 +65,10 @@ func (m *mockExtendedClient) RefreshAuth() error {
 	return nil
 }
 
+func (m *mockExtendedClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 // assertPanic asserts that fn panics with a message containing wantMsg.
 func assertPanic(t *testing.T, fn func(), wantMsg string) {
 	t.Helper()

--- a/internal/infrastructure/llm/gemini/gemini.go
+++ b/internal/infrastructure/llm/gemini/gemini.go
@@ -203,3 +203,8 @@ func (c *Client) GenerateImages(ctx context.Context, model, prompt string, mimeT
 
 	return results, nil
 }
+
+// ExtractDocument is not supported by Gemini.
+func (c *Client) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -739,6 +739,10 @@ func (c *client) GenerateImages(ctx context.Context, model, prompt string, mimeT
 	return nil, fmt.Errorf("GenerateImages not implemented for OpenAI")
 }
 
+func (c *client) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return c.extractDocument(ctx, data, filename)
+}
+
 func (c *client) RefreshAuth() error {
 	c.authenticator.Invalidate()
 	return nil

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -736,7 +736,7 @@ func (c *client) parseResponseToolCalls(toolCalls []toolCall, content *llm.Conte
 }
 
 func (c *client) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
-	return nil, fmt.Errorf("GenerateImages not implemented for OpenAI")
+	return nil, llm.ErrNotImplemented
 }
 
 func (c *client) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {

--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"mime/multipart"
 	"net/http"
+	"time"
 )
 
 // fileObject is the API response from POST /v1/files.
@@ -138,8 +139,11 @@ func (c *client) extractDocument(ctx context.Context, data []byte, filename stri
 		return "", fmt.Errorf("upload document: %w", err)
 	}
 	defer func() {
-		// Best-effort cleanup; don't shadow the primary error
-		_ = c.deleteFile(ctx, fileID)
+		// Best-effort cleanup with detached context — not gated by
+		// the caller's context deadline.
+		cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 10*time.Second)
+		defer cancel()
+		_ = c.deleteFile(cleanupCtx, fileID)
 	}()
 
 	content, err := c.getFileContent(ctx, fileID)

--- a/internal/infrastructure/llm/resilient_client.go
+++ b/internal/infrastructure/llm/resilient_client.go
@@ -101,3 +101,8 @@ func (r *resilientClient) RefreshAuth() error {
 func (r *resilientClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
 	return r.client.GenerateImages(ctx, model, prompt, mimeType)
 }
+
+// ExtractDocument delegates to the underlying client.
+func (r *resilientClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return r.client.ExtractDocument(ctx, data, filename)
+}

--- a/internal/infrastructure/llm/resilient_client_test.go
+++ b/internal/infrastructure/llm/resilient_client_test.go
@@ -216,6 +216,10 @@ func (m *mockLLMClient) GenerateImages(ctx context.Context, model, prompt string
 	return nil, nil
 }
 
+func (m *mockLLMClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+
 func (m *mockLLMClient) ResetConnections() {
 	m.resetCalled = true
 }

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -75,6 +75,9 @@ func (m *mediaManager) createImage(ctx context.Context, args map[string]interfac
 
 	images, err := m.client.GenerateImages(ctx, req.Model, prompt, "image/png")
 	if err != nil {
+		if errors.Is(err, llm.ErrNotImplemented) {
+			return tools.ToolResult{}, tools.ErrNotImplemented
+		}
 		return tools.ToolResult{}, fmt.Errorf("generate images: %w", err)
 	}
 

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -260,7 +260,7 @@ func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Mana
 		return err
 	}
 
-	if err := r.RegisterToToolkit("media", &tools.ToolDeclaration{
+	if err := r.RegisterToToolkitWithOptions("media", &tools.ToolDeclaration{
 		Name:        "read_document",
 		Description: "Extracts text content from a document file (PDF, DOCX, MD, TXT, etc.) using the provider's document extraction API. Returns the full extracted text.",
 		Parameters: &tools.Schema{
@@ -273,7 +273,7 @@ func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Mana
 			},
 			Required: []string{"filepath"},
 		},
-	}, m.readDocument); err != nil {
+	}, m.readDocument, tools.ToolOptions{LongRunning: true}); err != nil {
 		return err
 	}
 	return nil

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -5,6 +5,7 @@ package integrations
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -172,6 +173,48 @@ func (m *mediaManager) readImage(ctx context.Context, args map[string]interface{
 	}, nil
 }
 
+func (m *mediaManager) readDocument(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	if m.client == nil {
+		return tools.ToolResult{}, tools.ErrNotImplemented
+	}
+
+	var a struct {
+		Filepath string `json:"filepath"`
+	}
+	if err := tools.UnmarshalArgs(args, &a); err != nil {
+		return tools.ToolResult{}, fmt.Errorf("unmarshal args: %w", err)
+	}
+
+	if m.sm == nil {
+		return tools.ToolResult{}, fmt.Errorf("path validator is required")
+	}
+
+	safePath, err := m.sm.IsPathSafe(a.Filepath)
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("security validation failed for path %s: %w", a.Filepath, err)
+	}
+
+	data, err := m.fs.ReadFile(ctx, safePath)
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("read file %s: %w", safePath, err)
+	}
+
+	stop := telemetry.StartHeartbeat(ctx, m.heartbeatInterval, hb)
+	defer stop()
+
+	text, err := m.client.ExtractDocument(ctx, data, filepath.Base(safePath))
+	if err != nil {
+		if errors.Is(err, llm.ErrNotImplemented) {
+			return tools.ToolResult{}, tools.ErrNotImplemented
+		}
+		return tools.ToolResult{}, fmt.Errorf("extract document: %w", err)
+	}
+
+	return tools.ToolResult{
+		Text: fmt.Sprintf("--- Extracted content from %s ---\n%s", safePath, text),
+	}, nil
+}
+
 func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Manager, client llm.LLMClient, assetsDir string) error {
 	m := newMediaManager(fs, sm, client, assetsDir)
 
@@ -214,6 +257,23 @@ func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Mana
 			Required: []string{"filepath"},
 		},
 	}, m.readImage); err != nil {
+		return err
+	}
+
+	if err := r.RegisterToToolkit("media", &tools.ToolDeclaration{
+		Name:        "read_document",
+		Description: "Extracts text content from a document file (PDF, DOCX, MD, TXT, etc.) using the provider's document extraction API. Returns the full extracted text.",
+		Parameters: &tools.Schema{
+			Type: "OBJECT",
+			Properties: map[string]*tools.Schema{
+				"filepath": {
+					Type:        "STRING",
+					Description: "The path to the document file (e.g., './assets/report.pdf').",
+				},
+			},
+			Required: []string{"filepath"},
+		},
+	}, m.readDocument); err != nil {
 		return err
 	}
 	return nil

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"go.uber.org/goleak"
@@ -645,4 +646,103 @@ func TestRegisterMedia_ErrorPaths(t *testing.T) {
 			t.Errorf("expected simulated error, got: %v", err)
 		}
 	})
+
+	t.Run("third RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 2)
+		err := registerMedia(r, fs, sm, client, tmpDir)
+		if err == nil {
+			t.Fatal("expected error on third registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
 }
+
+func TestReadDocument(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.pdf")
+	content := "extracted document text"
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := newMediaMockSecurityManager()
+
+	client := &documentExtractorClient{text: content}
+
+	m := newMediaManager(persistencetest.NewPlainOSFileSystem(), sm, client, tempDir,
+		withMediaHeartbeatInterval(10*time.Millisecond),
+	)
+
+	ctx := context.Background()
+	res, err := m.readDocument(ctx, map[string]interface{}{
+		"filepath": path,
+	}, nil)
+	if err != nil {
+		t.Fatalf("readDocument: %v", err)
+	}
+	if !strings.Contains(res.Text, content) {
+		t.Errorf("expected extracted text, got %q", res.Text)
+	}
+	if !strings.Contains(res.Text, path) {
+		t.Errorf("expected path in output, got %q", res.Text)
+	}
+}
+
+func TestReadDocument_NotImplemented(t *testing.T) {
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, "test.pdf")
+	if err := os.WriteFile(path, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	sm := newMediaMockSecurityManager()
+
+	client := &notImplementedDocumentClient{}
+
+	m := newMediaManager(persistencetest.NewPlainOSFileSystem(), sm, client, tempDir,
+		withMediaHeartbeatInterval(10*time.Millisecond),
+	)
+
+	ctx := context.Background()
+	_, err := m.readDocument(ctx, map[string]interface{}{
+		"filepath": path,
+	}, nil)
+	if err == nil {
+		t.Fatal("expected ErrNotImplemented")
+	}
+	if !errors.Is(err, tools.ErrNotImplemented) {
+		t.Errorf("expected ErrNotImplemented, got %v", err)
+	}
+}
+
+// documentExtractorClient implements llm.LLMClient with a stub ExtractDocument.
+type documentExtractorClient struct {
+	text string
+}
+
+func (c *documentExtractorClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return c.text, nil
+}
+
+func (c *documentExtractorClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+func (c *documentExtractorClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (c *documentExtractorClient) RefreshAuth() error { return nil }
+
+type notImplementedDocumentClient struct{}
+
+func (c *notImplementedDocumentClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", llm.ErrNotImplemented
+}
+func (c *notImplementedDocumentClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+func (c *notImplementedDocumentClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (c *notImplementedDocumentClient) RefreshAuth() error { return nil }

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -589,13 +589,13 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 		},
 		{
 			name:            "network wraps error",
-			failAfter:       27,
+			failAfter:       28,
 			wantSubstring:   "network",
 			setAtlassianEnv: true,
 		},
 		{
 			name:            "teams wraps error",
-			failAfter:       29,
+			failAfter:       30,
 			wantSubstring:   "teams",
 			setAtlassianEnv: true,
 		},


### PR DESCRIPTION
Adds `read_document` agent tool that extracts text from documents (PDF, DOCX, MD, etc.) using the provider's file extraction API.

## Changes

- **types.go**: `ExtractDocument(ctx, data, filename) (string, error)` added to `LLMClient` interface + `ErrNotImplemented` sentinel
- **openai/client.go**: delegates to existing `extractDocument` in `files.go` (Kimi file API: upload → get content → delete)
- **anthropic, gemini**: return `ErrNotImplemented`
- **resilient_client, failover, lazy_client**: delegate through
- **media.go**: `readDocument` method on `mediaManager` — security-validated file read → `client.ExtractDocument` → returns extracted text. Handles `ErrNotImplemented` for non-Kimi providers. Tool registered as `read_document` in media toolkit.
- All mock/stub types updated with `ExtractDocument` stubs.

## Usage

```
read_document(filepath="/path/to/report.pdf")
→ "--- Extracted content from report.pdf ---\n[full text]"
```

Replaces the 5-turn `pdftotext`/`gs`/`read_image` workaround for PDFs. Works only with Kimi provider (uses `/v1/files` with `purpose="file-extract"`).