### PR TITLE
refactor: convert auth dispatch to switch + enable exhaustive linter (#1281)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,5 +9,5 @@ linters:
         - "SA"
         - "-SA5011"
     exhaustive:
-      default-signifies-exhaustive: true
+      default-signifies-exhaustive: false
       explicit-exhaustive-switch: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,13 @@
 version: "2"
 
 linters:
+  enable:
+    - exhaustive
   settings:
     staticcheck:
       checks:
         - "SA"
         - "-SA5011"
+    exhaustive:
+      default-signifies-exhaustive: true
+      explicit-exhaustive-switch: true

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -218,7 +218,7 @@ func createAuthenticator(p *config.LLMProvider) (auth.Authenticator, error) {
 		return resolveGoogleAuth(p)
 	default:
 		// Defensive: unreachable given Family()'s totality, but
-		// guarded as a safety net per ADR-022 "fail loud."
+		// guarded as a safety net to fail loudly on programmer error.
 		return nil, fmt.Errorf("API key or Service Account JSON is required for provider: %s", p.Type)
 	}
 }

--- a/internal/infrastructure/llm/factory.go
+++ b/internal/infrastructure/llm/factory.go
@@ -43,6 +43,7 @@ func buildBaseClient(p config.LLMProvider, authenticator auth.Authenticator, per
 	var baseClient llm.LLMClient
 	var err error
 
+	//exhaustive:enforce
 	switch p.Family() {
 	case config.APIOpenAI:
 		opts := []openai.Option{
@@ -207,19 +208,20 @@ func createAuthenticator(p *config.LLMProvider) (auth.Authenticator, error) {
 		}
 	}
 
-	if strategy, ok := authStrategies[p.Family()]; ok {
-		return strategy(p)
+	//exhaustive:enforce
+	switch p.Family() {
+	case config.APIOpenAI:
+		return openAIFamilyAuth(p)
+	case config.APIAnthropic:
+		return anthropicFamilyAuth(p)
+	case config.APIGemini:
+		return resolveGoogleAuth(p)
+	default:
+		// Defensive: unreachable given Family()'s totality, but
+		// guarded as a safety net per ADR-022 "fail loud."
+		return nil, fmt.Errorf("API key or Service Account JSON is required for provider: %s", p.Type)
 	}
-
-	// Fallback for any unknown provider with an explicit API key
-	if p.APIKey != "" {
-		return &auth.APIKeyAuth{APIKey: p.APIKey}, nil
-	}
-
-	return nil, fmt.Errorf("API key or Service Account JSON is required for provider: %s", p.Type)
 }
-
-type authStrategy func(*config.LLMProvider) (auth.Authenticator, error)
 
 // openAIFamilyAuth returns the authenticator for OpenAI-compatible providers
 // (openai, deepseek, kimi). For kimi, there is no Vertex fallback and an
@@ -236,15 +238,6 @@ func openAIFamilyAuth(p *config.LLMProvider) (auth.Authenticator, error) {
 		return nil, fmt.Errorf("API key is required for provider: %s", p.Type)
 	}
 	return &auth.BearerAuth{Token: p.APIKey}, nil
-}
-
-// authStrategies maps each wire-protocol family to its authenticator factory.
-// Label-specific overrides (e.g. kimi's no-Vertex constraint) are handled
-// inside the family function, not as separate map entries.
-var authStrategies = map[config.APIFamily]authStrategy{
-	config.APIOpenAI:    openAIFamilyAuth,
-	config.APIAnthropic: anthropicFamilyAuth,
-	config.APIGemini:    resolveGoogleAuth,
 }
 
 // anthropicFamilyAuth returns the authenticator for Anthropic providers.

--- a/internal/infrastructure/llm/factory_test.go
+++ b/internal/infrastructure/llm/factory_test.go
@@ -226,6 +226,14 @@ func assertMissingKeysResult(t *testing.T, a auth.Authenticator, err error, want
 				t.Errorf("expected *auth.APIKeyAuth for unknown provider with key, got %T", a)
 			}
 		}
+
+		// unknown providers with no key and no Vertex URL still get
+		// VertexAuth via the APIGemini family default.
+		if provider == "unknown" && apiKey == "" && url == "" {
+			if _, ok := a.(*auth.VertexAuth); !ok {
+				t.Errorf("expected *auth.VertexAuth for unknown provider (Gemini default), got %T", a)
+			}
+		}
 	}
 }
 

--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -212,6 +212,7 @@ func (c *llmProviderHealthChecker) classifyErrorStatus(statusCode int, report *p
 func (c *llmProviderHealthChecker) getPingEndpoint() (string, string, error) {
 	// This switch is exhaustive — c.family is an APIFamily, and
 	// LLMProvider.Family() always returns one of the three constants.
+	//exhaustive:enforce
 	switch c.family {
 	case config.APIOpenAI:
 		return "GET", c.baseURL + "/models", nil

--- a/internal/infrastructure/llm/provider_health.go
+++ b/internal/infrastructure/llm/provider_health.go
@@ -31,6 +31,7 @@ type llmProviderHealthChecker struct {
 // NewLLMProviderHealthChecker creates a new llmProviderHealthChecker.
 func NewLLMProviderHealthChecker(family config.APIFamily, providerName string, authenticator auth.Authenticator, baseURL string, gateway llm.LLMGateway) *llmProviderHealthChecker {
 	if baseURL == "" {
+		//exhaustive:enforce
 		switch family {
 		case config.APIOpenAI:
 			baseURL = "https://api.openai.com/v1"


### PR DESCRIPTION
## Summary

Completes the APIFamily centralization arc (#1277 -> #1278 -> #1279/#1280) by converting the last remaining map dispatch to switch and enabling compile-time exhaustiveness checking.

Closes #1281.

## Changes

| Change | Detail |
|---|---|
| Map -> switch | `createAuthenticator` now uses `switch p.Family()` (3 cases + ADR-022 `default:`), consistent with `buildBaseClient` |
| Dead code removed | `authStrategies` map variable + `authStrategy` type alias deleted |
| Test gap fixed | `assertMissingKeysResult` now pins `*auth.VertexAuth` for unknown/no-key/no-url case |
| Exhaustive linter | `exhaustive` linter enabled in `.golangci.yml`, all 3 APIFamily switch sites annotated with `//exhaustive:enforce` |

## The guarantee

Adding a 4th `APIFamily` constant now causes the linter to flag every annotated switch site. This fulfills the promise from the `APIFamily` doc comment in #1278:

> "Enable the 'exhaustive' linter for this type to make it a compile-time error."

## Verification

- [x] `go build ./...` -- PASS
- [x] `go test ./internal/infrastructure/llm/...` -- PASS (5 packages)
- [x] `go test ./internal/domain/config/...` -- PASS
- [x] `go test ./internal/infrastructure/di/...` -- PASS
- [x] `make verify-architecture` -- PASS
- [x] `golangci-lint` -- 0 issues (including `exhaustive`)
- [x] 4th-family linter test: adding `APIBogus` correctly flagged by `exhaustive`
