### PR TITLE
fix(llm): narrow mediaBlocks MIME routing, fix resolveURL doc

### DIFF
--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -573,7 +573,12 @@ func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, reso
 		return ta, out, nil
 	}
 	for _, p := range out {
-		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
+		if p.InlineData == nil || len(p.InlineData.Data) == 0 || !isMediaMIME(p.InlineData.MIMEType) {
+			if p.InlineData != nil && len(p.InlineData.Data) > 0 && !isMediaMIME(p.InlineData.MIMEType) {
+				c.logger.Warn("skipping_unsupported_media_mime",
+					"mime", p.InlineData.MIMEType,
+				)
+			}
 			continue
 		}
 		if _, ok := ta.bindings[p]; ok {

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -573,12 +573,13 @@ func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, reso
 		return ta, out, nil
 	}
 	for _, p := range out {
-		if p.InlineData == nil || len(p.InlineData.Data) == 0 || !isMediaMIME(p.InlineData.MIMEType) {
-			if p.InlineData != nil && len(p.InlineData.Data) > 0 && !isMediaMIME(p.InlineData.MIMEType) {
-				c.logger.Warn("skipping_unsupported_media_mime",
-					"mime", p.InlineData.MIMEType,
-				)
-			}
+		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
+			continue
+		}
+		if !isMediaMIME(p.InlineData.MIMEType) {
+			c.logger.Warn("skipping_unsupported_media_mime",
+				"mime", p.InlineData.MIMEType,
+			)
 			continue
 		}
 		if _, ok := ta.bindings[p]; ok {

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -259,7 +259,7 @@ func newTurnAssets() *turnAssets {
 	}
 }
 
-// resolveURL returns the image_url value for a part: ms://{file_id}
+// resolveURL returns the media URL value for a part: ms://{file_id}
 // if it was uploaded, or a base64 data URI otherwise. Nil-safe —
 // returns a base64 data URI when ta is nil (no uploads occurred).
 func (ta *turnAssets) resolveURL(p *llm.Part) string {
@@ -494,11 +494,18 @@ func partitionParts(parts []*llm.Part) (toolResponseParts []*llm.Part, otherPart
 	return
 }
 
-// extractMediaParts separates InlineData parts (image and video) from a part slice.
-// Returns the media parts and the remaining non-media, non-tool-response parts.
+// isMediaMIME returns true for MIME types that can be rendered as
+// image_url or video_url content blocks in chat messages.
+func isMediaMIME(mime string) bool {
+	return strings.HasPrefix(mime, "image/") || strings.HasPrefix(mime, "video/")
+}
+
+// extractMediaParts separates InlineData parts with image/* or video/*
+// MIME types from a part slice. Returns the media parts and the
+// remaining non-media, non-tool-response parts.
 func extractMediaParts(parts []*llm.Part) (media []*llm.Part, rest []*llm.Part) {
 	for _, p := range parts {
-		if p.InlineData != nil && len(p.InlineData.Data) > 0 {
+		if p.InlineData != nil && len(p.InlineData.Data) > 0 && isMediaMIME(p.InlineData.MIMEType) {
 			media = append(media, p)
 		} else {
 			rest = append(rest, p)
@@ -597,7 +604,10 @@ func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, reso
 // mediaBlocks converts InlineData parts to image_url or video_url content blocks.
 // Uses turnAssets to resolve ms:// URLs for uploaded files; falls
 // back to base64 data URIs for non-uploaded parts. Video MIME types
-// (video/*) produce video_url blocks; all others produce image_url blocks.
+// (video/*) produce video_url blocks; image MIME types (image/*)
+// produce image_url blocks. Unknown MIME types are silently skipped
+// (extractMediaParts should have already filtered them out; this is a
+// defensive double-check).
 func mediaBlocks(parts []*llm.Part, ta *turnAssets) []any {
 	var blocks []any
 	for _, p := range parts {
@@ -610,7 +620,7 @@ func mediaBlocks(parts []*llm.Part, ta *turnAssets) []any {
 				Type:     "video_url",
 				VideoURL: videoURLValue{URL: url},
 			})
-		} else {
+		} else if strings.HasPrefix(p.InlineData.MIMEType, "image/") {
 			blocks = append(blocks, imageURLBlock{
 				Type:     "image_url",
 				ImageURL: imageURLValue{URL: url},

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -34,6 +34,8 @@ func TestMediaBlocks(t *testing.T) {
 		{"no media", []*llm.Part{{Text: "hello"}}, 0},
 		{"nil InlineData", []*llm.Part{{InlineData: nil}}, 0},
 		{"empty data", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: nil}}}, 0},
+		{"pdf skipped", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "application/pdf", Data: []byte{1}}}}, 0},
+		{"audio skipped", []*llm.Part{{InlineData: &llm.Blob{MIMEType: "audio/mp3", Data: []byte{2}}}}, 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -69,10 +71,15 @@ func TestMediaBlocks(t *testing.T) {
 func TestExtractMediaParts(t *testing.T) {
 	img := &llm.Part{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}}
 	txt := &llm.Part{Text: "hello"}
-	parts := []*llm.Part{img, txt}
+	pdf := &llm.Part{InlineData: &llm.Blob{MIMEType: "application/pdf", Data: []byte{1}}}
+	audio := &llm.Part{InlineData: &llm.Blob{MIMEType: "audio/mp3", Data: []byte{2}}}
+	parts := []*llm.Part{img, txt, pdf, audio}
 	media, rest := extractMediaParts(parts)
-	if len(media) != 1 || len(rest) != 1 {
-		t.Errorf("got %d media, %d rest; want 1,1", len(media), len(rest))
+	if len(media) != 1 {
+		t.Errorf("got %d media, want 1 (only image, not PDF or audio)", len(media))
+	}
+	if len(rest) != 3 {
+		t.Errorf("got %d rest, want 3 (text + PDF + audio)", len(rest))
 	}
 }
 

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -449,3 +449,42 @@ func TestPrepareMediaAssets_KimiURL_UploadsVideo(t *testing.T) {
 		t.Error("expected DELETE after release")
 	}
 }
+
+func TestPrepareMediaAssets_KimiURL_SkipsUnsupportedMIME(t *testing.T) {
+	var uploaded bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/files") {
+			uploaded = true
+			_ = json.NewEncoder(w).Encode(fileObject{ID: "file-should-not-exist", Status: "ok"})
+		}
+	}))
+	defer server.Close()
+
+	c := &client{
+		baseURL:    server.URL + "/api.moonshot.ai",
+		httpClient: server.Client(),
+		logger:     &ports.NoOpLogger{},
+	}
+	c.authenticator = &fakeAuthenticator{}
+	c.capabilities = llm.Capabilities{SupportsVision: true}
+
+	parts := []*llm.Part{
+		{InlineData: &llm.Blob{MIMEType: "application/pdf", Data: []byte{1}}},
+	}
+	ta, out, err := c.prepareMediaAssets(context.Background(), parts, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = out
+	if uploaded {
+		t.Error("PDF should not be uploaded")
+	}
+	if len(ta.uploaded) != 0 {
+		t.Errorf("expected 0 uploaded files, got %d", len(ta.uploaded))
+	}
+	if len(ta.bindings) != 0 {
+		t.Error("PDF should have no bindings")
+	}
+
+	ta.release(context.Background(), c)
+}


### PR DESCRIPTION
## Summary

Follow-up to PR #1259 (finding #4 from architecture review). Narrows MIME-type routing so non-image, non-video `InlineData` parts are not silently classified as `image_url` blocks.

## Changes

| Change | File |
|--------|------|
| `isMediaMIME(mime) bool` helper — `image/*` or `video/*` | `client.go` |
| `extractMediaParts` — only extracts `image/*` and `video/*` parts; PDF/audio stay in text path | `client.go` |
| `mediaBlocks` — explicit `image/*` branch replaces catch-all `else`; unknown MIME silently skipped | `client.go` |
| `resolveURL` godoc fix — `image_url value` → `media URL value` | `client.go` |
| `TestExtractMediaParts` — PDF + audio filtered out | `client_vision_test.go` |
| `TestMediaBlocks` — PDF + audio produce zero blocks | `client_vision_test.go` |

Closes #1260