### PR TITLE
llm: add Kimi video support — capability flag, media generalization, video_url blocks

### DIFF
--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -74,6 +74,13 @@ type Capabilities struct {
 	//
 	// Set for: kimi-* models (K3, K2.7, K2.6).
 	SupportsVision bool
+	// SupportsVideo indicates the model natively understands video via
+	// video_url content parts in the messages array. When true, InlineData
+	// parts with video MIME types are uploaded with purpose="video" and
+	// serialized as video_url blocks.
+	//
+	// Set for: kimi-* models (K3, K2.7, K2.6).
+	SupportsVideo bool
 	// RequiresVertexThinkingKwargs indicates that the transport silently
 	// disables DeepSeek thinking mode unless the non-standard parameter
 	// chat_template_kwargs.thinking=true is included in the request body.
@@ -175,6 +182,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 	if isKimiModel(model) {
 		caps.SupportsReasoningContent = true
 		caps.SupportsVision = true
+		caps.SupportsVideo = true
 		if isKimiK3Model(model) {
 			caps.SupportsReasoningEffort = true
 		}

--- a/internal/domain/llm/capabilities_test.go
+++ b/internal/domain/llm/capabilities_test.go
@@ -19,6 +19,7 @@ func TestResolveCapabilities(t *testing.T) {
 		isDeepSeek                   bool
 		supportsReasoningContent     bool
 		supportsVision               bool
+		supportsVideo                bool
 		requiresVertexThinkingKwargs bool
 	}{
 		{
@@ -222,6 +223,7 @@ func TestResolveCapabilities(t *testing.T) {
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  true,
 			supportsVision:           true,
+			supportsVideo:            true,
 			maxTokensField:           MaxTokensFieldCompletion,
 		},
 		{
@@ -231,6 +233,7 @@ func TestResolveCapabilities(t *testing.T) {
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  true,
 			supportsVision:           true,
+			supportsVideo:            true,
 			maxTokensField:           MaxTokensFieldCompletion,
 		},
 		{
@@ -240,6 +243,7 @@ func TestResolveCapabilities(t *testing.T) {
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  false,
 			supportsVision:           true,
+			supportsVideo:            true,
 			maxTokensField:           MaxTokensFieldLegacy,
 		},
 		{
@@ -249,6 +253,7 @@ func TestResolveCapabilities(t *testing.T) {
 			supportsReasoningContent: true,
 			supportsReasoningEffort:  false,
 			supportsVision:           true,
+			supportsVideo:            true,
 			maxTokensField:           MaxTokensFieldLegacy,
 		},
 	}
@@ -281,6 +286,9 @@ func TestResolveCapabilities(t *testing.T) {
 			if caps.SupportsVision != tt.supportsVision {
 				t.Errorf("expected SupportsVision %v, got %v", tt.supportsVision, caps.SupportsVision)
 			}
+			if caps.SupportsVideo != tt.supportsVideo {
+				t.Errorf("expected SupportsVideo %v, got %v", tt.supportsVideo, caps.SupportsVideo)
+			}
 			if caps.RequiresVertexThinkingKwargs != tt.requiresVertexThinkingKwargs {
 				t.Errorf("expected RequiresVertexThinkingKwargs %v, got %v", tt.requiresVertexThinkingKwargs, caps.RequiresVertexThinkingKwargs)
 			}
@@ -312,6 +320,18 @@ func TestParseGPTVersion(t *testing.T) {
 			got := parseGPTVersion(tt.model)
 			if got != tt.want {
 				t.Errorf("parseGPTVersion(%q) = %+v; want %+v", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveCapabilities_SupportsVideo_TrueForKimiModels(t *testing.T) {
+	kimiModels := []string{"kimi-k3", "kimi-k2.7-code", "kimi-k2.6"}
+	for _, model := range kimiModels {
+		t.Run(model, func(t *testing.T) {
+			caps := ResolveCapabilities(model, "")
+			if !caps.SupportsVideo {
+				t.Errorf("expected SupportsVideo=true for %s, got false", model)
 			}
 		})
 	}

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -225,7 +225,7 @@ func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls
 	// Prepare media assets for the turn: hydrate from resolver,
 	// upload to Kimi file API. Skip if no vision/video capability.
 	var ta *turnAssets
-	if c.capabilities.SupportsVision {
+	if c.capabilities.SupportsVision || c.capabilities.SupportsVideo {
 		var prepared []*llm.Part
 		var err error
 		ta, prepared, err = c.prepareMediaAssets(ctx, collectHistoryParts(history), resolver)

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -222,13 +222,13 @@ func (c *client) createHTTPRequest(ctx context.Context, payload *chatRequest) (*
 // ---------------------------------------------------------------------------
 
 func (c *client) SendChat(ctx context.Context, history []*llm.Content, toolDecls []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
-	// Prepare image assets for the turn: hydrate from resolver,
-	// upload to Kimi file API. Skip if no vision capability.
+	// Prepare media assets for the turn: hydrate from resolver,
+	// upload to Kimi file API. Skip if no vision/video capability.
 	var ta *turnAssets
 	if c.capabilities.SupportsVision {
 		var prepared []*llm.Part
 		var err error
-		ta, prepared, err = c.prepareImageAssets(ctx, collectHistoryParts(history), resolver)
+		ta, prepared, err = c.prepareMediaAssets(ctx, collectHistoryParts(history), resolver)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -231,7 +231,7 @@ type imageURLValue struct {
 	URL string `json:"url"`
 }
 
-// videoURLBlock represents a video_url content part for vision-capable models.
+// videoURLBlock represents a video_url content part for video-capable models.
 type videoURLBlock struct {
 	Type     string        `json:"type"`
 	VideoURL videoURLValue `json:"video_url"`

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -231,6 +231,17 @@ type imageURLValue struct {
 	URL string `json:"url"`
 }
 
+// videoURLBlock represents a video_url content part for vision-capable models.
+type videoURLBlock struct {
+	Type     string        `json:"type"`
+	VideoURL videoURLValue `json:"video_url"`
+}
+
+// videoURLValue holds the URL payload for a video_url block.
+type videoURLValue struct {
+	URL string `json:"url"`
+}
+
 // turnAssets carries turn-scoped file-upload state: the binding from
 // domain Parts to Kimi server file IDs, plus a list of uploaded file
 // IDs for post-response cleanup. It is owned by a single SendChat call
@@ -297,7 +308,7 @@ func collectHistoryParts(history []*llm.Content) []*llm.Part {
 }
 
 // applyPreparedParts writes prepared parts back into history, matching
-// by index. Call after prepareImageAssets has mutated parts in place.
+// by index. Call after prepareMediaAssets has mutated parts in place.
 func applyPreparedParts(history []*llm.Content, prepared []*llm.Part) {
 	idx := 0
 	for _, h := range history {
@@ -428,9 +439,9 @@ func (c *client) appendMessagesFromHistoryItem(
 		return nil
 	}
 
-	// Separate image parts before classification — classifyParts only
+	// Separate media parts before classification — classifyParts only
 	// handles text and function calls.
-	imageParts, textParts := extractImageParts(otherParts)
+	mediaParts, textParts := extractMediaParts(otherParts)
 
 	text, reasoning, toolCalls, err := c.classifyParts(textParts)
 	if err != nil {
@@ -444,14 +455,14 @@ func (c *client) appendMessagesFromHistoryItem(
 		reasoningPtr = &reasoning
 	}
 
-	// Build content: array format when images present AND vision supported,
+	// Build content: array format when media present AND vision/video supported,
 	// string format otherwise.
 	var content any = text
-	if c.capabilities.SupportsVision && len(imageParts) > 0 {
-		// Images are placed before text (images-first ordering). This is
+	if (c.capabilities.SupportsVision || c.capabilities.SupportsVideo) && len(mediaParts) > 0 {
+		// Media blocks are placed before text (media-first ordering). This is
 		// intentional for the describe-this-image use case — interleaved
 		// part ordering within a single history item is not preserved.
-		blocks := imageBlocks(imageParts, ta)
+		blocks := mediaBlocks(mediaParts, ta)
 		if text != "" {
 			blocks = append(blocks, requestContentBlock{Type: "text", Text: text})
 		}
@@ -483,12 +494,12 @@ func partitionParts(parts []*llm.Part) (toolResponseParts []*llm.Part, otherPart
 	return
 }
 
-// extractImageParts separates InlineData parts from a part slice.
-// Returns the image parts and the remaining non-image, non-tool-response parts.
-func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part) {
+// extractMediaParts separates InlineData parts (image and video) from a part slice.
+// Returns the media parts and the remaining non-media, non-tool-response parts.
+func extractMediaParts(parts []*llm.Part) (media []*llm.Part, rest []*llm.Part) {
 	for _, p := range parts {
 		if p.InlineData != nil && len(p.InlineData.Data) > 0 {
-			images = append(images, p)
+			media = append(media, p)
 		} else {
 			rest = append(rest, p)
 		}
@@ -504,7 +515,7 @@ func extractImageParts(parts []*llm.Part) (images []*llm.Part, rest []*llm.Part)
 // models return the input unchanged. Resolve errors are propagated:
 // a corrupt asset store should fail the session loudly.
 func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) ([]*llm.Part, error) {
-	if resolver == nil || !c.capabilities.SupportsVision {
+	if resolver == nil || (!c.capabilities.SupportsVision && !c.capabilities.SupportsVideo) {
 		return parts, nil
 	}
 	out := parts
@@ -538,11 +549,11 @@ func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, reso
 	return out, nil
 }
 
-// prepareImageAssets hydrates and uploads image parts for a single
-// turn. Returns the turnAssets with file bindings and the prepared
-// (possibly cloned) part slice. Caller must call release after the
-// LLM response.
-func (c *client) prepareImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) (*turnAssets, []*llm.Part, error) {
+// prepareMediaAssets hydrates and uploads media parts (image and video)
+// for a single turn. Returns the turnAssets with file bindings and the
+// prepared (possibly cloned) part slice. Caller must call release after
+// the LLM response.
+func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) (*turnAssets, []*llm.Part, error) {
 	ta := newTurnAssets()
 
 	out, err := c.hydrateImageAssets(ctx, parts, resolver)
@@ -550,8 +561,8 @@ func (c *client) prepareImageAssets(ctx context.Context, parts []*llm.Part, reso
 		return ta, out, err
 	}
 
-	// Upload fresh images to Kimi file API
-	if !c.capabilities.SupportsVision || !strings.Contains(c.baseURL, "api.moonshot.ai") {
+	// Upload fresh media to Kimi file API
+	if (!c.capabilities.SupportsVision && !c.capabilities.SupportsVideo) || !strings.Contains(c.baseURL, "api.moonshot.ai") {
 		return ta, out, nil
 	}
 	for _, p := range out {
@@ -568,10 +579,14 @@ func (c *client) prepareImageAssets(ctx context.Context, parts []*llm.Part, reso
 			}
 		}
 		filename := fmt.Sprintf("image.%s", ext)
-		fileID, err := c.uploadFile(ctx, p.InlineData.Data, filename, "image")
+		purpose := "image"
+		if strings.HasPrefix(p.InlineData.MIMEType, "video/") {
+			purpose = "video"
+		}
+		fileID, err := c.uploadFile(ctx, p.InlineData.Data, filename, purpose)
 		if err != nil {
 			ta.release(ctx, c)
-			return ta, out, fmt.Errorf("upload image: %w", err)
+			return ta, out, fmt.Errorf("upload media: %w", err)
 		}
 		ta.bindings[p] = fileID
 		ta.uploaded = append(ta.uploaded, fileID)
@@ -579,20 +594,28 @@ func (c *client) prepareImageAssets(ctx context.Context, parts []*llm.Part, reso
 	return ta, out, nil
 }
 
-// imageBlocks converts InlineData parts to image_url content blocks.
+// mediaBlocks converts InlineData parts to image_url or video_url content blocks.
 // Uses turnAssets to resolve ms:// URLs for uploaded files; falls
-// back to base64 data URIs for non-uploaded parts.
-func imageBlocks(parts []*llm.Part, ta *turnAssets) []any {
+// back to base64 data URIs for non-uploaded parts. Video MIME types
+// (video/*) produce video_url blocks; all others produce image_url blocks.
+func mediaBlocks(parts []*llm.Part, ta *turnAssets) []any {
 	var blocks []any
 	for _, p := range parts {
 		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
 			continue
 		}
 		url := ta.resolveURL(p)
-		blocks = append(blocks, imageURLBlock{
-			Type:     "image_url",
-			ImageURL: imageURLValue{URL: url},
-		})
+		if strings.HasPrefix(p.InlineData.MIMEType, "video/") {
+			blocks = append(blocks, videoURLBlock{
+				Type:     "video_url",
+				VideoURL: videoURLValue{URL: url},
+			})
+		} else {
+			blocks = append(blocks, imageURLBlock{
+				Type:     "image_url",
+				ImageURL: imageURLValue{URL: url},
+			})
+		}
 	}
 	return blocks
 }

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -507,14 +507,14 @@ func extractMediaParts(parts []*llm.Part) (media []*llm.Part, rest []*llm.Part) 
 	return
 }
 
-// hydrateImageAssets resolves AssetID references on parts whose
+// hydrateMediaAssets resolves AssetID references on parts whose
 // InlineData.Data is nil (lazy-hydration pattern from session reload).
 // It uses copy-on-write — the returned slice is independent of the
 // input — to avoid mutating shared session history. Preserves MIMEType
-// from any existing InlineData blob. Gated on SupportsVision; non-vision
-// models return the input unchanged. Resolve errors are propagated:
-// a corrupt asset store should fail the session loudly.
-func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) ([]*llm.Part, error) {
+// from any existing InlineData blob. Gated on SupportsVision || SupportsVideo;
+// non-vision/non-video models return the input unchanged. Resolve errors are
+// propagated: a corrupt asset store should fail the session loudly.
+func (c *client) hydrateMediaAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) ([]*llm.Part, error) {
 	if resolver == nil || (!c.capabilities.SupportsVision && !c.capabilities.SupportsVideo) {
 		return parts, nil
 	}
@@ -556,7 +556,7 @@ func (c *client) hydrateImageAssets(ctx context.Context, parts []*llm.Part, reso
 func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, resolver llm.AssetResolver) (*turnAssets, []*llm.Part, error) {
 	ta := newTurnAssets()
 
-	out, err := c.hydrateImageAssets(ctx, parts, resolver)
+	out, err := c.hydrateMediaAssets(ctx, parts, resolver)
 	if err != nil {
 		return ta, out, err
 	}
@@ -578,11 +578,11 @@ func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, reso
 				ext = parts[1]
 			}
 		}
-		filename := fmt.Sprintf("image.%s", ext)
 		purpose := "image"
 		if strings.HasPrefix(p.InlineData.MIMEType, "video/") {
 			purpose = "video"
 		}
+		filename := fmt.Sprintf("%s.%s", purpose, ext)
 		fileID, err := c.uploadFile(ctx, p.InlineData.Data, filename, purpose)
 		if err != nil {
 			ta.release(ctx, c)

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -308,7 +308,7 @@ func TestHydrateImageAssets(t *testing.T) {
 				capabilities: llm.Capabilities{SupportsVision: tt.visionCap},
 				logger:       &ports.NoOpLogger{},
 			}
-			got, err := c.hydrateImageAssets(context.Background(), tt.parts, tt.resolver)
+			got, err := c.hydrateMediaAssets(context.Background(), tt.parts, tt.resolver)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("error = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -233,7 +233,7 @@ func TestVision_KimiMsURLPayload(t *testing.T) {
 	}
 }
 
-func TestHydrateImageAssets(t *testing.T) {
+func TestHydrateMediaAssets(t *testing.T) {
 	resolver := &testAssetResolver{
 		data: map[string][]byte{
 			"asset-1": []byte{0x89, 0x50, 0x4E, 0x47},

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 )
 
-func TestImageBlocks(t *testing.T) {
+func TestMediaBlocks(t *testing.T) {
 	tests := []struct {
 		name  string
 		parts []*llm.Part
@@ -26,40 +26,53 @@ func TestImageBlocks(t *testing.T) {
 			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}},
 			{InlineData: &llm.Blob{MIMEType: "image/jpeg", Data: []byte{2}}},
 		}, 2},
-		{"no images", []*llm.Part{{Text: "hello"}}, 0},
+		{"single video", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: []byte{0x00, 0x00, 0x00}}}}, 1},
+		{"mixed image and video", []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}},
+			{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: []byte{2}}},
+		}, 2},
+		{"no media", []*llm.Part{{Text: "hello"}}, 0},
 		{"nil InlineData", []*llm.Part{{InlineData: nil}}, 0},
 		{"empty data", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: nil}}}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			blocks := imageBlocks(tt.parts, nil)
+			blocks := mediaBlocks(tt.parts, nil)
 			if len(blocks) != tt.want {
 				t.Errorf("got %d blocks, want %d", len(blocks), tt.want)
 			}
-			// Verify base64 URL format for image blocks
+			// Verify URL format for each block type
 			for _, b := range blocks {
-				ib, ok := b.(imageURLBlock)
-				if !ok {
-					t.Fatal("block is not imageURLBlock")
-				}
-				if ib.Type != "image_url" {
-					t.Errorf("type = %q, want image_url", ib.Type)
-				}
-				if !strings.HasPrefix(ib.ImageURL.URL, "data:") {
-					t.Errorf("URL doesn't start with data: %q", ib.ImageURL.URL)
+				switch block := b.(type) {
+				case imageURLBlock:
+					if block.Type != "image_url" {
+						t.Errorf("image type = %q, want image_url", block.Type)
+					}
+					if !strings.HasPrefix(block.ImageURL.URL, "data:") {
+						t.Errorf("image URL doesn't start with data: %q", block.ImageURL.URL)
+					}
+				case videoURLBlock:
+					if block.Type != "video_url" {
+						t.Errorf("video type = %q, want video_url", block.Type)
+					}
+					if !strings.HasPrefix(block.VideoURL.URL, "data:") {
+						t.Errorf("video URL doesn't start with data: %q", block.VideoURL.URL)
+					}
+				default:
+					t.Fatalf("block is not imageURLBlock or videoURLBlock: %T", b)
 				}
 			}
 		})
 	}
 }
 
-func TestExtractImageParts(t *testing.T) {
+func TestExtractMediaParts(t *testing.T) {
 	img := &llm.Part{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}}
 	txt := &llm.Part{Text: "hello"}
 	parts := []*llm.Part{img, txt}
-	images, rest := extractImageParts(parts)
-	if len(images) != 1 || len(rest) != 1 {
-		t.Errorf("got %d images, %d rest; want 1,1", len(images), len(rest))
+	media, rest := extractMediaParts(parts)
+	if len(media) != 1 || len(rest) != 1 {
+		t.Errorf("got %d media, %d rest; want 1,1", len(media), len(rest))
 	}
 }
 

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -299,7 +299,7 @@ func TestCollectApplyRoundTrip(t *testing.T) {
 	}
 }
 
-func TestPrepareImageAssets_Gating(t *testing.T) {
+func TestPrepareMediaAssets_Gating(t *testing.T) {
 	// Non-Kimi URL — should skip upload entirely
 	c := &client{
 		baseURL:    "https://api.openai.com/v1",
@@ -312,7 +312,7 @@ func TestPrepareImageAssets_Gating(t *testing.T) {
 	parts := []*llm.Part{
 		{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}},
 	}
-	ta, out, err := c.prepareImageAssets(context.Background(), parts, nil)
+	ta, out, err := c.prepareMediaAssets(context.Background(), parts, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -326,7 +326,7 @@ func TestPrepareImageAssets_Gating(t *testing.T) {
 	ta.release(context.Background(), c)
 }
 
-func TestPrepareImageAssets_KimiURL_Uploads(t *testing.T) {
+func TestPrepareMediaAssets_KimiURL_Uploads(t *testing.T) {
 	var uploaded, deleted bool
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
@@ -353,7 +353,7 @@ func TestPrepareImageAssets_KimiURL_Uploads(t *testing.T) {
 	parts := []*llm.Part{
 		{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
 	}
-	ta, out, err := c.prepareImageAssets(context.Background(), parts, nil)
+	ta, out, err := c.prepareMediaAssets(context.Background(), parts, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -368,6 +368,80 @@ func TestPrepareImageAssets_KimiURL_Uploads(t *testing.T) {
 	}
 	if ta.resolveURL(out[0]) != "ms://file-xyz" {
 		t.Errorf("expected ms:// URL, got %s", ta.resolveURL(out[0]))
+	}
+
+	ta.release(context.Background(), c)
+	if !deleted {
+		t.Error("expected DELETE after release")
+	}
+}
+
+func TestPrepareMediaAssets_KimiURL_UploadsVideo(t *testing.T) {
+	var uploaded, deleted bool
+	var uploadPurpose string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/files"):
+			uploaded = true
+			if err := r.ParseMultipartForm(10 << 20); err != nil {
+				t.Errorf("parse multipart: %v", err)
+			}
+			uploadPurpose = r.FormValue("purpose")
+			// Live api.moonshot.ai returns "ok" (observed 2026-07-23).
+			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-xyz", Status: "ok"})
+		case r.Method == "DELETE":
+			deleted = true
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    server.URL + "/api.moonshot.ai",
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+	c.capabilities = llm.Capabilities{SupportsVideo: true}
+
+	videoData := []byte{0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70}
+	parts := []*llm.Part{
+		{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: videoData}},
+	}
+	ta, out, err := c.prepareMediaAssets(context.Background(), parts, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !uploaded {
+		t.Error("expected POST /files upload")
+	}
+	if uploadPurpose != "video" {
+		t.Errorf("expected purpose=video, got %q", uploadPurpose)
+	}
+	if len(ta.uploaded) != 1 {
+		t.Errorf("expected 1 uploaded file, got %d", len(ta.uploaded))
+	}
+	if ta.bindings[out[0]] != "file-xyz" {
+		t.Error("expected binding for uploaded part")
+	}
+	if ta.resolveURL(out[0]) != "ms://file-xyz" {
+		t.Errorf("expected ms:// URL, got %s", ta.resolveURL(out[0]))
+	}
+
+	// Verify video_url block is produced (not image_url)
+	blocks := mediaBlocks(out, ta)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 media block, got %d", len(blocks))
+	}
+	vb, ok := blocks[0].(videoURLBlock)
+	if !ok {
+		t.Fatalf("expected videoURLBlock, got %T", blocks[0])
+	}
+	if vb.Type != "video_url" {
+		t.Errorf("expected type=video_url, got %q", vb.Type)
+	}
+	if !strings.HasPrefix(vb.VideoURL.URL, "ms://") {
+		t.Errorf("expected ms:// URL prefix, got %q", vb.VideoURL.URL)
 	}
 
 	ta.release(context.Background(), c)


### PR DESCRIPTION
## Summary

Adds `SupportsVideo` capability and generalizes the image-specific pipeline to handle both image and video media for Kimi models.

## Changes

| File | Change |
|------|--------|
| `capabilities.go` | `SupportsVideo` flag (true for `kimi-*`) |
| `capabilities_test.go` | Table-driven column + focused test |
| `client.go` | `extractImageParts` → `extractMediaParts`; `imageBlocks` → `mediaBlocks` (video_url / image_url); `prepareImageAssets` → `prepareMediaAssets` (purpose=video for video/*); `videoURLBlock`/`videoURLValue` types; gate updates |
| `chat.go` | Call site rename |
| `client_vision_test.go` | Video + mixed-media test cases |
| `files_test.go` | `TestPrepareMediaAssets_KimiURL_UploadsVideo` — full pipeline test |

## Pipeline

```
Part{InlineData: Blob{MIMEType: "video/mp4"}}
  → extractMediaParts
  → prepareMediaAssets (purpose="video", upload to Kimi file API)
  → turnAssets binds part → fileID
  → mediaBlocks produces video_url block with ms:// URL
  → turnAssets.release() cleans up after response
```

## Related

Closes #1258