### PR TITLE
fix(history): make UpdateTurnContent durability-first (#1301)

### DIFF
--- a/internal/domain/ports/history.go
+++ b/internal/domain/ports/history.go
@@ -37,9 +37,9 @@ type HistoryReader interface {
 
 // HistoryWriter defines the interface for adding or modifying chat history.
 type HistoryWriter interface {
-	// SetContents replaces the entire in-memory history with the given
-	// slice. The previous history is discarded without being persisted.
-	// Call Save to persist the new contents to disk.
+	// SetContents replaces the entire history with the given slice and
+	// persists it immediately. If persistence fails, the previous
+	// in-memory history is retained.
 	SetContents(ctx context.Context, contents []*llm.Content) error
 
 	// AddContent appends a single Content entry to the in-memory history.
@@ -97,9 +97,10 @@ type HistoryModifier interface {
 	GetModelTurn(ctx context.Context, index int) (*llm.Content, error)
 
 	// UpdateTurnContent replaces the text and thought parts of the Content at
-	// the given index in memory, then persists the change via Save.
-	// The index must reference a model-role entry. Passing an empty string for
-	// newThought removes any existing thought part from that turn.
+	// the given index. The change is persisted before the in-memory entry is
+	// updated (durability-first). The index must reference a model-role entry.
+	// Passing an empty string for newThought removes any existing thought part
+	// from that turn.
 	UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error
 }
 

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -623,8 +623,9 @@ func collectUpdatedParts(original []*llm.Part, newText string, newThought string
 }
 
 // UpdateTurnContent replaces the text and thought parts of the Content at
-// the given index, then persists via Save. The index must reference a
-// model-role entry. An empty newThought removes any thought part.
+// the given index. The replacement is persisted via Save before memory is
+// updated (durability-first). The index must reference a model-role entry.
+// An empty newThought removes any thought part.
 func (m *Manager) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -636,11 +637,21 @@ func (m *Manager) UpdateTurnContent(ctx context.Context, index int, newText stri
 		return fmt.Errorf("index %d has role %q, expected \"model\"", index, m.Contents[index].Role)
 	}
 
-	m.Contents[index].Parts = collectUpdatedParts(m.Contents[index].Parts, newText, newThought)
-
-	if err := m.store.Save(ctx, m.Contents); err != nil {
+	newParts := collectUpdatedParts(m.Contents[index].Parts, newText, newThought)
+	copyOfContents := make([]*llm.Content, len(m.Contents))
+	for i, c := range m.Contents {
+		if i == index {
+			cc := *c // shallow struct copy — Content has no map fields
+			cc.Parts = newParts
+			copyOfContents[i] = &cc
+		} else {
+			copyOfContents[i] = c // safe: Save deep-clones its input
+		}
+	}
+	if err := m.store.Save(ctx, copyOfContents); err != nil {
 		return fmt.Errorf("save after updating turn %d: %w", index, err)
 	}
+	m.Contents[index].Parts = newParts
 	return nil
 }
 

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -1033,6 +1033,90 @@ func (m *mockFailingAppendPartsStore) AppendParts(ctx context.Context, index int
 
 func (m *mockFailingAppendPartsStore) Sync(ctx context.Context) error { return nil }
 
+// recordingStore captures the slice passed to Save for inspection.
+type recordingStore struct {
+	mockStore
+	lastSaved []*llm.Content
+}
+
+func (m *recordingStore) Save(ctx context.Context, contents []*llm.Content) error {
+	m.lastSaved = contents
+	return nil
+}
+
+func TestHistoryManager_UpdateTurnContent_DurabilityFirst(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	historyFile := filepath.Join(tmp, "history.jsonl")
+	archiveFile := filepath.Join(tmp, "archive.jsonl")
+
+	m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+
+	if err := m.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "old response"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := 1
+
+	expectedErr := errors.New("save failed")
+	m.setStore(&mockFailingStore{err: expectedErr})
+
+	err := m.UpdateTurnContent(ctx, idx, "new response", "")
+	if err == nil || !errors.Is(err, expectedErr) {
+		t.Errorf("expected error %v, got %v", expectedErr, err)
+	}
+
+	// Verify in-memory state was NOT updated (durability-first)
+	if len(m.Contents[idx].Parts) != 1 || m.Contents[idx].Parts[0].Text != "old response" {
+		t.Errorf("expected original parts after failed save, got %+v", m.Contents[idx].Parts)
+	}
+}
+
+func TestHistoryManager_UpdateTurnContent_SaveReceivesEdit(t *testing.T) {
+	ctx := context.Background()
+	tmp := t.TempDir()
+	historyFile := filepath.Join(tmp, "history.jsonl")
+	archiveFile := filepath.Join(tmp, "archive.jsonl")
+
+	m := NewManager(infrapersistence.NewOSFileSystem(), historyFile, archiveFile)
+
+	if err := m.AddContent(ctx, &llm.Content{Role: "user", Parts: []*llm.Part{{Text: "hello"}}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.AddContent(ctx, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "old response"}}}); err != nil {
+		t.Fatal(err)
+	}
+
+	idx := 1
+
+	rec := &recordingStore{}
+	m.setStore(rec)
+
+	if err := m.UpdateTurnContent(ctx, idx, "new response", ""); err != nil {
+		t.Fatalf("UpdateTurnContent: %v", err)
+	}
+
+	if rec.lastSaved == nil {
+		t.Fatal("expected Save to be called")
+	}
+	if len(rec.lastSaved) != len(m.Contents) {
+		t.Fatalf("expected %d entries saved, got %d", len(m.Contents), len(rec.lastSaved))
+	}
+
+	// The slice passed to Save must carry the edit at index (not just memory)
+	if len(rec.lastSaved[idx].Parts) != 1 || rec.lastSaved[idx].Parts[0].Text != "new response" {
+		t.Errorf("Save received unedited entry at index %d: %+v", idx, rec.lastSaved[idx].Parts)
+	}
+
+	// The entry handed to Save must be a copy, not the live in-memory entry
+	if rec.lastSaved[idx] == m.Contents[idx] {
+		t.Error("Save received the live in-memory entry; expected a copy")
+	}
+}
+
 // setupLegacyHistoryWithNoIDs creates a Manager backed by a persisted history
 // file containing entries that lack UUIDs. It then loads a fresh Manager which
 // triggers the backfill logic, returning the Manager with backfilled IDs.


### PR DESCRIPTION
Closes #1301.

## Summary
`Manager.UpdateTurnContent` mutated in-memory contents BEFORE persisting via Save, violating the codified durability-first convention (persist succeeds before memory is mutated). On Save failure the browser kept a "live" edit that a subsequent 'r' rollback would durably write to disk.

Fixed with the grilled, verbatim shallow-struct-copy form: build a copy of contents with the edit at `index`, persist first, and only assign `m.Contents[index].Parts` on success. Never replaces the live entry (preserves `TransientParts`).

Also updated the contract comments that codified the bug:
- `history.go` UpdateTurnContent doc comment (mandatory)
- `ports/history.go` UpdateTurnContent interface comment (mandatory)
- `ports/history.go` SetContents comment (optional courtesy — was stale)

## Verification
| Check | Status |
|-------|--------|
| RED-first: both new tests failed pre-fix, green post-fix (independently confirmed by Architect via stash) | PASS |
| `go test ./internal/infrastructure/history/` | PASS |
| `go vet` / `gofmt` | PASS |
| make check-full (fmt, tidy, build, lint, verify-arch, vulncheck, test, dead-code, race, coverage) | PASS |
| Scope: exactly 3 files, zero caller changes | PASS |

New regression guards:
- `TestHistoryManager_UpdateTurnContent_DurabilityFirst` — failing store → error + memory unchanged
- `TestHistoryManager_UpdateTurnContent_SaveReceivesEdit` — Save receives a copy carrying the edit (broken-fix guard)