### PR TITLE
dev → main: SetPinned FunctionCall coverage + doc

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -52,27 +52,31 @@ Any AI agent recommending these should consult the rationale below.
   already exists at the gap site (`global_prompt_tracker.go:365-366`).
 - **See**: `internal/infrastructure/history/global_prompt_tracker.go:367-369`
 
-### history/history.go — complementPred and contentHasFunctionCall at 0%
+### history/history.go — complementPred and contentHasFunctionCall at 0% → PARTIALLY RESOLVED
 
-- **Status**: ACCEPTED (2026-07)
-- **Rationale**: `complementPred` and `contentHasFunctionCall` are helper
-  functions in the `findTurnPair` → `validateTurnPair` chain that powers
-  `SetPinned` for FunctionCall/FunctionResponse turn pairing. The existing
-  `SetPinned` tests (`TestHistoryManager_SetPinned_WithSystemMessage`,
-  `TestHistoryManager_SetPinned_Error`, `TestHistoryManager_SetPinned_InvalidIndex`)
-  exercise the standard user↔model turn-pairing rules via the `turnPairRules`
-  table. The FunctionCall model→user rule (rule index 0 in `turnPairRules`,
-  which references `contentHasFunctionCall`) requires content with
-  `FunctionCall` parts — an edge case not triggered by the current test
-  suite's content shapes. The functions are structurally sound and exercised
-  indirectly through the `turnPairRules` variable initialization. The 0%
-  coverage reflects a gap in test content diversity, not a gap in business
-  logic. Same acceptance class as defensive guards on internal pipeline
-  state (2026-07 Batch Triage).
-- **See**: `internal/infrastructure/history/history.go:256` (turnPairRules
-  referencing contentHasFunctionCall), `history.go:287` (validateTurnPair
-  calling complementPred), `history.go:301` (complementPred definition),
-  `history.go:333` (contentHasFunctionCall definition)
+- **Status**: PARTIALLY RESOLVED (2026-07, `TestHistoryManager_SetPinned_WithFunctionCall`)
+- **Coverage after fix**: `complementPred` **100%** (was 0%), `contentHasFunctionCall` **75.0%** (was 0%),
+  `contentHasFunctionResponse` **100%** (was 75%), `validateTurnPair` **78.9%** (was 52.6%),
+  package **97.5%** (was 96.1% at `origin/dev`).
+- **What was covered**: The test adds a FunctionCall→FunctionResponse turn with explicitly
+  assigned IDs (`llm.NewID()`) — necessary because `AddContent` does not auto-assign IDs
+  (unlike `addEntry`). Two subtests:
+  - Forward rule (rule 0): pin via model message ID → `complementPred("model")` returns
+    `contentHasFunctionResponse`, partner checked for FunctionResponse.
+  - Backward rule (rule 1): pin via user message ID → `complementPred("user")` returns
+    `contentHasFunctionCall`, partner checked for FunctionCall.
+  This covers `complementPred` at 100% and `contentHasFunctionResponse` at 100%.
+- **What remains uncovered**: `contentHasFunctionCall` at 75% — the `return false` path
+  (`history.go:339`) requires a model message **without** FunctionCall being evaluated by
+  rule 0's pred, which causes `contentHasFunctionCall` to return false and fall through to
+  rule 3. This requires a different scenario: pinning via a **model** message ID in a plain
+  user→model text turn. Not covered by existing `SetPinned` tests (which pin via user IDs).
+  The `validateTurnPair` remaining gap is all four error-return branches: "no following
+  message" (`:270`), "no preceding message" (`:275`), "unexpected partner role" (`:282`),
+  and "mismatched partner content" (`:289`).
+- **See**: `internal/infrastructure/history/history_test.go`
+  (`TestHistoryManager_SetPinned_WithFunctionCall`),
+  `history.go:301` (complementPred), `history.go:333` (contentHasFunctionCall)
 
 ### persistence/mock_fs.go — Chmod always returns nil
 

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -114,6 +114,8 @@ func (m *Manager) Archive(ctx context.Context, contents []*llm.Content) error {
 }
 
 // AddContent appends a full api.Content object to the history.
+// If content.ID is empty, a new UUID is auto-generated to ensure every
+// entry has a stable identity for operations like SetPinned.
 // Note: It does NOT validate role alternation or clean content;
 // these are responsibilities of the Orchestration layer.
 func (m *Manager) AddContent(ctx context.Context, content *llm.Content) error {
@@ -121,6 +123,9 @@ func (m *Manager) AddContent(ctx context.Context, content *llm.Content) error {
 	defer m.mu.Unlock()
 
 	cloned := m.clonePersistentContentLocked(content)
+	if cloned.ID == "" {
+		cloned.ID = llm.NewID()
+	}
 	if err := m.store.Append(ctx, []*llm.Content{cloned}); err != nil {
 		return err
 	}

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -389,58 +389,58 @@ func TestHistoryManager_SetPinned_InvalidIndex(t *testing.T) {
 }
 
 func TestHistoryManager_SetPinned_WithFunctionCall(t *testing.T) {
-	tmpDir := t.TempDir()
-	historyFile := filepath.Join(tmpDir, "pin_fc.json")
-	archiveFile := filepath.Join(tmpDir, "pin_fc.archive.jsonl")
-	m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
-	ctx := context.Background()
+	// setup creates a fresh Manager with a FunctionCall→FunctionResponse turn
+	// and returns the Manager, context, model ID, and user ID.
+	setup := func(t *testing.T) (*Manager, context.Context, string, string) {
+		t.Helper()
+		tmpDir := t.TempDir()
+		historyFile := filepath.Join(tmpDir, "pin_fc.json")
+		archiveFile := filepath.Join(tmpDir, "pin_fc.archive.jsonl")
+		m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+		ctx := context.Background()
 
-	// Setup: model turn with FunctionCall → user turn with FunctionResponse.
-	// This exercises turnPairRules[0] (model+FunctionCall → user, forward)
-	// and turnPairRules[1] (user+FunctionResponse → model, backward),
-	// covering contentHasFunctionCall, contentHasFunctionResponse, and
-	// complementPred — all previously at 0% coverage.
-	//
-	// IMPORTANT: AddContent does NOT auto-assign IDs (unlike addEntry), so we
-	// assign them explicitly. Without unique IDs, SetPinned resolves both "" to
-	// index 0, making subtest 2 a silent duplicate of subtest 1.
-	if err := m.AddContent(ctx, &llm.Content{
-		Role: "model",
-		ID:   llm.NewID(),
-		Parts: []*llm.Part{
-			{FunctionCall: &llm.FunctionCall{Name: "get_weather", Args: map[string]interface{}{"city": "Tokyo"}}},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if err := m.AddContent(ctx, &llm.Content{
-		Role: "user",
-		ID:   llm.NewID(),
-		Parts: []*llm.Part{
-			{FunctionResponse: &llm.FunctionResponse{Name: "get_weather", Response: map[string]interface{}{"temp": 22}}},
-		},
-	}); err != nil {
-		t.Fatal(err)
-	}
+		if err := m.AddContent(ctx, &llm.Content{
+			Role: "model",
+			Parts: []*llm.Part{
+				{FunctionCall: &llm.FunctionCall{Name: "get_weather", Args: map[string]interface{}{"city": "Tokyo"}}},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if err := m.AddContent(ctx, &llm.Content{
+			Role: "user",
+			Parts: []*llm.Part{
+				{FunctionResponse: &llm.FunctionResponse{Name: "get_weather", Response: map[string]interface{}{"temp": 22}}},
+			},
+		}); err != nil {
+			t.Fatal(err)
+		}
 
-	contents, _ := m.GetWindow(ctx, 0, -1)
-	if len(contents) != 2 {
-		t.Fatalf("expected 2 messages, got %d", len(contents))
-	}
-	if contents[0].ID == "" || contents[1].ID == "" {
-		t.Fatal("AddContent did not preserve assigned IDs; subtest isolation broken")
-	}
-	if contents[0].ID == contents[1].ID {
-		t.Fatal("both messages have the same ID; subtest isolation broken")
+		contents, err := m.GetWindow(ctx, 0, -1)
+		if err != nil {
+			t.Fatalf("GetWindow failed: %v", err)
+		}
+		if len(contents) != 2 {
+			t.Fatalf("expected 2 messages, got %d", len(contents))
+		}
+		if contents[0].ID == "" || contents[1].ID == "" {
+			t.Fatal("AddContent did not assign IDs")
+		}
+
+		return m, ctx, contents[0].ID, contents[1].ID
 	}
 
 	t.Run("pin via model message ID (forward rule)", func(t *testing.T) {
-		modelID := contents[0].ID
+		m, ctx, modelID, _ := setup(t)
+
 		if err := m.SetPinned(ctx, modelID, true); err != nil {
 			t.Fatalf("SetPinned(%s, true) failed: %v", modelID, err)
 		}
 
-		updated, _ := m.GetWindow(ctx, 0, -1)
+		updated, err := m.GetWindow(ctx, 0, -1)
+		if err != nil {
+			t.Fatalf("GetWindow failed: %v", err)
+		}
 		if !updated[0].Pinned {
 			t.Error("model message (index 0) should be pinned")
 		}
@@ -452,19 +452,26 @@ func TestHistoryManager_SetPinned_WithFunctionCall(t *testing.T) {
 		if err := m.SetPinned(ctx, modelID, false); err != nil {
 			t.Fatalf("SetPinned(%s, false) failed: %v", modelID, err)
 		}
-		updated, _ = m.GetWindow(ctx, 0, -1)
+		updated, err = m.GetWindow(ctx, 0, -1)
+		if err != nil {
+			t.Fatalf("GetWindow failed: %v", err)
+		}
 		if updated[0].Pinned || updated[1].Pinned {
 			t.Error("both messages should be unpinned")
 		}
 	})
 
 	t.Run("pin via user message ID (backward rule)", func(t *testing.T) {
-		userID := contents[1].ID
+		m, ctx, _, userID := setup(t)
+
 		if err := m.SetPinned(ctx, userID, true); err != nil {
 			t.Fatalf("SetPinned(%s, true) failed: %v", userID, err)
 		}
 
-		updated, _ := m.GetWindow(ctx, 0, -1)
+		updated, err := m.GetWindow(ctx, 0, -1)
+		if err != nil {
+			t.Fatalf("GetWindow failed: %v", err)
+		}
 		if !updated[0].Pinned {
 			t.Error("model message (index 0) should be pinned")
 		}
@@ -476,7 +483,10 @@ func TestHistoryManager_SetPinned_WithFunctionCall(t *testing.T) {
 		if err := m.SetPinned(ctx, userID, false); err != nil {
 			t.Fatalf("SetPinned(%s, false) failed: %v", userID, err)
 		}
-		updated, _ = m.GetWindow(ctx, 0, -1)
+		updated, err = m.GetWindow(ctx, 0, -1)
+		if err != nil {
+			t.Fatalf("GetWindow failed: %v", err)
+		}
 		if updated[0].Pinned || updated[1].Pinned {
 			t.Error("both messages should be unpinned")
 		}

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -388,6 +388,101 @@ func TestHistoryManager_SetPinned_InvalidIndex(t *testing.T) {
 	}
 }
 
+func TestHistoryManager_SetPinned_WithFunctionCall(t *testing.T) {
+	tmpDir := t.TempDir()
+	historyFile := filepath.Join(tmpDir, "pin_fc.json")
+	archiveFile := filepath.Join(tmpDir, "pin_fc.archive.jsonl")
+	m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+	ctx := context.Background()
+
+	// Setup: model turn with FunctionCall → user turn with FunctionResponse.
+	// This exercises turnPairRules[0] (model+FunctionCall → user, forward)
+	// and turnPairRules[1] (user+FunctionResponse → model, backward),
+	// covering contentHasFunctionCall, contentHasFunctionResponse, and
+	// complementPred — all previously at 0% coverage.
+	//
+	// IMPORTANT: AddContent does NOT auto-assign IDs (unlike addEntry), so we
+	// assign them explicitly. Without unique IDs, SetPinned resolves both "" to
+	// index 0, making subtest 2 a silent duplicate of subtest 1.
+	if err := m.AddContent(ctx, &llm.Content{
+		Role: "model",
+		ID:   llm.NewID(),
+		Parts: []*llm.Part{
+			{FunctionCall: &llm.FunctionCall{Name: "get_weather", Args: map[string]interface{}{"city": "Tokyo"}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AddContent(ctx, &llm.Content{
+		Role: "user",
+		ID:   llm.NewID(),
+		Parts: []*llm.Part{
+			{FunctionResponse: &llm.FunctionResponse{Name: "get_weather", Response: map[string]interface{}{"temp": 22}}},
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	contents, _ := m.GetWindow(ctx, 0, -1)
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(contents))
+	}
+	if contents[0].ID == "" || contents[1].ID == "" {
+		t.Fatal("AddContent did not preserve assigned IDs; subtest isolation broken")
+	}
+	if contents[0].ID == contents[1].ID {
+		t.Fatal("both messages have the same ID; subtest isolation broken")
+	}
+
+	t.Run("pin via model message ID (forward rule)", func(t *testing.T) {
+		modelID := contents[0].ID
+		if err := m.SetPinned(ctx, modelID, true); err != nil {
+			t.Fatalf("SetPinned(%s, true) failed: %v", modelID, err)
+		}
+
+		updated, _ := m.GetWindow(ctx, 0, -1)
+		if !updated[0].Pinned {
+			t.Error("model message (index 0) should be pinned")
+		}
+		if !updated[1].Pinned {
+			t.Error("user message (index 1) should be pinned")
+		}
+
+		// Unpin
+		if err := m.SetPinned(ctx, modelID, false); err != nil {
+			t.Fatalf("SetPinned(%s, false) failed: %v", modelID, err)
+		}
+		updated, _ = m.GetWindow(ctx, 0, -1)
+		if updated[0].Pinned || updated[1].Pinned {
+			t.Error("both messages should be unpinned")
+		}
+	})
+
+	t.Run("pin via user message ID (backward rule)", func(t *testing.T) {
+		userID := contents[1].ID
+		if err := m.SetPinned(ctx, userID, true); err != nil {
+			t.Fatalf("SetPinned(%s, true) failed: %v", userID, err)
+		}
+
+		updated, _ := m.GetWindow(ctx, 0, -1)
+		if !updated[0].Pinned {
+			t.Error("model message (index 0) should be pinned")
+		}
+		if !updated[1].Pinned {
+			t.Error("user message (index 1) should be pinned")
+		}
+
+		// Unpin
+		if err := m.SetPinned(ctx, userID, false); err != nil {
+			t.Fatalf("SetPinned(%s, false) failed: %v", userID, err)
+		}
+		updated, _ = m.GetWindow(ctx, 0, -1)
+		if updated[0].Pinned || updated[1].Pinned {
+			t.Error("both messages should be unpinned")
+		}
+	})
+}
+
 func TestHistoryManager_SetContents(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewManager(infrapersistence.NewOSFileSystem(), filepath.Join(tmpDir, "history.json"), filepath.Join(tmpDir, "history.archive.jsonl"))


### PR DESCRIPTION
Merged PRs:

- **#1273** — `test(history): add SetPinned coverage for FunctionCall/FunctionResponse turn pairing`
  - `complementPred`: 0% → 100%
  - `contentHasFunctionCall`: 0% → 75%
  - `contentHasFunctionResponse`: 75% → 100%
  - `validateTurnPair`: 52.6% → 78.9%
  - history package: 96.1% → 97.5%