### PR TITLE
feat: introduce APIFamily typed enum for wire-protocol dispatch (#1277)

### DIFF
--- a/docs/domain-model/tell-me-go.modelith.md
+++ b/docs/domain-model/tell-me-go.modelith.md
@@ -14,6 +14,16 @@ A high-performance CLI assistant that unifies reasoning engines (Gemini, OpenAI,
 
 ## Enums
 
+### `APIFamily`
+
+The wire-protocol family backing an LLM `Provider`. There are exactly three families — this is the compile-time-safe dispatch dimension (distinct from the user-facing `Provider.type` label string, which may include OpenAI-compatible providers like "deepseek" or "kimi").
+
+| Value | Definition |
+| --- | --- |
+| `openai` | OpenAI-compatible API (covers openai, deepseek, kimi, and any future provider speaking the OpenAI protocol). |
+| `anthropic` | Anthropic Messages API. |
+| `gemini` | Google Gemini / Vertex AI API (covers google, gemini, vertex). |
+
 ### `LLMError`
 
 Categories of `Provider` error that affect retry and failover behaviour. Distinguishing these lets the `Orchestrator` decide whether to retry the same `Provider`, switch to a fallback, or surface the error to the user.
@@ -25,17 +35,6 @@ Categories of `Provider` error that affect retry and failover behaviour. Disting
 | `auth_failure` | The API key or credentials are invalid — no retry. |
 | `server_error` | A transient 5xx from the `Provider`; may succeed on retry or failover. |
 | `timeout` | The `Provider` did not respond within `Config.HTTP_TIMEOUT`. |
-
-### `ProviderType`
-
-The API family backing an LLM `Provider`.
-
-| Value | Definition |
-| --- | --- |
-| `gemini` | Google Vertex AI (Gemini 3.0 / 3.1). |
-| `openai` | OpenAI API (GPT-5.4 / 5.5). |
-| `deepseek` | DeepSeek API (V3.2 / V4) or Vertex AI Model-as-a-Service. |
-| `anthropic` | Anthropic API or Vertex AI hosted Claude (Opus 4.7). |
 
 ## Entities
 
@@ -141,7 +140,8 @@ An LLM backend reachable via a specific API. Encapsulates the type (gemini/opena
 | Name | Type | Description |
 | --- | --- | --- |
 | `name` | string | The registry key identifying this `Provider` (e.g. "vertex-flash", "deepseek-pro"). Note: In Go, this is the map key in `Config.Providers`, not a field on the `LLMProvider` struct. It is listed here because it is the `Provider`'s primary identity in the domain. |
-| `type` | ProviderType |  |
+| `type` | string | The user-facing label identifying this `Provider` (e.g. "vertex-flash", "deepseek-pro", "kimi"). This is a free-form string, not an enum — multiple labels map to the same `APIFamily`. The `family` attribute (derived) resolves this label to a wire-protocol family. |
+| `family` | APIFamily | _Derived:_ Resolved from `type` via `LLMProvider.Family()` — "openai"/"deepseek"/"kimi" → openai, "anthropic" → anthropic, "google"/"gemini"/"" → gemini. |
 | `model` | string | The model identifier sent on the wire. |
 | `url` | string | Base API endpoint. |
 | `maxTokens` | integer |  |

--- a/docs/domain-model/tell-me-go.modelith.yaml
+++ b/docs/domain-model/tell-me-go.modelith.yaml
@@ -33,17 +33,19 @@ glossary:
     controlled by `Config.bypassConfirmation`.
 
 enums:
-  ProviderType:
-    description: The API family backing an LLM `Provider`.
+  APIFamily:
+    description: >
+      The wire-protocol family backing an LLM `Provider`. There are exactly
+      three families — this is the compile-time-safe dispatch dimension
+      (distinct from the user-facing `Provider.type` label string, which
+      may include OpenAI-compatible providers like "deepseek" or "kimi").
     values:
-      - name: gemini
-        definition: Google Vertex AI (Gemini 3.0 / 3.1).
       - name: openai
-        definition: OpenAI API (GPT-5.4 / 5.5).
-      - name: deepseek
-        definition: DeepSeek API (V3.2 / V4) or Vertex AI Model-as-a-Service.
+        definition: OpenAI-compatible API (covers openai, deepseek, kimi, and any future provider speaking the OpenAI protocol).
       - name: anthropic
-        definition: Anthropic API or Vertex AI hosted Claude (Opus 4.7).
+        definition: Anthropic Messages API.
+      - name: gemini
+        definition: Google Gemini / Vertex AI API (covers google, gemini, vertex).
 
   LLMError:
     description: >
@@ -244,7 +246,18 @@ entities:
           Note: In Go, this is the map key in `Config.Providers`, not a field on the `LLMProvider` struct.
           It is listed here because it is the `Provider`'s primary identity in the domain.
       - name: type
-        type: ProviderType
+        type: string
+        description: >
+          The user-facing label identifying this `Provider` (e.g. "vertex-flash",
+          "deepseek-pro", "kimi"). This is a free-form string, not an enum —
+          multiple labels map to the same `APIFamily`. The `family` attribute
+          (derived) resolves this label to a wire-protocol family.
+      - name: family
+        type: APIFamily
+        derived: true
+        derivation: >
+          Resolved from `type` via `LLMProvider.Family()` — "openai"/"deepseek"/"kimi"
+          → openai, "anthropic" → anthropic, "google"/"gemini"/"" → gemini.
       - name: model
         type: string
         description: The model identifier sent on the wire.

--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -35,8 +35,10 @@ var userIDRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 // with a provider, as opposed to LLMProvider.Type which is the
 // user-facing label string (e.g., "kimi", "deepseek").
 //
-// There are exactly three API families. Adding a fourth is a
-// compile-time error at every exhaustive switch site.
+// There are exactly three API families. The set is intended to be
+// exhaustive — adding a fourth should be a deliberate, grep-able change
+// at every switch site. Enable the 'exhaustive' linter for this type
+// to make it a compile-time error.
 type APIFamily string
 
 const (
@@ -127,7 +129,7 @@ func (p *LLMProvider) validate(name string, logger *slog.Logger) error {
 		}
 	}
 
-	if p.Type == "anthropic" && p.MaxTokens > 0 && p.ThinkingBudget > 0 &&
+	if p.Family() == APIAnthropic && p.MaxTokens > 0 && p.ThinkingBudget > 0 &&
 		p.MaxTokens < p.ThinkingBudget+anthropicThinkingBudgetHeadroom {
 		logger.Warn("provider_max_tokens_below_thinking_budget_floor",
 			"provider", name,

--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -30,6 +30,21 @@ const (
 // Must match [a-zA-Z0-9\-_]+ per DeepSeek API spec.
 var userIDRegex = regexp.MustCompile(`^[a-zA-Z0-9\-_]+$`)
 
+// APIFamily identifies the wire-protocol family of an LLM provider.
+// It is the compile-time-safe representation of how to communicate
+// with a provider, as opposed to LLMProvider.Type which is the
+// user-facing label string (e.g., "kimi", "deepseek").
+//
+// There are exactly three API families. Adding a fourth is a
+// compile-time error at every exhaustive switch site.
+type APIFamily string
+
+const (
+	APIOpenAI    APIFamily = "openai"    // OpenAI-compatible: openai, deepseek, kimi
+	APIAnthropic APIFamily = "anthropic" // Anthropic Messages API
+	APIGemini    APIFamily = "gemini"    // Google Gemini / Vertex AI
+)
+
 // LLMProvider represents the configuration for a specific AI service provider.
 type LLMProvider struct {
 	Type           string `yaml:"TYPE"`            // e.g., "openai", "anthropic", "gemini"
@@ -55,6 +70,22 @@ type LLMProvider struct {
 	// 512. Do not include PII. Emitted only when non-empty for providers
 	// with SupportsThinkingToggle capability.
 	UserID string `yaml:"USER_ID"`
+}
+
+// Family returns the wire-protocol family for this provider,
+// derived from its Type label. Unknown types default to APIGemini
+// for backward compatibility with the existing factory switch.
+func (p *LLMProvider) Family() APIFamily {
+	switch p.Type {
+	case "openai", "deepseek", "kimi":
+		return APIOpenAI
+	case "anthropic":
+		return APIAnthropic
+	case "google", "gemini", "":
+		return APIGemini
+	default:
+		return APIGemini
+	}
 }
 
 // anthropicThinkingBudgetHeadroom mirrors the Anthropic client's

--- a/internal/domain/config/config_test.go
+++ b/internal/domain/config/config_test.go
@@ -780,3 +780,38 @@ func TestConfig_ValidateBounds(t *testing.T) {
 		})
 	}
 }
+
+func TestLLMProvider_Family(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  string
+		want APIFamily
+	}{
+		// OpenAI-compatible labels
+		{"openai", "openai", APIOpenAI},
+		{"deepseek", "deepseek", APIOpenAI},
+		{"kimi", "kimi", APIOpenAI},
+		// Anthropic
+		{"anthropic", "anthropic", APIAnthropic},
+		// Gemini family
+		{"gemini", "gemini", APIGemini},
+		{"google", "google", APIGemini},
+		// Edge cases
+		{"empty string falls to Gemini", "", APIGemini},
+		{"unknown type falls to Gemini", "bogus", APIGemini},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			p := LLMProvider{Type: tt.typ}
+			got := p.Family()
+			if got != tt.want {
+				t.Errorf("LLMProvider{Type: %q}.Family() = %q; want %q",
+					tt.typ, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/di/health_factory.go
+++ b/internal/infrastructure/di/health_factory.go
@@ -29,7 +29,7 @@ func (f *defaultHealthFactory) BuildHealthManager(cfg *config.Config, sessionPro
 
 	healthCheckers := map[ports.Component]ports.HealthChecker{
 		ports.CompPersistence: sessionProvider.GetHealthChecker(),
-		ports.CompLLMProvider: infra_llm.NewLLMProviderHealthChecker(p.Type, authenticator, p.URL, lazyClient),
+		ports.CompLLMProvider: infra_llm.NewLLMProviderHealthChecker(p.Family(), p.Type, authenticator, p.URL, lazyClient),
 		ports.CompToolchain:   tf.BuildHealthChecker(),
 	}
 

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -43,8 +43,8 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 	var baseClient llm.LLMClient
 	var err error
 
-	switch p.Type {
-	case "openai", "deepseek", "kimi":
+	switch p.Family() {
+	case config.APIOpenAI:
 		opts := []openai.Option{
 			openai.WithHeaders(p.Headers),
 			openai.WithPersona(persona),
@@ -69,7 +69,7 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 				"deadline", "2026-07-24T15:59:00Z",
 			)
 		}
-	case "anthropic":
+	case config.APIAnthropic:
 		baseClient = anthropic.NewClient(p.URL, p.Model, authenticator,
 			anthropic.WithHeaders(p.Headers),
 			anthropic.WithThinkingBudget(maxBudget),
@@ -78,7 +78,7 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 			anthropic.WithTimeout(timeout),
 			anthropic.WithLogger(logger),
 		)
-	case "google", "gemini", "":
+	case config.APIGemini:
 		fallthrough
 	default:
 		baseClient, err = gemini.NewClient(p.URL, p.Model, authenticator,

--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
@@ -20,6 +21,7 @@ import (
 // llmProviderHealthChecker implements ports.HealthChecker for LLM providers.
 type llmProviderHealthChecker struct {
 	providerName  string
+	family        config.APIFamily // wire-protocol family for dispatch
 	authenticator auth.Authenticator
 	baseURL       string
 	httpClient    *http.Client
@@ -27,20 +29,21 @@ type llmProviderHealthChecker struct {
 }
 
 // NewLLMProviderHealthChecker creates a new llmProviderHealthChecker.
-func NewLLMProviderHealthChecker(providerName string, authenticator auth.Authenticator, baseURL string, gateway llm.LLMGateway) *llmProviderHealthChecker {
+func NewLLMProviderHealthChecker(family config.APIFamily, providerName string, authenticator auth.Authenticator, baseURL string, gateway llm.LLMGateway) *llmProviderHealthChecker {
 	if baseURL == "" {
-		switch strings.ToLower(providerName) {
-		case "openai", "deepseek", "kimi":
+		switch family {
+		case config.APIOpenAI:
 			baseURL = "https://api.openai.com/v1"
-		case "anthropic":
+		case config.APIAnthropic:
 			baseURL = "https://api.anthropic.com/v1"
-		case "google", "gemini":
+		case config.APIGemini:
 			baseURL = "https://generativelanguage.googleapis.com/v1beta"
 		}
 	}
 
 	return &llmProviderHealthChecker{
 		providerName:  providerName,
+		family:        family,
 		authenticator: authenticator,
 		baseURL:       strings.TrimSuffix(baseURL, "/"),
 		httpClient: &http.Client{
@@ -207,11 +210,10 @@ func (c *llmProviderHealthChecker) classifyErrorStatus(statusCode int, report *p
 }
 
 func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
-	p := strings.ToLower(c.providerName)
-	switch p {
-	case "openai", "deepseek", "kimi":
+	switch c.family {
+	case config.APIOpenAI:
 		return "GET", c.baseURL + "/models", nil
-	case "google", "gemini":
+	case config.APIGemini:
 		// Gemini API often uses a different base for models or needs the key as a query param.
 		// But if we use the baseURL passed in (which usually includes the key or uses headers),
 		// we try a standard models list.
@@ -219,7 +221,7 @@ func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
 			return "GET", c.baseURL + "/models", nil
 		}
 		return "GET", c.baseURL + "/models", nil
-	case "anthropic":
+	case config.APIAnthropic:
 		// Anthropic's Messages API has no standard GET ping endpoint.
 		// GET /v1/messages returns 405; GET /v1/models is not a Messages endpoint.
 		// We ping the base URL directly. The expected response is 404 (Not Found)

--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -210,6 +210,8 @@ func (c *llmProviderHealthChecker) classifyErrorStatus(statusCode int, report *p
 }
 
 func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
+	// This switch is exhaustive — c.family is an APIFamily, and
+	// LLMProvider.Family() always returns one of the three constants.
 	switch c.family {
 	case config.APIOpenAI:
 		return "GET", c.baseURL + "/models", nil
@@ -230,7 +232,6 @@ func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
 		// responded, proving connectivity. See ADR-022 "fail loud" principle:
 		// we do NOT silently succeed; we explicitly document the workaround.
 		return "GET", c.baseURL, nil
-	default:
-		return "", "", fmt.Errorf("unknown provider type %q: cannot determine health check endpoint", c.providerName)
 	}
+	panic("unreachable: APIFamily must be one of APIOpenAI, APIAnthropic, or APIGemini")
 }

--- a/internal/infrastructure/llm/provider_health_test.go
+++ b/internal/infrastructure/llm/provider_health_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/auth"
 )
@@ -37,7 +38,7 @@ func TestLLMProviderHealthChecker_Healthy(t *testing.T) {
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, server.URL, nil)
 
 	report, err := checker.Check(context.Background())
 	if err != nil {
@@ -60,7 +61,7 @@ func TestLLMProviderHealthChecker_Healthy(t *testing.T) {
 func TestLLMProviderHealthChecker_UnhealthyMissingKey(t *testing.T) {
 	t.Parallel()
 	authMock := &auth.BearerAuth{Token: ""}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://localhost", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://localhost", nil)
 
 	report, err := checker.Check(context.Background())
 	if err != nil {
@@ -77,7 +78,7 @@ func TestLLMProviderHealthChecker_UnhealthyMissingKey(t *testing.T) {
 func TestLLMProviderHealthChecker_UnhealthyApplyError(t *testing.T) {
 	t.Parallel()
 	authMock := &errorAuthenticator{}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://localhost", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://localhost", nil)
 
 	report, _ := checker.Check(context.Background())
 	if report.Status != ports.StatusUnhealthy {
@@ -96,7 +97,7 @@ func TestLLMProviderHealthChecker_UnhealthyInvalidKey(t *testing.T) {
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "bad-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, server.URL, nil)
 
 	report, _ := checker.Check(context.Background())
 	if report.Status != ports.StatusUnhealthy {
@@ -115,7 +116,7 @@ func TestLLMProviderHealthChecker_DegradedTransient(t *testing.T) {
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, server.URL, nil)
 
 	report, _ := checker.Check(context.Background())
 	if report.Status != ports.StatusDegraded {
@@ -126,7 +127,7 @@ func TestLLMProviderHealthChecker_DegradedTransient(t *testing.T) {
 func TestLLMProviderHealthChecker_DegradedConnectivity(t *testing.T) {
 	t.Parallel()
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://127.0.0.1:1", nil)
 
 	report, _ := checker.Check(context.Background())
 	if report.Status != ports.StatusDegraded {
@@ -142,7 +143,7 @@ func TestLLMProviderHealthChecker_AnthropicHealthyFallback(t *testing.T) {
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("anthropic", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIAnthropic, "anthropic", authMock, server.URL, nil)
 
 	report, _ := checker.Check(context.Background())
 	if report.Status != ports.StatusHealthy {
@@ -155,38 +156,45 @@ func TestNewLLMProviderHealthChecker_BaseURLFallback(t *testing.T) {
 
 	tests := []struct {
 		name            string
+		family          config.APIFamily
 		providerName    string
 		expectedBaseURL string
 	}{
 		{
 			name:            "openai fallback",
+			family:          config.APIOpenAI,
 			providerName:    "openai",
 			expectedBaseURL: "https://api.openai.com/v1",
 		},
 		{
 			name:            "deepseek fallback",
+			family:          config.APIOpenAI,
 			providerName:    "deepseek",
 			expectedBaseURL: "https://api.openai.com/v1",
 		},
 		{
 			name:            "anthropic fallback",
+			family:          config.APIAnthropic,
 			providerName:    "anthropic",
 			expectedBaseURL: "https://api.anthropic.com/v1",
 		},
 		{
 			name:            "google fallback",
+			family:          config.APIGemini,
 			providerName:    "google",
 			expectedBaseURL: "https://generativelanguage.googleapis.com/v1beta",
 		},
 		{
 			name:            "gemini fallback",
+			family:          config.APIGemini,
 			providerName:    "gemini",
 			expectedBaseURL: "https://generativelanguage.googleapis.com/v1beta",
 		},
 		{
-			name:            "unknown provider no fallback",
+			name:            "unknown provider defaults to gemini",
+			family:          config.APIGemini,
 			providerName:    "unknown-provider",
-			expectedBaseURL: "",
+			expectedBaseURL: "https://generativelanguage.googleapis.com/v1beta",
 		},
 	}
 
@@ -195,7 +203,7 @@ func TestNewLLMProviderHealthChecker_BaseURLFallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			checker := NewLLMProviderHealthChecker(tt.providerName, nil, "", nil)
+			checker := NewLLMProviderHealthChecker(tt.family, tt.providerName, nil, "", nil)
 			report, err := checker.Check(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -225,7 +233,7 @@ func TestLLMProviderHealthChecker_BuildRequestError(t *testing.T) {
 	t.Parallel()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "://invalid", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "://invalid", nil)
 
 	report, err := checker.Check(context.Background())
 	if err != nil {
@@ -252,7 +260,7 @@ func TestLLMProviderHealthChecker_NonTransientNonAuthError(t *testing.T) {
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, server.URL, nil)
 
 	report, err := checker.Check(context.Background())
 	if err != nil {
@@ -275,16 +283,19 @@ func TestLLMProviderHealthChecker_GeminiEndpointSelection(t *testing.T) {
 
 	tests := []struct {
 		name         string
+		family       config.APIFamily
 		providerName string
 		baseURL      string
 	}{
 		{
 			name:         "vertex aiplatform url",
+			family:       config.APIGemini,
 			providerName: "gemini",
 			baseURL:      "https://us-central1-aiplatform.googleapis.com/v1",
 		},
 		{
 			name:         "custom proxy url",
+			family:       config.APIGemini,
 			providerName: "gemini",
 			baseURL:      "https://my-proxy.example.com/v1",
 		},
@@ -295,7 +306,7 @@ func TestLLMProviderHealthChecker_GeminiEndpointSelection(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			checker := NewLLMProviderHealthChecker(tt.providerName, nil, tt.baseURL, nil)
+			checker := NewLLMProviderHealthChecker(tt.family, tt.providerName, nil, tt.baseURL, nil)
 			report, err := checker.Check(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -320,23 +331,24 @@ func TestLLMProviderHealthChecker_GeminiEndpointSelection(t *testing.T) {
 func TestLLMProviderHealthChecker_UnknownProvider(t *testing.T) {
 	t.Parallel()
 
+	// Unknown provider types are mapped to APIGemini by LLMProvider.Family(),
+	// so they inherit Gemini's ping endpoint and behavior. This test verifies
+	// that an unknown type with Gemini family proceeds through the normal
+	// health-check flow (no "unknown provider type" error).
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("unknown-provider", authMock, server.URL, nil)
+	checker := NewLLMProviderHealthChecker(config.APIGemini, "unknown-provider", authMock, server.URL, nil)
 
 	report, err := checker.Check(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if report.Status != ports.StatusUnhealthy {
-		t.Errorf("expected StatusUnhealthy, got %s: %s", report.Status, report.Message)
-	}
-	if !strings.Contains(report.Message, "unknown provider type") {
-		t.Errorf("expected message to contain 'unknown provider type', got: %s", report.Message)
+	if report.Status != ports.StatusHealthy {
+		t.Errorf("expected StatusHealthy (unknown maps to Gemini), got %s: %s", report.Status, report.Message)
 	}
 }
 
@@ -345,7 +357,7 @@ func TestLLMProviderHealthChecker_NilResponseNilError(t *testing.T) {
 	// Call handleHTTPResponse directly with (nil, nil) — this path is reachable
 	// if custom middleware or refactored code bypasses the stdlib's RoundTripper guard.
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://127.0.0.1:1", nil)
 
 	details := make(map[string]any)
 	report := &ports.ComponentReport{
@@ -371,6 +383,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 
 	tests := []struct {
 		name            string
+		family          config.APIFamily
 		providerName    string
 		baseURL         string
 		useServer       bool
@@ -384,6 +397,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// but httpClient.Do fails immediately with "context canceled" → connectivity error.
 		{
 			name:            "pre-cancelled context",
+			family:          config.APIOpenAI,
 			providerName:    "openai",
 			baseURL:         "http://127.0.0.1:1",
 			cancelCtx:       true,
@@ -394,6 +408,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// Gap 2: Google/Gemini without googleapis.com in URL — hits the false branch.
 		{
 			name:            "gemini without googleapis in URL",
+			family:          config.APIGemini,
 			providerName:    "gemini",
 			baseURL:         "http://127.0.0.1:1",
 			authenticator:   &auth.APIKeyAuth{APIKey: "test-key"},
@@ -403,6 +418,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// Gap 3: Google/Gemini WITH googleapis.com in URL — hits the true branch.
 		{
 			name:            "gemini with googleapis in URL",
+			family:          config.APIGemini,
 			providerName:    "google",
 			baseURL:         "http://127.0.0.1:1/googleapis.com",
 			authenticator:   &auth.APIKeyAuth{APIKey: "test-key"},
@@ -412,6 +428,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// Gap 5: 405 MethodNotAllowed → classifyErrorStatus returns StatusHealthy (same as 404).
 		{
 			name:         "method not allowed fallback",
+			family:       config.APIOpenAI,
 			providerName: "openai",
 			useServer:    true,
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -424,6 +441,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// Gap 6a: 502 Bad Gateway → classified as transient → StatusDegraded.
 		{
 			name:         "bad gateway 502",
+			family:       config.APIOpenAI,
 			providerName: "openai",
 			useServer:    true,
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -436,6 +454,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// Gap 6b: 504 Gateway Timeout → classified as transient → StatusDegraded.
 		{
 			name:         "gateway timeout 504",
+			family:       config.APIOpenAI,
 			providerName: "openai",
 			useServer:    true,
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -449,6 +468,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 		// falls through to classifyErrorStatus → StatusUnhealthy.
 		{
 			name:         "forbidden 403",
+			family:       config.APIOpenAI,
 			providerName: "openai",
 			useServer:    true,
 			serverHandler: func(w http.ResponseWriter, r *http.Request) {
@@ -474,7 +494,7 @@ func TestLLMProviderHealthChecker_ComprehensiveEdgeCases(t *testing.T) {
 				baseURL = tt.baseURL
 			}
 
-			checker := NewLLMProviderHealthChecker(tt.providerName, tt.authenticator, baseURL, nil)
+			checker := NewLLMProviderHealthChecker(tt.family, tt.providerName, tt.authenticator, baseURL, nil)
 
 			ctx := context.Background()
 			if tt.cancelCtx {
@@ -521,7 +541,7 @@ func TestLLMProviderHealthChecker_DefaultTransportFallback(t *testing.T) {
 
 	// 2. Construct the checker — the IIFE should hit the else branch
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://127.0.0.1:1", nil)
 
 	// 3. Verify the transport is our custom one (not a clone)
 	client := GetHTTPClient(checker)
@@ -537,7 +557,7 @@ func TestLLMProviderHealthChecker_TransportClone(t *testing.T) {
 	t.Parallel()
 
 	authMock := &auth.BearerAuth{Token: "test-key"}
-	checker := NewLLMProviderHealthChecker("openai", authMock, "http://127.0.0.1:1", nil)
+	checker := NewLLMProviderHealthChecker(config.APIOpenAI, "openai", authMock, "http://127.0.0.1:1", nil)
 
 	client := GetHTTPClient(checker)
 


### PR DESCRIPTION
## Summary

Replace raw-string provider-type dispatch with a compile-time-safe 3-value `APIFamily` type. `LLMProvider.Type` remains a free-form user-facing label; `LLMProvider.Family()` resolves it to the wire protocol.

Closes #1277.

## Changes

| File | Change |
|---|---|
| `internal/domain/config/config.go` | Add `APIFamily` type + `Family()` method on `LLMProvider` |
| `internal/infrastructure/llm/factory.go` | `buildBaseClient` switch: `p.Type` → `p.Family()` |
| `internal/infrastructure/llm/provider_health.go` | Add `family` field, migrate baseURL + ping endpoint switches |
| `internal/infrastructure/di/health_factory.go` | Pass `p.Family()` to health checker constructor |
| `internal/infrastructure/llm/provider_health_test.go` | Update all 19+ test call sites |
| `docs/domain-model/tell-me-go.modelith.yaml` | `ProviderType` (4 values) → `APIFamily` (3 values); `Provider.type` → string, `Provider.family` → derived APIFamily |

## Verification

- [x] `go build ./...` — PASS
- [x] All tests — PASS (config, llm, di)
- [x] `make verify-architecture` — PASS
- [x] `make modelith-lint` — 0 errors
- [x] `make modelith-check` — up to date
- [x] `golangci-lint` — 0 issues
- [x] Zero behavior change