### PR TITLE
feat(llm): DeepSeek/Kimi thinking toggle + user_id with config wiring

### DIFF
--- a/docs/adr/2026-07-deepseek-thinking-toggle.md
+++ b/docs/adr/2026-07-deepseek-thinking-toggle.md
@@ -1,0 +1,105 @@
+# ADR-052: DeepSeek/Kimi Thinking Mode Toggle and user_id Isolation
+
+## Status
+Accepted (2026-07)
+
+## Context and Problem Statement
+
+DeepSeek models support a thinking mode (chain-of-thought reasoning) controlled by a non-standard `{"thinking":{"type":"enabled|disabled"}}` request field. The thinking toggle defaults to **enabled** for DeepSeek reasoner-class models and **disabled** for `deepseek-chat`. DeepSeek also supports a `user_id` parameter for content-safety, KVCache, and scheduling isolation.
+
+An initial implementation (PR #1269) was reverted because of two architectural blockers:
+
+1. **Unconditional wire-format change:** The `thinking` field was emitted for every model with `SupportsReasoningContent` (a response-side flag), overriding provider defaults with no opt-out. This forced thinking mode on `deepseek-chat` (which defaults to OFF) and risked bricking Kimi traffic if the provider rejects unknown fields.
+
+2. **Dead code in production:** The `WithThinkingEnabled` and `WithUserID` options existed only at the adapter layer — no config fields, no factory wiring, unreachable by operators.
+
+## Decision Drivers
+
+1. **Preserve provider defaults:** Unconfigured deployments must see zero wire-format change. The thinking field must be omitted unless the operator explicitly sets `THINKING_ENABLED` in YAML.
+
+2. **Decouple request-side from response-side capabilities:** The reverted implementation gated thinking toggle emission on `SupportsReasoningContent`, but Vertex MaaS DeepSeek already proves these vary independently (`RequiresVertexThinkingKwargs` exists because that transport silently ignores the standard `thinking` field).
+
+3. **Fail-fast on misconfiguration:** Invalid `user_id` values must be rejected at startup, not surface as opaque HTTP 400s that abort the failover chain.
+
+4. **Vertex MaaS consistency:** When `THINKING_ENABLED` is explicitly set, `chat_template_kwargs.thinking` must match — otherwise an explicit disable is silently defeated on Vertex transports.
+
+## Considered Options
+
+1. **Gate on `SupportsReasoningContent` (reverted approach):** Rejected. Couples a request-side extension to a response-side flag known to diverge (Vertex MaaS).
+
+2. **Make thinking toggle DeepSeek-only, skip Kimi:** Rejected. Kimi models share the same OpenAI-compatible API surface; scoping them in now avoids a second config change later, and the `SupportsThinkingToggle` gate provides a clean kill-switch if Kimi rejects the field.
+
+3. **Dedicated capability + tri-state config + Vertex reconciliation (chosen).**
+
+## Decision Outcome
+
+Chosen option: **Dedicated `SupportsThinkingToggle` capability with tri-state config and Vertex MaaS reconciliation.**
+
+### Implementation Details
+
+1. **Capability model (`capabilities.go`):**
+   - Added `SupportsThinkingToggle bool` to `Capabilities`, resolved independently in `resolveDeepSeekFamily` and `resolveKimiFamily`.
+   - Set `true` for all `deepseek-*` and `kimi-*` models. All other models default to `false` (zero value).
+   - `SupportsReasoningContent` remains unchanged; it governs only response-side `reasoning_content` serialization.
+
+2. **Config (`config.go`):**
+   - `ThinkingEnabled *bool` — tri-state pointer. `nil` = unset (field omitted from wire), `true`/`false` = explicit. YAML key: `THINKING_ENABLED`.
+   - `UserID string` — validated at startup: `[a-zA-Z0-9\-_]+`, max 512 characters. YAML key: `USER_ID`.
+
+3. **Client options (`openai/client.go`):**
+   - `WithThinkingEnabled(bool)` — sets both `thinkingEnabled` and `thinkingEnabledSet` sentinel. The sentinel distinguishes "explicit false" from "never called" (both have boolean value `false`).
+   - `WithUserID(string)` — sets the user_id value.
+
+4. **Request assembly (`openai/chat.go`):**
+   - Thinking toggle emitted only when `SupportsThinkingToggle && thinkingEnabledSet`. When unset, the field is omitted, preserving provider defaults.
+   - `user_id` emitted only when `SupportsThinkingToggle && userID != ""`.
+   - `injectTransportHints` (Vertex MaaS): `chat_template_kwargs.thinking` honors the resolved toggle value. Defaults to `true` when unconfigured (backward compat). When `thinkingEnabledSet=true`, uses the configured value.
+
+5. **Factory wiring (`factory.go`):**
+   - `buildBaseClient` conditionally appends `WithThinkingEnabled` and `WithUserID` to the option slice when config values are present.
+
+### Cross-Provider Support Matrix
+
+| Provider | `SupportsThinkingToggle` | `thinking` field | `user_id` | Notes |
+|----------|--------------------------|------------------|-----------|-------|
+| `deepseek-*` | `true` | Emitted when configured | Emitted when configured | Includes Vertex MaaS via `chat_template_kwargs` |
+| `kimi-*` | `true` | Emitted when configured | Emitted when configured | Acceptance not yet proven against live API |
+| `gpt-*`, `o1-*`, `o3-*` | `false` | Never emitted | Never emitted | |
+| Anthropic | `false` | Never emitted | Never emitted | Uses separate client path |
+| Gemini | `false` | Never emitted | Never emitted | Uses separate client path |
+
+### Kimi Risk Mitigation
+
+The `SupportsThinkingToggle` capability is set `true` for Kimi models based on their shared OpenAI-compatible API surface. If live testing reveals that the Moonshot/Kimi API rejects the `thinking` field (HTTP 400), mitigation is a one-line change: set `supportsThinkingToggle = false` in `resolveKimiFamily`. No config migration needed — the capability gate makes this a build-time toggle.
+
+## Consequences
+
+- **Positive:** Operators can explicitly control DeepSeek thinking mode from YAML. Unconfigured deployments see zero wire-format change.
+- **Positive:** Multi-tenant deployments gain `user_id`-based KVCache and scheduling isolation, validated at startup.
+- **Positive:** Vertex MaaS thinking toggle no longer silently defeats explicit configuration.
+- **Negative:** Kimi `thinking` field acceptance is unproven. Mitigated by the `SupportsThinkingToggle` kill-switch.
+- **Neutral:** `thinkingEnabledSet` sentinel adds a bool field to `client`. Acceptable complexity trade-off for tri-state semantics.
+
+## Verification
+
+The implementation is pinned by tests in three packages:
+
+- `internal/domain/llm/capabilities_test.go::TestResolveCapabilities` — table-driven capability matrix asserting `SupportsThinkingToggle` for all DeepSeek and Kimi model variants, and `false` for GPT/o-series.
+- `internal/infrastructure/llm/openai/chat_test.go` — 10 test functions covering thinking toggle tri-state (explicit enable, explicit disable, unset-omitted), capability gating (gpt-4 ignores), user_id emission and gating, and Vertex MaaS kwargs reconciliation (explicit disable honored, unset defaults true, non-Vertex no kwargs).
+- `internal/infrastructure/llm/factory_test.go` — 5 factory pass-through tests verifying `THINKING_ENABLED` (`true`, `false`, unset) and `USER_ID` (set, empty) reach the wire through the full `newClient → buildBaseClient → NewClient → SendChat` pipeline.
+- `internal/domain/config/provider_validation_test.go` — existing tests continue to pass, validating the `user_id` format/length constraints are not triggered by zero-value configs.
+
+## Related ADRs
+
+- [**ADR-001**](2026-01-multi-llm-provider-strategy.md): Hybrid LLM Infrastructure Strategy — established the multi-provider architecture that makes per-provider capability gating necessary.
+- [**ADR-023**](2026-04-reasoning-token-accounting.md): Reasoning-Token Accounting — same architectural pattern of normalising provider-specific quirks at the SDK boundary.
+- [**ADR-024**](2026-04-openai-budget-field-divergence.md): OpenAI Chat-vs-Responses Budget-Field Divergence — precedent for `Capabilities` enum modelling of provider-specific wire-format decisions.
+
+## References
+- PR #1269 — initial (reverted) implementation
+- PR #1270 — reinstatement with proper architecture
+- DeepSeek API reference (thinking toggle): <https://api-docs.deepseek.com/guides/thinking_mode>
+- DeepSeek API reference (user_id): <https://api-docs.deepseek.com/guides/per_user_limits>
+
+---
+*Last Updated: 2026-07*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -57,6 +57,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-049** | Third-Party Skill Injection Security Model | 2026-07 | Accepted | [2026-07-skills-sh-injection-security.md](2026-07-skills-sh-injection-security.md) |
 | **ADR-050** | Duplicate Skill Name Resolution Policy | 2026-07 | Accepted | [2026-07-skills-sh-duplicate-resolution.md](2026-07-skills-sh-duplicate-resolution.md) |
 | **ADR-051** | Async TUI Rendering for Large Responses | 2026-07 | Accepted | [2026-07-async-tui-rendering.md](2026-07-async-tui-rendering.md) |
+| **ADR-052** | DeepSeek/Kimi Thinking Mode Toggle and user_id Isolation | 2026-07 | Accepted | [2026-07-deepseek-thinking-toggle.md](2026-07-deepseek-thinking-toggle.md) |
 
 ## How to Create a New ADR
 

--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -25,6 +26,10 @@ const (
 	SystemContextBuffer       = 1000 // Reserved space for system warnings/instructions
 )
 
+// userIDRegex validates the DeepSeek user_id format.
+// Must match [a-zA-Z0-9\-_]+ per DeepSeek API spec.
+var userIDRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
+
 // LLMProvider represents the configuration for a specific AI service provider.
 type LLMProvider struct {
 	Type           string `yaml:"TYPE"`            // e.g., "openai", "anthropic", "gemini"
@@ -38,6 +43,18 @@ type LLMProvider struct {
 	// to this field require a process restart to take effect.
 	MaxTokens int               `yaml:"MAX_TOKENS"`
 	Headers   map[string]string `yaml:"HEADERS"` // Custom HTTP headers
+
+	// ThinkingEnabled controls the DeepSeek/Kimi thinking-mode toggle.
+	// Tri-state: nil = omit the field from the wire (preserve provider
+	// default); true = thinking enabled; false = thinking disabled.
+	// Only emitted for providers with SupportsThinkingToggle capability.
+	ThinkingEnabled *bool `yaml:"THINKING_ENABLED"`
+
+	// UserID is the DeepSeek user_id for content safety, KVCache, and
+	// scheduling isolation. Must match [a-zA-Z0-9\-_]+ with max length
+	// 512. Do not include PII. Emitted only when non-empty for providers
+	// with SupportsThinkingToggle capability.
+	UserID string `yaml:"USER_ID"`
 }
 
 // anthropicThinkingBudgetHeadroom mirrors the Anthropic client's
@@ -67,6 +84,18 @@ func (p *LLMProvider) validate(name string, logger *slog.Logger) error {
 	if p.MaxTokens < 0 {
 		return fmt.Errorf("PROVIDERS.%s.MAX_TOKENS must be >= 0, got %d", name, p.MaxTokens)
 	}
+
+	// user_id validation: enforce format + length constraint at startup
+	// rather than letting invalid values surface as runtime HTTP 400s.
+	if p.UserID != "" {
+		if len(p.UserID) > 512 {
+			return fmt.Errorf("PROVIDERS.%s.USER_ID must be <= 512 characters, got %d", name, len(p.UserID))
+		}
+		if !userIDRegex.MatchString(p.UserID) {
+			return fmt.Errorf("PROVIDERS.%s.USER_ID must match [a-zA-Z0-9\\-_]+, got %q", name, p.UserID)
+		}
+	}
+
 	if p.Type == "anthropic" && p.MaxTokens > 0 && p.ThinkingBudget > 0 &&
 		p.MaxTokens < p.ThinkingBudget+anthropicThinkingBudgetHeadroom {
 		logger.Warn("provider_max_tokens_below_thinking_budget_floor",

--- a/internal/domain/config/config_test.go
+++ b/internal/domain/config/config_test.go
@@ -4,6 +4,9 @@
 package config
 
 import (
+	"io"
+	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
@@ -514,6 +517,40 @@ func TestLLMProvider_Validate_EdgeCases(t *testing.T) {
 				assert.Contains(t, logged, "provider_max_tokens_below_thinking_budget_floor")
 			} else {
 				assert.NotContains(t, logged, "provider_max_tokens_below_thinking_budget_floor")
+			}
+		})
+	}
+}
+
+// TestLLMProvider_Validate_UserID pins the startup validation contract
+// for PROVIDERS.<name>.USER_ID. Valid values pass; too-long, bad
+// characters, and unicode are hard-rejected with actionable messages.
+func TestLLMProvider_Validate_UserID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		userID  string
+		wantErr bool
+	}{
+		{"empty allowed", "", false},
+		{"valid simple", "tenant-42", false},
+		{"valid with dash and underscore", "tenant_a-b", false},
+		{"exactly 512 chars accepted", strings.Repeat("a", 512), false},
+		{"513 chars rejected", strings.Repeat("a", 513), true},
+		{"space rejected", "tenant 42", true},
+		{"special char at rejected", "tenant@42", true},
+		{"unicode rejected", "tenant-\u2122", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			p := &LLMProvider{UserID: tt.userID}
+			err := p.validate("test-provider", slog.New(slog.NewTextHandler(io.Discard, nil)))
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validate() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -67,6 +67,18 @@ type Capabilities struct {
 	// Set for all models known to use reasoning_content natively:
 	// deepseek-* and kimi-* model families.
 	SupportsReasoningContent bool
+	// SupportsThinkingToggle indicates the model accepts the
+	// {"thinking":{"type":"enabled|disabled"}} request field to
+	// control thinking/chain-of-thought mode. When true, the
+	// client emits the toggle explicitly; when false, the field
+	// is omitted from the wire, preserving provider defaults.
+	//
+	// Set for: deepseek-* and kimi-* model families.
+	// Note: independent of SupportsReasoningContent — Vertex MaaS
+	// DeepSeek supports reasoning_content on the response side
+	// but uses chat_template_kwargs on the request side instead
+	// of the standard thinking field (RequiresVertexThinkingKwargs).
+	SupportsThinkingToggle bool
 	// SupportsVision indicates the model natively understands images via
 	// image_url content parts in the messages array. When true, InlineData
 	// parts are serialized as base64 image_url blocks rather than being
@@ -170,9 +182,10 @@ func resolveGPTFamily(model string) (isReasoner bool, requireResponses bool) {
 
 // resolveDeepSeekFamily derives DeepSeek capabilities from the model string and
 // base URL. The base URL is used only for RequiresVertexThinkingKwargs detection.
-func resolveDeepSeekFamily(model, baseURL string) (isDeepSeek, supportsReasoningContent, requiresVertexThinkingKwargs bool) {
+func resolveDeepSeekFamily(model, baseURL string) (isDeepSeek, supportsReasoningContent, supportsThinkingToggle, requiresVertexThinkingKwargs bool) {
 	isDeepSeek = isDeepSeekModel(model)
 	supportsReasoningContent = isDeepSeek
+	supportsThinkingToggle = isDeepSeek
 	if isDeepSeek && strings.Contains(baseURL, "aiplatform.googleapis.com") {
 		requiresVertexThinkingKwargs = true
 	}
@@ -180,11 +193,12 @@ func resolveDeepSeekFamily(model, baseURL string) (isDeepSeek, supportsReasoning
 }
 
 // resolveKimiFamily derives Kimi capabilities from the model string.
-func resolveKimiFamily(model string) (supportsReasoningContent, supportsVision, supportsVideo, supportsFileUpload, supportsReasoningEffort, isKimiK3 bool) {
+func resolveKimiFamily(model string) (supportsReasoningContent, supportsThinkingToggle, supportsVision, supportsVideo, supportsFileUpload, supportsReasoningEffort, isKimiK3 bool) {
 	if !isKimiModel(model) {
 		return
 	}
 	supportsReasoningContent = true
+	supportsThinkingToggle = true
 	supportsVision = true
 	supportsVideo = true
 	supportsFileUpload = true
@@ -202,8 +216,8 @@ func resolveKimiFamily(model string) (supportsReasoningContent, supportsVision, 
 // default to false.
 func ResolveCapabilities(model, baseURL string) Capabilities {
 	isReasoner, requireResponses := resolveGPTFamily(model)
-	isDeepSeek, dsReasoningContent, vertexThinkingKwargs := resolveDeepSeekFamily(model, baseURL)
-	kReasoningContent, supportsVision, supportsVideo, supportsFileUpload, kReasoningEffort, isKimiK3 := resolveKimiFamily(model)
+	isDeepSeek, dsReasoningContent, dsThinkingToggle, vertexThinkingKwargs := resolveDeepSeekFamily(model, baseURL)
+	kReasoningContent, kThinkingToggle, supportsVision, supportsVideo, supportsFileUpload, kReasoningEffort, isKimiK3 := resolveKimiFamily(model)
 
 	caps := Capabilities{
 		SupportsReasoningEffort:      isReasoner || kReasoningEffort,
@@ -211,6 +225,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 		UseDeveloperRole:             isReasoner,
 		IsDeepSeek:                   isDeepSeek,
 		SupportsReasoningContent:     dsReasoningContent || kReasoningContent,
+		SupportsThinkingToggle:       dsThinkingToggle || kThinkingToggle,
 		SupportsVision:               supportsVision,
 		SupportsVideo:                supportsVideo,
 		SupportsFileUpload:           supportsFileUpload,

--- a/internal/domain/llm/capabilities_test.go
+++ b/internal/domain/llm/capabilities_test.go
@@ -18,6 +18,7 @@ func TestResolveCapabilities(t *testing.T) {
 		maxTokensField               MaxTokensField
 		isDeepSeek                   bool
 		supportsReasoningContent     bool
+		supportsThinkingToggle       bool
 		supportsVision               bool
 		supportsVideo                bool
 		requiresVertexThinkingKwargs bool
@@ -134,6 +135,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsVision:           false,
 		},
 		{
@@ -144,6 +146,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsVision:           false,
 		},
 		{
@@ -154,6 +157,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsVision:           false,
 		},
 		{
@@ -164,6 +168,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsVision:           false,
 		},
 		{
@@ -174,6 +179,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:           MaxTokensFieldLegacy,
 			isDeepSeek:               true,
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsVision:           false,
 		},
 		{
@@ -183,6 +189,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsThinkingToggle:       true,
 			supportsVision:               false,
 			requiresVertexThinkingKwargs: true,
 		},
@@ -193,6 +200,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsThinkingToggle:       true,
 			supportsVision:               false,
 			requiresVertexThinkingKwargs: false,
 		},
@@ -213,6 +221,7 @@ func TestResolveCapabilities(t *testing.T) {
 			maxTokensField:               MaxTokensFieldLegacy,
 			isDeepSeek:                   true,
 			supportsReasoningContent:     true,
+			supportsThinkingToggle:       true,
 			supportsVision:               false,
 			requiresVertexThinkingKwargs: false,
 		},
@@ -221,6 +230,7 @@ func TestResolveCapabilities(t *testing.T) {
 			model:                    "kimi-k3",
 			baseURL:                  "",
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsReasoningEffort:  true,
 			supportsVision:           true,
 			supportsVideo:            true,
@@ -231,6 +241,7 @@ func TestResolveCapabilities(t *testing.T) {
 			model:                    "moonshotai/kimi-k3",
 			baseURL:                  "",
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsReasoningEffort:  true,
 			supportsVision:           true,
 			supportsVideo:            true,
@@ -241,6 +252,7 @@ func TestResolveCapabilities(t *testing.T) {
 			model:                    "kimi-k2.7-code",
 			baseURL:                  "",
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsReasoningEffort:  false,
 			supportsVision:           true,
 			supportsVideo:            true,
@@ -251,6 +263,7 @@ func TestResolveCapabilities(t *testing.T) {
 			model:                    "kimi-k2.6",
 			baseURL:                  "",
 			supportsReasoningContent: true,
+			supportsThinkingToggle:   true,
 			supportsReasoningEffort:  false,
 			supportsVision:           true,
 			supportsVideo:            true,
@@ -282,6 +295,9 @@ func TestResolveCapabilities(t *testing.T) {
 			}
 			if caps.SupportsReasoningContent != tt.supportsReasoningContent {
 				t.Errorf("expected SupportsReasoningContent %v, got %v", tt.supportsReasoningContent, caps.SupportsReasoningContent)
+			}
+			if caps.SupportsThinkingToggle != tt.supportsThinkingToggle {
+				t.Errorf("expected SupportsThinkingToggle %v, got %v", tt.supportsThinkingToggle, caps.SupportsThinkingToggle)
 			}
 			if caps.SupportsVision != tt.supportsVision {
 				t.Errorf("expected SupportsVision %v, got %v", tt.supportsVision, caps.SupportsVision)

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -45,14 +45,22 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 
 	switch p.Type {
 	case "openai", "deepseek", "kimi":
-		baseClient = openai.NewClient(p.URL, p.Model, authenticator,
+		opts := []openai.Option{
 			openai.WithHeaders(p.Headers),
 			openai.WithPersona(persona),
 			openai.WithTimeout(timeout),
 			openai.WithThinkingBudget(maxBudget),
 			openai.WithMaxTokens(p.MaxTokens),
 			openai.WithLogger(logger),
-		)
+		}
+		if p.ThinkingEnabled != nil {
+			opts = append(opts, openai.WithThinkingEnabled(*p.ThinkingEnabled))
+		}
+		if p.UserID != "" {
+			opts = append(opts, openai.WithUserID(p.UserID))
+		}
+		baseClient = openai.NewClient(p.URL, p.Model, authenticator, opts...)
+
 		// Warn if using a deprecated DeepSeek model name.
 		if replacement, deprecated := deprecatedDeepSeekModels[p.Model]; deprecated {
 			logger.Warn("deprecated_deepseek_model",

--- a/internal/infrastructure/llm/factory_test.go
+++ b/internal/infrastructure/llm/factory_test.go
@@ -488,6 +488,162 @@ func TestFactory_MaxTokensZero_PreservesProviderDefault(t *testing.T) {
 	})
 }
 
+// --- ThinkingEnabled and UserID factory wiring ---
+//
+// These tests pin the contract that PROVIDERS.<name>.THINKING_ENABLED
+// and PROVIDERS.<name>.USER_ID in YAML reach the per-provider request
+// payload via openai.WithThinkingEnabled / openai.WithUserID.
+
+func TestFactory_PassesThinkingEnabled_True_ToOpenAI(t *testing.T) {
+	var captured map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	enabled := true
+	cfg := &config.Config{
+		SelectedProvider: "deepseek",
+		Providers: map[string]config.LLMProvider{
+			"deepseek": {
+				Type:            "deepseek",
+				URL:             server.URL,
+				Model:           "deepseek-v4-flash",
+				APIKey:          "test-key",
+				ThinkingEnabled: &enabled,
+			},
+		},
+	}
+	runFactorySendChatAndCapture(t, cfg, pricing.PricingData{})
+
+	thinking, ok := captured["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'thinking' in request, got %v", captured)
+	}
+	if thinking["type"] != "enabled" {
+		t.Errorf("expected type='enabled', got %v", thinking["type"])
+	}
+}
+
+func TestFactory_PassesThinkingEnabled_False_ToOpenAI(t *testing.T) {
+	var captured map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	disabled := false
+	cfg := &config.Config{
+		SelectedProvider: "deepseek",
+		Providers: map[string]config.LLMProvider{
+			"deepseek": {
+				Type:            "deepseek",
+				URL:             server.URL,
+				Model:           "deepseek-v4-flash",
+				APIKey:          "test-key",
+				ThinkingEnabled: &disabled,
+			},
+		},
+	}
+	runFactorySendChatAndCapture(t, cfg, pricing.PricingData{})
+
+	thinking, ok := captured["thinking"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected 'thinking' in request, got %v", captured)
+	}
+	if thinking["type"] != "disabled" {
+		t.Errorf("expected type='disabled', got %v", thinking["type"])
+	}
+}
+
+func TestFactory_ThinkingEnabled_Unset_Omitted(t *testing.T) {
+	var captured map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		SelectedProvider: "deepseek",
+		Providers: map[string]config.LLMProvider{
+			"deepseek": {
+				Type:   "deepseek",
+				URL:    server.URL,
+				Model:  "deepseek-v4-flash",
+				APIKey: "test-key",
+				// ThinkingEnabled is nil (zero value)
+			},
+		},
+	}
+	runFactorySendChatAndCapture(t, cfg, pricing.PricingData{})
+
+	if _, ok := captured["thinking"]; ok {
+		t.Errorf("expected 'thinking' to be absent when unset, got %v", captured)
+	}
+}
+
+func TestFactory_PassesUserID_ToOpenAI(t *testing.T) {
+	var captured map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		SelectedProvider: "deepseek",
+		Providers: map[string]config.LLMProvider{
+			"deepseek": {
+				Type:   "deepseek",
+				URL:    server.URL,
+				Model:  "deepseek-v4-flash",
+				APIKey: "test-key",
+				UserID: "tenant-42",
+			},
+		},
+	}
+	runFactorySendChatAndCapture(t, cfg, pricing.PricingData{})
+
+	if captured["user_id"] != "tenant-42" {
+		t.Errorf("expected user_id='tenant-42', got %v", captured["user_id"])
+	}
+}
+
+func TestFactory_UserID_Empty_Omitted(t *testing.T) {
+	var captured map[string]any
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&captured)
+		_, _ = w.Write([]byte(`{"id":"x","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	cfg := &config.Config{
+		SelectedProvider: "deepseek",
+		Providers: map[string]config.LLMProvider{
+			"deepseek": {
+				Type:   "deepseek",
+				URL:    server.URL,
+				Model:  "deepseek-v4-flash",
+				APIKey: "test-key",
+				// UserID is empty (zero value)
+			},
+		},
+	}
+	runFactorySendChatAndCapture(t, cfg, pricing.PricingData{})
+
+	if _, ok := captured["user_id"]; ok {
+		t.Errorf("expected 'user_id' to be absent when empty, got %v", captured)
+	}
+}
+
 // captureLogger returns an slog.Logger that writes warn+ records to
 // the returned buffer. Used to assert factory-side soft-warning
 // emissions. Wrapped in a ports.Logger adapter so it slots into the

--- a/internal/infrastructure/llm/openai/chat.go
+++ b/internal/infrastructure/llm/openai/chat.go
@@ -169,7 +169,11 @@ func (c *client) applyOutputBudget(req *chatRequest, useResponses bool) {
 // certain API surfaces (e.g., Vertex AI thinking mode).
 func (c *client) injectTransportHints(req *chatRequest) {
 	if c.capabilities.RequiresVertexThinkingKwargs {
-		req.ChatTemplateKwargs = map[string]any{"thinking": true}
+		val := true // default: Vertex MaaS thinking ON (backward compat)
+		if c.thinkingEnabledSet {
+			val = c.thinkingEnabled
+		}
+		req.ChatTemplateKwargs = map[string]any{"thinking": val}
 	}
 }
 
@@ -185,6 +189,24 @@ func (c *client) prepareChatRequest(ctx context.Context, history []*llm.Content,
 	}
 
 	c.applyOutputBudget(req, strat.useResponses)
+
+	// DeepSeek/Kimi thinking-mode toggle.
+	// Emitted ONLY when SupportsThinkingToggle is true AND the option
+	// was explicitly called (thinkingEnabledSet). When unset, the field
+	// is omitted, preserving provider defaults.
+	if c.capabilities.SupportsThinkingToggle && c.thinkingEnabledSet {
+		mode := "disabled"
+		if c.thinkingEnabled {
+			mode = "enabled"
+		}
+		req.Thinking = &thinkingToggle{Type: mode}
+	}
+
+	// DeepSeek user_id isolation.
+	if c.capabilities.SupportsThinkingToggle && c.userID != "" {
+		req.UserID = c.userID
+	}
+
 	c.injectTransportHints(req)
 
 	return req, nil

--- a/internal/infrastructure/llm/openai/chat_test.go
+++ b/internal/infrastructure/llm/openai/chat_test.go
@@ -4,12 +4,14 @@
 package openai
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 )
@@ -102,5 +104,230 @@ func TestDecodeResponsesAPIResponse_EmitsTimingDebugLog(t *testing.T) {
 	}
 	if metrics.TotalTokens != 3 {
 		t.Errorf("expected TotalTokens=3, got %d", metrics.TotalTokens)
+	}
+}
+
+// TestThinkingToggle_DeepSeek_ExplicitEnable verifies that
+// WithThinkingEnabled(true) emits {"thinking":{"type":"enabled"}}
+// for models with SupportsThinkingToggle.
+func TestThinkingToggle_DeepSeek_ExplicitEnable(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "deepseek-v4-pro",
+		&auth.BearerAuth{Token: "k"},
+		WithThinkingEnabled(true),
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.Thinking == nil {
+		t.Fatal("expected Thinking field for DeepSeek with explicit enable")
+	}
+	if captured.Thinking.Type != "enabled" {
+		t.Errorf("expected 'enabled', got %q", captured.Thinking.Type)
+	}
+}
+
+// TestThinkingToggle_DeepSeek_ExplicitDisable verifies that
+// WithThinkingEnabled(false) emits {"thinking":{"type":"disabled"}}.
+func TestThinkingToggle_DeepSeek_ExplicitDisable(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "deepseek-v4-pro",
+		&auth.BearerAuth{Token: "k"},
+		WithThinkingEnabled(false),
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.Thinking == nil {
+		t.Fatal("expected Thinking field for explicit disable")
+	}
+	if captured.Thinking.Type != "disabled" {
+		t.Errorf("expected 'disabled', got %q", captured.Thinking.Type)
+	}
+}
+
+// TestThinkingToggle_DeepSeek_Unset_Omitted verifies the tri-state
+// contract: when WithThinkingEnabled is never called, the Thinking
+// field is omitted from the wire, preserving provider defaults.
+func TestThinkingToggle_DeepSeek_Unset_Omitted(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "deepseek-v4-pro",
+		&auth.BearerAuth{Token: "k"},
+		// No WithThinkingEnabled — simulates nil *bool in config
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.Thinking != nil {
+		t.Errorf("expected Thinking to be nil when unconfigured, got %+v", captured.Thinking)
+	}
+}
+
+// TestThinkingToggle_GPT4_NotEmitted verifies the capability gate:
+// gpt-4 lacks SupportsThinkingToggle, so the field is never emitted
+// even when explicitly enabled.
+func TestThinkingToggle_GPT4_NotEmitted(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "gpt-4",
+		&auth.BearerAuth{Token: "k"},
+		WithThinkingEnabled(true),
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.Thinking != nil {
+		t.Errorf("expected Thinking nil for gpt-4 (no SupportsThinkingToggle), got %+v", captured.Thinking)
+	}
+}
+
+// TestUserID_DeepSeek_Emitted verifies that WithUserID emits
+// "user_id" in the JSON request body for DeepSeek models.
+func TestUserID_DeepSeek_Emitted(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "deepseek-v4-pro",
+		&auth.BearerAuth{Token: "k"},
+		WithUserID("tenant-42"),
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.UserID != "tenant-42" {
+		t.Errorf("expected UserID='tenant-42', got %q", captured.UserID)
+	}
+}
+
+// TestUserID_DeepSeek_Empty_Omitted verifies that user_id is omitted
+// from the wire when no WithUserID option is provided.
+func TestUserID_DeepSeek_Empty_Omitted(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "deepseek-v4-pro",
+		&auth.BearerAuth{Token: "k"},
+		// No WithUserID
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.UserID != "" {
+		t.Errorf("expected UserID empty, got %q", captured.UserID)
+	}
+}
+
+// TestUserID_GPT4_NotEmitted verifies the capability gate for user_id:
+// gpt-4 lacks SupportsThinkingToggle, so user_id is never emitted.
+func TestUserID_GPT4_NotEmitted(t *testing.T) {
+	t.Parallel()
+
+	server, captured := captureChatRequest(t)
+	c := NewClient(server.URL, "gpt-4",
+		&auth.BearerAuth{Token: "k"},
+		WithUserID("tenant-42"),
+	)
+	_, _, err := c.SendChat(context.Background(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("SendChat failed: %v", err)
+	}
+
+	if captured.UserID != "" {
+		t.Errorf("expected UserID empty for gpt-4 (no SupportsThinkingToggle), got %q", captured.UserID)
+	}
+}
+
+// TestInjectTransportHints_HonorsExplicitDisable verifies that Vertex
+// MaaS chat_template_kwargs honors an explicit thinking disable.
+func TestInjectTransportHints_HonorsExplicitDisable(t *testing.T) {
+	t.Parallel()
+
+	c := &client{
+		capabilities: llm.Capabilities{
+			RequiresVertexThinkingKwargs: true,
+		},
+		thinkingEnabled:    false,
+		thinkingEnabledSet: true,
+	}
+
+	req := &chatRequest{}
+	c.injectTransportHints(req)
+
+	if req.ChatTemplateKwargs == nil {
+		t.Fatal("expected ChatTemplateKwargs")
+	}
+	val, ok := req.ChatTemplateKwargs["thinking"]
+	if !ok {
+		t.Fatal("expected 'thinking' key")
+	}
+	if val != false {
+		t.Errorf("expected false for explicit disable, got %v", val)
+	}
+}
+
+// TestInjectTransportHints_Unset_DefaultsTrue verifies backward compat:
+// when thinking is unconfigured, Vertex MaaS defaults to thinking ON.
+func TestInjectTransportHints_Unset_DefaultsTrue(t *testing.T) {
+	t.Parallel()
+
+	c := &client{
+		capabilities: llm.Capabilities{
+			RequiresVertexThinkingKwargs: true,
+		},
+		// thinkingEnabledSet defaults to false — simulates unconfigured
+	}
+
+	req := &chatRequest{}
+	c.injectTransportHints(req)
+
+	if req.ChatTemplateKwargs == nil {
+		t.Fatal("expected ChatTemplateKwargs")
+	}
+	val, ok := req.ChatTemplateKwargs["thinking"]
+	if !ok {
+		t.Fatal("expected 'thinking' key")
+	}
+	if val != true {
+		t.Errorf("expected true (backward compat default), got %v", val)
+	}
+}
+
+// TestInjectTransportHints_NonVertex_NoKwargs verifies that
+// ChatTemplateKwargs is not set for non-Vertex models.
+func TestInjectTransportHints_NonVertex_NoKwargs(t *testing.T) {
+	t.Parallel()
+
+	c := &client{
+		capabilities: llm.Capabilities{
+			RequiresVertexThinkingKwargs: false,
+		},
+		thinkingEnabled:    true,
+		thinkingEnabledSet: true,
+	}
+
+	req := &chatRequest{}
+	c.injectTransportHints(req)
+
+	if req.ChatTemplateKwargs != nil {
+		t.Errorf("expected nil ChatTemplateKwargs for non-Vertex, got %v", req.ChatTemplateKwargs)
 	}
 }

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -20,21 +20,21 @@ import (
 
 // client implements the llm.LLMClient interface for OpenAI-compatible APIs.
 type client struct {
-	httpClient     *http.Client
-	transport      http.RoundTripper
-	authenticator  auth.Authenticator
-	baseURL        string
-	model          string
-	capabilities   llm.Capabilities
-	headers        map[string]string
-	persona        string
-	thinkingBudget    int
-	maxTokens         int
-	thinkingEnabled    bool // thinking toggle value; meaningless unless thinkingEnabledSet is true
-	thinkingEnabledSet bool // true when WithThinkingEnabled was called (tri-state: unset vs explicit false)
+	httpClient         *http.Client
+	transport          http.RoundTripper
+	authenticator      auth.Authenticator
+	baseURL            string
+	model              string
+	capabilities       llm.Capabilities
+	headers            map[string]string
+	persona            string
+	thinkingBudget     int
+	maxTokens          int
+	thinkingEnabled    bool   // thinking toggle value; meaningless unless thinkingEnabledSet is true
+	thinkingEnabledSet bool   // true when WithThinkingEnabled was called (tri-state: unset vs explicit false)
 	userID             string // DeepSeek user_id for isolation
-	logger            ports.Logger
-	timeout        time.Duration
+	logger             ports.Logger
+	timeout            time.Duration
 }
 
 // Option defines a functional option for configuring the OpenAI Client.

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -28,40 +28,66 @@ type client struct {
 	capabilities   llm.Capabilities
 	headers        map[string]string
 	persona        string
-	thinkingBudget int
-	maxTokens      int
-	logger         ports.Logger
+	thinkingBudget    int
+	maxTokens         int
+	thinkingEnabled    bool // thinking toggle value; meaningless unless thinkingEnabledSet is true
+	thinkingEnabledSet bool // true when WithThinkingEnabled was called (tri-state: unset vs explicit false)
+	userID             string // DeepSeek user_id for isolation
+	logger            ports.Logger
 	timeout        time.Duration
 }
 
-// openaiOption defines a functional option for configuring the OpenAI Client.
-type openaiOption func(*client)
+// Option defines a functional option for configuring the OpenAI Client.
+type Option func(*client)
 
 // WithHeaders sets the custom headers for the OpenAI Client.
-func WithHeaders(headers map[string]string) openaiOption {
+func WithHeaders(headers map[string]string) Option {
 	return func(c *client) {
 		c.headers = headers
 	}
 }
 
 // WithPersona sets the initial persona instruction for the OpenAI Client.
-func WithPersona(persona string) openaiOption {
+func WithPersona(persona string) Option {
 	return func(c *client) {
 		c.persona = persona
 	}
 }
 
 // WithTimeout sets the HTTP timeout for the OpenAI Client.
-func WithTimeout(timeout time.Duration) openaiOption {
+func WithTimeout(timeout time.Duration) Option {
 	return func(c *client) {
 		c.timeout = timeout
 	}
 }
 
 // WithThinkingBudget sets the thinking budget for models that support it.
-func WithThinkingBudget(budget int) openaiOption {
+func WithThinkingBudget(budget int) Option {
 	return func(c *client) {
 		c.thinkingBudget = budget
+	}
+}
+
+// WithThinkingEnabled controls the DeepSeek/Kimi thinking-mode toggle.
+// When true, the request includes {"thinking": {"type": "enabled"}}.
+// When false, includes {"thinking": {"type": "disabled"}}.
+// When not called at all, the field is omitted from the wire, preserving
+// the provider's default. Only emitted for models where
+// SupportsThinkingToggle is true.
+func WithThinkingEnabled(enabled bool) Option {
+	return func(c *client) {
+		c.thinkingEnabled = enabled
+		c.thinkingEnabledSet = true
+	}
+}
+
+// WithUserID sets the DeepSeek user_id for content safety isolation,
+// KVCache isolation, and scheduling isolation. The value is validated
+// at config load ([a-zA-Z0-9\-_]+, max 512). Do not include PII.
+// Only emitted for models where SupportsThinkingToggle is true.
+func WithUserID(id string) Option {
+	return func(c *client) {
+		c.userID = id
 	}
 }
 
@@ -88,7 +114,7 @@ func WithThinkingBudget(budget int) openaiOption {
 // TestOpenAI_WithMaxTokens_ZeroAndNoThinkingBudget_FallsBackToDefault,
 // and TestOpenAI_WithMaxTokens_DeepSeek_PopulatesMaxTokensField in
 // maxtokens_test.go.
-func WithMaxTokens(n int) openaiOption {
+func WithMaxTokens(n int) Option {
 	return func(c *client) {
 		if n > 0 {
 			c.maxTokens = n
@@ -97,14 +123,14 @@ func WithMaxTokens(n int) openaiOption {
 }
 
 // WithLogger sets the logger for the OpenAI Client.
-func WithLogger(l ports.Logger) openaiOption {
+func WithLogger(l ports.Logger) Option {
 	return func(c *client) {
 		c.logger = l
 	}
 }
 
 // NewClient creates a new OpenAI-compatible client.
-func NewClient(baseURL, model string, authenticator auth.Authenticator, opts ...openaiOption) *client {
+func NewClient(baseURL, model string, authenticator auth.Authenticator, opts ...Option) *client {
 	if baseURL == "" {
 		baseURL = "https://api.openai.com/v1"
 	}
@@ -149,6 +175,13 @@ type chatRequest struct {
 	MaxOutputTokens     int              `json:"max_output_tokens,omitempty"` // NEW: for /responses endpoint
 	Reasoning           *reasoningConfig `json:"reasoning,omitempty"`
 	ReasoningEffort     string           `json:"reasoning_effort,omitempty"`
+	// Thinking controls the DeepSeek/Kimi thinking mode toggle.
+	// {"type": "enabled"} or {"type": "disabled"}. Omitted when nil.
+	Thinking *thinkingToggle `json:"thinking,omitempty"`
+
+	// UserID carries the DeepSeek user_id for isolation.
+	// Omitted when empty.
+	UserID string `json:"user_id,omitempty"`
 	// ChatTemplateKwargs carries non-standard template parameters required
 	// by certain transports. Used to enable thinking mode on Vertex AI's
 	// deepseek-ai/deepseek-v3.2-maas, which silently ignores the standard
@@ -168,6 +201,11 @@ type historyItem struct {
 
 type reasoningConfig struct {
 	Effort string `json:"effort,omitempty"`
+}
+
+// thinkingToggle controls the DeepSeek thinking mode.
+type thinkingToggle struct {
+	Type string `json:"type"`
 }
 
 type responsesAPIResponse struct {


### PR DESCRIPTION
## Summary

Reintroduces the thinking mode toggle and `user_id` features reverted from PR #1269, with proper architecture addressing all review findings.

Closes #1270.

## Design

### 1. Dedicated capability — `SupportsThinkingToggle`

Added to `Capabilities` and resolved independently per-family. Decoupled from the response-side `SupportsReasoningContent` flag. Set `true` for `deepseek-*` and `kimi-*`; `false` for all others.

### 2. Config wiring — tri-state `THINKING_ENABLED`

`config.LLMProvider` gains `ThinkingEnabled *bool` and `UserID string`. `*bool` is load-bearing: `nil` = unset (field omitted from wire, preserving provider defaults). `UserID` validated at startup: `[a-zA-Z0-9\-_]+`, max 512.

### 3. Vertex MaaS kwargs reconciliation

`injectTransportHints` no longer hardcodes `thinking: true`. Honors the resolved toggle value. Defaults to `true` for backward compat when unconfigured.

### 4. Kimi risk mitigation

`SupportsThinkingToggle` is `true` for Kimi, but gated behind the capability. If Kimi rejects the `thinking` field, mitigation is a one-line change: flip `supportsThinkingToggle = false` in `resolveKimiFamily`.

## Wire-format contract

| Config | Wire result |
|--------|------------|
| No `THINKING_ENABLED` | Field omitted (preserves provider defaults) |
| `THINKING_ENABLED: true` | `{"thinking":{"type":"enabled"}}` |
| `THINKING_ENABLED: false` | `{"thinking":{"type":"disabled"}}` |
| No `USER_ID` | Field omitted |
| `USER_ID: "tenant-42"` | `"user_id":"tenant-42"` |
| gpt-4 with either set | Neither emitted (capability gate) |

## Files changed

| File | Change |
|------|--------|
| `capabilities.go` | `SupportsThinkingToggle` capability |
| `capabilities_test.go` | Test cases for all model families |
| `config.go` | `ThinkingEnabled *bool` + `UserID string` + validation |
| `openai/client.go` | Export `Option` type; reinstate `WithThinkingEnabled`/`WithUserID` |
| `openai/chat.go` | Toggle + user_id emission gated on `SupportsThinkingToggle`; Vertex reconciliation |
| `openai/chat_test.go` | 10 tests: tri-state, capability gate, Vertex kwargs |
| `factory.go` | Slice form + conditional wiring |
| `factory_test.go` | 5 pass-through tests |
| `docs/adr/2026-07-deepseek-thinking-toggle.md` | ADR-052 |
| `docs/adr/README.md` | Index update |

All tests pass. Linter clean. ADR index consistent.