### PR TITLE
chore(analysis): re-anchor complexity pins; add verify-nonfix-catalog gate (#1297)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(OS),Windows_NT)
     endif
 endif
 
-.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-no-test-sleep verify-architecture verify-adr-index lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
+.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-no-test-sleep verify-architecture verify-nonfix-catalog verify-adr-index lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
 
 help:
 	@echo "tell-me-go development tasks:"
@@ -40,6 +40,7 @@ help:
 	@echo "  make test       - Run all tests (standard)"
 	@echo "  make test-race  - Run tests with race detector (AI-SAFE, package-by-package)"
 	@echo "  make verify-architecture - Verify Clean/Hexagonal Architecture layer discipline"
+	@echo "  make verify-nonfix-catalog - Verify the complexity-pin catalog partition (issue #1297)"
 	@echo "  make verify-no-test-sleep - Verify no time.Sleep for synchronization in tests"
 	@echo "  make test-coverage - Run tests with coverage (excludes mocks/generated)"
 	@echo "  make tidy       - Tidy and vendor dependencies"
@@ -409,6 +410,18 @@ else
 	@$(MAKE) modelith-layers
 endif
 
+# Verify the complexity-pin catalog partition (issue #1297): runs the real
+# GatherComplexities against the live INTENTIONAL_NON_FIXES.md catalog and
+# asserts the post-fix 25-cataloged / 1-alert partition by name (line +
+# recorded CC). RED-first: the gate must fail against a drifted catalog —
+# never weaken it to land green.
+verify-nonfix-catalog:
+ifeq ($(IS_POSIX),true)
+	@go test -tags=arch -run TestVerifyNonFixCatalog ./internal/tools/analysis
+else
+	@go test -tags=arch -run TestVerifyNonFixCatalog ./internal/tools/analysis
+endif
+
 # AI-SAFE RACE TEST: 
 # Running 'go test -race ./...' globally can time out in constrained environments.
 # This target iterates through packages sequentially for stability.
@@ -570,6 +583,8 @@ check: fmt tidy build
 	@$(MAKE) lint
 	@echo "=== verify-architecture ==="
 	@$(MAKE) verify-architecture
+	@echo "=== verify-nonfix-catalog ==="
+	@$(MAKE) verify-nonfix-catalog
 	@echo "=== verify-mock-pattern ==="
 	@$(MAKE) verify-mock-pattern
 	@echo "=== verify-session-provider-mock ==="
@@ -600,6 +615,8 @@ check-full: fmt tidy build
 	@$(MAKE) lint
 	@echo "=== verify-architecture ==="
 	@$(MAKE) verify-architecture
+	@echo "=== verify-nonfix-catalog ==="
+	@$(MAKE) verify-nonfix-catalog
 	@echo "=== verify-mock-pattern ==="
 	@$(MAKE) verify-mock-pattern
 	@echo "=== verify-session-provider-mock ==="

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -41,6 +41,8 @@ catalog a new gap no one reviewed. Policy:
 - **CC values in complexity entries are re-measured** whenever the referenced
   function changes; drift is recorded in the entry's rationale (see the
   2026-08 CC drift corrections for the pattern).
+- **Enforcement boundary**: complexity pins: mechanically verified by `verify-nonfix-catalog` on over-threshold functions; under-threshold pins are enforced at threshold-crossing, by construction; coverage pins: prose policy per ADR-054 consequences — the coverage matcher has no name axis to verify against.
+- **Coordination rule**: any legitimate catalog change (add/remove/re-anchor/CC re-verify) edits the partition test in the same PR.
 
 ---
 
@@ -794,7 +796,7 @@ catalog a new gap no one reviewed. Policy:
   test boilerplate assertions, not branching business logic. Same acceptance
   class as the existing structural concerns — test infrastructure where the cost
   of refactoring outweighs the maintainability benefit.
-- **See**: `tests/e2e/history_flags_test.go:142`
+- **See**: `tests/e2e/history_flags_test.go:161`
 
 ### cmd/tell-me-go/main.go — buildApp os.Getwd error path (non-Linux)
 
@@ -855,7 +857,7 @@ catalog a new gap no one reviewed. Policy:
   `internal/agent/session/ui/dispatcher.go`) would trade one well-understood
   Go pattern for another with no reduction in cognitive complexity. The code
   is already clean and well-structured.
-- **See**: `internal/ui/tui/progress/model.go`
+- **See**: `internal/ui/tui/progress/model.go:338`
 
 ### agent/session/ui/dispatcher.go — handleToolEvents (CC=10)
 
@@ -883,7 +885,7 @@ catalog a new gap no one reviewed. Policy:
   The complexity is structural, not cognitive — the same pattern appears in
   `handleUsageMetrics`, `handleTurnStatus`, `handleResponse`, and
   `handleSystemMessage`, each with identical comment documentation.
-- **See**: `internal/agent/session/ui/dispatcher.go`
+- **See**: `internal/agent/session/ui/dispatcher.go:147`
 
 ### Acceptance Rationale (Shared)
 
@@ -944,7 +946,7 @@ to reason about.
   function with no cognitive benefit. Same acceptance class as `handleDomainEvent`
   (type-switch dispatch pattern where CC is structural, not from branching
   business logic).
-- **See**: `internal/ui/tui/progress/model.go:250`
+- **See**: `internal/ui/tui/progress/model.go:251`
 
 ### ui/tui/progress/renderer.go — (*renderer).makeSubscriber (CC=11)
 
@@ -1066,7 +1068,7 @@ to reason about.
   is a single-line delegation or return. Same acceptance class as
   `handleDomainEvent` (CC=12) and `(*model).Update` (CC=14) — structural
   dispatch where CC is switch/branch count, not branching business logic.
-- **See**: `internal/agent/orchestrator/engine_phases.go:105`
+- **See**: `internal/agent/orchestrator/engine_phases.go:124`
 
 ---
 
@@ -1100,13 +1102,13 @@ to reason about.
 
 - **Status**: ACCEPTED (2026-07)
 - **Rationale**: Sequential state-mutation test verifying text clearing and thought preservation through multiple update cycles. Steps are not independent — each mutates shared history state. Splitting would duplicate setup. Same acceptance class as `TestHistoryNavigation_CompleteWorkflow`.
-- **See**: `internal/infrastructure/history/history_test.go:1028`
+- **See**: `internal/infrastructure/history/history_test.go:1274`
 
 ### internal/infrastructure/history/history_test.go — TestUpdateTurnContent_AddTextWhenNone (CC=12)
 
 - **Status**: ACCEPTED (2026-07)
 - **Rationale**: Same sequential state-mutation pattern as `TestUpdateTurnContent_ClearText`, verifying the complementary code path. CC is assertion boilerplate across dependent steps.
-- **See**: `internal/infrastructure/history/history_test.go:1115`
+- **See**: `internal/infrastructure/history/history_test.go:1361`
 
 ### internal/domain/llm/capabilities_test.go — TestResolveCapabilities (CC=13)
 
@@ -1142,7 +1144,7 @@ to reason about.
 
 - **Status**: ACCEPTED (2026-07)
 - **Rationale**: Table-driven test with 5 subtests covering valid index, OOB negative, OOB pos, non-model role, and deep-copy isolation for `GetModelTurn`. Each subtest contains its own setup (temp dir, `NewManager`, `AddContent`). CC comes from subtest enumeration and assertion boilerplate, not branching business logic. Same acceptance class as `TestUpdateTurnContent_ClearText` (CC=12) and `TestUpdateTurnContent_AddTextWhenNone` (CC=12) in the same file.
-- **See**: `internal/infrastructure/history/history_test.go:1198`
+- **See**: `internal/infrastructure/history/history_test.go:1445`
 
 ### internal/infrastructure/history/history_test.go — TestHistoryManager_SetPinned_WithFunctionCall (CC=21)
 

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -602,7 +602,7 @@ func TestCheckComplexity_AllCataloged(t *testing.T) {
 
 	catalog := "### ui/tui/progress/model.go — handleDomainEvent (CC=12)\n\n" +
 		"- **Status**: ACCEPTED (2026-07)\n" +
-		"- **See**: `internal/ui/tui/progress/model.go:250`\n"
+		"- **See**: `internal/ui/tui/progress/model.go:251`\n"
 	path := filepath.Join(t.TempDir(), "INTENTIONAL_NON_FIXES.md")
 	if err := os.WriteFile(path, []byte(catalog), 0644); err != nil {
 		t.Fatalf("write fixture: %v", err)
@@ -612,7 +612,7 @@ func TestCheckComplexity_AllCataloged(t *testing.T) {
 		catalogPath: path,
 		complexity: &stubComplexityAnalyzer{
 			complexities: []funcComplexity{
-				{Name: "(*model).Update", Complexity: 14, FilePath: "internal/ui/tui/progress/model.go", Line: 250},
+				{Name: "(*model).Update", Complexity: 14, FilePath: "internal/ui/tui/progress/model.go", Line: 251},
 			},
 		},
 	}

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+//go:build arch
+
+package analysis
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	"github.com/stretchr/testify/require"
+)
+
+// TestVerifyNonFixCatalog is the partition gate for the Intentional Non-Fixes
+// catalog: it recomputes the real complexity alerts against the LIVE repo and
+// cross-references them against the live docs/architect/INTENTIONAL_NON_FIXES.md
+// catalog (uncapped, mirroring bucketComplexityAlerts internals). Every
+// over-threshold function must be pinned by an ACCEPTED catalog entry — the
+// only allowed alert is the known genuine gap (buildE2EBinary, CC=12).
+//
+// The go test binary runs with its working directory set to the package
+// source directory, so the walk root and the catalog path are anchored to
+// the module root via findModuleRoot() — the same precedent as
+// TestVerifyRealArchitecture — to exercise the live repository and the live
+// catalog regardless of invocation directory.
+func TestVerifyNonFixCatalog(t *testing.T) {
+	// Construct the real complexity analyzer exactly as production does
+	// (manager.go newAnalysisManager): plain OS filesystem, mock security.
+	analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, persistencetest.NewPlainOSFileSystem())
+
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	complexities, _, err := analyzer.GatherComplexities(ctx, repoRoot, nil)
+	require.NoError(t, err)
+
+	// Load the REAL, live catalog (relative to the module root, since the
+	// test binary's working directory is the package source directory).
+	entries, err := loadNonFixCatalog(filepath.Join(repoRoot, defaultNonFixCatalogPath))
+	require.NoError(t, err)
+
+	// Partition over-threshold functions into cataloged vs actionable,
+	// mirroring bucketComplexityAlerts internals but UNCAPPED (no 5-name
+	// truncation): a function is cataloged when an ACCEPTED entry pins its
+	// exact file:line; otherwise it is a genuine alert.
+	cataloged := make(map[string]funcComplexity)
+	var alerts []string
+	for _, c := range complexities {
+		if c.Complexity <= 10 {
+			continue
+		}
+		normalized := normalizeCatalogFilePath(c.FilePath, repoRoot)
+		if catalogTitleFor(entries, normalized, c.Line) != "" {
+			cataloged[c.Name] = funcComplexity{Line: c.Line, Complexity: c.Complexity, FilePath: normalized}
+			continue
+		}
+		alerts = append(alerts, c.Name)
+	}
+
+	expectedCataloged := map[string]funcComplexity{
+		"TestHistoryManager_SetPinned_WithFunctionCall":   {Line: 391, Complexity: 21, FilePath: "internal/infrastructure/history/history_test.go"},
+		"TestStartSpinnerLifecycle":                       {Line: 176, Complexity: 17, FilePath: "internal/ui/renderer_spinner_test.go"},
+		"TestGetModelTurn":                                {Line: 1445, Complexity: 16, FilePath: "internal/infrastructure/history/history_test.go"},
+		"TestPrepareMediaAssets_KimiURL_UploadsVideo":     {Line: 379, Complexity: 16, FilePath: "internal/infrastructure/llm/openai/files_test.go"},
+		"(*rootBrowserModel).handleActionKeys":            {Line: 294, Complexity: 15, FilePath: "internal/ui/tui/browser.go"},
+		"TestHistoryNavigation_CompleteWorkflow":          {Line: 161, Complexity: 15, FilePath: "tests/e2e/history_flags_test.go"},
+		"(*indexer).snapshot":                             {Line: 112, Complexity: 14, FilePath: "internal/tools/analysis/index_snapshot_test.go"},
+		"(*model).Update":                                 {Line: 251, Complexity: 14, FilePath: "internal/ui/tui/progress/model.go"},
+		"TestFixtureIndexer_ConstructAndHarvest":          {Line: 158, Complexity: 13, FilePath: "internal/tools/analysis/index_fixture_test.go"},
+		"TestHydrateMediaAssets":                          {Line: 243, Complexity: 13, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
+		"TestResolveCapabilities":                         {Line: 10, Complexity: 13, FilePath: "internal/domain/llm/capabilities_test.go"},
+		"assertMissingKeysResult":                         {Line: 211, Complexity: 13, FilePath: "internal/infrastructure/llm/factory_test.go"},
+		"(*RecoveryStep).Process":                         {Line: 124, Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go"},
+		"(*model).handleDomainEvent":                      {Line: 338, Complexity: 12, FilePath: "internal/ui/tui/progress/model.go"},
+		"TestDeadCodeAnalyzer_Precision":                  {Line: 177, Complexity: 12, FilePath: "internal/tools/analysis/precision_test.go"},
+		"TestHistoryManager_SetPinned_ViaModelID":         {Line: 493, Complexity: 12, FilePath: "internal/infrastructure/history/history_test.go"},
+		"TestRecoveryStep_EmptyResponse_RetriesUpToLimit": {Line: 531, Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases_test.go"},
+		"TestUpdateTurnContent_AddTextWhenNone":           {Line: 1361, Complexity: 12, FilePath: "internal/infrastructure/history/history_test.go"},
+		"TestUpdateTurnContent_ClearText":                 {Line: 1274, Complexity: 12, FilePath: "internal/infrastructure/history/history_test.go"},
+		"TestVision_KimiImagePayload":                     {Line: 128, Complexity: 12, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
+		"createPrecisionWorkspace":                        {Line: 118, Complexity: 12, FilePath: "internal/tools/analysis/precision_test.go"},
+		"renderHistory":                                   {Line: 26, Complexity: 12, FilePath: "internal/ui/history.go"},
+		"(*renderer).makeSubscriber":                      {Line: 48, Complexity: 11, FilePath: "internal/ui/tui/progress/renderer.go"},
+		"TestMediaBlocks":                                 {Line: 18, Complexity: 11, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
+		"TestRunCommand_NonExitErrorWaitPath":             {Line: 817, Complexity: 11, FilePath: "internal/tools/workspace/process_executor_stream_test.go"},
+	}
+
+	require.Equal(t, expectedCataloged, cataloged)
+	require.Equal(t, []string{"buildE2EBinary"}, alerts)
+}


### PR DESCRIPTION
Closes #1297.

## Summary
Corrected premise: `get_code_health` reads `INTENTIONAL_NON_FIXES.md` live (no static exclusion list) — the surfacing alerts were **6 live drift signals + 1 genuine**, hidden behind the `bucketComplexityAlerts` display cap of 5.

**Catalog data fix — 8 pins re-anchored** (the issue listed 7; the Architect's re-verification found an 8th):
- 3 history_test.go pins corrected **+84 beyond the issue's stale table** (1274/1361/1445) — #1301 merged 84 lines after the issue was written
- `(*RecoveryStep).Process` 105→124 — drifted by #1302's 19 production lines (the unlisted 8th pin)
- `(*model).Update` 250→251, `handleDomainEvent` bare→:338, `TestHistoryNavigation_CompleteWorkflow` 142→161, `handleToolEvents` bare→:147

**New gate — `verify-nonfix-catalog`** (`internal/tools/analysis/real_nonfix_catalog_test.go`, `//go:build arch`):
- Loads the real catalog + runs real `GatherComplexities`, asserts the post-fix partition **by name**: 25 cataloged × (line, recorded CC) + 1 alert (`buildE2EBinary` — the live canary)
- **RED-first**: landed failing against the drifted catalog (18/25, 8 alerts), turned GREEN with the pin edits
- Asserts line AND recorded CC — mechanizes both drift-policy clauses (re-anchor + re-measure)
- Wired into `check`/`check-full` (NOT `make test` — arch tag excludes it from `go test ./...`)

**Fixture + policy**: `TestCheckComplexity_AllCataloged` fixture corrected (250→251); Drift Policy gains the enforcement-boundary and coordination-rule bullets.

## Verification
| Check | Status |
|-------|--------|
| RED-first demonstrated (gate failed pre-pins, green post-pins) | PASS |
| `make verify-nonfix-catalog` | PASS |
| `go test ./internal/tools/analysis` (non-arch) | PASS |
| make check-full (all 10 steps incl. race) | PASS |
| Scope: catalog data + test code + Makefile only — zero production Go files (ADR-054 containment) | PASS |

## Notes
- Two accepted deviations (Architect-reviewed): gate anchors to `findModuleRoot()` (`go test` CWD = package dir); pin set 7→8 (re-anchor of an existing ACCEPTED pin, within the #1303 scope guard)
- Known intended output change: `applyCatalogTitles` will tag `model.go:251`, `model.go:338`, `dispatcher.go:147` as ACCEPTED — accepted per issue Impact
- Follow-up matcher-robustness issue can now proceed with the pin-canary in place