### PR TITLE
feat: add WRAP_WIDTH config for wide non-TUI output

### DIFF
--- a/configs/assistant.yaml
+++ b/configs/assistant.yaml
@@ -86,6 +86,12 @@ USE_SEARCH: false
 SHOW_THOUGHTS: false
 SHOW_TOOLS: true
 
+# --- Output ---
+# WRAP_WIDTH: column width for word-wrapping non-TUI markdown output.
+# 0 (default) = glamour's built-in 80 columns. Env TELL_ME_WRAP_WIDTH
+# overrides. Read at session start; changes apply from the next session.
+# WRAP_WIDTH: 120
+
 # --- Global Timeouts & Streaming ---
 HTTP_TIMEOUT: 300
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -941,21 +941,24 @@ to reason about.
   `(*model).Update` (Bubble Tea dispatch).
 - **See**: `internal/ui/tui/history_editor.go:39`
 
-### ui/history.go — renderHistory (CC=11)
+### ui/history.go — renderHistory (CC=12 — increased from 11)
 
-- **Status**: ACCEPTED (2026-08)
+- **Status**: ACCEPTED (2026-08, PR #1294 — WRAP_WIDTH -l history width)
 - **Rationale**: Sequential history renderer with structural guards only:
   empty-history early return, `n > total` clamp, `GetWindow` error branch,
   `Raw`/`CustomRenderer` option branches (markdown renderer selection), and
   per-part nil guards inside the two loops. Every branch is a single-line
   guard, error return, or renderer assignment — zero branching business logic.
-  The CC is driven by the guard count (+7) and the two iteration loops (+2),
+  The CC is driven by the guard count (+8) and the two iteration loops (+2),
   not by decision complexity. Extracting guards into helpers would fragment a
   coherent sequential render for cosmetic CC reduction with no cognitive
   benefit. Same acceptance class as `(*HistoryEditor).Edit` (CC=10, sequential
   orchestration with error guards) and the other structural-dispatch entries
   in this section. Note: the shared `NewMarkdownRenderer` helper (2026-08)
   already removed the duplicated glamour construction from this function.
+  CC increased from 11→12 (2026-08, PR #1294) due to the single-line
+  `WrapWidth > 0` guard added to the markdown-renderer selection branch —
+  the same structural-guard acceptance class as the rest of this function.
 - **See**: `internal/ui/history.go:26`
 
 ### ui/tui/browser.go — (*rootBrowserModel).handleActionKeys (CC=15)

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -291,7 +291,7 @@ catalog a new gap no one reviewed. Policy:
   error-return branch flagged by coverage tools does not exist in the current
   single-file architecture. Structurally unreachable — same acceptance class
   as `json.Marshal` on all-string structs in `global_prompt_tracker.go`.
-- **See**: `internal/domain/config/config.go:183-185`
+- **See**: `internal/domain/config/config.go:224-229`
 
 ### domain/events/events.go — NoOpEventBus no-op stubs at 0%
 
@@ -346,7 +346,7 @@ catalog a new gap no one reviewed. Policy:
   internal pipeline state (2026-07 Batch Triage).
 - **See**: `internal/agent/orchestrator/middleware.go:255`
 
-### agent/agenttest/helpers.go — 0% coverage on interface-satisfying stubs (15 methods)
+### agent/agenttest/helpers.go — 0% coverage on interface-satisfying stubs (16 methods)
 
 - **Status**: ACCEPTED (2026-07)
 - **Rationale**: The following methods on test doubles in `agenttest/helpers.go`
@@ -356,7 +356,7 @@ catalog a new gap no one reviewed. Policy:
   `RenderResponse`, `LogTurnStatus`, `LogSystemMessage`, `LogUsage`,
   `LogToolCall`, `LogToolResult`, `RenderHealthReport`, `SetUseColor`,
   `SetForceSpinner`, `Render`, `GetSkillRepository`, `Subscribe`,
-  `WaitStarted`, `Warn`, `Prompt`.
+  `WaitStarted`, `Warn`, `Prompt`, `SetWordWrap`.
   Testing a mock's no-op method would test the mock itself, not production
   behavior — same acceptance class as `mockFileSystem.Chmod` and
   `domainFS.Chmod` already documented below.
@@ -379,7 +379,7 @@ catalog a new gap no one reviewed. Policy:
 - **See**: `internal/agent/agenttest/mock_cost_tracker.go:44`,
   `internal/agent/agenttest/mock_history_manager.go:139,152,158`,
   `internal/agent/agenttest/mock_logger.go:20`,
-  `internal/agent/agenttest/mock_ui_renderer.go:274`,
+  `internal/agent/agenttest/mock_ui_renderer.go:289`,
   `internal/domain/events/eventstest/test_event_bus.go:109`,
   `internal/agent/agenttest/mock_event_bus_fail.go:22,26`,
   `internal/agent/agenttest/mock_gateway.go:66`,
@@ -462,6 +462,20 @@ catalog a new gap no one reviewed. Policy:
   acceptance class as `glamour render error paths` in `renderer.go`:
   structurally unreachable in normal operation, cosmetic degrade only.
 - **See**: `internal/ui/tui/progress/model.go:746` (`renderMarkdownAsync`)
+
+### ui/renderer.go — SetWordWrap renderer rebuild error branch
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: The `if err != nil` branch in `stdUIRenderer.SetWordWrap` after
+  `NewMarkdownRenderer` is structurally unreachable: the renderer is rebuilt
+  with only `WithStandardStyle`, `WithEmoji`, and an optional `WithWordWrap`
+  option, none of which can fail. On the impossible error the previous
+  renderer is kept rather than degrading (consistent with ADR-007). Same
+  acceptance class as the cataloged glamour error paths in
+  `ui/tui/progress/renderer.go` (structurally unreachable, cosmetic degrade
+  only). Forcing coverage would require changing SetWordWrap's signature to
+  accept a failing option — disproportionate to the value.
+- **See**: `internal/ui/renderer.go:258-273` (SetWordWrap)
 
 ---
 
@@ -614,7 +628,7 @@ catalog a new gap no one reviewed. Policy:
   no value. Same acceptance class as `AppendTask`, `domainFS.Chmod`,
   `mockFileSystem.Chmod`, `plainOSFS.Chmod`, and `HasBareNewline` — all
   delegation wrappers already documented in this file.
-- **See**: `internal/agent/service.go:223-225`
+- **See**: `internal/agent/service.go:226-228`
 
 ### persistence/state.go — NewSessionStateFromEnv thin entry point at 0%
 

--- a/internal/agent/agenttest/helpers.go
+++ b/internal/agent/agenttest/helpers.go
@@ -42,6 +42,7 @@ func (s *stubUIRenderer) LogToolResult(ctx context.Context, name string, result 
 func (s *stubUIRenderer) RenderHealthReport(ctx context.Context, report *ports.HealthReport)       {}
 func (s *stubUIRenderer) SetUseColor(use bool)                                                     {}
 func (s *stubUIRenderer) SetForceSpinner(force bool)                                               {}
+func (s *stubUIRenderer) SetWordWrap(width int)                                                    {}
 func (s *stubUIRenderer) IsTerminalContext() bool                                                  { return false }
 func (s *stubUIRenderer) UpdateSpinnerStatus(ctx context.Context, status string, showMetrics bool) {}
 

--- a/internal/agent/agenttest/mock_ui_renderer.go
+++ b/internal/agent/agenttest/mock_ui_renderer.go
@@ -35,6 +35,7 @@ type MockUIRenderer struct {
 	calledRenderHealthReport      int
 	calledSetUseColor             int
 	calledSetForceSpinner         int
+	calledSetWordWrap             int
 	calledIsTerminalContext       int
 	calledUpdateSpinnerStatus     int
 	calledMethods                 []string
@@ -52,6 +53,7 @@ type MockUIRenderer struct {
 	RenderHealthReportFn      func(ctx context.Context, report *ports.HealthReport)
 	SetUseColorFn             func(use bool)
 	SetForceSpinnerFn         func(force bool)
+	SetWordWrapFn             func(width int)
 	IsTerminalContextFn       func() bool
 	UpdateSpinnerStatusFn     func(ctx context.Context, status string, showMetrics bool)
 }
@@ -61,7 +63,7 @@ type UIRendererSnapshot struct {
 	StartSpinner, StartSpinnerWithStatus, StartSpinnerWithMetrics int
 	RenderResponse, LogTurnStatus, LogUsage                       int
 	LogToolCall, LogToolResult, LogSystemMessage                  int
-	RenderHealthReport, SetUseColor, SetForceSpinner              int
+	RenderHealthReport, SetUseColor, SetForceSpinner, SetWordWrap int
 	IsTerminalContext, UpdateSpinnerStatus                        int
 	Methods                                                       []string
 }
@@ -85,6 +87,7 @@ func (m *MockUIRenderer) Snapshot() UIRendererSnapshot {
 		RenderHealthReport:      m.calledRenderHealthReport,
 		SetUseColor:             m.calledSetUseColor,
 		SetForceSpinner:         m.calledSetForceSpinner,
+		SetWordWrap:             m.calledSetWordWrap,
 		IsTerminalContext:       m.calledIsTerminalContext,
 		UpdateSpinnerStatus:     m.calledUpdateSpinnerStatus,
 		Methods:                 methods,
@@ -255,6 +258,18 @@ func (m *MockUIRenderer) SetForceSpinner(force bool) {
 
 	if fn != nil {
 		fn(force)
+	}
+}
+
+func (m *MockUIRenderer) SetWordWrap(width int) {
+	m.mu.Lock()
+	m.calledSetWordWrap++
+	m.calledMethods = append(m.calledMethods, "SetWordWrap")
+	fn := m.SetWordWrapFn
+	m.mu.Unlock()
+
+	if fn != nil {
+		fn(width)
 	}
 }
 

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -155,6 +155,9 @@ func (s *chatService) cleanupSession(deps ports.ChatterComposer, cleanup func(co
 
 // ProcessMessage implements ChatService.
 func (s *chatService) ProcessMessage(ctx context.Context, cfg *domain_config.Config, cmd ChatCommand, capturer CapturerInteractor) error {
+	// Apply the configured word-wrap width to the markdown renderer before any output.
+	s.UIRenderer.SetWordWrap(cfg.WrapWidth)
+
 	// 1. Build session dependencies
 	deps, hManager, cleanup, err := s.LifecycleManager.BuildSessionDependencies(ctx, cfg, cmd.ConfigPath, cmd.NewSession, capturer)
 	if err != nil {
@@ -293,6 +296,9 @@ func (s *chatService) StreamTurnsLog(ctx context.Context, cfg *domain_config.Con
 
 // RunDiagnostics implements ChatService.
 func (s *chatService) RunDiagnostics(ctx context.Context, cfg *domain_config.Config, configPath string, jsonOutput bool) error {
+	// Apply the configured word-wrap width to the markdown renderer before any output.
+	s.UIRenderer.SetWordWrap(cfg.WrapWidth)
+
 	// 1. Build session dependencies
 	deps, _, cleanup, err := s.LifecycleManager.BuildSessionDependencies(ctx, cfg, configPath, false, nil)
 	if err != nil {

--- a/internal/agent/session/context/gatekeeper_error_test.go
+++ b/internal/agent/session/context/gatekeeper_error_test.go
@@ -154,6 +154,7 @@ type mockFailingUIRenderer struct{}
 
 func (m *mockFailingUIRenderer) SetUseColor(bool)                                 {}
 func (m *mockFailingUIRenderer) SetForceSpinner(bool)                             {}
+func (m *mockFailingUIRenderer) SetWordWrap(width int)                            {}
 func (m *mockFailingUIRenderer) LogTurnStatus(context.Context, events.TurnStatus) {}
 func (m *mockFailingUIRenderer) StartSpinner(ctx context.Context) func()          { return func() {} }
 func (m *mockFailingUIRenderer) StartSpinnerWithStatus(ctx context.Context, status string) func() {

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -260,6 +260,7 @@ func (o *sessionManager) RenderHistory(hManager ports.HistoryManager, sCfg ports
 		Raw:          sCfg.GetRawOutput(),
 		ShowThoughts: cfg.ShowThoughts,
 		UseColor:     isTTY && !sCfg.GetRawOutput(),
+		WrapWidth:    cfg.WrapWidth,
 	})
 }
 
@@ -284,6 +285,7 @@ func (o *sessionManager) renderPostTUISummary(ts events.TurnStatus, sd ports.Cha
 			ShowThoughts:  cfg.ShowThoughts,
 			UseColor:      isTTY && !sc.GetRawOutput(),
 			SuppressRoles: true,
+			WrapWidth:     cfg.WrapWidth,
 		})
 	}
 

--- a/internal/agent/session/session_manager_test.go
+++ b/internal/agent/session/session_manager_test.go
@@ -362,6 +362,8 @@ func (m *behaviorMockUIRenderer) SetForceSpinner(force bool) {
 	}
 }
 
+func (m *behaviorMockUIRenderer) SetWordWrap(width int) {}
+
 func (m *behaviorMockUIRenderer) IsTerminalContext() bool {
 	m.tracker.record("UIRenderer.IsTerminalContext")
 	if m.IsTerminalContextFn != nil {

--- a/internal/agent/session/ui/dispatcher_bench_test.go
+++ b/internal/agent/session/ui/dispatcher_bench_test.go
@@ -38,6 +38,7 @@ func (b *benchRenderer) LogToolCall(_ context.Context, _ []*llm.FunctionCall, _,
 func (b *benchRenderer) LogToolResult(_ context.Context, _ string, _ tools.ToolResult, _ bool) {}
 func (b *benchRenderer) SetUseColor(_ bool)                                                    {}
 func (b *benchRenderer) SetForceSpinner(_ bool)                                                {}
+func (b *benchRenderer) SetWordWrap(width int)                                                 {}
 func (b *benchRenderer) IsTerminalContext() bool                                               { return false }
 func (b *benchRenderer) UpdateSpinnerStatus(_ context.Context, _ string, _ bool)               {}
 

--- a/internal/agent/session/ui/dispatcher_test.go
+++ b/internal/agent/session/ui/dispatcher_test.go
@@ -65,6 +65,7 @@ func (s *spyRenderer) LogSystemMessage(_ context.Context, _ string, _ string)   
 func (s *spyRenderer) RenderHealthReport(_ context.Context, _ *ports.HealthReport) {}
 func (s *spyRenderer) SetUseColor(_ bool)                                          {}
 func (s *spyRenderer) SetForceSpinner(_ bool)                                      {}
+func (s *spyRenderer) SetWordWrap(width int)                                       {}
 func (s *spyRenderer) IsTerminalContext() bool                                     { return false }
 func (s *spyRenderer) UpdateSpinnerStatus(_ context.Context, _ string, _ bool)     {}
 

--- a/internal/agent/session/ui/panic_test.go
+++ b/internal/agent/session/ui/panic_test.go
@@ -62,6 +62,7 @@ func (m *panicMockRenderer) RenderHealthReport(ctx context.Context, report *port
 func (m *panicMockRenderer) IsTerminalContext() bool                                            { return false }
 func (m *panicMockRenderer) SetUseColor(use bool)                                               {}
 func (m *panicMockRenderer) SetForceSpinner(force bool)                                         {}
+func (m *panicMockRenderer) SetWordWrap(width int)                                              {}
 func (m *panicMockRenderer) UpdateSpinnerStatus(_ context.Context, _ string, _ bool)            {}
 
 func TestUIBridge_PanicResilience(t *testing.T) {

--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -142,22 +142,26 @@ func (p *LLMProvider) validate(name string, logger *slog.Logger) error {
 
 // Config represents the application configuration loaded from a YAML file.
 type Config struct {
-	Mode               string                 `yaml:"MODE"`
-	Person             string                 `yaml:"PERSON"`
-	URL                string                 `yaml:"AIURL"`
-	Model              string                 `yaml:"AIMODEL"`
-	UseSearch          bool                   `yaml:"USE_SEARCH"`
-	MaxToolTurns       int                    `yaml:"MAX_TURNS"`          // Recursion limit
-	MaxHistoryTurns    int                    `yaml:"MAX_HISTORY_TURNS"`  // For pruning turns
-	MaxHistoryTokens   int                    `yaml:"MAX_HISTORY_TOKENS"` // For safety rollback
-	ThinkingBudget     int                    `yaml:"THINKING_BUDGET"`
-	ThinkingLevel      string                 `yaml:"THINKING_LEVEL"`
-	ShowThoughts       bool                   `yaml:"SHOW_THOUGHTS"`
-	ShowTools          bool                   `yaml:"SHOW_TOOLS"`
-	MaxConcurrentTools int                    `yaml:"MAX_CONCURRENT_TOOLS"` // Parallel tool execution
-	ToolTimeoutSeconds int                    `yaml:"TOOL_TIMEOUT"`         // Single tool timeout
-	HTTPTimeoutSeconds int                    `yaml:"HTTP_TIMEOUT"`         // LLM Client timeout
-	UseTUIPrompt       bool                   `yaml:"USE_TUI_PROMPT"`       // Enable TUI prompt with suggestions
+	Mode               string `yaml:"MODE"`
+	Person             string `yaml:"PERSON"`
+	URL                string `yaml:"AIURL"`
+	Model              string `yaml:"AIMODEL"`
+	UseSearch          bool   `yaml:"USE_SEARCH"`
+	MaxToolTurns       int    `yaml:"MAX_TURNS"`          // Recursion limit
+	MaxHistoryTurns    int    `yaml:"MAX_HISTORY_TURNS"`  // For pruning turns
+	MaxHistoryTokens   int    `yaml:"MAX_HISTORY_TOKENS"` // For safety rollback
+	ThinkingBudget     int    `yaml:"THINKING_BUDGET"`
+	ThinkingLevel      string `yaml:"THINKING_LEVEL"`
+	ShowThoughts       bool   `yaml:"SHOW_THOUGHTS"`
+	ShowTools          bool   `yaml:"SHOW_TOOLS"`
+	MaxConcurrentTools int    `yaml:"MAX_CONCURRENT_TOOLS"` // Parallel tool execution
+	ToolTimeoutSeconds int    `yaml:"TOOL_TIMEOUT"`         // Single tool timeout
+	HTTPTimeoutSeconds int    `yaml:"HTTP_TIMEOUT"`         // LLM Client timeout
+	UseTUIPrompt       bool   `yaml:"USE_TUI_PROMPT"`       // Enable TUI prompt with suggestions
+	// WrapWidth is the column width for word-wrapping non-TUI markdown
+	// output. Zero means "use glamour's built-in default (80)". Read at
+	// session start only — changes take effect from the next session.
+	WrapWidth          int                    `yaml:"WRAP_WIDTH"`
 	BypassConfirmation bool                   `yaml:"BYPASS_CONFIRMATION"`
 	Models             map[string]ModelConfig `yaml:"MODELS"` // Model-specific overrides
 	SelectedProvider   string                 `yaml:"SELECTED_PROVIDER"`
@@ -280,6 +284,9 @@ func (c *Config) ValidateBounds() error {
 	}
 	if c.HTTPTimeoutSeconds < 0 {
 		return fmt.Errorf("HTTP_TIMEOUT must be >= 0, got %d", c.HTTPTimeoutSeconds)
+	}
+	if c.WrapWidth < 0 {
+		return fmt.Errorf("WRAP_WIDTH must be >= 0, got %d", c.WrapWidth)
 	}
 	return nil
 }

--- a/internal/domain/ports/renderer.go
+++ b/internal/domain/ports/renderer.go
@@ -80,6 +80,11 @@ type RendererConfigurator interface {
 	// not a terminal. Useful for testing or when piping to a pager.
 	SetForceSpinner(force bool)
 
+	// SetWordWrap sets the word-wrap column width for subsequent markdown
+	// rendering. width <= 0 restores glamour's built-in default (80).
+	// Safe to call at any time; applies to subsequently rendered output.
+	SetWordWrap(width int)
+
 	// IsTerminalContext reports whether the renderer is connected to
 	// an interactive terminal. This determines default spinner behavior.
 	IsTerminalContext() bool

--- a/internal/domain/ports/renderer.go
+++ b/internal/domain/ports/renderer.go
@@ -127,6 +127,9 @@ type HistoryRenderOptions struct {
 	CustomRenderer interface{ Render(string) (string, error) }
 	// SuppressRoles omits [MODEL] and [USER] role headers from output.
 	SuppressRoles bool
+	// WrapWidth sets the word-wrap column width for markdown rendering.
+	// Zero means "use glamour's built-in default (80)".
+	WrapWidth int
 }
 
 // SystemMetricsProvider defines the interface for collecting host resource usage.

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -123,6 +123,7 @@ func configureViper(path string) (*viper.Viper, error) {
 	_ = v.BindEnv("PERSON", "GOSHARP_PERSON", "TELL_ME_PERSON")
 	_ = v.BindEnv("AIMODEL", "GOSHARP_AIMODEL", "TELL_ME_AIMODEL")
 	_ = v.BindEnv("AIURL", "GOSHARP_AIURL", "TELL_ME_AIURL")
+	_ = v.BindEnv("WRAP_WIDTH", "TELL_ME_WRAP_WIDTH")
 
 	return v, nil
 }

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -770,3 +770,125 @@ func TestLoad_ValidateBoundsError(t *testing.T) {
 		})
 	}
 }
+
+// TestLoad_WrapWidth_RoundTrip pins that the top-level WRAP_WIDTH field
+// round-trips correctly from YAML through Viper + mapstructure into the
+// domain Config.WrapWidth field, and that the loader rejects negative
+// values via the domain ValidateBounds path. Zero is the correct default
+// when the field is omitted.
+func TestLoad_WrapWidth_RoundTrip(t *testing.T) {
+	t.Setenv("TELL_ME_WRAP_WIDTH", "")        // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tests := []struct {
+		name    string
+		yamlVal string // text for the WRAP_WIDTH line; empty omits the field
+		wantErr bool
+		wantVal int
+		errFrag string
+	}{
+		{name: "positive value round-trips", yamlVal: "WRAP_WIDTH: 120", wantVal: 120},
+		{name: "explicit zero round-trips as zero", yamlVal: "WRAP_WIDTH: 0", wantVal: 0},
+		{name: "field omitted defaults to zero", yamlVal: "", wantVal: 0},
+		{name: "negative value rejected", yamlVal: "WRAP_WIDTH: -1", wantErr: true, errFrag: "WRAP_WIDTH"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "test_wrap_width.yaml")
+			// WRAP_WIDTH is a top-level key (unlike provider-scoped
+			// MAX_TOKENS), so the injected line must not be indented.
+			yamlContent := `
+SELECTED_PROVIDER: "claude"
+PROVIDERS:
+  claude:
+    TYPE: "anthropic"
+    MODEL: "claude-opus-4-6"
+    API_KEY: "test"
+` + tt.yamlVal + `
+`
+			if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			cfg, err := load(configPath)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("load() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				if !strings.Contains(err.Error(), tt.errFrag) {
+					t.Errorf("expected error containing %q, got %q", tt.errFrag, err.Error())
+				}
+				return
+			}
+			if got := cfg.WrapWidth; got != tt.wantVal {
+				t.Errorf("WrapWidth = %d; want %d", got, tt.wantVal)
+			}
+		})
+	}
+}
+
+// TestLoad_WrapWidth_EnvOverride pins that TELL_ME_WRAP_WIDTH takes
+// precedence over the WRAP_WIDTH value in the YAML file.
+func TestLoad_WrapWidth_EnvOverride(t *testing.T) {
+	t.Setenv("TELL_ME_WRAP_WIDTH", "200")
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_env_wrap_width.yaml")
+	yamlContent := `
+SELECTED_PROVIDER: "claude"
+PROVIDERS:
+  claude:
+    TYPE: "anthropic"
+    MODEL: "claude-opus-4-6"
+    API_KEY: "test"
+WRAP_WIDTH: 120
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := load(configPath)
+	if err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+
+	if got := cfg.WrapWidth; got != 200 {
+		t.Errorf("expected env override WRAP_WIDTH=200, got %d", got)
+	}
+}
+
+// TestLoad_WrapWidth_EnvOnly is the critical test: TELL_ME_WRAP_WIDTH set
+// in the environment MUST take effect even when WRAP_WIDTH is absent from
+// the YAML file entirely. This only works because configureViper registers
+// the key with BindEnv — AutomaticEnv alone cannot surface a key that
+// Unmarshal never asks for (viper.AllKeys() omits it).
+func TestLoad_WrapWidth_EnvOnly(t *testing.T) {
+	t.Setenv("TELL_ME_WRAP_WIDTH", "150")
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_env_only_wrap_width.yaml")
+	yamlContent := `
+SELECTED_PROVIDER: "claude"
+PROVIDERS:
+  claude:
+    TYPE: "anthropic"
+    MODEL: "claude-opus-4-6"
+    API_KEY: "test"
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := load(configPath)
+	if err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+
+	if got := cfg.WrapWidth; got != 150 {
+		t.Errorf("expected env-only WRAP_WIDTH=150, got %d", got)
+	}
+}

--- a/internal/ui/history.go
+++ b/internal/ui/history.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/charmbracelet/glamour"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 )
@@ -51,7 +52,11 @@ func renderHistory(w io.Writer, h ports.HistoryReader, n int, options ports.Hist
 		if options.CustomRenderer != nil {
 			hr.renderer = options.CustomRenderer
 		} else {
-			hr.renderer, _ = NewMarkdownRenderer()
+			var opts []glamour.TermRendererOption
+			if options.WrapWidth > 0 {
+				opts = append(opts, glamour.WithWordWrap(options.WrapWidth))
+			}
+			hr.renderer, _ = NewMarkdownRenderer(opts...)
 		}
 	}
 

--- a/internal/ui/history_test.go
+++ b/internal/ui/history_test.go
@@ -273,6 +273,52 @@ func TestHistory_RenderTextFallback(t *testing.T) {
 	})
 }
 
+func TestHistory_RenderWrapWidth(t *testing.T) {
+	// A long plain-text paragraph (no markdown syntax) so glamour wraps at
+	// word boundaries: 27 chars x 40 = ~1080 chars.
+	longText := strings.Repeat("lorem ipsum dolor sit amet ", 40)
+
+	tmp := t.TempDir()
+	historyPath := filepath.Join(tmp, "history.json")
+	h := history.NewManager(infrapersistence.NewOSFileSystem(), historyPath, historyPath+".archive")
+
+	ctx := context.Background()
+	if err := h.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: longText}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	maxLineLen := func(s string) int {
+		max := 0
+		for _, line := range strings.Split(s, "\n") {
+			if len(line) > max {
+				max = len(line)
+			}
+		}
+		return max
+	}
+
+	t.Run("wrap width 120 widens output beyond default 80", func(t *testing.T) {
+		var buf bytes.Buffer
+		ui.RenderHistory(&buf, h, 10, ports.HistoryRenderOptions{WrapWidth: 120})
+		maxLen := maxLineLen(stripANSI(buf.String()))
+		if maxLen > 120 {
+			t.Errorf("max line length %d exceeds wrap width 120", maxLen)
+		}
+		if maxLen <= 80 {
+			t.Errorf("max line length %d did not widen beyond default 80; WrapWidth 120 had no effect", maxLen)
+		}
+	})
+
+	t.Run("wrap width 0 keeps default 80", func(t *testing.T) {
+		var buf bytes.Buffer
+		ui.RenderHistory(&buf, h, 10, ports.HistoryRenderOptions{WrapWidth: 0})
+		maxLen := maxLineLen(stripANSI(buf.String()))
+		if maxLen > 80 {
+			t.Errorf("max line length %d exceeds default wrap width 80", maxLen)
+		}
+	})
+}
+
 // ── History render error reporting tests (G20) ──
 
 func TestHistory_RenderTextError(t *testing.T) {

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -267,6 +267,12 @@ func (r *stdUIRenderer) SetWordWrap(width int) {
 	}
 	tr, err := NewMarkdownRenderer(opts...)
 	if err != nil {
+		// Structurally unreachable — see the `structurally-unreachable`
+		// acceptance class (docs/architect/INTENTIONAL_NON_FIXES.md):
+		// NewMarkdownRenderer receives only WithStandardStyle + WithEmoji
+		// (+ optional WithWordWrap), none of which can fail. Keep the
+		// existing renderer on the impossible error rather than degrading
+		// (consistent with ADR-007 semantics).
 		return // keep existing renderer
 	}
 	r.renderer = tr

--- a/internal/ui/renderer.go
+++ b/internal/ui/renderer.go
@@ -250,6 +250,28 @@ func (r *stdUIRenderer) SetForceSpinner(force bool) {
 	r.forceSpinner = force
 }
 
+// SetWordWrap rebuilds the markdown renderer with the given word-wrap
+// width. width <= 0 restores glamour's built-in default (80). Acquires
+// ioMu — the same lock the render path holds when reading r.renderer.
+// If the renderer is degraded (glamour init failed, ADR-007) it stays
+// degraded; if the rebuild fails, the previous renderer is kept.
+func (r *stdUIRenderer) SetWordWrap(width int) {
+	r.ioMu.Lock()
+	defer r.ioMu.Unlock()
+	if r.renderer == nil {
+		return // stay degraded (ADR-007)
+	}
+	var opts []glamour.TermRendererOption
+	if width > 0 {
+		opts = append(opts, glamour.WithWordWrap(width))
+	}
+	tr, err := NewMarkdownRenderer(opts...)
+	if err != nil {
+		return // keep existing renderer
+	}
+	r.renderer = tr
+}
+
 // SetWriters allows overriding the output writers (primarily for testing).
 func (r *stdUIRenderer) SetWriters(stdout, stderr io.Writer) {
 	r.mu.Lock()

--- a/internal/ui/renderer_test.go
+++ b/internal/ui/renderer_test.go
@@ -1489,3 +1489,61 @@ func TestStdUIRenderer_RenderResponse_ThoughtPromotion(t *testing.T) {
 		r.RenderResponse(context.Background(), content, false, false)
 	})
 }
+
+func TestStdUIRenderer_SetWordWrap(t *testing.T) {
+	var stdout bytes.Buffer
+	locker := ui.NewMockLocker()
+	r := ui.NewRenderer(locker, &stdout, &stdout, nil, nil).(*ui.StdUIRenderer)
+
+	// Plain words (no markdown syntax) so glamour wraps at word boundaries.
+	// 40 repetitions of a 5-word phrase ≈ 1200 chars — comfortably above 120.
+	text := strings.Repeat("lorem ipsum dolor sit amet ", 40)
+
+	t.Run("width 120 widens output beyond default 80", func(t *testing.T) {
+		stdout.Reset()
+		r.SetWordWrap(120)
+		r.RenderMarkdown(text)
+		maxLen := 0
+		for _, ln := range strings.Split(stripANSI(stdout.String()), "\n") {
+			if len(ln) > maxLen {
+				maxLen = len(ln)
+			}
+		}
+		if maxLen > 120 {
+			t.Errorf("SetWordWrap(120): longest line %d exceeds 120", maxLen)
+		}
+		if maxLen <= 80 {
+			t.Errorf("SetWordWrap(120): longest line %d is not wider than the default 80 — width option not applied", maxLen)
+		}
+	})
+
+	t.Run("width 0 restores default 80", func(t *testing.T) {
+		stdout.Reset()
+		r.SetWordWrap(0)
+		r.RenderMarkdown(text)
+		maxLen := 0
+		for _, ln := range strings.Split(stripANSI(stdout.String()), "\n") {
+			if len(ln) > maxLen {
+				maxLen = len(ln)
+			}
+		}
+		if maxLen > 80 {
+			t.Errorf("SetWordWrap(0): longest line %d exceeds default 80", maxLen)
+		}
+	})
+
+	t.Run("degraded renderer stays degraded", func(t *testing.T) {
+		failingOpt := glamour.TermRendererOption(func(tr *glamour.TermRenderer) error {
+			return errors.New("injected glamour init failure")
+		})
+		var buf bytes.Buffer
+		deg := ui.NewRenderer(locker, &buf, &buf, nil, nil, ui.WithGlamourOption(failingOpt)).(*ui.StdUIRenderer)
+		if !deg.IsRendererDegraded() {
+			t.Fatal("expected degraded renderer after injected init failure")
+		}
+		deg.SetWordWrap(120)
+		if !deg.IsRendererDegraded() {
+			t.Error("expected renderer to stay degraded after SetWordWrap")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds a `WRAP_WIDTH` configuration (env `TELL_ME_WRAP_WIDTH`, precedence **env > YAML > default 80**) to control word-wrapping of non-TUI markdown output. Previously hardcoded at 80 columns by glamour; now configurable — including for the `-l` (--last) history display.

## Changes (3 commits)

- **feat(config) `20244340`** — core feature:
  - `WrapWidth` field on the domain `Config` (yaml `WRAP_WIDTH`) + `ValidateBounds` guard (negatives rejected).
  - `configureViper` `BindEnv("WRAP_WIDTH", "TELL_ME_WRAP_WIDTH")` — required for the env-only case (Viper `AllKeys()` excludes `AutomaticEnv` keys).
  - `SetWordWrap(width)` on the `RendererConfigurator` port: rebuilds the markdown renderer under `ioMu`, preserves the ADR-007 degraded state, keeps the previous renderer on rebuild error, never passes `WithWordWrap(0)` (glamour underflows on 0).
  - Applied at session start in `ProcessMessage` / `RunDiagnostics` (renderer is built at bootstrap, before config is loaded).
  - Tests: config round-trip / env-override / **env-only** (proves the BindEnv wiring), renderer width / restore / degraded. Mock + 5 test fakes updated for the port method.
  - Documented (commented) in `configs/assistant.yaml`.
- **docs(architect) `9205740e`** — catalog maintenance: re-anchored drifted `file:line` references per the catalog's Drift Policy; triaged the `SetWordWrap` rebuild-error branch as `structurally-unreachable` (ACCEPTED).
- **fix(ui) `c87b1966`** — `-l` history rendering now respects `WRAP_WIDTH` via `HistoryRenderOptions.WrapWidth` (the history renderer built its own glamour renderer at 80 with no width option).

## Behavior

- `WRAP_WIDTH: 0` or unset → glamour's built-in 80 columns (unchanged behavior).
- `WRAP_WIDTH: 120` (or `TELL_ME_WRAP_WIDTH=120`) → non-TUI chat output and `-l` history wrap at 120.
- Read at session start; changes take effect from the next session. TUI output unaffected.

## Verification

- `make check-full` green — race detector, e2e, integration, all packages.
- Dead-code scan clean (module-wide type-aware + repo `cmd/deadcode`).
- Coverage 96.7% overall; new code covered by config/env/renderer/history unit tests.
