### PR TITLE
test(history)+docs: patch-accumulation evidence benchmark and compaction-trigger narrative (#1298)

### DIFF
--- a/docs/domain-model/tell-me-go.modelith.md
+++ b/docs/domain-model/tell-me-go.modelith.md
@@ -96,7 +96,7 @@ The in-flight prompt payload assembled by the `Orchestrator` before each `Turn`.
 
 ### `History`
 
-The persisted record of a `Session`'s `Turn`s, stored as an append-only JSON Lines file (`history.jsonl`) with an incremental patch system for metadata updates (e.g. pinning). Older `Turn`s that have been summarised are moved to a separate archive file (`history.archive.jsonl`) to keep the in-memory working set bounded. The archive supports O(1) lazy navigation via byte-offset indexing (`file.Seek`) — it is never loaded fully into memory. Patches are merged into clean base records during compaction (triggered by `save` or `rollback`). Separate from the in-memory `Session` state.
+The persisted record of a `Session`'s `Turn`s, stored as an append-only JSON Lines file (`history.jsonl`) with an incremental patch system for metadata updates (e.g. pinning). Older `Turn`s that have been summarised are moved to a separate archive file (`history.archive.jsonl`) to keep the in-memory working set bounded. The archive supports O(1) lazy navigation via byte-offset indexing (`file.Seek`) — it is never loaded fully into memory. Patches are merged into clean base records during compaction (triggered by `save`, `rollback`, `edit`, and per-turn pipeline rewrites). Separate from the in-memory `Session` state.
 
 **Attributes**
 

--- a/docs/domain-model/tell-me-go.modelith.yaml
+++ b/docs/domain-model/tell-me-go.modelith.yaml
@@ -535,7 +535,7 @@ entities:
       the in-memory working set bounded. The archive supports O(1) lazy
       navigation via byte-offset indexing (`file.Seek`) — it is never loaded
       fully into memory. Patches are merged into clean base records during
-      compaction (triggered by `save` or `rollback`). Separate from the
+      compaction (triggered by `save`, `rollback`, `edit`, and per-turn pipeline rewrites). Separate from the
       in-memory `Session` state.
     attributes:
       - name: turns

--- a/internal/infrastructure/history/store_bench_test.go
+++ b/internal/infrastructure/history/store_bench_test.go
@@ -168,3 +168,42 @@ func BenchmarkJSONLStoreSave(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkJSONLStoreLoadWithPatches measures jsonlStore.Load latency with
+// _patch lines overlaid on a seeded base — the replay cost of accumulated
+// pin/append-parts patches (issue #1298, Finding 9). Sub-benchmarks vary
+// patch counts (0 = raw decode baseline, 50, 200) on a fixed 1000-line base.
+func BenchmarkJSONLStoreLoadWithPatches(b *testing.B) {
+	const baseSize = 1000
+	patchCounts := []int{0, 50, 200}
+	for _, patches := range patchCounts {
+		b.Run(fmt.Sprintf("patches=%d", patches), func(b *testing.B) {
+			ctx := context.Background()
+			tmpDir := b.TempDir()
+			fs := persistencetest.NewPlainOSFileSystem()
+			filePath := filepath.Join(tmpDir, "history.jsonl")
+			archivePath := filepath.Join(tmpDir, "archive.jsonl")
+
+			store := newJSONLStore(fs, filePath, archivePath)
+			seed := generateContents(baseSize)
+			if err := store.Save(ctx, seed); err != nil {
+				b.Fatalf("seed Save failed: %v", err)
+			}
+			// Overlay _patch lines via the real pin write path (UpdateMetadata),
+			// one line per call. Setup runs once, outside the timer.
+			for i := 0; i < patches; i++ {
+				if err := store.UpdateMetadata(ctx, i%baseSize, map[string]interface{}{"pinned": true}); err != nil {
+					b.Fatalf("patch overlay failed: %v", err)
+				}
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if _, err := store.Load(ctx); err != nil {
+					b.Fatalf("Load failed: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1298.

## Summary
Issue #1298 is a **wontfix-with-evidence** record (patch accumulation is bounded by pin behavior, not turn count — no production mechanism warranted). This PR ships its two actionable residue items:

1. **Benchmark (test-only)** — `BenchmarkJSONLStoreLoadWithPatches` in `store_bench_test.go`: seeds a 1000-line base, overlays 0/50/200 `_patch` lines via the real pin write path (`UpdateMetadata`), measures `Load`. Converts Finding 9's claim into measured evidence: **marginal replay cost of 200 patches ≈ 383–400 µs** (hundreds-of-µs as claimed; ~157 KB / ~2,600 allocs).

2. **Domain-model narrative** — `History` compaction triggers corrected from "save or rollback" to "`save`, `rollback`, `edit`, and per-turn pipeline rewrites" (the actual status quo per Finding 8(d1)); `.md` re-rendered via modelith and committed together with the `.yaml`.

## Verification
| Check | Status |
|-------|--------|
| Benchmark compiles + runs (patches=0: 2.47ms, 50: 2.73ms, 200: 2.88ms) | PASS |
| `make modelith-lint` (0 errors, 0 warnings) | PASS |
| `make modelith-check` (all 3 models up to date) | PASS |
| make check-full (all 10 steps incl. race) | PASS |
| Scope: test-only + docs; zero production code; no ADR | PASS |

No behavior change — the wontfix decision is now backed by reproducible evidence.