### PR TITLE
fix(llm): accept Kimi upload status "ok" alongside "ready"

### DIFF
--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -72,6 +72,7 @@ func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose 
 		return "", fmt.Errorf("decode upload response: %w", err)
 	}
 
+	// Live api.moonshot.ai returns "ok" (observed 2026-07-23); docs say "ready". Accept both.
 	if fo.Status != "ok" && fo.Status != "ready" {
 		return "", fmt.Errorf("upload status %q (expected ok or ready)", fo.Status)
 	}

--- a/internal/infrastructure/llm/openai/files.go
+++ b/internal/infrastructure/llm/openai/files.go
@@ -72,8 +72,8 @@ func (c *client) uploadFile(ctx context.Context, data []byte, filename, purpose 
 		return "", fmt.Errorf("decode upload response: %w", err)
 	}
 
-	if fo.Status != "ready" {
-		return "", fmt.Errorf("upload status %q (expected ready)", fo.Status)
+	if fo.Status != "ok" && fo.Status != "ready" {
+		return "", fmt.Errorf("upload status %q (expected ok or ready)", fo.Status)
 	}
 
 	return fo.ID, nil

--- a/internal/infrastructure/llm/openai/files_live_test.go
+++ b/internal/infrastructure/llm/openai/files_live_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package openai
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
+)
+
+// TestKimiFilesContract_Live verifies end-to-end file upload, content
+// extraction, and cleanup against the live Moonshot API. It is gated
+// behind MOONSHOT_API_KEY + KIMI_LIVE_TEST=1 and never runs in CI.
+//
+// Run manually:
+//
+//	KIMI_LIVE_TEST=1 go test -run TestKimiFilesContract_Live -v -count=1 ./internal/infrastructure/llm/openai/
+func TestKimiFilesContract_Live(t *testing.T) {
+	apiKey := os.Getenv("MOONSHOT_API_KEY")
+	if apiKey == "" || os.Getenv("KIMI_LIVE_TEST") != "1" {
+		t.Skip("skipping live contract test: set MOONSHOT_API_KEY and KIMI_LIVE_TEST=1")
+	}
+
+	c := &client{
+		baseURL:    "https://api.moonshot.ai/v1",
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &auth.BearerAuth{Token: apiKey}
+
+	ctx := context.Background()
+
+	// Upload a tiny text file and extract content end-to-end
+	content, err := c.extractDocument(ctx, []byte("hello from live contract test"), "contract-test.txt")
+	if err != nil {
+		t.Fatalf("extractDocument against live API: %v", err)
+	}
+
+	if content == "" {
+		t.Error("extracted content is empty — expected non-empty text")
+	}
+
+	t.Logf("extracted content: %s", content)
+}

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -45,9 +45,11 @@ func TestUploadFile(t *testing.T) {
 			t.Errorf("expected file content 'test', got %q", string(buf))
 		}
 
+		// Live api.moonshot.ai returns "ok" (observed 2026-07-23).
+		// Docs: https://platform.kimi.ai/docs/api/files-upload.md (example: "ready")
 		_ = json.NewEncoder(w).Encode(fileObject{
 			ID:     "file-abc123",
-			Status: "ready",
+			Status: "ok",
 		})
 	}))
 	defer server.Close()
@@ -106,8 +108,38 @@ func TestUploadFile_NotReady(t *testing.T) {
 	c.authenticator = &fakeAuthenticator{}
 
 	_, err := c.uploadFile(context.Background(), []byte("test"), "cat.png", "image")
-	if err == nil || !strings.Contains(err.Error(), "expected ready") {
-		t.Errorf("expected 'expected ready' error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "expected ok or ready") {
+		t.Errorf("expected 'expected ok or ready' error, got %v", err)
+	}
+}
+
+// TestUploadFile_ReadyAlsoAccepted verifies that the documented
+// "ready" status is accepted for forward-compatibility, even though
+// the live api.moonshot.ai currently returns "ok".
+func TestUploadFile_ReadyAlsoAccepted(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(fileObject{
+			ID: "file-ready123",
+			// Docs: https://platform.kimi.ai/docs/api/files-upload.md (example: "ready")
+			// Server may align with docs in the future — accept both.
+			Status: "ready",
+		})
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    strings.TrimSuffix(server.URL, "/"),
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+
+	id, err := c.uploadFile(context.Background(), []byte("test"), "doc.md", "file-extract")
+	if err != nil {
+		t.Fatalf("uploadFile with status 'ready': %v", err)
+	}
+	if id != "file-ready123" {
+		t.Errorf("expected file-ready123, got %s", id)
 	}
 }
 
@@ -162,7 +194,9 @@ func TestExtractDocument(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.Method == "POST" && r.URL.Path == "/files":
-			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-doc", Status: "ready"})
+			// Live api.moonshot.ai returns "ok" (observed 2026-07-23).
+			// Docs: https://platform.kimi.ai/docs/api/files-upload.md (example: "ready")
+			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-doc", Status: "ok"})
 		case r.Method == "GET" && strings.HasSuffix(r.URL.Path, "/content"):
 			_, _ = w.Write([]byte("doc content here"))
 		case r.Method == "DELETE":
@@ -298,7 +332,9 @@ func TestPrepareImageAssets_KimiURL_Uploads(t *testing.T) {
 		switch {
 		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/files"):
 			uploaded = true
-			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-xyz", Status: "ready"})
+			// Live api.moonshot.ai returns "ok" (observed 2026-07-23).
+			// Docs: https://platform.kimi.ai/docs/api/files-upload.md (example: "ready")
+			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-xyz", Status: "ok"})
 		case r.Method == "DELETE":
 			deleted = true
 			w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

The live Moonshot API (`api.moonshot.ai`) returns `status: "ok"` on successful file upload, but the published docs at https://platform.kimi.ai/docs/api/files-upload.md show `example: ready`. The gate at `uploadFile` previously only accepted `"ready"`, causing:

- **`read_document` tool**: 100% failure rate on Kimi provider
- **Kimi vision** image uploads: broken (same gate)

## Changes

| File | Change |
|------|--------|
| `internal/infrastructure/llm/openai/files.go:76` | Accept both `"ok"` and `"ready"`: `if fo.Status != "ok" && fo.Status != "ready"` |
| `internal/infrastructure/llm/openai/files_test.go` | Mock fixtures updated to return `"ok"` (observed live value), error assertion updated, new `TestUploadFile_ReadyAlsoAccepted` |
| `internal/infrastructure/llm/openai/files_live_test.go` | **New** — opt-in live contract test gated by `MOONSHOT_API_KEY` + `KIMI_LIVE_TEST=1` |

## Why tests didn't catch it

All three mock servers returned `Status: "ready"` — the doc-derived assumption. The suite green-lit a contract that doesn't exist in production. Live contract test prevents recurrence.

Fixes #1255