### PR TITLE
feat(browse): add 'e' keybinding to edit any history turn from browse TUI

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -841,6 +841,12 @@ to reason about.
   `(*model).Update` (Bubble Tea dispatch).
 - **See**: `internal/ui/tui/history_editor.go:39`
 
+### ui/tui/browser.go — (*rootBrowserModel).handleActionKeys (CC=15)
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Type-switch dispatching key actions in the browse TUI. The 'e' (edit) keybinding added 4 structural branches: bounds guard on `selectedTurn`, role guard (`"model" || "assistant"`), `GetModelTurn` error guard, and editor-creation. Each branch is a single-line guard or delegation, not branching business logic. Same acceptance class as `handleDomainEvent` (CC=12) and `(*model).Update` (CC=14) — type-switch dispatch where cyclomatic complexity is structural, not cognitive.
+- **See**: `internal/ui/tui/browser.go:294`
+
 ---
 
 ## Test Complexity (ACCEPTED — 2026-07 Supplemental)
@@ -911,6 +917,12 @@ to reason about.
 - **Rationale**: Sequential test exercising the command executor's error-handling paths for non-exit errors (signal, wait failure, context cancellation). Steps build on shared process state. CC is assertion boilerplate across error paths.
 - **See**: `internal/tools/workspace/process_executor_stream_test.go:817`
 
+### internal/infrastructure/history/history_test.go — TestGetModelTurn (CC=16)
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Table-driven test with 5 subtests covering valid index, OOB negative, OOB pos, non-model role, and deep-copy isolation for `GetModelTurn`. Each subtest contains its own setup (temp dir, `NewManager`, `AddContent`). CC comes from subtest enumeration and assertion boilerplate, not branching business logic. Same acceptance class as `TestUpdateTurnContent_ClearText` (CC=12) and `TestUpdateTurnContent_AddTextWhenNone` (CC=12) in the same file.
+- **See**: `internal/infrastructure/history/history_test.go:1198`
+
 ---
 
-*Last Updated: 2026-07 (Supplemental: Test Complexity batch documentation)*
+*Last Updated: 2026-07 (feat/multi-turn-edit: handleActionKeys + TestGetModelTurn complexity acceptance)*

--- a/internal/agent/agenttest/mock_history_manager.go
+++ b/internal/agent/agenttest/mock_history_manager.go
@@ -29,6 +29,7 @@ type MockHistoryManager struct {
 	SetContentsFunc func(ctx context.Context, contents []*llm.Content) error
 
 	GetLastModelTurnFunc  func(ctx context.Context) (int, *llm.Content, error)
+	GetModelTurnFunc      func(ctx context.Context, index int) (*llm.Content, error)
 	UpdateTurnContentFunc func(ctx context.Context, index int, newText string, newThought string) error
 }
 
@@ -147,6 +148,12 @@ func (m *MockHistoryManager) GetLastModelTurn(ctx context.Context) (int, *llm.Co
 		}
 	}
 	return 0, nil, nil
+}
+func (m *MockHistoryManager) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	if m.GetModelTurnFunc != nil {
+		return m.GetModelTurnFunc(ctx, index)
+	}
+	return nil, nil
 }
 func (m *MockHistoryManager) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	if m.UpdateTurnContentFunc != nil {

--- a/internal/agent/mocks_test.go
+++ b/internal/agent/mocks_test.go
@@ -171,6 +171,15 @@ func (m *mockHistoryManager) GetLastModelTurn(ctx context.Context) (int, *llm.Co
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+func (m *mockHistoryManager) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if index < 0 || index >= len(m.Contents) {
+		return nil, ports.ErrHistoryNotFound
+	}
+	return llm.CloneContent(m.Contents[index]), nil
+}
+
 func (m *mockHistoryManager) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	return nil
 }

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -530,6 +530,10 @@ func (m *mockHistoryManagerForRetry) GetLastModelTurn(ctx context.Context) (int,
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+func (m *mockHistoryManagerForRetry) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	return nil, ports.ErrHistoryNotFound
+}
+
 func (m *mockHistoryManagerForRetry) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	return nil
 }

--- a/internal/cli/test_helpers_test.go
+++ b/internal/cli/test_helpers_test.go
@@ -67,6 +67,10 @@ func (s *stubHistoryManager) GetLastModelTurn(_ stdctx.Context) (int, *llm.Conte
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+func (s *stubHistoryManager) GetModelTurn(_ stdctx.Context, _ int) (*llm.Content, error) {
+	return nil, ports.ErrHistoryNotFound
+}
+
 func (s *stubHistoryManager) UpdateTurnContent(_ stdctx.Context, _ int, _ string, _ string) error {
 	return nil
 }

--- a/internal/domain/ports/history.go
+++ b/internal/domain/ports/history.go
@@ -89,6 +89,13 @@ type HistoryModifier interface {
 	// ErrHistoryNotFound if no model turns exist in the history.
 	GetLastModelTurn(ctx context.Context) (index int, content *llm.Content, err error)
 
+	// GetModelTurn returns a deep copy of the model-role Content entry at the
+	// given index in the underlying content slice. The index refers to the
+	// position in the full content slice (0-based), not a turn number.
+	// Returns ErrHistoryNotFound if index is out of bounds or the entry at
+	// that position is not a model role.
+	GetModelTurn(ctx context.Context, index int) (*llm.Content, error)
+
 	// UpdateTurnContent replaces the text and thought parts of the Content at
 	// the given index in memory, then persists the change via Save.
 	// The index must reference a model-role entry. Passing an empty string for

--- a/internal/infrastructure/di/factory_error_test.go
+++ b/internal/infrastructure/di/factory_error_test.go
@@ -221,6 +221,10 @@ func (m *mockHistoryManagerFull) GetLastModelTurn(ctx context.Context) (int, *ll
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+func (m *mockHistoryManagerFull) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	return nil, ports.ErrHistoryNotFound
+}
+
 func (m *mockHistoryManagerFull) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	return nil
 }

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -483,6 +483,30 @@ func (m *Manager) GetLastModelTurn(ctx context.Context) (int, *llm.Content, erro
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+// GetModelTurn returns a deep copy of the model-role Content at the given index.
+func (m *Manager) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if index < 0 || index >= len(m.Contents) {
+		return nil, ports.ErrHistoryNotFound
+	}
+
+	entry := m.Contents[index]
+	if entry.Role != "model" {
+		return nil, ports.ErrHistoryNotFound
+	}
+
+	copied := *entry
+	copied.Parts = make([]*llm.Part, len(entry.Parts))
+	for i, p := range entry.Parts {
+		pc := *p
+		copied.Parts[i] = &pc
+	}
+
+	return &copied, nil
+}
+
 // isNonTextNonThought returns true when a part is neither a thought nor a
 // text part (i.e., it's a function call, function response, inline data, etc.).
 func isNonTextNonThought(p *llm.Part) bool {

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	infrapersistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
@@ -1194,4 +1195,89 @@ func TestUpdateTurnContent_MultiPartText(t *testing.T) {
 	if m.Contents[1].Parts[0].Text != "Edited" {
 		t.Errorf("expected text %q, got %q", "Edited", m.Contents[1].Parts[0].Text)
 	}
+}
+
+func TestGetModelTurn(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	historyFile := filepath.Join(tmp, "history.jsonl")
+	archiveFile := filepath.Join(tmp, "archive.jsonl")
+
+	m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+
+	// Setup: user → model turn
+	if err := m.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}); err != nil {
+		t.Fatal(err)
+	}
+	modelContent := &llm.Content{Role: "model", Parts: []*llm.Part{
+		{Text: "hi there"},
+		{Text: "thinking...", IsThought: true},
+	}}
+	if err := m.AddContent(ctx, modelContent); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("valid index returns model turn", func(t *testing.T) {
+		got, err := m.GetModelTurn(ctx, 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Role != "model" {
+			t.Errorf("expected role 'model', got %q", got.Role)
+		}
+		if len(got.Parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(got.Parts))
+		}
+		if got.Parts[0].Text != "hi there" {
+			t.Errorf("expected text 'hi there', got %q", got.Parts[0].Text)
+		}
+		if !got.Parts[1].IsThought || got.Parts[1].Text != "thinking..." {
+			t.Errorf("expected thought part 'thinking...', got %+v", got.Parts[1])
+		}
+	})
+
+	t.Run("out-of-bounds negative index", func(t *testing.T) {
+		_, err := m.GetModelTurn(ctx, -1)
+		if !errors.Is(err, ports.ErrHistoryNotFound) {
+			t.Errorf("expected ErrHistoryNotFound, got %v", err)
+		}
+	})
+
+	t.Run("out-of-bounds index beyond length", func(t *testing.T) {
+		_, err := m.GetModelTurn(ctx, 100)
+		if !errors.Is(err, ports.ErrHistoryNotFound) {
+			t.Errorf("expected ErrHistoryNotFound, got %v", err)
+		}
+	})
+
+	t.Run("non-model role returns ErrHistoryNotFound", func(t *testing.T) {
+		_, err := m.GetModelTurn(ctx, 0) // index 0 is the user entry
+		if !errors.Is(err, ports.ErrHistoryNotFound) {
+			t.Errorf("expected ErrHistoryNotFound, got %v", err)
+		}
+	})
+
+	t.Run("deep copy isolation", func(t *testing.T) {
+		// Fetch once
+		first, err := m.GetModelTurn(ctx, 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Mutate the returned copy
+		first.Parts[0].Text = "mutated"
+		first.Parts = append(first.Parts, &llm.Part{Text: "injected"})
+
+		// Fetch again — must return original, unmutated data
+		second, err := m.GetModelTurn(ctx, 1)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if second.Parts[0].Text != "hi there" {
+			t.Errorf("deep copy failed: expected 'hi there', got %q", second.Parts[0].Text)
+		}
+		if len(second.Parts) != 2 {
+			t.Errorf("deep copy failed: expected 2 parts, got %d", len(second.Parts))
+		}
+	})
 }

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -201,6 +201,10 @@ func (m *mockErrorHistoryReader) GetLastModelTurn(ctx context.Context) (int, *ll
 	return 0, nil, ports.ErrHistoryNotFound
 }
 
+func (m *mockErrorHistoryReader) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	return nil, ports.ErrHistoryNotFound
+}
+
 func (m *mockErrorHistoryReader) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	return nil
 }

--- a/internal/ui/tui/browser.go
+++ b/internal/ui/tui/browser.go
@@ -315,6 +315,10 @@ func (m *rootBrowserModel) handleActionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 			}
 		}
 		m.editor = editor.NewModel(text, thought)
+		// Seed the editor with the current window dimensions so its layout
+		// initializes before the first render. Bubble Tea does not re-send
+		// WindowSizeMsg to sub-models created after program startup.
+		_, _ = m.editor.Update(tea.WindowSizeMsg{Width: m.width, Height: m.height})
 		m.editing = true
 		m.editIndex = dto.OriginalIndex
 		return m, m.editor.Init()

--- a/internal/ui/tui/browser.go
+++ b/internal/ui/tui/browser.go
@@ -17,6 +17,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/fsnotify/fsnotify"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/ui/tui/editor"
 )
 
 var (
@@ -75,6 +76,11 @@ type rootBrowserModel struct {
 	watcherFactory    func() (*fsnotify.Watcher, error)
 	watcherErrorCount int // consecutive watcher error count for threshold alerting
 	watcherRestarting bool
+
+	// Editor sub-model fields
+	editor    *editor.EditorModel // non-nil when editing a turn
+	editing   bool                // true when editor is active
+	editIndex int                 // content-slice index of the turn being edited
 }
 
 // NewRootBrowserModel creates a new history browser root model.
@@ -176,6 +182,10 @@ func (m *rootBrowserModel) handleWatcherError(err error, ok bool) tea.Msg {
 
 // Update handles incoming messages and updates the model state.
 func (m *rootBrowserModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if m.editing {
+		return m.handleEditorMsg(msg)
+	}
+
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		return m.handleKeyMsg(msg)
@@ -203,7 +213,7 @@ func (m *rootBrowserModel) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "j", "k", "n", "N":
 		return m.handleNavigationKeys(msg)
-	case "p", "r", " ", "/":
+	case "p", "r", " ", "/", "e":
 		return m.handleActionKeys(msg)
 	}
 
@@ -283,6 +293,31 @@ func (m *rootBrowserModel) moveSearchMatch(delta int) {
 
 func (m *rootBrowserModel) handleActionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
+	case "e":
+		if m.selectedTurn < 0 || m.selectedTurn >= len(m.history) {
+			return m, nil
+		}
+		dto := m.history[m.selectedTurn]
+		if dto.Role != "model" && dto.Role != "assistant" {
+			return m, nil
+		}
+		content, err := m.cmdService.GetModelTurn(m.ctx, dto.OriginalIndex)
+		if err != nil {
+			m.err = fmt.Errorf("get model turn: %w", err)
+			return m, nil
+		}
+		var text, thought string
+		for _, p := range content.Parts {
+			if p.IsThought {
+				thought += p.Text
+			} else if p.Text != "" {
+				text += p.Text
+			}
+		}
+		m.editor = editor.NewModel(text, thought)
+		m.editing = true
+		m.editIndex = dto.OriginalIndex
+		return m, m.editor.Init()
 	case "p":
 		m.togglePin()
 		if m.isLoading {
@@ -303,6 +338,45 @@ func (m *rootBrowserModel) handleActionKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		return m, nil
 	}
 	return m, nil
+}
+
+// handleEditorMsg delegates messages to the editor sub-model and handles
+// save/abort completion. The editor signals completion via WasAborted() or
+// WasSaved() after processing a tea.KeyMsg.
+func (m *rootBrowserModel) handleEditorMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
+	// Forward window-size messages so the editor can lay out
+	if _, ok := msg.(tea.WindowSizeMsg); ok {
+		m.editor.Update(msg)
+		return m, nil
+	}
+
+	// Delegate key messages to the editor; check completion after
+	if _, ok := msg.(tea.KeyMsg); ok {
+		_, _ = m.editor.Update(msg)
+
+		if m.editor.WasAborted() {
+			m.editing = false
+			m.editor = nil
+			return m, nil
+		}
+		if m.editor.WasSaved() {
+			newText := m.editor.EditedText()
+			newThought := m.editor.EditedThought()
+			if err := m.cmdService.UpdateTurnContent(m.ctx, m.editIndex, newText, newThought); err != nil {
+				m.err = err
+			}
+			m.editing = false
+			m.editor = nil
+			m.lastMutationTime = time.Now()
+			m.updateViewportContent()
+			return m, nil
+		}
+		return m, nil
+	}
+
+	// Forward other messages to the editor
+	_, cmd := m.editor.Update(msg)
+	return m, cmd
 }
 
 func (m *rootBrowserModel) handleWindowSizeMsg(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
@@ -411,6 +485,10 @@ func (m *rootBrowserModel) handleFileChangedMsg(msg fileChangedMsg) (tea.Model, 
 
 // View renders the current state of the model.
 func (m *rootBrowserModel) View() string {
+	if m.editing {
+		return m.editor.View()
+	}
+
 	if m.err != nil {
 		return errorStyle.Render(fmt.Sprintf("Error: %v\nPress 'q' to quit.", m.err))
 	}

--- a/internal/ui/tui/browser.go
+++ b/internal/ui/tui/browser.go
@@ -368,6 +368,13 @@ func (m *rootBrowserModel) handleEditorMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 			newThought := m.editor.EditedThought()
 			if err := m.cmdService.UpdateTurnContent(m.ctx, m.editIndex, newText, newThought); err != nil {
 				m.err = err
+			} else if m.selectedTurn >= 0 && m.selectedTurn < len(m.history) {
+				// Update the in-memory DTO so the viewport renders the edited
+				// content immediately without a full history re-fetch.
+				dto := &m.history[m.selectedTurn]
+				dto.ContentPreview = newText
+				dto.ThoughtProcess = newThought
+				delete(m.cachedThoughts, dto.ID)
 			}
 			m.editing = false
 			m.editor = nil

--- a/internal/ui/tui/browser_test.go
+++ b/internal/ui/tui/browser_test.go
@@ -34,6 +34,7 @@ type mockHistoryModifier struct {
 	SetPinnedFunc     func(ctx context.Context, turnID string, pinned bool) error
 	GetFilePathFunc   func() string
 	RollbackTurnsFunc func(ctx context.Context, turns int) (int, int, int, error)
+	GetModelTurnFunc  func(ctx context.Context, index int) (*llm.Content, error)
 
 	SetPinnedCalled   bool
 	RollbackCalled    bool
@@ -77,6 +78,13 @@ func (m *mockHistoryModifier) RollbackTurns(ctx context.Context, turns int) (int
 
 func (m *mockHistoryModifier) GetLastModelTurn(ctx context.Context) (int, *llm.Content, error) {
 	return 0, nil, ports.ErrHistoryNotFound
+}
+
+func (m *mockHistoryModifier) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	if m.GetModelTurnFunc != nil {
+		return m.GetModelTurnFunc(ctx, index)
+	}
+	return nil, ports.ErrHistoryNotFound
 }
 
 func (m *mockHistoryModifier) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
@@ -1288,4 +1296,108 @@ func TestProcessWatcherEvents_ClosedWatcher(t *testing.T) {
 	if msg != nil {
 		t.Errorf("expected nil msg from closed watcher, got %T: %v", msg, msg)
 	}
+}
+
+// ── Browser edit keybinding tests ──
+
+func TestBrowserEditKeybinding(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("e on model turn opens editor", func(t *testing.T) {
+		mockProvider := &mockHistoryProvider{}
+		mockModifier := &mockHistoryModifier{
+			GetModelTurnFunc: func(ctx context.Context, index int) (*llm.Content, error) {
+				return &llm.Content{
+					Role: "model",
+					Parts: []*llm.Part{
+						{Text: "Hello world"},
+						{Text: "thinking...", IsThought: true},
+					},
+				}, nil
+			},
+		}
+		m := NewRootBrowserModel(ctx, mockProvider, mockModifier)
+		m.history = []ports.HistoryViewDTO{
+			{ID: "user-0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+			{ID: "model-0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		}
+		m.selectedTurn = 1 // Model turn
+
+		newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+		updated := newModel.(*rootBrowserModel)
+
+		if !updated.editing {
+			t.Error("expected editing to be true after 'e' on model turn")
+		}
+		if updated.editor == nil {
+			t.Error("expected editor to be non-nil after 'e' on model turn")
+		}
+		if updated.editIndex != 1 {
+			t.Errorf("expected editIndex 1, got %d", updated.editIndex)
+		}
+	})
+
+	t.Run("e on user turn does nothing", func(t *testing.T) {
+		mockProvider := &mockHistoryProvider{}
+		mockModifier := &mockHistoryModifier{}
+		m := NewRootBrowserModel(ctx, mockProvider, mockModifier)
+		m.history = []ports.HistoryViewDTO{
+			{ID: "user-0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+			{ID: "model-0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		}
+		m.selectedTurn = 0 // User turn
+
+		newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+		updated := newModel.(*rootBrowserModel)
+
+		if updated.editing {
+			t.Error("expected editing to be false after 'e' on user turn")
+		}
+	})
+
+	t.Run("e with no selection does nothing", func(t *testing.T) {
+		mockProvider := &mockHistoryProvider{}
+		mockModifier := &mockHistoryModifier{}
+		m := NewRootBrowserModel(ctx, mockProvider, mockModifier)
+		m.history = []ports.HistoryViewDTO{
+			{ID: "user-0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+			{ID: "model-0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		}
+		m.selectedTurn = -1 // No selection
+
+		newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+		updated := newModel.(*rootBrowserModel)
+
+		if updated.editing {
+			t.Error("expected editing to be false when nothing selected")
+		}
+	})
+
+	t.Run("e when GetModelTurn fails sets error", func(t *testing.T) {
+		mockProvider := &mockHistoryProvider{}
+		mockModifier := &mockHistoryModifier{
+			GetModelTurnFunc: func(ctx context.Context, index int) (*llm.Content, error) {
+				return nil, ports.ErrHistoryNotFound
+			},
+		}
+		m := NewRootBrowserModel(ctx, mockProvider, mockModifier)
+		m.history = []ports.HistoryViewDTO{
+			{ID: "user-0", Role: "user", ContentPreview: "hello", OriginalIndex: 0},
+			{ID: "model-0", Role: "assistant", ContentPreview: "hi", OriginalIndex: 1},
+		}
+		m.selectedTurn = 1 // Model turn
+
+		newModel, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("e")})
+		updated := newModel.(*rootBrowserModel)
+
+		if updated.editing {
+			t.Error("expected editing to remain false when GetModelTurn fails")
+		}
+		if updated.err == nil {
+			t.Fatal("expected error to be set when GetModelTurn fails")
+		}
+		if !strings.Contains(updated.err.Error(), "get model turn") {
+			t.Errorf("expected error to contain 'get model turn', got: %v", updated.err)
+		}
+	})
 }

--- a/internal/ui/tui/browser_viewport.go
+++ b/internal/ui/tui/browser_viewport.go
@@ -268,7 +268,7 @@ func (m *rootBrowserModel) renderFooter() string {
 	if !m.showThoughts {
 		thoughtsStatus = "OFF"
 	}
-	fmt.Fprintf(&sb, "↑/↓: Scroll • Space: Thoughts [%s] • /: Search • j/k: Select • p: Pin • r: Rollback • q: Quit", thoughtsStatus)
+	fmt.Fprintf(&sb, "↑/↓: Scroll • Space: Thoughts [%s] • /: Search • j/k: Select • e: Edit • p: Pin • r: Rollback • q: Quit", thoughtsStatus)
 
 	if m.currentQuery != "" {
 		matchInfo := ""

--- a/internal/ui/tui/editor/model.go
+++ b/internal/ui/tui/editor/model.go
@@ -73,8 +73,8 @@ func (m *EditorModel) EditedThought() string {
 	return strings.TrimSpace(m.thoughtArea.Value())
 }
 
-// wasSaved returns true if the user pressed Ctrl+S to save.
-func (m *EditorModel) wasSaved() bool {
+// WasSaved returns true if the user pressed Ctrl+S to save.
+func (m *EditorModel) WasSaved() bool {
 	return m.saved
 }
 

--- a/internal/ui/tui/editor/model_test.go
+++ b/internal/ui/tui/editor/model_test.go
@@ -19,8 +19,8 @@ func TestNewModel_WithThought(t *testing.T) {
 	if model.EditedThought() != "thinking..." {
 		t.Errorf("expected EditedThought %q, got %q", "thinking...", model.EditedThought())
 	}
-	if model.wasSaved() {
-		t.Error("expected wasSaved() to be false for new model")
+	if model.WasSaved() {
+		t.Error("expected WasSaved() to be false for new model")
 	}
 	if model.WasAborted() {
 		t.Error("expected WasAborted() to be false for new model")
@@ -103,8 +103,8 @@ func TestCtrlS_SavesAndQuits(t *testing.T) {
 	newModel, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlS})
 
 	editor := newModel.(*EditorModel)
-	if !editor.wasSaved() {
-		t.Error("expected wasSaved() to be true after Ctrl+S")
+	if !editor.WasSaved() {
+		t.Error("expected WasSaved() to be true after Ctrl+S")
 	}
 	if editor.WasAborted() {
 		t.Error("expected WasAborted() to be false after Ctrl+S")
@@ -126,8 +126,8 @@ func TestEsc_AbortsAndQuits(t *testing.T) {
 	if !editor.WasAborted() {
 		t.Error("expected WasAborted() to be true after Esc")
 	}
-	if editor.wasSaved() {
-		t.Error("expected wasSaved() to be false after Esc")
+	if editor.WasSaved() {
+		t.Error("expected WasSaved() to be false after Esc")
 	}
 	if cmd == nil {
 		t.Fatal("expected tea.Quit command after Esc")


### PR DESCRIPTION
### What

Adds ability to edit any model turn from the browse TUI by pressing 'e'.

- `tell-me-go -b` → navigate with j/k → press 'e' on any model turn → editor opens
- `tell-me-go -e` → edit last turn (unchanged fast path)

### Changes

- New `GetModelTurn(ctx, index)` on `HistoryModifier` interface with full implementation
- 'e' keybinding in browse TUI: fetch turn, open `EditorModel`, save via `UpdateTurnContent`
- Export `editor.WasSaved()` for sub-model completion detection
- Seed editor with `WindowSizeMsg` on creation (Bubble Tea doesn't re-send to late sub-models)
- Refresh in-memory DTO after save so viewport updates immediately
- Tests: `GetModelTurn` (5 cases) + browse edit keybinding (4 cases)

### Files

14 files, +360/−10