### PR TITLE
feat(llm): extract SupportsFileUpload capability from moonshot.ai URL sniff

### DIFF
--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -81,6 +81,14 @@ type Capabilities struct {
 	//
 	// Set for: kimi-* models (K3, K2.7, K2.6).
 	SupportsVideo bool
+	// SupportsFileUpload indicates the model supports file uploads via a
+	// provider-specific file API (e.g., Kimi / Moonshot). When true,
+	// InlineData parts with image or video MIME types are uploaded as
+	// files before the chat request and referenced via provider-specific
+	// URL schemes (e.g., ms://) in the message payload.
+	//
+	// Set for: kimi-* model family.
+	SupportsFileUpload bool
 	// RequiresVertexThinkingKwargs indicates that the transport silently
 	// disables DeepSeek thinking mode unless the non-standard parameter
 	// chat_template_kwargs.thinking=true is included in the request body.
@@ -183,6 +191,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 		caps.SupportsReasoningContent = true
 		caps.SupportsVision = true
 		caps.SupportsVideo = true
+		caps.SupportsFileUpload = true
 		if isKimiK3Model(model) {
 			caps.SupportsReasoningEffort = true
 		}

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -569,7 +569,7 @@ func (c *client) prepareMediaAssets(ctx context.Context, parts []*llm.Part, reso
 	}
 
 	// Upload fresh media to Kimi file API
-	if (!c.capabilities.SupportsVision && !c.capabilities.SupportsVideo) || !strings.Contains(c.baseURL, "api.moonshot.ai") {
+	if !c.capabilities.SupportsFileUpload {
 		return ta, out, nil
 	}
 	for _, p := range out {

--- a/internal/infrastructure/llm/openai/files_test.go
+++ b/internal/infrastructure/llm/openai/files_test.go
@@ -300,7 +300,7 @@ func TestCollectApplyRoundTrip(t *testing.T) {
 }
 
 func TestPrepareMediaAssets_Gating(t *testing.T) {
-	// Non-Kimi URL — should skip upload entirely
+	// no upload capability — should skip
 	c := &client{
 		baseURL:    "https://api.openai.com/v1",
 		httpClient: http.DefaultClient,
@@ -343,12 +343,12 @@ func TestPrepareMediaAssets_KimiURL_Uploads(t *testing.T) {
 	defer server.Close()
 
 	c := &client{
-		baseURL:    server.URL + "/api.moonshot.ai",
+		baseURL:    server.URL,
 		httpClient: server.Client(),
 		logger:     &ports.NoOpLogger{},
 	}
 	c.authenticator = &fakeAuthenticator{}
-	c.capabilities = llm.Capabilities{SupportsVision: true}
+	c.capabilities = llm.Capabilities{SupportsFileUpload: true}
 
 	parts := []*llm.Part{
 		{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
@@ -397,12 +397,12 @@ func TestPrepareMediaAssets_KimiURL_UploadsVideo(t *testing.T) {
 	defer server.Close()
 
 	c := &client{
-		baseURL:    server.URL + "/api.moonshot.ai",
+		baseURL:    server.URL,
 		httpClient: server.Client(),
 		logger:     &ports.NoOpLogger{},
 	}
 	c.authenticator = &fakeAuthenticator{}
-	c.capabilities = llm.Capabilities{SupportsVideo: true}
+	c.capabilities = llm.Capabilities{SupportsFileUpload: true}
 
 	videoData := []byte{0x00, 0x00, 0x00, 0x1C, 0x66, 0x74, 0x79, 0x70}
 	parts := []*llm.Part{
@@ -461,12 +461,12 @@ func TestPrepareMediaAssets_KimiURL_SkipsUnsupportedMIME(t *testing.T) {
 	defer server.Close()
 
 	c := &client{
-		baseURL:    server.URL + "/api.moonshot.ai",
+		baseURL:    server.URL,
 		httpClient: server.Client(),
 		logger:     &ports.NoOpLogger{},
 	}
 	c.authenticator = &fakeAuthenticator{}
-	c.capabilities = llm.Capabilities{SupportsVision: true}
+	c.capabilities = llm.Capabilities{SupportsFileUpload: true}
 
 	parts := []*llm.Part{
 		{InlineData: &llm.Blob{MIMEType: "application/pdf", Data: []byte{1}}},


### PR DESCRIPTION
Closes #1262. Supersedes #1257.

## Summary

Replaces the request-time `strings.Contains(baseURL, "api.moonshot.ai")` URL sniff in `prepareMediaAssets` with a domain-level `SupportsFileUpload` capability flag set at construction time. This is the lone outlier — every other URL-derived behavior (`RequiresVertexThinkingKwargs`) is already resolved once in `ResolveCapabilities`.

## Changes

| File | Change |
|------|--------|
| `internal/domain/llm/capabilities.go` | Added `SupportsFileUpload bool` to `Capabilities`; set for `kimi-*` models in `ResolveCapabilities` |
| `internal/infrastructure/llm/openai/client.go` | Replaced URL sniff with `!c.capabilities.SupportsFileUpload` |
| `internal/infrastructure/llm/openai/files_test.go` | Replaced 3× `server.URL + "/api.moonshot.ai"` hacks with explicit `{SupportsFileUpload: true}`; updated gating test comment |

## Behavioral impact

| Scenario | Before | After |
|---|---|---|
| kimi + moonshot URL | upload | upload (same) |
| non-kimi model | skip | skip (same) |
| kimi + non-moonshot URL (proxy/gateway) | **silent skip** | upload ✅ |

## Verification

- `make check` — all green (fmt, build, lint, architecture, tests, coverage)
- No `moonshot.ai` string literals remain in production code
- Approach follows the established template from #1259 (`SupportsVideo`)
- See [architectural review](https://github.com/gosharplite/tell-me-go/issues/1257#issuecomment-5056379476) for the full layer-split rationale
