### PR TITLE
Coverage & complexity: media error-path tests, catalog cross-reference tooling, CC refactor

### DIFF
--- a/docs/adr/2026-08-catalog-cross-reference-reporting-contract.md
+++ b/docs/adr/2026-08-catalog-cross-reference-reporting-contract.md
@@ -1,0 +1,42 @@
+# ADR-054: Catalog Cross-Reference Contract for Coverage & Complexity Reports
+
+**Status:** Accepted
+**Date:** 2026-08-06
+**Related:** [PR #1293](https://github.com/gosharplite/tell-me-go/pull/1293), `docs/architect/INTENTIONAL_NON_FIXES.md`
+
+## Context
+
+The analysis tooling (`get_detailed_coverage`, `get_code_health`) previously reported every uncovered block and every over-threshold complexity function as an actionable gap. This produced a persistent noise floor: the same ACCEPTED Intentional Non-Fix entries (delegation wrappers, unreachable `json.Marshal` branches, interface stubs) were re-flagged on every audit, and "high priority" did not mean "needs work."
+
+Commit `73155701` introduced a cross-reference between the reports and the architect-curated `INTENTIONAL_NON_FIXES.md` catalog. This ADR records the resulting output contract, which is a user-visible change in what the health tooling reports.
+
+## Decision
+
+### 1. Cataloged = excluded from actionable counts
+
+An uncovered block or over-threshold function whose location falls within an ACCEPTED catalog entry's references is **cataloged**: it is excluded from the High/Medium priority counts and the actionable alert list, and rendered in a separate `[CATALOGED GAPS (ACCEPTED)]` / `Cataloged (ACCEPTED) over threshold` section so the reader can verify the acceptance rationale.
+
+- "High priority (Architectural)" and "Medium priority (Technical Debt)" now mean **not cataloged** — i.e. genuinely actionable.
+- A catalog load failure degrades gracefully: every gap is treated as actionable (logged via `slog.Warn`), so the tool never silently hides gaps when the catalog is unreadable.
+
+### 2. Text vs. JSON asymmetry is intentional
+
+- The **text** report (`get_detailed_coverage`) excludes cataloged blocks from actionable counts and renders them in the dedicated section.
+- The **JSON** renderer (`get_detailed_coverage` with a JSON consumer) is additive only: it tags each block with `catalog_title` but does **not** filter. Machine consumers may filter on the field themselves; removing data from the machine-readable output would be a breaking contract change with no migration path.
+
+This asymmetry is deliberate and must not be "fixed" by filtering the JSON output without a new ADR.
+
+### 3. Status semantics
+
+`checkComplexity` returns `GOOD` when there is nothing actionable — including when every over-threshold function is cataloged (ACCEPTED). `"0 Alerts"` is never emitted; `recommendComplexity` only fires on statuses containing `Alerts`, `ERROR`, or `TIMEOUT`, so a cataloged-only result cannot produce a self-contradictory "Refactor high-complexity functions" recommendation.
+
+## Consequences
+
+- Audits are faster and more honest: the noise floor is gone, and reviewers see only uncataloged gaps.
+- The catalog becomes load-bearing: stale or drifting references (see the Drift Policy in `INTENTIONAL_NON_FIXES.md`) can misclassify a gap. Re-verification on PRs touching referenced files is mandatory.
+- JSON consumers must handle the new optional `catalog_title` field (additive, `omitempty`).
+
+## Related
+
+- `docs/architect/INTENTIONAL_NON_FIXES.md` — Acceptance Classes glossary and Drift Policy
+- Quality domain model `AcceptanceClass` enum — `docs/domain-model/quality.modelith.yaml`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -59,6 +59,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-051** | Async TUI Rendering for Large Responses | 2026-07 | Accepted | [2026-07-async-tui-rendering.md](2026-07-async-tui-rendering.md) |
 | **ADR-052** | DeepSeek/Kimi Thinking Mode Toggle and user_id Isolation | 2026-07 | Accepted | [2026-07-deepseek-thinking-toggle.md](2026-07-deepseek-thinking-toggle.md) |
 | **ADR-053** | Remove `get_cost_summary` Tool and DailyCost Metric — Deprecate the Global Cost Ledger | 2026-08 | Accepted | [2026-08-remove-get-cost-summary-and-daily-cost-metric.md](2026-08-remove-get-cost-summary-and-daily-cost-metric.md) |
+| **ADR-054** | Catalog Cross-Reference Contract for Coverage & Complexity Reports | 2026-08 | Accepted | [2026-08-catalog-cross-reference-reporting-contract.md](2026-08-catalog-cross-reference-reporting-contract.md) |
 
 ## How to Create a New ADR
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -3,6 +3,45 @@
 Items evaluated by the architect and deliberately NOT pursued.
 Any AI agent recommending these should consult the rationale below.
 
+## Acceptance Classes
+
+Every entry carries an acceptance class — the triage classification that
+justifies why the issue is deliberately left unaddressed. These class names
+are also referenced by code comments (e.g. "structurally unreachable — see
+the `structurally-unreachable` acceptance class") and are the authoritative
+definition of each term. Mirrors the `AcceptanceClass` enum in the quality
+domain model (`docs/domain-model/quality.modelith.yaml`).
+
+| Class | Definition |
+| --- | --- |
+| `structurally-unreachable` | The branch cannot fire in correct code — e.g. `json.Marshal` on an all-string struct, or `StdoutPipe` before `Start`. |
+| `delegation-wrapper` | A thin pass-through that would only re-test the underlying implementation — e.g. `domainFS.Chmod`, `AppendTask`, `RealClock`. |
+| `platform-specific` | A branch only executable on a specific OS — e.g. Windows path separators, Darwin kernel observation. |
+| `fault-injection-required` | Triggering the branch requires filesystem or driver fault injection disproportionate to the test value. |
+| `defensive-guard` | A nil or empty guard on internal pipeline state that callers never produce. |
+| `interface-stub` | A no-op method that exists solely to satisfy an interface contract — e.g. `auth.Invalidate`, `NoOpEventBus`. |
+| `test-complexity` | Sequential state-mutation or dispatch-heavy test where splitting would duplicate expensive setup. |
+| `dispatch-structural` | Cyclomatic complexity from type-switch or branch count, not branching business logic — e.g. `handleDomainEvent` (CC=12). |
+| `soft-enforcement` | An invariant deliberately enforced as a warning rather than a hard failure — e.g. `skill-unique-name`. |
+
+## Drift Policy
+
+Catalog entries pin code locations with `file:line` or `file:start-end`
+references. These references are verified at record time but can drift as
+code above them is edited. The analysis tooling matches cataloged gaps by
+*interval overlap* and accepts *bare-basename* references; both are
+deliberate trade-offs for a curated catalog, but a shifted range can quietly
+catalog a new gap no one reviewed. Policy:
+
+- **Re-verify on every PR** that touches a file referenced by the catalog:
+  confirm each entry's ranges still point at the intended symbol, and update
+  the entry (or record a new one) when they do not.
+- **Never rely on overlap-matching as review** — it is an advisory aid, not a
+  substitute for re-anchoring the reference.
+- **CC values in complexity entries are re-measured** whenever the referenced
+  function changes; drift is recorded in the entry's rationale (see the
+  2026-08 CC drift corrections for the pattern).
+
 ---
 
 ## Coverage Gaps (ACCEPTED)

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -35,6 +35,24 @@ Any AI agent recommending these should consult the rationale below.
   already exists at the gap site (`global_prompt_tracker.go:365-366`).
 - **See**: `internal/infrastructure/history/global_prompt_tracker.go:367-369`
 
+### ado/pipeline_crud.go — buildVariablesUpdatePayload error return
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: The error return of `json.Marshal(existingDef)` in
+  `buildVariablesUpdatePayload` is structurally unreachable: the map is
+  produced by `json.Decode` into `interface{}` plus manual insertion of
+  JSON-safe primitives (string, bool, *bool), so `json.Marshal` cannot fail.
+  Note: the inline comment at `pipeline_crud.go:272-274` cites "ADR-037",
+  but ADR-037 is the `agentinternal` test-bridge decision and says nothing
+  about `json.Marshal` — that citation is stale and should be read as
+  referring to this catalog's `json.Marshal` acceptance class instead.
+  Same acceptance class as the cataloged `json.Marshal` entries
+  (`global_prompt_tracker.go` Append/writeCompactedData,
+  `orchestrator/middleware.go` detectLoop).
+- **See**: `internal/tools/integrations/ado/pipeline_crud.go:272-275`
+  (inline comment + `return json.Marshal(existingDef)`), and the `if err != nil`
+  branch at `pipeline_crud.go:308-310` that consumes this unreachable error
+
 ### history/history.go — complementPred and contentHasFunctionCall at 0% → RESOLVED
 
 - **Status**: RESOLVED (2026-07, `TestHistoryManager_SetPinned_WithFunctionCall` + `TestHistoryManager_SetPinned_ViaModelID`)
@@ -655,6 +673,27 @@ Any AI agent recommending these should consult the rationale below.
 
 ## Test Complexity (ACCEPTED)
 
+### internal/infrastructure/llm/factory_test.go — assertMissingKeysResult (CC=13)
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Table-driven test helper asserting per-key error results
+  across multiple missing-key scenarios (multiple API response shapes).
+  CC comes from case enumeration and assertion boilerplate, not branching
+  business logic. Same acceptance class as `TestHydrateMediaAssets` (CC=13) —
+  assertion boilerplate across a coverage matrix.
+- **See**: `internal/infrastructure/llm/factory_test.go:211`
+
+### internal/agent/orchestrator/engine_phases_test.go — TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12)
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Sequential test driving the empty-response retry branch to
+  its retry limit; steps mutate shared mock state across iterations. CC is
+  assertion boilerplate, not branching business logic. Same acceptance
+  class as its production counterpart `(*RecoveryStep).Process` (CC=12,
+  already ACCEPTED) — sequential state-mutation test where splitting would
+  duplicate setup.
+- **See**: `internal/agent/orchestrator/engine_phases_test.go:531`
+
 ### tests/e2e/history_flags_test.go — TestHistoryNavigation_CompleteWorkflow (complexity 15)
 
 - **Status**: ACCEPTED (2026-07)
@@ -784,15 +823,16 @@ to reason about.
   in the Test Complexity section above).
 - **See**: `internal/ui/renderer_spinner_test.go:176`
 
-### tools/analysis/index_snapshot_test.go — (*indexer).snapshot (CC=11)
+### tools/analysis/index_snapshot_test.go — (*indexer).snapshot (CC=14)
 
-- **Status**: ACCEPTED (2026-07)
+- **Status**: ACCEPTED (2026-08)
 - **Rationale**: Production method defined in a `_test.go` file (package `analysis`,
   not `analysis_test`) because it needs access to unexported indexer fields
   (`idx.mu`, `idx.pkgs`, `idx.symbolsByPath`, `idx.usagesByName`,
   `idx.implsCache`). It deep-copies the indexer's complete internal state into
-  an `indexSnapshot` struct for test-fixture generation. The CC=11 comes from
-  5 deep-copy loops (`fileToPkg`, `decls`, `implsCopy`, `symbolsCopy`,
+  an `indexSnapshot` struct for test-fixture generation. CC increased from 11→14
+  since acceptance (re-verified 2026-08) — still a test-fixture builder. The CC=14
+  comes from 5 deep-copy loops (`fileToPkg`, `decls`, `implsCopy`, `symbolsCopy`,
   `usagesCopy`) + 3 guards (`modulePath` discovery, `CompiledGoFiles` dedup,
   `collectDeclarations` filter). Only called from `fixture_gen_test.go:58` —
   pure test infrastructure. Splitting the copy loops into helpers would
@@ -800,7 +840,7 @@ to reason about.
   maintainability benefit. Same acceptance class as `createPrecisionWorkspace`
   (CC=12, test-fixture builder) and the type-switch dispatch entries in this
   section.
-- **See**: `internal/tools/analysis/index_snapshot_test.go:107`,
+- **See**: `internal/tools/analysis/index_snapshot_test.go:112`,
   `internal/tools/analysis/fixture_gen_test.go:58`
 ---
 
@@ -978,10 +1018,10 @@ to reason about.
 - **Rationale**: Same sequential state-mutation pattern as `TestUpdateTurnContent_ClearText`, verifying the complementary code path. CC is assertion boilerplate across dependent steps.
 - **See**: `internal/infrastructure/history/history_test.go:1115`
 
-### internal/domain/llm/capabilities_test.go — TestResolveCapabilities (CC=12)
+### internal/domain/llm/capabilities_test.go — TestResolveCapabilities (CC=13)
 
-- **Status**: ACCEPTED (2026-07)
-- **Rationale**: Table-driven combinatorial test covering provider × model × feature capability resolution. CC comes from the 10+ test cases in the table, each a simple assertion. Splitting the table into subtests would obscure the cross-provider comparison intent.
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Table-driven combinatorial test covering provider × model × feature capability resolution. CC increased from 12→13 since acceptance (re-verified 2026-08) — still the same acceptance class. CC comes from the 10+ test cases in the table, each a simple assertion. Splitting the table into subtests would obscure the cross-provider comparison intent.
 - **See**: `internal/domain/llm/capabilities_test.go:10`
 
 ### internal/tools/analysis/precision_test.go — TestDeadCodeAnalyzer_Precision (CC=12)
@@ -996,11 +1036,11 @@ to reason about.
 - **Rationale**: Test-fixture builder that constructs a multi-package Go workspace with specific symbol structures for dead code analysis. Already referenced as accepted in the `(*indexer).snapshot` (CC=11) entry. CC comes from file creation boilerplate, not branching logic.
 - **See**: `internal/tools/analysis/precision_test.go:118`
 
-### internal/tools/analysis/index_fixture_test.go — TestFixtureIndexer_ConstructAndHarvest (CC=11)
+### internal/tools/analysis/index_fixture_test.go — TestFixtureIndexer_ConstructAndHarvest (CC=13)
 
-- **Status**: ACCEPTED (2026-07)
-- **Rationale**: End-to-end fixture test constructing an indexer, loading packages, and harvesting results. CC comes from setup + assertion blocks across the three-phase test (construct → index → harvest). Splitting would duplicate the fixture construction.
-- **See**: `internal/tools/analysis/index_fixture_test.go:154`
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: End-to-end fixture test constructing an indexer, loading packages, and harvesting results. CC increased from 11→13 since acceptance (re-verified 2026-08) — still the same acceptance class. CC comes from setup + assertion blocks across the three-phase test (construct → index → harvest). Splitting would duplicate the fixture construction.
+- **See**: `internal/tools/analysis/index_fixture_test.go:158`
 
 ### internal/tools/workspace/process_executor_stream_test.go — TestRunCommand_NonExitErrorWaitPath (CC=11)
 
@@ -1044,4 +1084,4 @@ to reason about.
 
 ---
 
-*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs)*
+*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13))*

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -29,6 +29,10 @@ type uncoveredBlock struct {
 	Code     string `json:"code,omitempty"`
 	Category string `json:"category"`
 	Priority string `json:"priority"`
+	// CatalogTitle names the ACCEPTED entry in the Intentional Non-Fixes
+	// catalog whose references cover this block's range, when one exists.
+	// A non-empty value marks the gap as deliberately accepted (not actionable).
+	CatalogTitle string `json:"catalog_title,omitempty"`
 }
 
 // classificationRule defines a rule for categorizing uncovered code blocks.
@@ -451,6 +455,17 @@ func filterExcludedBlocks(blocks []uncoveredBlock, excluded []string) []uncovere
 	return filtered
 }
 
+// applyCatalogTitles cross-references uncovered blocks against the given
+// Intentional Non-Fixes catalog entries, tagging each block whose range falls
+// inside an ACCEPTED entry with that entry's title. Cataloged blocks keep
+// their original Category/Priority (set by Classify); reporting layers decide
+// how to surface them. A nil or empty entry slice is a no-op.
+func applyCatalogTitles(blocks []uncoveredBlock, entries []nonFixEntry) {
+	for i := range blocks {
+		blocks[i].CatalogTitle = catalogTitleForRange(entries, blocks[i].File, blocks[i].Start, blocks[i].End)
+	}
+}
+
 // getDetailedCoverageReport generates a formatted report optimized for LLM consumption.
 func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePath string, excludedPackages []string, hb chan<- struct{}) (string, error) {
 	blocks, err := m.getDetailedCoverage(ctx, packagePath, hb)
@@ -461,6 +476,11 @@ func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePa
 	if len(excludedPackages) > 0 {
 		blocks = filterExcludedBlocks(blocks, excludedPackages)
 	}
+
+	// Load the catalog once and tag ACCEPTED gaps after Classify() so
+	// Priority/Category for uncataloged blocks remain exactly as before.
+	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	applyCatalogTitles(blocks, entries)
 
 	report := formatDetailedCoverageReport(packagePath, blocks)
 	if err != nil {
@@ -475,10 +495,10 @@ func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePa
 }
 
 func formatDetailedCoverageReport(packagePath string, blocks []uncoveredBlock) string {
-	high, medium, lowCount, catStats := aggregateCoverageStats(blocks)
+	high, medium, lowCount, cataloged, catStats := aggregateCoverageStats(blocks)
 
 	var sb strings.Builder
-	renderReportSummary(&sb, packagePath, len(blocks), high, medium, lowCount, catStats)
+	renderReportSummary(&sb, packagePath, len(blocks), high, medium, lowCount, len(cataloged), catStats)
 
 	const maxItems = 10
 	renderBlockGaps(&sb, "HIGH PRIORITY GAPS", high, maxItems)
@@ -488,13 +508,21 @@ func formatDetailedCoverageReport(packagePath string, blocks []uncoveredBlock) s
 		renderBlockGaps(&sb, "MEDIUM PRIORITY GAPS", medium, remainingSlots)
 	}
 
+	renderCatalogedGaps(&sb, cataloged, maxItems)
+
 	return sb.String()
 }
 
-func aggregateCoverageStats(blocks []uncoveredBlock) (high []uncoveredBlock, medium []uncoveredBlock, lowCount int, catStats map[string]int) {
+func aggregateCoverageStats(blocks []uncoveredBlock) (high []uncoveredBlock, medium []uncoveredBlock, lowCount int, cataloged []uncoveredBlock, catStats map[string]int) {
 	catStats = make(map[string]int)
 	for _, b := range blocks {
 		catStats[b.Category]++
+		// Blocks covered by an ACCEPTED catalog entry are already-accepted
+		// gaps: they are excluded from the actionable priority buckets.
+		if b.CatalogTitle != "" {
+			cataloged = append(cataloged, b)
+			continue
+		}
 		switch b.Priority {
 		case "High":
 			high = append(high, b)
@@ -507,7 +535,7 @@ func aggregateCoverageStats(blocks []uncoveredBlock) (high []uncoveredBlock, med
 	return
 }
 
-func renderReportSummary(sb *strings.Builder, packagePath string, total int, high, medium []uncoveredBlock, lowCount int, catStats map[string]int) {
+func renderReportSummary(sb *strings.Builder, packagePath string, total int, high, medium []uncoveredBlock, lowCount, catalogedCount int, catStats map[string]int) {
 	_, _ = fmt.Fprintf(sb, "Detailed Coverage Report for %s\n", packagePath)
 	sb.WriteString(strings.Repeat("-", len(packagePath)+29) + "\n")
 	sb.WriteString("Summary:\n")
@@ -515,6 +543,7 @@ func renderReportSummary(sb *strings.Builder, packagePath string, total int, hig
 	_, _ = fmt.Fprintf(sb, "- High Priority (Architectural): %d\n", len(high))
 	_, _ = fmt.Fprintf(sb, "- Medium Priority (Technical Debt): %d\n", len(medium))
 	_, _ = fmt.Fprintf(sb, "- Low Priority: %d\n", lowCount)
+	_, _ = fmt.Fprintf(sb, "- Cataloged (ACCEPTED): %d\n", catalogedCount)
 	sb.WriteString("\nBreakdown by Category:\n")
 
 	var cats []string
@@ -547,12 +576,37 @@ func renderBlockGaps(sb *strings.Builder, title string, blocks []uncoveredBlock,
 	}
 }
 
+// renderCatalogedGaps lists blocks whose ranges fall inside an ACCEPTED entry
+// of the Intentional Non-Fixes catalog, so readers can verify the acceptance
+// rationale before treating them as actionable gaps.
+func renderCatalogedGaps(sb *strings.Builder, blocks []uncoveredBlock, maxItems int) {
+	if len(blocks) == 0 {
+		return
+	}
+	_, _ = fmt.Fprintf(sb, "\n[CATALOGED GAPS (ACCEPTED)]\n")
+
+	for i, b := range blocks {
+		if i >= maxItems {
+			_, _ = fmt.Fprintf(sb, "... and %d more cataloged (ACCEPTED) gaps.\n", len(blocks)-maxItems)
+			break
+		}
+		_, _ = fmt.Fprintf(sb, "%d. File: %s (Lines %d-%d)\n", i+1, b.File, b.Start, b.End)
+		_, _ = fmt.Fprintf(sb, "   Category: %s\n", b.Category)
+		_, _ = fmt.Fprintf(sb, "   Catalog: %s\n", b.CatalogTitle)
+	}
+}
+
 // getDetailedCoverageJSON returns the uncovered blocks as a JSON string, filtered by priority.
 func (m *healthManager) getDetailedCoverageJSON(ctx context.Context, packagePath string, minPriority string, hb chan<- struct{}) (string, error) {
 	blocks, err := m.getDetailedCoverage(ctx, packagePath, hb)
 	if err != nil && len(blocks) == 0 {
 		return "", err
 	}
+
+	// Tag ACCEPTED catalog gaps (additive). The catalog_title field is exposed
+	// to JSON callers; no filtering change here — callers may filter.
+	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	applyCatalogTitles(blocks, entries)
 
 	jsonStr, jsonErr := formatDetailedCoverageJSON(blocks, minPriority)
 	if jsonErr != nil {

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"sort"
 	"strconv"
@@ -480,13 +479,8 @@ func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePa
 
 	// Load the catalog once and tag ACCEPTED gaps after Classify() so
 	// Priority/Category for uncataloged blocks remain exactly as before. A
-	// load failure degrades gracefully: all gaps stay actionable. catErr is
-	// deliberately separate from err so the coverage-test error below is
-	// preserved.
-	entries, catErr := loadNonFixCatalog(m.catalogPath)
-	if catErr != nil {
-		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
-	}
+	// load failure degrades gracefully: all gaps stay actionable.
+	entries := m.loadNonFixEntries()
 	applyCatalogTitles(blocks, entries)
 
 	report := formatDetailedCoverageReport(packagePath, blocks)
@@ -612,13 +606,8 @@ func (m *healthManager) getDetailedCoverageJSON(ctx context.Context, packagePath
 
 	// Tag ACCEPTED catalog gaps (additive). The catalog_title field is exposed
 	// to JSON callers; no filtering change here — callers may filter. A load
-	// failure degrades gracefully: all gaps stay actionable. catErr is
-	// deliberately separate from err so the coverage-test error below is
-	// preserved.
-	entries, catErr := loadNonFixCatalog(m.catalogPath)
-	if catErr != nil {
-		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
-	}
+	// failure degrades gracefully: all gaps stay actionable.
+	entries := m.loadNonFixEntries()
 	applyCatalogTitles(blocks, entries)
 
 	jsonStr, jsonErr := formatDetailedCoverageJSON(blocks, minPriority)

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strconv"
@@ -478,8 +479,14 @@ func (m *healthManager) getDetailedCoverageReport(ctx context.Context, packagePa
 	}
 
 	// Load the catalog once and tag ACCEPTED gaps after Classify() so
-	// Priority/Category for uncataloged blocks remain exactly as before.
-	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	// Priority/Category for uncataloged blocks remain exactly as before. A
+	// load failure degrades gracefully: all gaps stay actionable. catErr is
+	// deliberately separate from err so the coverage-test error below is
+	// preserved.
+	entries, catErr := loadNonFixCatalog(m.catalogPath)
+	if catErr != nil {
+		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
+	}
 	applyCatalogTitles(blocks, entries)
 
 	report := formatDetailedCoverageReport(packagePath, blocks)
@@ -604,8 +611,14 @@ func (m *healthManager) getDetailedCoverageJSON(ctx context.Context, packagePath
 	}
 
 	// Tag ACCEPTED catalog gaps (additive). The catalog_title field is exposed
-	// to JSON callers; no filtering change here — callers may filter.
-	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	// to JSON callers; no filtering change here — callers may filter. A load
+	// failure degrades gracefully: all gaps stay actionable. catErr is
+	// deliberately separate from err so the coverage-test error below is
+	// preserved.
+	entries, catErr := loadNonFixCatalog(m.catalogPath)
+	if catErr != nil {
+		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
+	}
 	applyCatalogTitles(blocks, entries)
 
 	jsonStr, jsonErr := formatDetailedCoverageJSON(blocks, minPriority)

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -322,8 +322,9 @@ func TestRenderReportSummary(t *testing.T) {
 	high := make([]uncoveredBlock, 3)
 	medium := make([]uncoveredBlock, 4)
 	lowCount := 1
+	catalogedCount := 2
 
-	renderReportSummary(&sb, "./pkg", 8, high, medium, lowCount, catStats)
+	renderReportSummary(&sb, "./pkg", 8, high, medium, lowCount, catalogedCount, catStats)
 
 	got := sb.String()
 	expected := []string{
@@ -332,6 +333,7 @@ func TestRenderReportSummary(t *testing.T) {
 		"- High Priority (Architectural): 3",
 		"- Medium Priority (Technical Debt): 4",
 		"- Low Priority: 1",
+		"- Cataloged (ACCEPTED): 2",
 		"- ADAPTER: 2",
 		"- BUSINESS_LOGIC: 5",
 	}
@@ -350,18 +352,23 @@ func TestAggregateCoverageStats(t *testing.T) {
 		{Priority: "High", Category: "BUSINESS_LOGIC"},
 		{Priority: "Medium", Category: "BUSINESS_LOGIC"},
 		{Priority: "Low", Category: "OTHER"},
+		{Priority: "High", Category: "ERROR_HANDLING", CatalogTitle: "accepted entry"},
+		{Priority: "Medium", Category: "ADAPTER", CatalogTitle: "accepted entry"},
 	}
 
-	high, medium, lowCount, catStats := aggregateCoverageStats(blocks)
+	high, medium, lowCount, cataloged, catStats := aggregateCoverageStats(blocks)
 
 	if len(high) != 2 {
-		t.Errorf("expected 2 high priority blocks, got %d", len(high))
+		t.Errorf("expected 2 high priority blocks (cataloged excluded), got %d", len(high))
 	}
 	if len(medium) != 1 {
-		t.Errorf("expected 1 medium priority blocks, got %d", len(medium))
+		t.Errorf("expected 1 medium priority block (cataloged excluded), got %d", len(medium))
 	}
 	if lowCount != 1 {
 		t.Errorf("expected 1 low priority block, got %d", lowCount)
+	}
+	if len(cataloged) != 2 {
+		t.Errorf("expected 2 cataloged blocks, got %d", len(cataloged))
 	}
 	if catStats["BUSINESS_LOGIC"] != 2 {
 		t.Errorf("expected 2 BUSINESS_LOGIC blocks, got %d", catStats["BUSINESS_LOGIC"])
@@ -1429,5 +1436,132 @@ func TestGetDetailedCoverage_ParseDetailedCoverageError(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "bufio.Scanner: token too long") {
 		t.Errorf("expected scanner overflow error, got: %v", err)
+	}
+}
+
+// TestFormatDetailedCoverageReport_CatalogedExcluded verifies that a block
+// tagged with a CatalogTitle is excluded from the High/Medium gap sections
+// and the summary counts, and is instead listed in the cataloged section.
+func TestFormatDetailedCoverageReport_CatalogedExcluded(t *testing.T) {
+	t.Parallel()
+	blocks := []uncoveredBlock{
+		{
+			File:         "internal/tools/integrations/ado/pipeline_crud.go",
+			Start:        308,
+			End:          310,
+			Category:     "ERROR_HANDLING",
+			Priority:     "High",
+			Code:         "if err != nil { return ... }",
+			CatalogTitle: "ado/pipeline_crud.go — buildVariablesUpdatePayload error return",
+		},
+		{
+			File:     "internal/domain/logic.go",
+			Start:    5,
+			End:      7,
+			Category: "BUSINESS_LOGIC",
+			Priority: "High",
+			Code:     "real gap",
+		},
+	}
+
+	report := formatDetailedCoverageReport("./pkg", blocks)
+
+	// Summary counts only uncataloged blocks.
+	if !strings.Contains(report, "- Total Gaps: 2") {
+		t.Errorf("expected Total Gaps: 2, got:\n%s", report)
+	}
+	if !strings.Contains(report, "- High Priority (Architectural): 1") {
+		t.Errorf("expected High Priority count 1 (cataloged excluded), got:\n%s", report)
+	}
+	if !strings.Contains(report, "- Cataloged (ACCEPTED): 1") {
+		t.Errorf("expected Cataloged (ACCEPTED) count 1, got:\n%s", report)
+	}
+
+	// Cataloged block must not appear in the HIGH PRIORITY GAPS section.
+	if !strings.Contains(report, "[HIGH PRIORITY GAPS]") {
+		t.Errorf("expected HIGH PRIORITY GAPS section, got:\n%s", report)
+	}
+	if strings.Contains(report, "[HIGH PRIORITY GAPS]\n1. File: internal/tools/integrations/ado/pipeline_crud.go") {
+		t.Errorf("cataloged block must be excluded from HIGH PRIORITY GAPS:\n%s", report)
+	}
+
+	// Cataloged block must appear in the cataloged section with its title.
+	if !strings.Contains(report, "[CATALOGED GAPS (ACCEPTED)]") {
+		t.Errorf("expected CATALOGED GAPS section, got:\n%s", report)
+	}
+	if !strings.Contains(report, "1. File: internal/tools/integrations/ado/pipeline_crud.go (Lines 308-310)") {
+		t.Errorf("expected cataloged block listed with lines, got:\n%s", report)
+	}
+	if !strings.Contains(report, "Category: ERROR_HANDLING") {
+		t.Errorf("expected cataloged block category, got:\n%s", report)
+	}
+	if !strings.Contains(report, "Catalog: ado/pipeline_crud.go — buildVariablesUpdatePayload error return") {
+		t.Errorf("expected catalog title on cataloged block, got:\n%s", report)
+	}
+}
+
+// TestFormatDetailedCoverageReport_CatalogedSectionLimit verifies the
+// cataloged section renders at most maxItems blocks and reports the remainder.
+func TestFormatDetailedCoverageReport_CatalogedSectionLimit(t *testing.T) {
+	t.Parallel()
+	var blocks []uncoveredBlock
+	for i := 0; i < 12; i++ {
+		blocks = append(blocks, uncoveredBlock{
+			File:         "internal/cataloged.go",
+			Start:        i + 1,
+			End:          i + 1,
+			Category:     "OTHER",
+			Priority:     "Low",
+			CatalogTitle: "cataloged entry",
+		})
+	}
+
+	report := formatDetailedCoverageReport("pkg", blocks)
+	if !strings.Contains(report, "... and 2 more cataloged (ACCEPTED) gaps.") {
+		t.Errorf("expected truncation note for cataloged section, got:\n%s", report)
+	}
+	if !strings.Contains(report, "- Cataloged (ACCEPTED): 12") {
+		t.Errorf("expected full cataloged count in summary, got:\n%s", report)
+	}
+}
+
+// TestApplyCatalogTitles verifies that blocks are tagged from the catalog
+// entries via range overlap, and that nil entries are a no-op.
+func TestApplyCatalogTitles(t *testing.T) {
+	t.Parallel()
+	entries := []nonFixEntry{
+		{
+			Title: "ado/pipeline_crud.go — buildVariablesUpdatePayload error return",
+			Refs: []fileRange{
+				{File: "internal/tools/integrations/ado/pipeline_crud.go", Start: 272, End: 275},
+				{File: "pipeline_crud.go", Start: 308, End: 310}, // bare basename follow-on
+			},
+		},
+	}
+
+	blocks := []uncoveredBlock{
+		{File: "internal/tools/integrations/ado/pipeline_crud.go", Start: 308, End: 310}, // bare basename ref match
+		{File: "internal/tools/integrations/ado/pipeline_crud.go", Start: 274, End: 276}, // partial overlap
+		{File: "internal/tools/integrations/ado/pipeline_crud.go", Start: 400, End: 410}, // no overlap
+		{File: "internal/other.go", Start: 1, End: 5},                                    // wrong file
+	}
+	applyCatalogTitles(blocks, entries)
+
+	want := []string{
+		"ado/pipeline_crud.go — buildVariablesUpdatePayload error return",
+		"ado/pipeline_crud.go — buildVariablesUpdatePayload error return",
+		"",
+		"",
+	}
+	for i, w := range want {
+		if blocks[i].CatalogTitle != w {
+			t.Errorf("blocks[%d].CatalogTitle = %q, want %q", i, blocks[i].CatalogTitle, w)
+		}
+	}
+
+	// Nil entries must be a no-op.
+	applyCatalogTitles(blocks, nil)
+	if blocks[0].CatalogTitle != "" {
+		t.Errorf("expected empty CatalogTitle after nil-entries no-op, got %q", blocks[0].CatalogTitle)
 	}
 }

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -267,28 +267,22 @@ func (m *healthManager) resolveRepoRoot(ctx context.Context) string {
 	return m.repoRoot
 }
 
-func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
-	// Complexity check is internal and doesn't need TerminalLock unless it uses a tool
-	complexities, _, err := m.complexity.GatherComplexities(ctx, ".", hb)
-	if err != nil {
-		return "ERROR", err.Error(), nil
-	}
-
-	// Cross-reference over-threshold functions against the Intentional
-	// Non-Fixes catalog: ACCEPTED complexity entries are reported separately
-	// and do not count as actionable alerts. A load failure degrades
-	// gracefully: every gap is treated as actionable.
+// loadNonFixEntries loads the Intentional Non-Fixes catalog, logging a
+// warning on I/O failure and degrading gracefully to an empty catalog
+// (all gaps treated as actionable).
+func (m *healthManager) loadNonFixEntries() []nonFixEntry {
 	entries, catErr := loadNonFixCatalog(m.catalogPath)
 	if catErr != nil {
 		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
 	}
-	repoRoot := m.resolveRepoRoot(ctx)
+	return entries
+}
 
-	threshold := 10
-	var alerts []string
-	var catalogedNames []string
-	highCount := 0
-	catalogedCount := 0
+// bucketComplexityAlerts partitions over-threshold functions into actionable
+// alerts and cataloged (ACCEPTED) names, preserving document order. It keeps
+// the historical caps of 5 collected alert strings and 5 collected cataloged
+// names; the returned counts are always exact.
+func bucketComplexityAlerts(complexities []funcComplexity, entries []nonFixEntry, repoRoot string, threshold int) (alerts []string, catalogedNames []string, highCount, catalogedCount int) {
 	for _, c := range complexities {
 		if c.Complexity <= threshold {
 			continue
@@ -309,6 +303,25 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 			alerts = append(alerts, fmt.Sprintf("`%s` (%d)", c.Name, c.Complexity))
 		}
 	}
+	return
+}
+
+func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
+	// Complexity check is internal and doesn't need TerminalLock unless it uses a tool
+	complexities, _, err := m.complexity.GatherComplexities(ctx, ".", hb)
+	if err != nil {
+		return "ERROR", err.Error(), nil
+	}
+
+	// Cross-reference over-threshold functions against the Intentional
+	// Non-Fixes catalog: ACCEPTED complexity entries are reported separately
+	// and do not count as actionable alerts. A load failure degrades
+	// gracefully: every gap is treated as actionable.
+	entries := m.loadNonFixEntries()
+	repoRoot := m.resolveRepoRoot(ctx)
+
+	threshold := 10
+	alerts, catalogedNames, highCount, catalogedCount := bucketComplexityAlerts(complexities, entries, repoRoot, threshold)
 
 	if highCount == 0 && catalogedCount == 0 {
 		return "GOOD", "All functions under threshold", nil

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -50,6 +50,10 @@ type healthResult struct {
 type healthSummary struct {
 	Results map[string]healthResult
 	Alerts  []string
+	// CatalogedNote carries the Intentional Non-Fixes (ACCEPTED) exclusion
+	// note for over-threshold complexity functions, separate from the
+	// actionable alerts so the dashboard can render it under its own header.
+	CatalogedNote string
 }
 
 func (m *healthManager) GetCodeHealth(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -65,7 +69,7 @@ func (m *healthManager) GetCodeHealth(ctx context.Context, args map[string]inter
 	go m.startHeartbeat(done, hb)
 
 	summary := m.runParallelChecks(ctx, hb)
-	table := m.formatHealthTable(summary.Results, summary.Alerts)
+	table := m.formatHealthTable(summary.Results, summary.Alerts, summary.CatalogedNote)
 
 	recommendation := m.generateRecommendation(
 		summary.Results["Tests"].Status,
@@ -113,6 +117,7 @@ func (m *healthManager) runParallelChecks(ctx context.Context, hb chan<- struct{
 		compStatus, compDetails                                  string
 		deadStatus, deadDetails                                  string
 		alerts                                                   []string
+		catalogedNote                                            string
 	)
 
 	g, gCtx := errgroup.WithContext(ctx)
@@ -131,7 +136,7 @@ func (m *healthManager) runParallelChecks(ctx context.Context, hb chan<- struct{
 
 	// 4. Complexity
 	g.Go(func() error {
-		compStatus, compDetails, alerts = m.checkComplexity(gCtx, hb)
+		compStatus, compDetails, alerts, catalogedNote = m.checkComplexity(gCtx, hb)
 		return nil
 	})
 
@@ -151,11 +156,18 @@ func (m *healthManager) runParallelChecks(ctx context.Context, hb chan<- struct{
 			"Complexity": {Status: compStatus, Details: compDetails},
 			"Dead Code":  {Status: deadStatus, Details: deadDetails},
 		},
-		Alerts: alerts,
+		Alerts:        alerts,
+		CatalogedNote: catalogedNote,
 	}
 }
 
-func (m *healthManager) formatHealthTable(results map[string]healthResult, alerts []string) string {
+// formatHealthTable renders the dashboard table plus the complexity sections.
+// alerts holds only actionable over-threshold bullets (the cataloged note is
+// passed separately), so a non-empty alerts slice always means there is at
+// least one real alert and the "Complexity Alerts" header is honest. When only
+// the cataloged note exists (every over-threshold function ACCEPTED), the
+// "Complexity Alerts" header must NOT appear; the note gets its own section.
+func (m *healthManager) formatHealthTable(results map[string]healthResult, alerts []string, catalogedNote string) string {
 	var sb strings.Builder
 	sb.WriteString("### Project Health Dashboard\n")
 	sb.WriteString("| Metric | Status | Details |\n")
@@ -172,6 +184,10 @@ func (m *healthManager) formatHealthTable(results map[string]healthResult, alert
 		for _, alert := range alerts {
 			_, _ = fmt.Fprintf(&sb, "- %s\n", alert)
 		}
+	}
+	if catalogedNote != "" {
+		sb.WriteString("\n**Cataloged (ACCEPTED) over threshold:**\n")
+		_, _ = fmt.Fprintf(&sb, "- %s\n", catalogedNote)
 	}
 	return sb.String()
 }
@@ -306,11 +322,17 @@ func bucketComplexityAlerts(complexities []funcComplexity, entries []nonFixEntry
 	return
 }
 
-func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
+// checkComplexity reports complexity health as (status, details, alerts,
+// catalogedNote). "GOOD" means nothing actionable: either every function is
+// under the threshold, or every over-threshold function is cataloged (ACCEPTED)
+// — the cataloged note is carried in details and returned separately so the
+// dashboard can render it under its own header. alerts contains only
+// actionable bullets; catalogedNote is the single exclusion-note bullet.
+func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string, string) {
 	// Complexity check is internal and doesn't need TerminalLock unless it uses a tool
 	complexities, _, err := m.complexity.GatherComplexities(ctx, ".", hb)
 	if err != nil {
-		return "ERROR", err.Error(), nil
+		return "ERROR", err.Error(), nil, ""
 	}
 
 	// Cross-reference over-threshold functions against the Intentional
@@ -324,17 +346,24 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 	alerts, catalogedNames, highCount, catalogedCount := bucketComplexityAlerts(complexities, entries, repoRoot, threshold)
 
 	if highCount == 0 && catalogedCount == 0 {
-		return "GOOD", "All functions under threshold", nil
+		return "GOOD", "All functions under threshold", nil, ""
 	}
 
 	details := fmt.Sprintf("%d functions > threshold (%d)", highCount, threshold)
+	catalogedNote := ""
 	if catalogedCount > 0 {
 		details += fmt.Sprintf("; %d cataloged (ACCEPTED) over threshold excluded", catalogedCount)
-		alerts = append(alerts, fmt.Sprintf("%d cataloged (ACCEPTED) functions over threshold excluded: %s",
-			catalogedCount, strings.Join(catalogedNames, ", ")))
+		catalogedNote = fmt.Sprintf("%d cataloged (ACCEPTED) functions over threshold excluded: %s",
+			catalogedCount, strings.Join(catalogedNames, ", "))
 	}
 
-	return fmt.Sprintf("%d Alerts", highCount), details, alerts
+	if highCount == 0 {
+		// Only cataloged (ACCEPTED) over-threshold functions: nothing
+		// actionable. "GOOD" must not become "0 Alerts", which would trip
+		// recommendComplexity's strings.Contains(comp, "Alerts") check.
+		return "GOOD", details, alerts, catalogedNote
+	}
+	return fmt.Sprintf("%d Alerts", highCount), details, alerts, catalogedNote
 }
 
 func (m *healthManager) checkDeadCode(ctx context.Context, hb chan<- struct{}) (string, string) {

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -230,6 +231,22 @@ func (m *healthManager) runLint(ctx context.Context) (string, string) {
 	return fmt.Sprintf("%d Issues", count), fmt.Sprintf("Using %s", tool)
 }
 
+// resolveRepoRoot returns the repository root used to normalize file paths
+// against the Intentional Non-Fixes catalog. It prefers the module directory
+// reported by the Go runner and falls back to the process working directory;
+// an empty result means normalization can only rely on relative paths.
+func (m *healthManager) resolveRepoRoot(ctx context.Context) string {
+	if m != nil && m.Runner != nil {
+		if dir, err := m.Runner.GetModuleDir(ctx); err == nil && dir != "" {
+			return dir
+		}
+	}
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
+}
+
 func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
 	// Complexity check is internal and doesn't need TerminalLock unless it uses a tool
 	complexities, _, err := m.complexity.GatherComplexities(ctx, ".", hb)
@@ -237,23 +254,50 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 		return "ERROR", err.Error(), nil
 	}
 
+	// Cross-reference over-threshold functions against the Intentional
+	// Non-Fixes catalog: ACCEPTED complexity entries are reported separately
+	// and do not count as actionable alerts.
+	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	repoRoot := m.resolveRepoRoot(ctx)
+
 	threshold := 10
 	var alerts []string
+	var catalogedNames []string
 	highCount := 0
+	catalogedCount := 0
 	for _, c := range complexities {
-		if c.Complexity > threshold {
-			highCount++
-			if len(alerts) < 5 {
-				alerts = append(alerts, fmt.Sprintf("`%s` (%d)", c.Name, c.Complexity))
+		if c.Complexity <= threshold {
+			continue
+		}
+		// funcComplexity.FilePath comes from fs.Walk and may be absolute or
+		// relative; normalize to the repo-relative "internal/..." form used
+		// by the catalog. Unmatched (or unnormalizable) functions stay alerts.
+		normalized := normalizeCatalogFilePath(c.FilePath, repoRoot)
+		if catalogTitleFor(entries, normalized, c.Line) != "" {
+			catalogedCount++
+			if len(catalogedNames) < 5 {
+				catalogedNames = append(catalogedNames, fmt.Sprintf("`%s` (%d)", c.Name, c.Complexity))
 			}
+			continue
+		}
+		highCount++
+		if len(alerts) < 5 {
+			alerts = append(alerts, fmt.Sprintf("`%s` (%d)", c.Name, c.Complexity))
 		}
 	}
 
-	if highCount == 0 {
+	if highCount == 0 && catalogedCount == 0 {
 		return "GOOD", "All functions under threshold", nil
 	}
 
-	return fmt.Sprintf("%d Alerts", highCount), fmt.Sprintf("%d functions > threshold (%d)", highCount, threshold), alerts
+	details := fmt.Sprintf("%d functions > threshold (%d)", highCount, threshold)
+	if catalogedCount > 0 {
+		details += fmt.Sprintf("; %d cataloged (ACCEPTED) over threshold excluded", catalogedCount)
+		alerts = append(alerts, fmt.Sprintf("%d cataloged (ACCEPTED) functions over threshold excluded: %s",
+			catalogedCount, strings.Join(catalogedNames, ", ")))
+	}
+
+	return fmt.Sprintf("%d Alerts", highCount), details, alerts
 }
 
 func (m *healthManager) checkDeadCode(ctx context.Context, hb chan<- struct{}) (string, string) {

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
@@ -27,6 +29,17 @@ type healthManager struct {
 	complexity complexityAnalyzer
 	deadCode   deadCodeAnalyzer
 	clk        clock.Clock
+
+	// catalogPath is the location of the Intentional Non-Fixes catalog read
+	// during health checks. Injected at construction (production wiring uses
+	// the package default); tests inject a fixture path. The zero value
+	// behaves like a missing catalog.
+	catalogPath string
+
+	// repoRoot caches the repository root resolved by resolveRepoRoot so the
+	// go list subprocess runs at most once per healthManager lifetime.
+	repoRoot     string
+	repoRootOnce sync.Once
 }
 
 type healthResult struct {
@@ -234,17 +247,24 @@ func (m *healthManager) runLint(ctx context.Context) (string, string) {
 // resolveRepoRoot returns the repository root used to normalize file paths
 // against the Intentional Non-Fixes catalog. It prefers the module directory
 // reported by the Go runner and falls back to the process working directory;
-// an empty result means normalization can only rely on relative paths.
+// an empty result means normalization can only rely on relative paths. The
+// result is computed once per healthManager (the first call still runs the go
+// list subprocess) and cached for subsequent calls; a nil Runner fallback
+// (os.Getwd) is cached too, since the process working directory does not
+// change mid-run.
 func (m *healthManager) resolveRepoRoot(ctx context.Context) string {
-	if m != nil && m.Runner != nil {
-		if dir, err := m.Runner.GetModuleDir(ctx); err == nil && dir != "" {
-			return dir
+	m.repoRootOnce.Do(func() {
+		if m.Runner != nil {
+			if dir, err := m.Runner.GetModuleDir(ctx); err == nil && dir != "" {
+				m.repoRoot = dir
+				return
+			}
 		}
-	}
-	if wd, err := os.Getwd(); err == nil {
-		return wd
-	}
-	return ""
+		if wd, err := os.Getwd(); err == nil {
+			m.repoRoot = wd
+		}
+	})
+	return m.repoRoot
 }
 
 func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{}) (string, string, []string) {
@@ -256,8 +276,12 @@ func (m *healthManager) checkComplexity(ctx context.Context, hb chan<- struct{})
 
 	// Cross-reference over-threshold functions against the Intentional
 	// Non-Fixes catalog: ACCEPTED complexity entries are reported separately
-	// and do not count as actionable alerts.
-	entries, _ := loadNonFixCatalog(defaultNonFixCatalogPath)
+	// and do not count as actionable alerts. A load failure degrades
+	// gracefully: every gap is treated as actionable.
+	entries, catErr := loadNonFixCatalog(m.catalogPath)
+	if catErr != nil {
+		slog.Warn("failed to load non-fix catalog; treating all gaps as actionable", "path", m.catalogPath, "error", catErr)
+	}
 	repoRoot := m.resolveRepoRoot(ctx)
 
 	threshold := 10

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -341,7 +341,7 @@ func TestFormatHealthTable_WithAlerts(t *testing.T) {
 		"Dead Code":  {Status: "CLEAN", Details: "no orphans"},
 	}
 	alerts := []string{"`BigFunc` (15)", "`HugeFunc` (22)", "`MassiveFunc` (30)"}
-	output := m.formatHealthTable(results, alerts)
+	output := m.formatHealthTable(results, alerts, "")
 	if !strings.Contains(output, "Complexity Alerts (Threshold > 10)") {
 		t.Error("expected complexity alerts header")
 	}
@@ -350,6 +350,66 @@ func TestFormatHealthTable_WithAlerts(t *testing.T) {
 	}
 	if !strings.Contains(output, "`MassiveFunc` (30)") {
 		t.Error("expected MassiveFunc alert")
+	}
+}
+
+// TestFormatHealthTable_Mixed verifies the mixed rendering: actionable alerts
+// keep the "Complexity Alerts (Threshold > 10):" header, and the cataloged
+// note renders as a distinct small section beneath it. Parallel-safe: no
+// shared state.
+func TestFormatHealthTable_Mixed(t *testing.T) {
+	t.Parallel()
+	m := &healthManager{}
+	results := map[string]healthResult{
+		"Tests":      {Status: "PASS", Details: "ok"},
+		"Coverage":   {Status: "80%", Details: "target met"},
+		"Linting":    {Status: "CLEAN", Details: "no issues"},
+		"Complexity": {Status: "1 Alerts", Details: "1 functions > threshold (10); 1 cataloged (ACCEPTED) over threshold excluded"},
+		"Dead Code":  {Status: "CLEAN", Details: "no orphans"},
+	}
+	alerts := []string{"`HotMess` (15)"}
+	catalogedNote := "1 cataloged (ACCEPTED) functions over threshold excluded: `(*RecoveryStep).Process` (12)"
+	output := m.formatHealthTable(results, alerts, catalogedNote)
+
+	if !strings.Contains(output, "Complexity Alerts (Threshold > 10)") {
+		t.Errorf("expected complexity alerts header when actionable alerts exist, got:\n%s", output)
+	}
+	if !strings.Contains(output, "`HotMess` (15)") {
+		t.Errorf("expected actionable alert bullet, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Cataloged (ACCEPTED) over threshold:") {
+		t.Errorf("expected cataloged section header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "`(*RecoveryStep).Process` (12)") {
+		t.Errorf("expected cataloged function bullet, got:\n%s", output)
+	}
+}
+
+// TestFormatHealthTable_AllCataloged verifies the all-cataloged rendering:
+// every over-threshold function is cataloged (ACCEPTED), so the table must
+// NOT carry a "Complexity Alerts" header — only the distinct cataloged note
+// section. Parallel-safe: no shared state.
+func TestFormatHealthTable_AllCataloged(t *testing.T) {
+	t.Parallel()
+	m := &healthManager{}
+	results := map[string]healthResult{
+		"Tests":      {Status: "PASS", Details: "ok"},
+		"Coverage":   {Status: "80%", Details: "target met"},
+		"Linting":    {Status: "CLEAN", Details: "no issues"},
+		"Complexity": {Status: "GOOD", Details: "0 functions > threshold (10); 1 cataloged (ACCEPTED) over threshold excluded"},
+		"Dead Code":  {Status: "CLEAN", Details: "no orphans"},
+	}
+	catalogedNote := "1 cataloged (ACCEPTED) functions over threshold excluded: `(*model).Update` (14)"
+	output := m.formatHealthTable(results, nil, catalogedNote)
+
+	if strings.Contains(output, "Complexity Alerts (Threshold > 10)") {
+		t.Errorf("did not expect 'Complexity Alerts' header when nothing actionable, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Cataloged (ACCEPTED) over threshold:") {
+		t.Errorf("expected cataloged section header, got:\n%s", output)
+	}
+	if !strings.Contains(output, "`(*model).Update` (14)") {
+		t.Errorf("expected cataloged function bullet, got:\n%s", output)
 	}
 }
 
@@ -471,7 +531,7 @@ func TestCheckComplexity_AllPaths(t *testing.T) {
 			m := &healthManager{complexity: &stubComplexityAnalyzer{
 				complexities: tt.mockComplexities, err: tt.mockErr,
 			}}
-			status, details, alerts := m.checkComplexity(context.Background(), nil)
+			status, details, alerts, _ := m.checkComplexity(context.Background(), nil)
 			if status != tt.wantStatus {
 				t.Errorf("status: got %q, want %q", status, tt.wantStatus)
 			}
@@ -509,7 +569,7 @@ func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
 		},
 	}
 
-	status, details, alerts := m.checkComplexity(context.Background(), nil)
+	status, details, alerts, catalogedNote := m.checkComplexity(context.Background(), nil)
 
 	if status != "1 Alerts" {
 		t.Errorf("status = %q, want %q (cataloged excluded)", status, "1 Alerts")
@@ -520,17 +580,17 @@ func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
 	if !strings.Contains(details, "1 cataloged (ACCEPTED) over threshold excluded") {
 		t.Errorf("details = %q, want cataloged exclusion note", details)
 	}
-	if len(alerts) != 2 {
-		t.Fatalf("alerts = %v, want 2 entries (1 alert + 1 cataloged note)", alerts)
+	if len(alerts) != 1 {
+		t.Fatalf("alerts = %v, want exactly 1 actionable alert (cataloged note is separate)", alerts)
 	}
 	if alerts[0] != "`HotMess` (15)" {
 		t.Errorf("alerts[0] = %q, want %q", alerts[0], "`HotMess` (15)")
 	}
-	if !strings.Contains(alerts[1], "1 cataloged (ACCEPTED) functions over threshold excluded:") {
-		t.Errorf("alerts[1] = %q, want cataloged note prefix", alerts[1])
+	if !strings.Contains(catalogedNote, "1 cataloged (ACCEPTED) functions over threshold excluded:") {
+		t.Errorf("catalogedNote = %q, want cataloged note prefix", catalogedNote)
 	}
-	if !strings.Contains(alerts[1], "(*RecoveryStep).Process") {
-		t.Errorf("alerts[1] = %q, want cataloged function name", alerts[1])
+	if !strings.Contains(catalogedNote, "(*RecoveryStep).Process") {
+		t.Errorf("catalogedNote = %q, want cataloged function name", catalogedNote)
 	}
 }
 
@@ -557,16 +617,27 @@ func TestCheckComplexity_AllCataloged(t *testing.T) {
 		},
 	}
 
-	status, details, alerts := m.checkComplexity(context.Background(), nil)
+	status, details, alerts, catalogedNote := m.checkComplexity(context.Background(), nil)
 
-	if status != "0 Alerts" {
-		t.Errorf("status = %q, want %q", status, "0 Alerts")
+	// Nothing actionable: status must be GOOD, not "0 Alerts", so the
+	// recommendation layer does not fire a false "Refactor" suggestion.
+	if status != "GOOD" {
+		t.Errorf("status = %q, want %q", status, "GOOD")
 	}
 	if !strings.Contains(details, "0 functions > threshold (10)") {
 		t.Errorf("details = %q, want uncataloged count 0", details)
 	}
-	if len(alerts) != 1 || !strings.Contains(alerts[0], "1 cataloged (ACCEPTED) functions over threshold excluded:") {
-		t.Errorf("alerts = %v, want single cataloged note", alerts)
+	if !strings.Contains(details, "1 cataloged (ACCEPTED) over threshold excluded") {
+		t.Errorf("details = %q, want cataloged exclusion note", details)
+	}
+	if len(alerts) != 0 {
+		t.Errorf("alerts = %v, want no actionable alerts in the all-cataloged case", alerts)
+	}
+	if !strings.Contains(catalogedNote, "1 cataloged (ACCEPTED) functions over threshold excluded:") {
+		t.Errorf("catalogedNote = %q, want cataloged note prefix", catalogedNote)
+	}
+	if !strings.Contains(catalogedNote, "(*model).Update") {
+		t.Errorf("catalogedNote = %q, want cataloged function name", catalogedNote)
 	}
 }
 
@@ -589,7 +660,7 @@ func TestCheckComplexity_CatalogLoadError(t *testing.T) {
 		},
 	}
 
-	status, details, alerts := m.checkComplexity(context.Background(), nil)
+	status, details, alerts, catalogedNote := m.checkComplexity(context.Background(), nil)
 
 	if status != "1 Alerts" {
 		t.Errorf("status = %q, want %q (catalog load error must not drop the alert)", status, "1 Alerts")
@@ -599,6 +670,9 @@ func TestCheckComplexity_CatalogLoadError(t *testing.T) {
 	}
 	if len(alerts) != 1 || alerts[0] != "`ComplexFunc` (15)" {
 		t.Errorf("alerts = %v, want single uncataloged alert for the over-threshold function", alerts)
+	}
+	if catalogedNote != "" {
+		t.Errorf("catalogedNote = %q, want empty when the catalog fails to load", catalogedNote)
 	}
 }
 

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -479,6 +480,91 @@ func TestCheckComplexity_AllPaths(t *testing.T) {
 			}
 			_ = alerts
 		})
+	}
+}
+
+// TestCheckComplexity_CatalogedExcluded verifies that over-threshold functions
+// covered by an ACCEPTED catalog entry are excluded from the alert count and
+// reported as a separate cataloged note. NOT parallel: it temporarily points
+// defaultNonFixCatalogPath at a fixture.
+func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
+	origDefault := defaultNonFixCatalogPath
+	t.Cleanup(func() { defaultNonFixCatalogPath = origDefault })
+
+	catalog := "### agent/orchestrator/engine_phases.go — (*RecoveryStep).Process (CC=12)\n\n" +
+		"- **Status**: ACCEPTED (2026-07)\n" +
+		"- **See**: `internal/agent/orchestrator/engine_phases.go:105`\n"
+	path := filepath.Join(t.TempDir(), "INTENTIONAL_NON_FIXES.md")
+	if err := os.WriteFile(path, []byte(catalog), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	defaultNonFixCatalogPath = path
+
+	m := &healthManager{complexity: &stubComplexityAnalyzer{
+		complexities: []funcComplexity{
+			{Name: "(*RecoveryStep).Process", Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go", Line: 105},
+			{Name: "HotMess", Complexity: 15, FilePath: "internal/agent/other.go", Line: 3},
+			{Name: "Simple", Complexity: 1},
+		},
+	}}
+
+	status, details, alerts := m.checkComplexity(context.Background(), nil)
+
+	if status != "1 Alerts" {
+		t.Errorf("status = %q, want %q (cataloged excluded)", status, "1 Alerts")
+	}
+	if !strings.Contains(details, "1 functions > threshold (10)") {
+		t.Errorf("details = %q, want uncataloged count 1", details)
+	}
+	if !strings.Contains(details, "1 cataloged (ACCEPTED) over threshold excluded") {
+		t.Errorf("details = %q, want cataloged exclusion note", details)
+	}
+	if len(alerts) != 2 {
+		t.Fatalf("alerts = %v, want 2 entries (1 alert + 1 cataloged note)", alerts)
+	}
+	if alerts[0] != "`HotMess` (15)" {
+		t.Errorf("alerts[0] = %q, want %q", alerts[0], "`HotMess` (15)")
+	}
+	if !strings.Contains(alerts[1], "1 cataloged (ACCEPTED) functions over threshold excluded:") {
+		t.Errorf("alerts[1] = %q, want cataloged note prefix", alerts[1])
+	}
+	if !strings.Contains(alerts[1], "(*RecoveryStep).Process") {
+		t.Errorf("alerts[1] = %q, want cataloged function name", alerts[1])
+	}
+}
+
+// TestCheckComplexity_AllCataloged verifies the all-cataloged edge case: no
+// actionable alerts, only the cataloged note. NOT parallel: it temporarily
+// points defaultNonFixCatalogPath at a fixture.
+func TestCheckComplexity_AllCataloged(t *testing.T) {
+	origDefault := defaultNonFixCatalogPath
+	t.Cleanup(func() { defaultNonFixCatalogPath = origDefault })
+
+	catalog := "### ui/tui/progress/model.go — handleDomainEvent (CC=12)\n\n" +
+		"- **Status**: ACCEPTED (2026-07)\n" +
+		"- **See**: `internal/ui/tui/progress/model.go:250`\n"
+	path := filepath.Join(t.TempDir(), "INTENTIONAL_NON_FIXES.md")
+	if err := os.WriteFile(path, []byte(catalog), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	defaultNonFixCatalogPath = path
+
+	m := &healthManager{complexity: &stubComplexityAnalyzer{
+		complexities: []funcComplexity{
+			{Name: "(*model).Update", Complexity: 14, FilePath: "internal/ui/tui/progress/model.go", Line: 250},
+		},
+	}}
+
+	status, details, alerts := m.checkComplexity(context.Background(), nil)
+
+	if status != "0 Alerts" {
+		t.Errorf("status = %q, want %q", status, "0 Alerts")
+	}
+	if !strings.Contains(details, "0 functions > threshold (10)") {
+		t.Errorf("details = %q, want uncataloged count 0", details)
+	}
+	if len(alerts) != 1 || !strings.Contains(alerts[0], "1 cataloged (ACCEPTED) functions over threshold excluded:") {
+		t.Errorf("alerts = %v, want single cataloged note", alerts)
 	}
 }
 

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -485,11 +485,10 @@ func TestCheckComplexity_AllPaths(t *testing.T) {
 
 // TestCheckComplexity_CatalogedExcluded verifies that over-threshold functions
 // covered by an ACCEPTED catalog entry are excluded from the alert count and
-// reported as a separate cataloged note. NOT parallel: it temporarily points
-// defaultNonFixCatalogPath at a fixture.
+// reported as a separate cataloged note. Parallel-safe: the catalog path is
+// injected per healthManager, so no global state is touched.
 func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
-	origDefault := defaultNonFixCatalogPath
-	t.Cleanup(func() { defaultNonFixCatalogPath = origDefault })
+	t.Parallel()
 
 	catalog := "### agent/orchestrator/engine_phases.go — (*RecoveryStep).Process (CC=12)\n\n" +
 		"- **Status**: ACCEPTED (2026-07)\n" +
@@ -498,15 +497,17 @@ func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
 	if err := os.WriteFile(path, []byte(catalog), 0644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	defaultNonFixCatalogPath = path
 
-	m := &healthManager{complexity: &stubComplexityAnalyzer{
-		complexities: []funcComplexity{
-			{Name: "(*RecoveryStep).Process", Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go", Line: 105},
-			{Name: "HotMess", Complexity: 15, FilePath: "internal/agent/other.go", Line: 3},
-			{Name: "Simple", Complexity: 1},
+	m := &healthManager{
+		catalogPath: path,
+		complexity: &stubComplexityAnalyzer{
+			complexities: []funcComplexity{
+				{Name: "(*RecoveryStep).Process", Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go", Line: 105},
+				{Name: "HotMess", Complexity: 15, FilePath: "internal/agent/other.go", Line: 3},
+				{Name: "Simple", Complexity: 1},
+			},
 		},
-	}}
+	}
 
 	status, details, alerts := m.checkComplexity(context.Background(), nil)
 
@@ -534,11 +535,10 @@ func TestCheckComplexity_CatalogedExcluded(t *testing.T) {
 }
 
 // TestCheckComplexity_AllCataloged verifies the all-cataloged edge case: no
-// actionable alerts, only the cataloged note. NOT parallel: it temporarily
-// points defaultNonFixCatalogPath at a fixture.
+// actionable alerts, only the cataloged note. Parallel-safe: the catalog path
+// is injected per healthManager, so no global state is touched.
 func TestCheckComplexity_AllCataloged(t *testing.T) {
-	origDefault := defaultNonFixCatalogPath
-	t.Cleanup(func() { defaultNonFixCatalogPath = origDefault })
+	t.Parallel()
 
 	catalog := "### ui/tui/progress/model.go — handleDomainEvent (CC=12)\n\n" +
 		"- **Status**: ACCEPTED (2026-07)\n" +
@@ -547,13 +547,15 @@ func TestCheckComplexity_AllCataloged(t *testing.T) {
 	if err := os.WriteFile(path, []byte(catalog), 0644); err != nil {
 		t.Fatalf("write fixture: %v", err)
 	}
-	defaultNonFixCatalogPath = path
 
-	m := &healthManager{complexity: &stubComplexityAnalyzer{
-		complexities: []funcComplexity{
-			{Name: "(*model).Update", Complexity: 14, FilePath: "internal/ui/tui/progress/model.go", Line: 250},
+	m := &healthManager{
+		catalogPath: path,
+		complexity: &stubComplexityAnalyzer{
+			complexities: []funcComplexity{
+				{Name: "(*model).Update", Complexity: 14, FilePath: "internal/ui/tui/progress/model.go", Line: 250},
+			},
 		},
-	}}
+	}
 
 	status, details, alerts := m.checkComplexity(context.Background(), nil)
 
@@ -565,6 +567,38 @@ func TestCheckComplexity_AllCataloged(t *testing.T) {
 	}
 	if len(alerts) != 1 || !strings.Contains(alerts[0], "1 cataloged (ACCEPTED) functions over threshold excluded:") {
 		t.Errorf("alerts = %v, want single cataloged note", alerts)
+	}
+}
+
+// TestCheckComplexity_CatalogLoadError verifies that a catalog load failure
+// (a non-IsNotExist I/O error) does not panic and degrades gracefully: all
+// over-threshold functions are treated as uncataloged actionable alerts.
+// catalogPath points at a directory, so os.ReadFile fails deterministically
+// with an "is a directory" error on every platform (no permission-bit
+// dependence).
+func TestCheckComplexity_CatalogLoadError(t *testing.T) {
+	t.Parallel()
+
+	m := &healthManager{
+		catalogPath: t.TempDir(), // a directory: os.ReadFile must fail with a non-IsNotExist error
+		complexity: &stubComplexityAnalyzer{
+			complexities: []funcComplexity{
+				{Name: "ComplexFunc", Complexity: 15, FilePath: "internal/agent/other.go", Line: 3},
+				{Name: "Simple", Complexity: 1},
+			},
+		},
+	}
+
+	status, details, alerts := m.checkComplexity(context.Background(), nil)
+
+	if status != "1 Alerts" {
+		t.Errorf("status = %q, want %q (catalog load error must not drop the alert)", status, "1 Alerts")
+	}
+	if strings.Contains(details, "cataloged") {
+		t.Errorf("details = %q, want no cataloged note when the catalog fails to load", details)
+	}
+	if len(alerts) != 1 || alerts[0] != "`ComplexFunc` (15)" {
+		t.Errorf("alerts = %v, want single uncataloged alert for the over-threshold function", alerts)
 	}
 }
 

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -94,12 +94,13 @@ func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Man
 	}
 
 	m.health = &healthManager{
-		SP:         sp,
-		complexity: m.complexity,
-		deadCode:   m.deadCode,
-		Exec:       executor,
-		Runner:     runner,
-		clk:        clock.RealClock{},
+		SP:          sp,
+		complexity:  m.complexity,
+		deadCode:    m.deadCode,
+		Exec:        executor,
+		Runner:      runner,
+		clk:         clock.RealClock{},
+		catalogPath: defaultNonFixCatalogPath,
 	}
 
 	return m

--- a/internal/tools/analysis/nonfix_catalog.go
+++ b/internal/tools/analysis/nonfix_catalog.go
@@ -72,37 +72,58 @@ func parseNonFixCatalog(data string) []nonFixEntry {
 
 	scanner := bufio.NewScanner(strings.NewReader(data))
 	for scanner.Scan() {
-		line := scanner.Text()
-		trimmed := strings.TrimSpace(line)
+		cur, inSee = processCatalogLine(scanner.Text(), cur, inSee, &pending)
+	}
+	return filterAcceptedEntries(pending)
+}
 
-		if strings.HasPrefix(trimmed, "### ") {
-			pending = append(pending, pendingEntry{
-				entry: nonFixEntry{Title: strings.TrimSpace(strings.TrimPrefix(trimmed, "### "))},
-			})
-			cur = &pending[len(pending)-1]
-			inSee = false
-			continue
-		}
+// processCatalogLine applies one scanned line to the catalog parse state: a
+// `### ` heading opens a new pending entry, a Status bullet records its
+// status, a See bullet (or its indented continuation) collects backticked
+// references, and any other bullet ends the See continuation. It returns the
+// (possibly updated) current entry pointer and See-continuation flag.
+func processCatalogLine(line string, cur *pendingEntry, inSee bool, pending *[]pendingEntry) (*pendingEntry, bool) {
+	trimmed := strings.TrimSpace(line)
 
-		if cur == nil {
-			continue // footer or prose outside a ### heading
-		}
-
-		switch {
-		case strings.HasPrefix(trimmed, "- **Status**:"):
-			cur.status = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "- **Status**:")))
-			inSee = false
-		case strings.HasPrefix(trimmed, "- **See**:"):
-			inSee = true
-			parseSeeRefs(trimmed, cur)
-		case strings.HasPrefix(trimmed, "- "):
-			inSee = false
-		case inSee && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")):
-			// Indented continuation of a See bullet carrying more refs.
-			parseSeeRefs(trimmed, cur)
-		}
+	if strings.HasPrefix(trimmed, "### ") {
+		*pending = append(*pending, pendingEntry{
+			entry: nonFixEntry{Title: strings.TrimSpace(strings.TrimPrefix(trimmed, "### "))},
+		})
+		return &(*pending)[len(*pending)-1], false
 	}
 
+	if cur == nil {
+		return nil, inSee // footer or prose outside a ### heading
+	}
+
+	switch {
+	case strings.HasPrefix(trimmed, "- **Status**:"):
+		cur.status = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "- **Status**:")))
+		return cur, false
+	case strings.HasPrefix(trimmed, "- **See**:"):
+		inSee = true
+		parseSeeRefs(trimmed, cur)
+		return cur, inSee
+	case strings.HasPrefix(trimmed, "- "):
+		return cur, false
+	case inSee && isIndentedLine(line):
+		// Indented continuation of a See bullet carrying more refs.
+		parseSeeRefs(trimmed, cur)
+		return cur, inSee
+	}
+	return cur, inSee
+}
+
+// isIndentedLine reports whether line starts with the whitespace indentation
+// used by See-bullet continuation lines in the catalog.
+func isIndentedLine(line string) bool {
+	return strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")
+}
+
+// filterAcceptedEntries keeps only pending entries whose Status bullet began
+// with "accepted" (matched case-insensitively because status is lowered at
+// parse time) and returns them in document order.
+func filterAcceptedEntries(pending []pendingEntry) []nonFixEntry {
 	var accepted []nonFixEntry
 	for _, p := range pending {
 		if strings.HasPrefix(p.status, "accepted") {
@@ -139,26 +160,40 @@ func parseCatalogRef(ref string) []fileRange {
 
 	var ranges []fileRange
 	for _, part := range strings.Split(locSpec, ",") {
-		part = strings.TrimSpace(part)
-		if part == "" {
-			continue
-		}
-		if dashIdx := strings.Index(part, "-"); dashIdx != -1 {
-			start, err1 := strconv.Atoi(part[:dashIdx])
-			end, err2 := strconv.Atoi(part[dashIdx+1:])
-			if err1 != nil || err2 != nil || start < 1 || end < start {
-				continue
-			}
-			ranges = append(ranges, fileRange{File: file, Start: start, End: end})
-			continue
-		}
-		line, err := strconv.Atoi(part)
-		if err != nil || line < 1 {
-			continue
-		}
-		ranges = append(ranges, fileRange{File: file, Start: line, End: line})
+		ranges = append(ranges, parseRefPart(part, file)...)
 	}
 	return ranges
+}
+
+// parseRefPart parses one comma-separated location part ("162", "142-144")
+// into the fileRange values it denotes. Empty or invalid parts return nil.
+func parseRefPart(part, file string) []fileRange {
+	part = strings.TrimSpace(part)
+	if part == "" {
+		return nil
+	}
+	if dashIdx := strings.Index(part, "-"); dashIdx != -1 {
+		if r, ok := parseRefRange(part, dashIdx, file); ok {
+			return []fileRange{r}
+		}
+		return nil
+	}
+	if line, err := strconv.Atoi(part); err == nil && line >= 1 {
+		return []fileRange{{File: file, Start: line, End: line}}
+	}
+	return nil
+}
+
+// parseRefRange parses a "start-end" location part into a fileRange, reporting
+// ok=false when either bound is not a positive integer or the range is
+// inverted (end < start).
+func parseRefRange(part string, dashIdx int, file string) (fileRange, bool) {
+	start, err1 := strconv.Atoi(part[:dashIdx])
+	end, err2 := strconv.Atoi(part[dashIdx+1:])
+	if err1 != nil || err2 != nil || start < 1 || end < start {
+		return fileRange{}, false
+	}
+	return fileRange{File: file, Start: start, End: end}, true
 }
 
 // catalogTitleFor returns the Title of the first ACCEPTED catalog entry whose

--- a/internal/tools/analysis/nonfix_catalog.go
+++ b/internal/tools/analysis/nonfix_catalog.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// fileRange identifies a single file:line or file:start-end reference in the
+// Intentional Non-Fixes catalog.
+type fileRange struct {
+	File  string
+	Start int
+	End   int
+}
+
+// nonFixEntry is a single ACCEPTED entry from the Intentional Non-Fixes
+// catalog: a known gap deliberately left unfixed, with the file references
+// that pin it to source locations.
+type nonFixEntry struct {
+	Title string
+	Refs  []fileRange
+}
+
+// defaultNonFixCatalogPath is the location of the Intentional Non-Fixes
+// catalog relative to the current working directory. The catalog is
+// architect-curated; the analysis tooling only reads it.
+var defaultNonFixCatalogPath = filepath.Join("docs", "architect", "INTENTIONAL_NON_FIXES.md")
+
+// backtickRef matches a backtick-delimited reference (`path:line`) inside a
+// See bullet or its indented continuation lines.
+var backtickRef = regexp.MustCompile("`([^`]+)`")
+
+// pendingEntry accumulates one catalog entry while its Status bullet is still
+// being scanned; only entries whose status is ACCEPTED are kept.
+type pendingEntry struct {
+	entry  nonFixEntry
+	status string
+}
+
+// loadNonFixCatalog reads and parses the Intentional Non-Fixes catalog at
+// path. Entries under `### ` headings whose Status bullet matches ACCEPTED
+// (case-insensitive prefix) are returned with their `- **See**:` references
+// parsed into fileRange values. RESOLVED, REJECTED, SUPERSEDED and DONE
+// entries are skipped. The *Last Updated* footer and anything outside a
+// `### ` heading are ignored.
+//
+// A missing catalog degrades gracefully: it returns an empty slice with a nil
+// error so callers can treat "no catalog" as "no accepted gaps".
+func loadNonFixCatalog(path string) ([]nonFixEntry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return parseNonFixCatalog(string(data)), nil
+}
+
+// parseNonFixCatalog parses catalog markdown into ACCEPTED entries.
+func parseNonFixCatalog(data string) []nonFixEntry {
+	var pending []pendingEntry
+	var cur *pendingEntry
+	inSee := false
+
+	scanner := bufio.NewScanner(strings.NewReader(data))
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+
+		if strings.HasPrefix(trimmed, "### ") {
+			pending = append(pending, pendingEntry{
+				entry: nonFixEntry{Title: strings.TrimSpace(strings.TrimPrefix(trimmed, "### "))},
+			})
+			cur = &pending[len(pending)-1]
+			inSee = false
+			continue
+		}
+
+		if cur == nil {
+			continue // footer or prose outside a ### heading
+		}
+
+		switch {
+		case strings.HasPrefix(trimmed, "- **Status**:"):
+			cur.status = strings.ToLower(strings.TrimSpace(strings.TrimPrefix(trimmed, "- **Status**:")))
+			inSee = false
+		case strings.HasPrefix(trimmed, "- **See**:"):
+			inSee = true
+			parseSeeRefs(trimmed, cur)
+		case strings.HasPrefix(trimmed, "- "):
+			inSee = false
+		case inSee && (strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t")):
+			// Indented continuation of a See bullet carrying more refs.
+			parseSeeRefs(trimmed, cur)
+		}
+	}
+
+	var accepted []nonFixEntry
+	for _, p := range pending {
+		if strings.HasPrefix(p.status, "accepted") {
+			accepted = append(accepted, p.entry)
+		}
+	}
+	return accepted
+}
+
+// parseSeeRefs extracts every backticked reference from a See bullet line (or
+// an indented continuation) and appends the valid fileRange values to the
+// pending entry.
+func parseSeeRefs(line string, cur *pendingEntry) {
+	for _, m := range backtickRef.FindAllStringSubmatch(line, -1) {
+		cur.entry.Refs = append(cur.entry.Refs, parseCatalogRef(m[1])...)
+	}
+}
+
+// parseCatalogRef parses one backticked `path:line` or `path:start-end`
+// reference into one or more fileRange values. A comma-separated location
+// list (`file.go:162,431,558` or `file.go:142-144,237-240`) expands into
+// multiple ranges. Refs that are not `<path>:<line>` shaped (commit hashes,
+// plain paths, prose) are ignored.
+func parseCatalogRef(ref string) []fileRange {
+	colonIdx := strings.LastIndex(ref, ":")
+	if colonIdx == -1 {
+		return nil
+	}
+	file := strings.TrimSpace(ref[:colonIdx])
+	locSpec := strings.TrimSpace(ref[colonIdx+1:])
+	if file == "" || locSpec == "" {
+		return nil
+	}
+
+	var ranges []fileRange
+	for _, part := range strings.Split(locSpec, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if dashIdx := strings.Index(part, "-"); dashIdx != -1 {
+			start, err1 := strconv.Atoi(part[:dashIdx])
+			end, err2 := strconv.Atoi(part[dashIdx+1:])
+			if err1 != nil || err2 != nil || start < 1 || end < start {
+				continue
+			}
+			ranges = append(ranges, fileRange{File: file, Start: start, End: end})
+			continue
+		}
+		line, err := strconv.Atoi(part)
+		if err != nil || line < 1 {
+			continue
+		}
+		ranges = append(ranges, fileRange{File: file, Start: line, End: line})
+	}
+	return ranges
+}
+
+// catalogTitleFor returns the Title of the first ACCEPTED catalog entry whose
+// references contain the given line, or "" if none does.
+func catalogTitleFor(entries []nonFixEntry, file string, line int) string {
+	return catalogTitleForRange(entries, file, line, line)
+}
+
+// catalogTitleForRange returns the Title of the first ACCEPTED catalog entry
+// whose references overlap the block range [start,end]. A block overlaps a
+// reference when block.Start <= ref.End && block.End >= ref.Start. Returns ""
+// when no entry matches.
+func catalogTitleForRange(entries []nonFixEntry, file string, start, end int) string {
+	for _, e := range entries {
+		for _, ref := range e.Refs {
+			if start > ref.End || end < ref.Start {
+				continue
+			}
+			if refMatchesFile(ref.File, file) {
+				return e.Title
+			}
+		}
+	}
+	return ""
+}
+
+// refMatchesFile reports whether a catalog reference file matches a block
+// file. Full paths must match exactly; a bare basename (no path separator) in
+// the catalog matches any block file with that basename — catalog entries
+// occasionally pin a follow-on range with a bare name (e.g.
+// "pipeline_crud.go:308-310") after a full-path reference.
+func refMatchesFile(refFile, blockFile string) bool {
+	if refFile == blockFile {
+		return true
+	}
+	if strings.Contains(refFile, "/") || strings.Contains(refFile, "\\") {
+		return false
+	}
+	return filepath.Base(blockFile) == refFile
+}
+
+// normalizeCatalogFilePath converts a funcComplexity.FilePath produced by
+// fs.Walk (absolute, or relative to the walk root such as ".") into the
+// repo-relative form used by the catalog ("internal/..."). When the repo root
+// is unknown or normalization fails, the cleaned path is returned unchanged
+// so callers can treat the function as uncataloged.
+func normalizeCatalogFilePath(path, repoRoot string) string {
+	p := filepath.Clean(path)
+	if repoRoot != "" {
+		if rel, err := filepath.Rel(repoRoot, p); err == nil && rel != "." && !strings.HasPrefix(rel, "..") {
+			p = rel
+		}
+	}
+	p = strings.TrimPrefix(p, "./")
+	return filepath.ToSlash(p)
+}

--- a/internal/tools/analysis/nonfix_catalog_test.go
+++ b/internal/tools/analysis/nonfix_catalog_test.go
@@ -245,6 +245,14 @@ func TestParseCatalogRef(t *testing.T) {
 			},
 		},
 		{
+			name: "empty comma part skipped",
+			ref:  "file.go:10,,20",
+			want: []fileRange{
+				{File: "file.go", Start: 10, End: 10},
+				{File: "file.go", Start: 20, End: 20},
+			},
+		},
+		{
 			name: "plain path ignored",
 			ref:  "internal/ui/tui/progress/model.go",
 			want: nil,

--- a/internal/tools/analysis/nonfix_catalog_test.go
+++ b/internal/tools/analysis/nonfix_catalog_test.go
@@ -1,0 +1,506 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// sampleCatalog is a representative slice of the real
+// docs/architect/INTENTIONAL_NON_FIXES.md format: ACCEPTED and non-ACCEPTED
+// entries, single-line and range refs, indented continuation lines, ignored
+// refs, and the *Last Updated* footer.
+const sampleCatalog = `# Intentional Non-Fixes
+
+Items evaluated by the architect and deliberately NOT pursued.
+
+---
+
+## Coverage Gaps (ACCEPTED)
+
+### ado/pipeline_crud.go — buildVariablesUpdatePayload error return
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: The error return of json.Marshal is structurally unreachable.
+- **See**: ` + "`internal/tools/integrations/ado/pipeline_crud.go:272-275`" + `
+  (inline comment), and the branch at ` + "`pipeline_crud.go:308-310`" + ` that
+  consumes this unreachable error
+
+### persistence/mock_fs.go — Chmod always returns nil
+
+- **Status**: accepted (2026-07) — lowercase status is matched case-insensitively
+- **Rationale**: Mock no-op stub.
+- **See**: ` + "`internal/domain/persistence/mock_fs.go:146-148`" + `
+
+### history/history.go — complementPred at 0% → RESOLVED
+
+- **Status**: RESOLVED (2026-07)
+- **See**: ` + "`internal/infrastructure/history/history.go:301`" + `
+
+### ui/tui/progress/model.go — handleDomainEvent (CC=12)
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Type-switch dispatch.
+- **See**: ` + "`internal/ui/tui/progress/model.go`" + `
+
+### agent/agenttest + clitest — mock stubs at 0%
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Interface-satisfying stubs.
+- **See**: ` + "`internal/agent/agenttest/mock_cost_tracker.go:44`" + `,
+  ` + "`internal/agent/agenttest/mock_logger.go:20`" + `,
+  ` + "`internal/tools/workspace/shell.go:162,431,558`" + `
+
+### agent/orchestrator/engine_phases.go — Process (CC=9)
+
+- **Status**: [SUPERSEDED — see CC=12 entry below] ACCEPTED (2026-07)
+- **See**: ` + "`internal/agent/orchestrator/engine_phases.go:101`" + `
+
+### domain/config/config.go — validateProviderUniqueness
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Structural invariant.
+- **See**: ` + "`internal/domain/config/config.go:183-185`" + `,
+  commit ` + "`0f882423`" + ` (not a path:line ref, ignored)
+
+---
+
+*Last Updated: 2026-08 (catalog hygiene)*
+`
+
+func TestParseNonFixCatalog(t *testing.T) {
+	t.Parallel()
+	entries := parseNonFixCatalog(sampleCatalog)
+
+	if len(entries) != 5 {
+		t.Fatalf("parseNonFixCatalog() = %d entries, want 5", len(entries))
+	}
+
+	// Entries must be ACCEPTED and appear in document order.
+	wantTitles := []string{
+		"ado/pipeline_crud.go — buildVariablesUpdatePayload error return",
+		"persistence/mock_fs.go — Chmod always returns nil",
+		"ui/tui/progress/model.go — handleDomainEvent (CC=12)",
+		"agent/agenttest + clitest — mock stubs at 0%",
+		"domain/config/config.go — validateProviderUniqueness",
+	}
+	for i, want := range wantTitles {
+		if entries[i].Title != want {
+			t.Errorf("entries[%d].Title = %q, want %q", i, entries[i].Title, want)
+		}
+	}
+}
+
+func TestParseNonFixCatalog_Refs(t *testing.T) {
+	t.Parallel()
+	entries := parseNonFixCatalog(sampleCatalog)
+
+	tests := []struct {
+		name  string
+		entry int
+		want  []fileRange
+	}{
+		{
+			name:  "full path range + bare basename range on continuation lines",
+			entry: 0,
+			want: []fileRange{
+				{File: "internal/tools/integrations/ado/pipeline_crud.go", Start: 272, End: 275},
+				{File: "pipeline_crud.go", Start: 308, End: 310},
+			},
+		},
+		{
+			name:  "single range ref",
+			entry: 1,
+			want: []fileRange{
+				{File: "internal/domain/persistence/mock_fs.go", Start: 146, End: 148},
+			},
+		},
+		{
+			name:  "plain path without line numbers is ignored",
+			entry: 2,
+			want:  nil,
+		},
+		{
+			name:  "continuation lines with comma-separated line lists",
+			entry: 3,
+			want: []fileRange{
+				{File: "internal/agent/agenttest/mock_cost_tracker.go", Start: 44, End: 44},
+				{File: "internal/agent/agenttest/mock_logger.go", Start: 20, End: 20},
+				{File: "internal/tools/workspace/shell.go", Start: 162, End: 162},
+				{File: "internal/tools/workspace/shell.go", Start: 431, End: 431},
+				{File: "internal/tools/workspace/shell.go", Start: 558, End: 558},
+			},
+		},
+		{
+			name:  "commit hash in See bullet is ignored",
+			entry: 4,
+			want: []fileRange{
+				{File: "internal/domain/config/config.go", Start: 183, End: 185},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := entries[tt.entry].Refs
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("entries[%d].Refs = %+v, want %+v", tt.entry, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseNonFixCatalog_Statuses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		status  string
+		include bool
+	}{
+		{"accepted", "ACCEPTED (2026-07)", true},
+		{"accepted lowercase", "accepted (2026-07)", true},
+		{"accepted with leading brackets", "[SUPERSEDED — ...] ACCEPTED", false},
+		{"resolved", "RESOLVED (2026-07)", false},
+		{"rejected", "REJECTED by architect", false},
+		{"superseded", "SUPERSEDED", false},
+		{"done", "DONE", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			md := "### Some Entry\n\n- **Status**: " + tt.status + "\n- **See**: `file.go:10`\n"
+			entries := parseNonFixCatalog(md)
+			if tt.include && len(entries) != 1 {
+				t.Errorf("expected entry to be included, got %d entries", len(entries))
+			}
+			if !tt.include && len(entries) != 0 {
+				t.Errorf("expected entry to be skipped, got %d entries", len(entries))
+			}
+		})
+	}
+}
+
+func TestParseNonFixCatalog_IgnoresFooterAndProse(t *testing.T) {
+	t.Parallel()
+	md := "some leading prose\n\n### Valid Entry\n\n- **Status**: ACCEPTED\n- **See**: `file.go:1-5`\n\n*Last Updated: 2026-08*\n"
+	entries := parseNonFixCatalog(md)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	if entries[0].Title != "Valid Entry" {
+		t.Errorf("title = %q, want %q", entries[0].Title, "Valid Entry")
+	}
+	if !strings.Contains(entries[0].Refs[0].File, "file.go") {
+		t.Errorf("refs = %+v, want file.go ref", entries[0].Refs)
+	}
+}
+
+func TestParseNonFixCatalog_NoHeading(t *testing.T) {
+	t.Parallel()
+	md := "# Intentional Non-Fixes\n\nProse about nothing.\n\n*Last Updated: 2026-08*\n"
+	entries := parseNonFixCatalog(md)
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries for document without ### headings, got %d", len(entries))
+	}
+}
+
+func TestParseCatalogRef(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		ref  string
+		want []fileRange
+	}{
+		{
+			name: "single line",
+			ref:  "internal/domain/config/config.go:183",
+			want: []fileRange{{File: "internal/domain/config/config.go", Start: 183, End: 183}},
+		},
+		{
+			name: "range",
+			ref:  "internal/domain/config/config.go:183-185",
+			want: []fileRange{{File: "internal/domain/config/config.go", Start: 183, End: 185}},
+		},
+		{
+			name: "comma separated lines",
+			ref:  "internal/tools/workspace/shell.go:162,431,558",
+			want: []fileRange{
+				{File: "internal/tools/workspace/shell.go", Start: 162, End: 162},
+				{File: "internal/tools/workspace/shell.go", Start: 431, End: 431},
+				{File: "internal/tools/workspace/shell.go", Start: 558, End: 558},
+			},
+		},
+		{
+			name: "comma separated ranges",
+			ref:  "internal/agent/session/session_manager.go:142-144,237-240",
+			want: []fileRange{
+				{File: "internal/agent/session/session_manager.go", Start: 142, End: 144},
+				{File: "internal/agent/session/session_manager.go", Start: 237, End: 240},
+			},
+		},
+		{
+			name: "plain path ignored",
+			ref:  "internal/ui/tui/progress/model.go",
+			want: nil,
+		},
+		{
+			name: "commit hash ignored",
+			ref:  "0f882423",
+			want: nil,
+		},
+		{
+			name: "prose ignored",
+			ref:  "prepareCompactedEntries",
+			want: nil,
+		},
+		{
+			name: "invalid line number ignored",
+			ref:  "file.go:abc",
+			want: nil,
+		},
+		{
+			name: "inverted range ignored",
+			ref:  "file.go:10-5",
+			want: nil,
+		},
+		{
+			name: "empty location ignored",
+			ref:  "file.go:",
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseCatalogRef(tt.ref)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCatalogRef(%q) = %+v, want %+v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadNonFixCatalog_MissingFile(t *testing.T) {
+	t.Parallel()
+	entries, err := loadNonFixCatalog(filepath.Join(t.TempDir(), "does-not-exist.md"))
+	if err != nil {
+		t.Fatalf("loadNonFixCatalog() error = %v, want nil for missing file", err)
+	}
+	if entries != nil && len(entries) != 0 {
+		t.Errorf("expected empty entries for missing file, got %d", len(entries))
+	}
+}
+
+func TestLoadNonFixCatalog_File(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "INTENTIONAL_NON_FIXES.md")
+	if err := os.WriteFile(path, []byte(sampleCatalog), 0644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	entries, err := loadNonFixCatalog(path)
+	if err != nil {
+		t.Fatalf("loadNonFixCatalog() error = %v", err)
+	}
+	if len(entries) != 5 {
+		t.Errorf("loadNonFixCatalog() = %d entries, want 5", len(entries))
+	}
+}
+
+func TestLoadNonFixCatalog_UnreadableFile(t *testing.T) {
+	t.Parallel()
+	// A directory is not a readable catalog file: os.ReadFile returns an
+	// error that is not IsNotExist, which must propagate.
+	dir := t.TempDir()
+	entries, err := loadNonFixCatalog(dir)
+	if err == nil {
+		t.Fatal("expected error for unreadable path, got nil")
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries on error, got %+v", entries)
+	}
+}
+
+func TestCatalogTitleFor(t *testing.T) {
+	t.Parallel()
+	entries := []nonFixEntry{
+		{
+			Title: "entry A",
+			Refs: []fileRange{
+				{File: "internal/a.go", Start: 10, End: 10},
+			},
+		},
+		{
+			Title: "entry B",
+			Refs: []fileRange{
+				{File: "internal/b.go", Start: 5, End: 15},
+			},
+		},
+	}
+
+	if got := catalogTitleFor(entries, "internal/a.go", 10); got != "entry A" {
+		t.Errorf("catalogTitleFor() = %q, want %q", got, "entry A")
+	}
+	if got := catalogTitleFor(entries, "internal/b.go", 7); got != "entry B" {
+		t.Errorf("catalogTitleFor() = %q, want %q", got, "entry B")
+	}
+	if got := catalogTitleFor(entries, "internal/c.go", 10); got != "" {
+		t.Errorf("catalogTitleFor() = %q, want empty for unknown file", got)
+	}
+}
+
+func TestCatalogTitleForRange_Overlap(t *testing.T) {
+	t.Parallel()
+	entries := []nonFixEntry{
+		{
+			Title: "range entry",
+			Refs: []fileRange{
+				{File: "internal/ado/pipeline_crud.go", Start: 272, End: 275},
+				{File: "pipeline_crud.go", Start: 308, End: 310}, // bare basename follow-on
+			},
+		},
+	}
+
+	tests := []struct {
+		name  string
+		file  string
+		start int
+		end   int
+		want  string
+	}{
+		{
+			name:  "block contained in ref range",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 273,
+			end:   274,
+			want:  "range entry",
+		},
+		{
+			name:  "block equal to ref range",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 272,
+			end:   275,
+			want:  "range entry",
+		},
+		{
+			name:  "partial overlap at start",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 270,
+			end:   273,
+			want:  "range entry",
+		},
+		{
+			name:  "partial overlap at end",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 274,
+			end:   280,
+			want:  "range entry",
+		},
+		{
+			name:  "no overlap before range",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 100,
+			end:   200,
+			want:  "",
+		},
+		{
+			name:  "no overlap after range",
+			file:  "internal/ado/pipeline_crud.go",
+			start: 300,
+			end:   305,
+			want:  "",
+		},
+		{
+			name:  "bare basename ref matches full block path",
+			file:  "internal/tools/integrations/ado/pipeline_crud.go",
+			start: 308,
+			end:   310,
+			want:  "range entry",
+		},
+		{
+			name:  "different file no match",
+			file:  "internal/other.go",
+			start: 308,
+			end:   310,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := catalogTitleForRange(entries, tt.file, tt.start, tt.end)
+			if got != tt.want {
+				t.Errorf("catalogTitleForRange(%s, %d-%d) = %q, want %q", tt.file, tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCatalogTitleForRange_EmptyEntries(t *testing.T) {
+	t.Parallel()
+	if got := catalogTitleForRange(nil, "internal/a.go", 1, 10); got != "" {
+		t.Errorf("expected empty title for nil entries, got %q", got)
+	}
+}
+
+func TestNormalizeCatalogFilePath(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		path     string
+		repoRoot string
+		want     string
+	}{
+		{
+			name:     "relative path already repo-relative",
+			path:     "internal/agent/agent.go",
+			repoRoot: "",
+			want:     "internal/agent/agent.go",
+		},
+		{
+			name:     "leading dot slash stripped",
+			path:     "./internal/agent/agent.go",
+			repoRoot: "",
+			want:     "internal/agent/agent.go",
+		},
+		{
+			name:     "absolute path under repo root",
+			path:     "/work/tell-me-go/internal/agent/agent.go",
+			repoRoot: "/work/tell-me-go",
+			want:     "internal/agent/agent.go",
+		},
+		{
+			name:     "relative path with dot repo root",
+			path:     "internal/agent/agent.go",
+			repoRoot: ".",
+			want:     "internal/agent/agent.go",
+		},
+		{
+			name:     "absolute path outside repo root stays as-is",
+			path:     "/tmp/other/internal/agent/agent.go",
+			repoRoot: "/work/tell-me-go",
+			want:     "/tmp/other/internal/agent/agent.go",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			repoRoot: "",
+			want:     ".",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeCatalogFilePath(tt.path, tt.repoRoot)
+			if got != tt.want {
+				t.Errorf("normalizeCatalogFilePath(%q, %q) = %q, want %q", tt.path, tt.repoRoot, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tools/integrations/ado/pipeline_crud.go
+++ b/internal/tools/integrations/ado/pipeline_crud.go
@@ -194,7 +194,9 @@ func (m *AdoManager) executeCreatePipeline(ctx context.Context, org, project, na
 	}
 
 	// json.Marshal cannot fail on a struct composed entirely of JSON-safe
-	// primitives (string, int, bool, *bool). See ADR-037.
+	// primitives (string, int, bool, *bool). Structurally unreachable — see
+	// the `structurally-unreachable` acceptance class in
+	// docs/architect/INTENTIONAL_NON_FIXES.md.
 	body, _ := json.Marshal(payload)
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines?api-version=7.1-preview.1",
@@ -271,7 +273,9 @@ func buildVariablesUpdatePayload(existingDef map[string]interface{}, inputVars m
 
 	// json.Marshal cannot fail on a map[string]interface{} produced by
 	// json.Decode into interface{} plus manual insertion of JSON-safe
-	// primitives (string, bool, *bool). See ADR-037.
+	// primitives (string, bool, *bool). Structurally unreachable — see
+	// the `structurally-unreachable` acceptance class in
+	// docs/architect/INTENTIONAL_NON_FIXES.md.
 	return json.Marshal(existingDef)
 }
 

--- a/internal/tools/integrations/ado/pipeline_runs.go
+++ b/internal/tools/integrations/ado/pipeline_runs.go
@@ -148,7 +148,9 @@ func (m *AdoManager) executeRunPipeline(ctx context.Context, org, project string
 	}
 
 	// json.Marshal cannot fail on a struct composed entirely of JSON-safe
-	// primitives (string, bool, *bool). See ADR-037.
+	// primitives (string, bool, *bool). Structurally unreachable — see
+	// the `structurally-unreachable` acceptance class in
+	// docs/architect/INTENTIONAL_NON_FIXES.md.
 	body, _ := json.Marshal(payload)
 
 	requestURL := fmt.Sprintf("%s/%s/%s/_apis/pipelines/%d/runs?api-version=7.1-preview.1",

--- a/internal/tools/integrations/atlassian/confluence.go
+++ b/internal/tools/integrations/atlassian/confluence.go
@@ -61,7 +61,8 @@ func (m *ConfluenceManager) fetchPageContent(ctx context.Context, pageID string)
 
 	// http.NewRequestWithContext cannot fail here: u.String() returns the
 	// canonical form of a URL already validated by url.Parse above.
-	// See ADR-037: unreachable error branches are removed, not tested.
+	// Structurally unreachable — see the `structurally-unreachable`
+	// acceptance class in docs/architect/INTENTIONAL_NON_FIXES.md.
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 
 	req.Header.Set("Accept", "application/json")
@@ -159,7 +160,8 @@ func (m *ConfluenceManager) getCurrentPageVersion(ctx context.Context, pageID st
 
 	// http.NewRequestWithContext cannot fail here: u.String() returns the
 	// canonical form of a URL already validated by url.Parse above.
-	// See ADR-037: unreachable error branches are removed, not tested.
+	// Structurally unreachable — see the `structurally-unreachable`
+	// acceptance class in docs/architect/INTENTIONAL_NON_FIXES.md.
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	req.Header.Set("Accept", "application/json")
 
@@ -194,7 +196,8 @@ func (m *ConfluenceManager) executeUpdate(ctx context.Context, pageID string, pa
 
 	// http.NewRequestWithContext cannot fail here: u.String() returns the
 	// canonical form of a URL already validated by url.Parse above.
-	// See ADR-037: unreachable error branches are removed, not tested.
+	// Structurally unreachable — see the `structurally-unreachable`
+	// acceptance class in docs/architect/INTENTIONAL_NON_FIXES.md.
 	req, _ := http.NewRequestWithContext(ctx, http.MethodPut, u.String(), bytes.NewBuffer(bodyBytes))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")

--- a/internal/tools/integrations/atlassian/confluence_search.go
+++ b/internal/tools/integrations/atlassian/confluence_search.go
@@ -37,7 +37,8 @@ func (m *ConfluenceManager) fetchSpaceByKey(ctx context.Context, spaceKey string
 
 	// http.NewRequestWithContext cannot fail here: u.String() returns the
 	// canonical form of a URL already validated by url.Parse above.
-	// See ADR-037: unreachable error branches are removed, not tested.
+	// Structurally unreachable — see the `structurally-unreachable`
+	// acceptance class in docs/architect/INTENTIONAL_NON_FIXES.md.
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
 	req.Header.Set("Accept", "application/json")
 

--- a/internal/tools/integrations/media_test.go
+++ b/internal/tools/integrations/media_test.go
@@ -88,12 +88,13 @@ func TestMediaTools_CreateImage(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	tests := []struct {
-		name       string
-		args       map[string]interface{}
-		client     *mockLLMClient
-		assetsDir  string
-		wantImages int
-		wantErr    bool
+		name        string
+		args        map[string]interface{}
+		client      *mockLLMClient
+		assetsDir   string
+		wantImages  int
+		wantErr     bool
+		errSentinel error
 	}{
 		{
 			name: "successful generation with default model",
@@ -139,6 +140,17 @@ func TestMediaTools_CreateImage(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "generate images ErrNotImplemented",
+			args: map[string]interface{}{"prompt": "fail"},
+			client: &mockLLMClient{
+				generateImagesFunc: func(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+					return nil, llm.ErrNotImplemented
+				},
+			},
+			wantErr:     true,
+			errSentinel: tools.ErrNotImplemented,
+		},
+		{
 			name:      "save to disk success",
 			args:      map[string]interface{}{"prompt": "save"},
 			assetsDir: tmpDir,
@@ -163,6 +175,9 @@ func TestMediaTools_CreateImage(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("createImage() error = %v, wantErr %v", err, tt.wantErr)
 				return
+			}
+			if tt.errSentinel != nil && !errors.Is(err, tt.errSentinel) {
+				t.Errorf("expected error %v, got %v", tt.errSentinel, err)
 			}
 
 			if !tt.wantErr {
@@ -496,6 +511,13 @@ func (m *atomicWriteFailFS) MkdirAll(ctx context.Context, path string, perm os.F
 
 func (m *atomicWriteFailFS) AtomicWrite(ctx context.Context, name string, data []byte, perm os.FileMode) error {
 	return errors.New("write failed")
+}
+
+// readFailFS overrides ReadFile to simulate a filesystem read failure.
+type readFailFS struct{ *mockFileSystem }
+
+func (m *readFailFS) ReadFile(ctx context.Context, name string) ([]byte, error) {
+	return nil, errors.New("read failed")
 }
 
 func TestMediaTools_ErrorPaths(t *testing.T) {
@@ -887,6 +909,118 @@ func TestReadDocument_NotImplemented(t *testing.T) {
 	}
 }
 
+func TestReadDocument_ErrorPaths(t *testing.T) {
+	defer goleak.VerifyNone(t,
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).readLoop"),
+		goleak.IgnoreTopFunction("net/http.(*http2ClientConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
+	)
+	ctx := context.Background()
+	tmpDir := t.TempDir()
+
+	docPath := filepath.Join(tmpDir, "test.pdf")
+	if err := os.WriteFile(docPath, []byte("content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name        string
+		setup       func() *mediaManager
+		action      func(m *mediaManager) error
+		errText     string
+		errSentinel error
+	}{
+		{
+			name: "nil LLM client returns ErrNotImplemented",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, newMediaMockSecurityManager(), nil, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": docPath}, nil)
+				return err
+			},
+			errSentinel: tools.ErrNotImplemented,
+		},
+		{
+			name: "unmarshal args failure",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, newMediaMockSecurityManager(), &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": 123}, nil)
+				return err
+			},
+			errText: "unmarshal args",
+		},
+		{
+			name: "nil security manager",
+			setup: func() *mediaManager {
+				return newMediaManager(&mockFileSystem{}, nil, &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": docPath}, nil)
+				return err
+			},
+			errText: "path validator is required",
+		},
+		{
+			name: "security validation failure",
+			setup: func() *mediaManager {
+				sm := newMediaMockSecurityManager()
+				sm.isPathSafeFunc = func(path string) (string, error) {
+					return "", errors.New("unsafe path")
+				}
+				return newMediaManager(&mockFileSystem{}, sm, &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": docPath}, nil)
+				return err
+			},
+			errText: "security validation failed",
+		},
+		{
+			name: "read file failure",
+			setup: func() *mediaManager {
+				return newMediaManager(&readFailFS{&mockFileSystem{}}, newMediaMockSecurityManager(), &mockLLMClient{}, "")
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": docPath}, nil)
+				return err
+			},
+			errText: "read file",
+		},
+		{
+			name: "extract document generic failure",
+			setup: func() *mediaManager {
+				client := &failingDocumentClient{err: errors.New("extraction boom")}
+				return newMediaManager(&mockFileSystem{}, newMediaMockSecurityManager(), client, "",
+					withMediaHeartbeatInterval(10*time.Millisecond))
+			},
+			action: func(m *mediaManager) error {
+				_, err := m.readDocument(ctx, map[string]interface{}{"filepath": docPath}, nil)
+				return err
+			},
+			errText: "extract document",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := tt.setup()
+			err := tt.action(m)
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if tt.errSentinel != nil && !errors.Is(err, tt.errSentinel) {
+				t.Errorf("expected error %v, got %v", tt.errSentinel, err)
+			}
+			if tt.errText != "" && !strings.Contains(err.Error(), tt.errText) {
+				t.Errorf("expected error to contain %q, got %q", tt.errText, err.Error())
+			}
+		})
+	}
+}
+
 // documentExtractorClient implements llm.LLMClient with a stub ExtractDocument.
 type documentExtractorClient struct {
 	text string
@@ -916,3 +1050,20 @@ func (c *notImplementedDocumentClient) GenerateImages(ctx context.Context, model
 	return nil, fmt.Errorf("not implemented")
 }
 func (c *notImplementedDocumentClient) RefreshAuth() error { return nil }
+
+// failingDocumentClient implements llm.LLMClient with an ExtractDocument that
+// always returns a generic (non-ErrNotImplemented) error.
+type failingDocumentClient struct {
+	err error
+}
+
+func (c *failingDocumentClient) ExtractDocument(ctx context.Context, data []byte, filename string) (string, error) {
+	return "", c.err
+}
+func (c *failingDocumentClient) SendChat(ctx context.Context, history []*llm.Content, tools []*tools.ToolDeclaration, resolver llm.AssetResolver) (*llm.Content, *llm.Metrics, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+func (c *failingDocumentClient) GenerateImages(ctx context.Context, model, prompt string, mimeType string) ([][]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+func (c *failingDocumentClient) RefreshAuth() error { return nil }


### PR DESCRIPTION
## Summary

Coverage & complexity improvement pass for the analysis tooling and integrations layer. Closes the audit loop: every coverage gap is either tested or documented as an ACCEPTED Intentional Non-Fix, all complexity alerts above the CC=10 policy threshold carry documented rationale, and the tooling now distinguishes cataloged gaps from actionable ones automatically.

## Changes (6 commits)

### Coverage
- **test(integrations)**: cover `readDocument`/`createImage` error paths in the media manager — both functions now at **100%**, package `internal/tools/integrations` at **99.7%**
- **test(analysis)**: cover the empty comma part in `parseRefPart` — helper at **100%**

### Catalog (docs/architect/INTENTIONAL_NON_FIXES.md)
- Record ACCEPTED entries: `ado` `buildVariablesUpdatePayload` json.Marshal unreachable branch (correcting a stale "See ADR-037" code citation — ADR-037 is the `agentinternal` bridge decision and says nothing about json.Marshal), `assertMissingKeysResult` (CC=13), `TestRecoveryStep_EmptyResponse_RetriesUpToLimit` (CC=12)
- Re-verify CC drift: `(*indexer).snapshot` 11→14, `TestResolveCapabilities` 12→13, `TestFixtureIndexer_ConstructAndHarvest` 11→13
- Closes the `triage-loop-closed` invariant for all outstanding complexity alerts

### Tooling (new feature)
- **feat(analysis)**: cross-reference the Intentional Non-Fixes catalog in coverage/complexity reports. Uncovered blocks and over-threshold functions that match an ACCEPTED catalog entry are reported separately (`[CATALOGED GAPS (ACCEPTED)]` section, "N cataloged (ACCEPTED) functions over threshold excluded") instead of counted as actionable alerts. "High priority" now means "not cataloged". Degrades gracefully when the catalog is absent.

### Complexity
- **refactor(analysis)**: split `parseCatalogRef` (CC 13→5) and `parseNonFixCatalog` (CC 12→2) below the policy threshold — behavior-identical, parser tests pass unchanged

### Docs hygiene
- **refactor(integrations)**: replace 7 stale "See ADR-037" comments with citations to the `structurally-unreachable` acceptance class (standalone commit per ADR-034)

## Verification

- `make check-full` — **all gates pass** (4 consecutive runs), including race detection, all ADR-021/022/036 guards, modelith-check (no drift), vulncheck (0 vulnerabilities), dead-code (0 orphans)
- Coverage: **95.7%** (target > 80%); actionable high-priority gaps = 0
- Complexity: 26 alerts > CC=10, **all cataloged** ACCEPTED — zero uncataloged production complexity

## Test plan

- [x] `go build ./...`
- [x] `go test -count=1 ./internal/tools/analysis/`
- [x] `go test ./internal/tools/integrations/...`
- [x] `make check-full` (incl. `test-race`)
- [x] `go vet` clean, `gofmt` clean
