### PR TITLE
fix(orchestrator): make emergencySave idempotent on partial persistence failure (#1302)

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -1174,4 +1174,24 @@ to reason about.
 
 ---
 
-*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13); design rejection: split internal/agent façade — issue #1299)*
+## Coverage Gaps (ACCEPTED — 2026-08 #1302 emergencySave double-append)
+
+### agent/orchestrator/engine_phases.go — ghost-response path (structurally unreachable)
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: The `IsTransient` branch in `PersistenceStep.Process` is structurally
+  unreachable for history-store errors — store errors are raw filesystem errors,
+  never transient (`IsTransient` matches only `ErrTransient`/`ErrRateLimit`,
+  gateway.go:36). The ghost-response path (partial success + hypothetically
+  transient store error → recovery re-infers and appends a fresh response while
+  the old stays) is therefore NOT reachable today. Same acceptance class as
+  defensive guards on internal pipeline state (2026-07 Batch Triage).
+- **Note**: The Sync-wrinkle disk-duplicate (store.go:252-283 — write succeeds,
+  deferred `Sync` fails) is accepted as out-of-scope for #1302; the durable fix
+  belongs in the history store package (fault-injection-required class — fsync
+  failure requires real I/O faults).
+- **See**: `internal/agent/orchestrator/engine_phases.go:79-92` (architect-acceptance comment + `IsTransient` classification)
+
+---
+
+*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go)*

--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -361,7 +361,11 @@ func (e *Engine) finalizeTurnTrace(trace *telemetry.TurnTrace, err error) {
 }
 
 func (e *Engine) emergencySave(Turn *Turn) {
-	if Turn.State.Response != nil && len(Turn.State.Response.Parts) > 0 {
+	// #1302: with clear-after-append in PersistenceStep, the guard must also
+	// cover ToolResponse — else a failed tool-results append would never be
+	// retried after the Response was cleared on success.
+	if (Turn.State.Response != nil && len(Turn.State.Response.Parts) > 0) ||
+		(Turn.State.ToolResponse != nil && len(Turn.State.ToolResponse.Parts) > 0) {
 		e.mu.RLock()
 		p, ok := e.processors[PhasePersisting]
 		e.mu.RUnlock()

--- a/internal/agent/orchestrator/engine_coverage_test.go
+++ b/internal/agent/orchestrator/engine_coverage_test.go
@@ -92,6 +92,83 @@ func TestRunPhaseLoop_EmergencySave(t *testing.T) {
 	assert.True(t, saveCalled, "emergencySave should have triggered PhasePersisting")
 }
 
+// failOnNthAddContent is a local embedded double of MockHistoryManager whose
+// AddContent fails on the failCall-th invocation with a raw filesystem error.
+// The error is intentionally NOT transient (per gateway.go:36, IsTransient
+// matches only ErrTransient/ErrRateLimit) so the turn fails terminally and
+// drives the emergencySave re-run path.
+type failOnNthAddContent struct {
+	*agenttest.MockHistoryManager
+	calls    int
+	failCall int
+}
+
+func (m *failOnNthAddContent) AddContent(ctx context.Context, content *llm.Content) error {
+	m.calls++
+	if m.calls == m.failCall {
+		return errors.New("disk full") // raw fs error — NOT transient, per gateway.go:36
+	}
+	return m.MockHistoryManager.AddContent(ctx, content) // default append semantics
+}
+
+func TestEmergencySave_PartialPersistenceFailure_NoDuplicate(t *testing.T) {
+	// Issue #1302: when PersistenceStep partially succeeds (Response persisted,
+	// ToolResponse append fails), the emergencySave re-run must be idempotent —
+	// no duplicate Response parts, and the failed ToolResponse must be retried.
+
+	gw := &agenttest.MockGateway{}
+	ex := &agenttest.MockAgentExecutor{}
+	reg := &agenttest.MockToolRegistry{}
+	bus := events.NewSimpleEventBus(context.Background(), events.WithAsync(false))
+	eventstest.CleanupBus(t, bus)
+	counter := &agenttest.MockTokenCounter{}
+
+	// Seed with a user message so the role-alternation path in cm.AddContent
+	// validates: the first append is "model", the second is "tool".
+	hMock := &failOnNthAddContent{
+		MockHistoryManager: &agenttest.MockHistoryManager{
+			Contents: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "initial user message"}}}},
+		},
+		failCall: 2, // partial success: first append succeeds, second fails
+	}
+	cm := sessctx.NewManager(sessctx.NewStrategy(counter), hMock, bus, nil)
+
+	engine := NewEngine(gw, ex, cm, reg, bus, counter)
+
+	turn := engine.CreateTurn(0, time.Now(), "")
+	turn.State.Phase = PhasePersisting
+	turn.State.Response = &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "resp"}}}
+	turn.State.ToolResponse = &llm.Content{Role: "tool", Parts: []*llm.Part{{Text: "tool"}}}
+
+	err := engine.runPhaseLoop(context.Background(), turn)
+
+	assert.Error(t, err, "turn failure semantics must be unchanged")
+
+	// Exactly one Response: the model entry must contain exactly one "resp" part.
+	// Pre-fix the emergencySave re-run hits the AppendParts fast path and
+	// duplicates the part inside the entry (2 "resp" parts in one model entry).
+	var modelEntries, respPartCount, toolEntries int
+	for _, c := range hMock.Contents {
+		switch c.Role {
+		case "model":
+			modelEntries++
+			for _, p := range c.Parts {
+				if p.Text == "resp" {
+					respPartCount++
+				}
+			}
+		case "tool":
+			toolEntries++
+		}
+	}
+	assert.Equal(t, 1, modelEntries, "exactly one model entry must be persisted")
+	assert.Equal(t, 1, respPartCount, "the model entry must contain exactly one 'resp' part (no duplicate append)")
+
+	// ToolResponse retried: post-fix WITHOUT the widened emergencySave guard
+	// this is 0 — the failed tool-results append would never be retried.
+	assert.Equal(t, 1, toolEntries, "the failed tool response must be retried exactly once")
+}
+
 func TestRunPhaseLoop_StopSignal(t *testing.T) {
 	engine := &Engine{
 		processors: map[TurnPhase]TurnProcessor{

--- a/internal/agent/orchestrator/engine_phases.go
+++ b/internal/agent/orchestrator/engine_phases.go
@@ -76,12 +76,29 @@ type PersistenceStep struct{}
 func (p *PersistenceStep) Process(ctx context.Context, Turn *Turn) (ProcessResult, error) {
 	if Turn.State.Response != nil {
 		if err := Turn.CtxManager.AddContent(ctx, Turn.State.Response); err != nil {
+			// Architect-acceptance (2026-07): this IsTransient branch is
+			// structurally unreachable for history-store errors. Store errors
+			// are raw filesystem errors — IsTransient matches only
+			// ErrTransient/ErrRateLimit (gateway.go:36) — so a partial-success
+			// append (first write landed, second failed) is always classified
+			// ErrTerminal here, never transient. The ghost-response path
+			// (partial success + hypothetically transient store error →
+			// recovery re-infers and appends a fresh response while the old
+			// stays) is therefore NOT reachable today. No test is written for
+			// it (unreachable). Same acceptance class as defensive guards on
+			// internal pipeline state (2026-07 Batch Triage).
+			// See: docs/architect/INTENTIONAL_NON_FIXES.md.
 			category := llm.ErrTerminal
 			if IsTransient(err) {
 				category = llm.ErrTransient
 			}
 			return ProcessResult{}, NewAgentError(category, "history error", err)
 		}
+		// #1302: clear-after-append makes the emergencySave re-run idempotent —
+		// no-op for already-persisted content, retries only what failed. On the
+		// error path above the field is deliberately NOT cleared so the retry
+		// sees what failed. Mirrors handleLoopBreak (middleware.go:213-214).
+		Turn.State.Response = nil
 	}
 
 	if Turn.State.ToolResponse != nil {
@@ -92,6 +109,8 @@ func (p *PersistenceStep) Process(ctx context.Context, Turn *Turn) (ProcessResul
 			}
 			return ProcessResult{}, NewAgentError(category, "failed to persist tool results", err)
 		}
+		// #1302: clear-after-append — see the Response comment above.
+		Turn.State.ToolResponse = nil
 	}
 
 	return ProcessResult{NextPhase: PhaseComplete}, nil


### PR DESCRIPTION
Closes #1302.

## Summary
`emergencySave` could append a duplicate response when `PersistenceStep` partially failed: store errors are never transient (`IsTransient` matches only `ErrTransient`/`ErrRateLimit`), so a persistence failure is terminal → `RecoveryStep` gives up → `runPhaseLoop` calls `emergencySave` → `PersistenceStep` re-runs with the same never-cleared `Turn.State.Response` → duplicate append.

**Fix (idempotent-processor sketch + guard widening):**
- `PersistenceStep.Process` now clears `Turn.State.Response` / `Turn.State.ToolResponse` after each **successful** `AddContent` — the emergencySave re-run becomes a no-op for already-persisted content and retries only what failed (error path deliberately does not clear).
- `emergencySave`'s guard widened to fire when **either** response is pending — otherwise, with clear-after-append, a failed tool-results append would never be retried after the Response was cleared (data loss). Mirrors the `handleLoopBreak` precedent.

**Guard record (architect-approved):** the ghost-response path (partial success + hypothetically transient store error) is structurally unreachable today — recorded as an `INTENTIONAL_NON_FIXES.md` entry (Coverage Gaps, ACCEPTED, class `structurally-unreachable`) with an inline architect-acceptance comment. The Sync-wrinkle disk-duplicate is noted as out-of-scope (durable fix belongs in the history store package).

## Verification
| Check | Status |
|-------|--------|
| RED-first: new test failed pre-fix with exactly the predicted assertion (2 vs 1 'resp' parts — AppendParts fast-path duplication) | PASS |
| `go test ./internal/agent/orchestrator/ -count=1` | PASS |
| `go vet` / `gofmt` | PASS |
| make check-full (fmt, tidy, build, lint, verify-arch, vulncheck, test, dead-code, race, coverage) | PASS |
| Scope: 3 code files + 1 catalog entry, zero cross-package changes | PASS |

New regression guard:
- `TestEmergencySave_PartialPersistenceFailure_NoDuplicate` — partial-success precondition (second `AddContent` fails after first succeeds via `failOnNthAddContent`), drives the full `runPhaseLoop → RecoveryStep → emergencySave → PersistenceStep re-run` path, asserts exactly one Response part and exactly one ToolResponse entry (tripwire for the widened guard).