### PR TITLE
feat(media): add read_video tool for Kimi video analysis (#1264)

### DIFF
--- a/internal/domain/security/policy.go
+++ b/internal/domain/security/policy.go
@@ -181,6 +181,7 @@ func DefaultPolicy() *Policy {
 			// Media Tools
 			"create_image":  true,
 			"read_image":    true,
+			"read_video":    true,
 			"read_document": true,
 		},
 		AutoApprovableCommands: map[string]bool{

--- a/internal/tools/integrations/media.go
+++ b/internal/tools/integrations/media.go
@@ -176,6 +176,57 @@ func (m *mediaManager) readImage(ctx context.Context, args map[string]interface{
 	}, nil
 }
 
+func (m *mediaManager) readVideo(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+	// readVideo is a synchronous read operation (not registered as LongRunning),
+	// so heartbeat is intentionally not started. The hb parameter is required by
+	// the tools.ToolFunc interface signature.
+	_ = hb
+
+	var a struct {
+		Filepath string `json:"filepath"`
+	}
+	if err := tools.UnmarshalArgs(args, &a); err != nil {
+		return tools.ToolResult{}, fmt.Errorf("unmarshal args: %w", err)
+	}
+
+	if m.sm == nil {
+		return tools.ToolResult{}, fmt.Errorf("path validator is required")
+	}
+
+	safePath, err := m.sm.IsPathSafe(a.Filepath)
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("security validation failed for path %s: %w", a.Filepath, err)
+	}
+
+	data, err := m.fs.ReadFile(ctx, safePath)
+	if err != nil {
+		return tools.ToolResult{}, fmt.Errorf("read file %s: %w", safePath, err)
+	}
+
+	mimeType := "video/mp4"
+	ext := strings.ToLower(filepath.Ext(safePath))
+	switch ext {
+	case ".mov":
+		mimeType = "video/quicktime"
+	case ".webm":
+		mimeType = "video/webm"
+	case ".avi":
+		mimeType = "video/x-msvideo"
+	case ".mkv":
+		mimeType = "video/x-matroska"
+	}
+
+	return tools.ToolResult{
+		Text: fmt.Sprintf("Successfully read video from %s", safePath),
+		BinaryData: []tools.BinaryData{
+			{
+				MIMEType: mimeType,
+				Data:     data,
+			},
+		},
+	}, nil
+}
+
 func (m *mediaManager) readDocument(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	if m.client == nil {
 		return tools.ToolResult{}, tools.ErrNotImplemented
@@ -260,6 +311,23 @@ func registerMedia(r tools.Registry, fs persistence.FileSystem, sm security.Mana
 			Required: []string{"filepath"},
 		},
 	}, m.readImage); err != nil {
+		return err
+	}
+
+	if err := r.RegisterToToolkit("media", &tools.ToolDeclaration{
+		Name:        "read_video",
+		Description: "Reads a local video file for vision/video analysis. The model can describe scenes, actions, and content within the video.",
+		Parameters: &tools.Schema{
+			Type: "OBJECT",
+			Properties: map[string]*tools.Schema{
+				"filepath": {
+					Type:        "STRING",
+					Description: "The path to the video file (e.g., './assets/demo.mp4').",
+				},
+			},
+			Required: []string{"filepath"},
+		},
+	}, m.readVideo); err != nil {
 		return err
 	}
 

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -310,6 +310,143 @@ func TestMediaTools_ReadImage(t *testing.T) {
 	}
 }
 
+func TestReadVideo(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).readLoop"),
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	// Create test video files
+	mp4File := filepath.Join(tmpDir, "test.mp4")
+	_ = os.WriteFile(mp4File, []byte("mp4-data"), 0644)
+
+	movFile := filepath.Join(tmpDir, "test.mov")
+	_ = os.WriteFile(movFile, []byte("mov-data"), 0644)
+
+	webmFile := filepath.Join(tmpDir, "test.webm")
+	_ = os.WriteFile(webmFile, []byte("webm-data"), 0644)
+
+	aviFile := filepath.Join(tmpDir, "test.avi")
+	_ = os.WriteFile(aviFile, []byte("avi-data"), 0644)
+
+	mkvFile := filepath.Join(tmpDir, "test.mkv")
+	_ = os.WriteFile(mkvFile, []byte("mkv-data"), 0644)
+
+	unknownExtFile := filepath.Join(tmpDir, "test.mpg")
+	_ = os.WriteFile(unknownExtFile, []byte("mpg-data"), 0644)
+
+	// Create a directory
+	subDir := filepath.Join(tmpDir, "subdir")
+	_ = os.Mkdir(subDir, 0755)
+
+	// Create a write-only file (on Unix-like systems)
+	unreadableFile := filepath.Join(tmpDir, "unreadable.mp4")
+	_ = os.WriteFile(unreadableFile, []byte("secret"), 0200)
+
+	tests := []struct {
+		name         string
+		filepath     string
+		isPathSafe   bool
+		wantMimeType string
+		wantErr      bool
+	}{
+		{
+			name:         "read valid mp4",
+			filepath:     mp4File,
+			isPathSafe:   true,
+			wantMimeType: "video/mp4",
+		},
+		{
+			name:         "read valid mov",
+			filepath:     movFile,
+			isPathSafe:   true,
+			wantMimeType: "video/quicktime",
+		},
+		{
+			name:         "read valid webm",
+			filepath:     webmFile,
+			isPathSafe:   true,
+			wantMimeType: "video/webm",
+		},
+		{
+			name:         "read valid avi",
+			filepath:     aviFile,
+			isPathSafe:   true,
+			wantMimeType: "video/x-msvideo",
+		},
+		{
+			name:         "read valid mkv",
+			filepath:     mkvFile,
+			isPathSafe:   true,
+			wantMimeType: "video/x-matroska",
+		},
+		{
+			name:         "read unknown extension defaults to mp4",
+			filepath:     unknownExtFile,
+			isPathSafe:   true,
+			wantMimeType: "video/mp4",
+		},
+		{
+			name:       "security violation",
+			filepath:   "/etc/passwd",
+			isPathSafe: false,
+			wantErr:    true,
+		},
+		{
+			name:       "file not found",
+			filepath:   filepath.Join(tmpDir, "nonexistent.mp4"),
+			isPathSafe: true,
+			wantErr:    true,
+		},
+		{
+			name:       "read directory failure",
+			filepath:   subDir,
+			isPathSafe: true,
+			wantErr:    true,
+		},
+		{
+			name:       "permission denied failure",
+			filepath:   unreadableFile,
+			isPathSafe: true,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "permission denied failure" && runtime.GOOS == "windows" {
+				t.Skip("Skipping on Windows: os.Chmod(0200) does not reliably make files unreadable for the owner.")
+			}
+			sm := newMediaMockSecurityManager()
+			sm.isPathSafeFunc = func(path string) (string, error) {
+				if !tt.isPathSafe {
+					return "", errors.New("unsafe path")
+				}
+				return path, nil
+			}
+			fs := &mockFileSystem{}
+			m := newMediaManager(fs, sm, nil, "")
+
+			res, err := m.readVideo(ctx, map[string]interface{}{"filepath": tt.filepath}, nil)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("readVideo() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr {
+				if len(res.BinaryData) != 1 {
+					t.Fatalf("got %d videos, want 1", len(res.BinaryData))
+				}
+				if res.BinaryData[0].MIMEType != tt.wantMimeType {
+					t.Errorf("got MIME %s, want %s", res.BinaryData[0].MIMEType, tt.wantMimeType)
+				}
+			}
+		})
+	}
+}
+
 func TestNewMediaManager(t *testing.T) {
 	sm := newMediaMockSecurityManager()
 	fs := &mockFileSystem{}
@@ -590,13 +727,13 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 		},
 		{
 			name:            "network wraps error",
-			failAfter:       28,
+			failAfter:       29,
 			wantSubstring:   "network",
 			setAtlassianEnv: true,
 		},
 		{
 			name:            "teams wraps error",
-			failAfter:       30,
+			failAfter:       31,
 			wantSubstring:   "teams",
 			setAtlassianEnv: true,
 		},
@@ -647,11 +784,22 @@ func TestRegisterMedia_ErrorPaths(t *testing.T) {
 		}
 	})
 
-	t.Run("third RegisterToToolkitWithOptions fails", func(t *testing.T) {
+	t.Run("third RegisterToToolkit fails", func(t *testing.T) {
 		r := newFaultyRegistry(registry.New(), 2)
 		err := registerMedia(r, fs, sm, client, tmpDir)
 		if err == nil {
 			t.Fatal("expected error on third registration failure")
+		}
+		if !strings.Contains(err.Error(), "simulated registration failure") {
+			t.Errorf("expected simulated error, got: %v", err)
+		}
+	})
+
+	t.Run("fourth RegisterToToolkitWithOptions fails", func(t *testing.T) {
+		r := newFaultyRegistry(registry.New(), 3)
+		err := registerMedia(r, fs, sm, client, tmpDir)
+		if err == nil {
+			t.Fatal("expected error on fourth registration failure")
 		}
 		if !strings.Contains(err.Error(), "simulated registration failure") {
 			t.Errorf("expected simulated error, got: %v", err)


### PR DESCRIPTION
## Summary

Adds `read_video` tool to the `media` toolkit, enabling Kimi k3 to describe video content.

The transport pipeline was already ready — `SupportsVideo` (#1259), `video_url` serialization, and `SupportsFileUpload` (#1262) are all in place. This was the last missing piece: a user-facing tool to feed video bytes into the conversation.

## Changes

| File | Change |
|---|---|
| `media.go` | Add `readVideo` method + register `read_video` tool in `registerMedia()` |
| `policy.go` | Add `read_video` to `AllowedCommands` security whitelist |
| `media_test.go` | Add `TestReadVideo` (10 subtests), 4th error path test, shift `failAfter` values |

## Design

- Follows `readImage` pattern: synchronous, `IsPathSafe` → `ReadFile` → MIME switch → `BinaryData`
- MIME support: mp4 (default), mov, webm, avi, mkv
- No transport changes needed — existing `prepareMediaAssets` handles video upload to Kimi file API
- Security: read-only, same path validation as `read_image`

Closes #1264