### PR TITLE
refactor(analysis): inject persistence.FileSystem into transaction; add ADR-055 (#1295, PR1)

### DIFF
--- a/docs/adr/2026-08-tools-filesystem-injection.md
+++ b/docs/adr/2026-08-tools-filesystem-injection.md
@@ -1,0 +1,60 @@
+# ADR-055: Tools-Layer Filesystem Access via Injected Domain Port (defaultFS Fallback)
+
+**Status:** Accepted
+**Date:** 2026-08-08
+**Related:** [Issue #1295](https://github.com/gosharplite/tell-me-go/issues/1295) (PR1: analysis transaction port-routing; PR2: workspace convention + import gate), [ADR-034](2026-05-cosmetic-lint-fix-pr-separation.md) (cited for sequencing only), `docs/sop/technical/architecture_and_packages.md`
+
+## Context
+
+Two production files in `internal/tools/` — `internal/tools/analysis/refactor.go` and `internal/tools/workspace/process_executor.go` — were the only production files in the tools layer importing `internal/infrastructure/persistence`. Each constructed `infra_persistence.NewOSFileSystem()` directly, building an infrastructure adapter inside the tools (application use-case) layer.
+
+The corrected framing: the DI thread already exists end-to-end. `ToolRegistrationParams.FileSystem` (`internal/tools/tools.go`) is populated in `internal/infrastructure/di/toolchain_factory.go` (`FileSystem: infra_persistence.NewDomainFS(f.FileSystem)`) and passed into `workspace.Register` and `analysis.Register`. The real defect was **two dropped parameters**:
+
+- `analysis/manager.go` → `newRefactorManager(sp)` dropped `fs` → `newTransaction()` self-constructed the adapter.
+- `workspace/registration.go` → `registerSystem(...)` (no `fs` param) → `newshellTool(...)` → `newprocessExecutor()` self-constructed the adapter.
+
+This is a package-boundary refactoring (ADR trigger #2: Domain vs. Infrastructure) that introduces a new design pattern (ADR trigger #3): the injection convention with a named `defaultFS` fallback.
+
+**ADR-034 is cited for sequencing only.** Its "cosmetic" definition does NOT cover this change — the dependency graph is altered.
+
+## Decision
+
+### 1. Injection convention + `defaultFS` fallback + seam panic
+
+Every live tool path uses the injected domain port (`persistence.FileSystem`). Direct adapter construction in tools is confined to exactly one sanctioned `default_fs.go` fallback per package (`internal/tools/analysis/default_fs.go`, `internal/tools/workspace/default_fs.go`), holding `var defaultFS = infra_persistence.NewOSFileSystem()`. The zero-arg `newTransaction()` remains and delegates to `defaultFS`; the injected path goes through `newTransactionWithFS(fs)`, which panics on nil with an actionable message ("use newTransaction() for the default") — a contract-violation guard on a test-reachable seam (in production the hub guarantees non-nil). An import-based gate (`verify-tools-adapter-import`, landing with PR2) enforces that no other tools production file imports `internal/infrastructure/persistence`.
+
+### 2. `Commit` → `AtomicWrite` semantics
+
+`transaction.Commit` (analysis) now buffers each formatted file and writes via `tx.fs.AtomicWrite(ctx, path, buf.Bytes(), 0644)` instead of hand-rolling a fixed-name `.tmp` + `os.Rename` sequence. This changes write semantics on a core path:
+
+- **Permissions tighten from `0666` to `0644`** (regression-visible; deliberate). `0644` matches the existing tools precedent (`workspace/backup.go`, `integrations/media.go`).
+- **fsync**: `AtomicWrite` syncs the temp file before rename (guards against zero-byte files on power loss).
+- **Retry**: rename retries up to 5 attempts with linear backoff on transient failures.
+- **EXDEV**: cross-device rename falls back to copy + remove.
+- **Windows transient-rename handling**: "Access is denied" / "used by another process" (non-directory target) is retried instead of failing `rename_symbol` / `move_definition`.
+- **Context cancellation** aborts mid-commit (checked before write, before sync, and in the retry loop) instead of writing against a cancelled context.
+- Cross-file partial-commit semantics are unchanged: per-file atomic writes; earlier files stay committed on a mid-commit failure (same as before).
+
+### 3. `LoadFile` port-routing
+
+`transaction.LoadFile(ctx, path)` reads via `tx.fs.ReadFile(ctx, path)` and parses the returned bytes — completing the transaction's read path through the port.
+
+### 4. Non-goals
+
+- `loadGoFilesForRename`'s `filepath.Glob` discovery stays OS-bound — the domain port has no `Glob`; a `ReadDir`+matcher is new code, out of scope. Memory-FS testability covers the transaction's read/write paths only.
+- Shape B (full port-routing of the `processExecutor` write path in workspace) is rejected — out of scope, separate ADR'd issue if ever wanted.
+- Swap-validation desync: the write path is swappable; validation remains OS-bound by design.
+
+## Consequences
+
+- **Positive**: the transaction is unit-testable against an in-memory filesystem (`persistence.NewMockFileSystem`) — a proof-property test (`TestTransaction_MemoryFS_LoadTransformCommit`) fails against pre-change code and passes post-change; Windows `rename_symbol`/`move_definition` no longer fail on transient rename errors; context cancellation is honored mid-commit; adapter construction in tools is confined to one named fallback per package, mechanically gated.
+- **Regression-visible**: file permissions written by the analysis transaction tighten from umask-dependent `0666` to exact `0644` — deliberate, documented here.
+- **Memory profile**: the whole formatted file is buffered in memory instead of streaming into an fd — non-issue for Go sources (`format.Node` already holds the AST).
+- **Factual note on workspace**: the workspace changes (PR2) are **zero-runtime-delta by design** — the value is the boundary rule and its gate, not behavior.
+- **SafePath**: injection makes `fs` a zero-friction registered dependency in `ToolRegistrationParams`; SafePath-before-write is enforced by convention and domain-model invariants, not by the injection mechanism. No new unvalidated write path is created — validation precedes FS use in both paths today and remains.
+- **Plugin contract**: unchanged. `plugin.go` already ships `PluginDependencies.FileSystem persistence.FileSystem`; third-party plugins live outside the module and the gate cannot see them.
+
+## Related
+
+- `docs/sop/technical/architecture_and_packages.md` — tools-layer boundary rule (see Step 3)
+- [ADR-034](2026-05-cosmetic-lint-fix-pr-separation.md) — sequencing reference only

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -60,6 +60,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-052** | DeepSeek/Kimi Thinking Mode Toggle and user_id Isolation | 2026-07 | Accepted | [2026-07-deepseek-thinking-toggle.md](2026-07-deepseek-thinking-toggle.md) |
 | **ADR-053** | Remove `get_cost_summary` Tool and DailyCost Metric — Deprecate the Global Cost Ledger | 2026-08 | Accepted | [2026-08-remove-get-cost-summary-and-daily-cost-metric.md](2026-08-remove-get-cost-summary-and-daily-cost-metric.md) |
 | **ADR-054** | Catalog Cross-Reference Contract for Coverage & Complexity Reports | 2026-08 | Accepted | [2026-08-catalog-cross-reference-reporting-contract.md](2026-08-catalog-cross-reference-reporting-contract.md) |
+| **ADR-055** | Tools-Layer Filesystem Access via Injected Domain Port (defaultFS Fallback) | 2026-08 | Accepted | [2026-08-tools-filesystem-injection.md](2026-08-tools-filesystem-injection.md) |
 
 ## How to Create a New ADR
 

--- a/docs/sop/technical/architecture_and_packages.md
+++ b/docs/sop/technical/architecture_and_packages.md
@@ -68,6 +68,7 @@ The project is organized into the following top-level directories:
 - **Constructor Pattern**: Use `New<StructName>` functions to initialize packages (e.g., `func NewClient(apiKey string) *Client`).
 - **Interfaces**: Define interfaces at the *consumer* side to enable easy mocking in tests.
 - **Avoid Globals**: Do not use global variables for state. Pass dependencies explicitly via constructors.
+- **Tools-Layer Filesystem Boundary**: Tools-layer packages must not import `internal/infrastructure/persistence` except the two `default_fs.go` files (`internal/tools/analysis/default_fs.go`, `internal/tools/workspace/default_fs.go`), enforced by the `verify-tools-adapter-import` gate (ADR-055). Every live tool path uses the injected domain port (`persistence.FileSystem`); the named `defaultFS` fallback is the only sanctioned adapter construction site per package.
 
 ---
 

--- a/internal/tools/analysis/default_fs.go
+++ b/internal/tools/analysis/default_fs.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+// defaultFS is the single sanctioned construction site for the OS
+// filesystem adapter in this package (issue #1295, ADR-055). Every live
+// tool path uses the injected domain port (persistence.FileSystem); this
+// fallback exists so the zero-arg newTransaction() keeps working for
+// call sites that predate injection. Do not add further
+// internal/infrastructure/persistence imports to production files in this
+// package — the verify-tools-adapter-import gate (PR2) enforces the
+// boundary.
+var defaultFS = infra_persistence.NewOSFileSystem()

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -87,7 +87,7 @@ func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Man
 		types:      newTypeManager(idx, cache, sp, fs),
 		deadCode:   dc,
 
-		refactor: newRefactorManager(sp),
+		refactor: newRefactorManager(fs, sp),
 		info:     &infoManager{SP: sp, Cache: cache, FS: fs, Events: bus, Runner: runner, Policy: wp, clk: clock.RealClock{}},
 		search:   &searchManager{SP: sp, FS: fs, Policy: wp},
 		arch:     &architectureManager{SP: sp, Runner: runner, idx: idx, clk: clock.RealClock{}},

--- a/internal/tools/analysis/refactor.go
+++ b/internal/tools/analysis/refactor.go
@@ -1,16 +1,15 @@
 package analysis
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"go/ast"
 	"go/format"
 	"go/parser"
 	"go/token"
-	"os"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
-	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 // transform represents a single code transformation.
@@ -27,10 +26,22 @@ type transaction struct {
 }
 
 func newTransaction() *transaction {
+	return newTransactionWithFS(defaultFS)
+}
+
+// newTransactionWithFS constructs a transaction bound to an explicitly
+// injected filesystem. nil is a contract violation: use newTransaction()
+// for the package default (defaultFS). In production the DI hub always
+// provides a non-nil persistence.FileSystem; the panic guards test-reachable
+// seams and misuse.
+func newTransactionWithFS(fs persistence.FileSystem) *transaction {
+	if fs == nil {
+		panic("nil FileSystem to newTransactionWithFS: use newTransaction() for the default")
+	}
 	return &transaction{
 		fset:  token.NewFileSet(),
 		files: make(map[string]*ast.File),
-		fs:    infra_persistence.NewOSFileSystem(),
+		fs:    fs,
 	}
 }
 
@@ -45,31 +56,13 @@ func (tx *transaction) Commit(ctx context.Context) error {
 		}
 	}
 
-	var writtenFiles []string
 	for path, file := range tx.files {
-		tmpPath := path + ".tmp"
-		f, err := tx.fs.OpenFile(ctx, tmpPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
-		if err != nil {
-			tx.rollback(writtenFiles)
-			return fmt.Errorf("create temp file %s: %w", tmpPath, err)
-		}
-		if err := tx.safeFormat(f, file); err != nil {
-			_ = f.Close()
-			_ = os.Remove(tmpPath)
-			tx.rollback(writtenFiles)
+		var buf bytes.Buffer
+		if err := tx.safeFormat(&buf, file); err != nil {
 			return fmt.Errorf("format %s: %w", path, err)
 		}
-		_ = f.Close()
-		writtenFiles = append(writtenFiles, path)
-	}
-
-	for i, path := range writtenFiles {
-		if err := os.Rename(path+".tmp", path); err != nil {
-			// Clean up remaining .tmp files from this point onward
-			for _, p := range writtenFiles[i:] {
-				_ = os.Remove(p + ".tmp")
-			}
-			return fmt.Errorf("failed to finalize %s: %w", path, err)
+		if err := tx.fs.AtomicWrite(ctx, path, buf.Bytes(), 0644); err != nil {
+			return fmt.Errorf("atomic write %s: %w", path, err)
 		}
 	}
 
@@ -89,18 +82,17 @@ func (tx *transaction) safeFormat(w interface {
 	return format.Node(w, tx.fset, file)
 }
 
-func (tx *transaction) rollback(writtenFiles []string) {
-	for _, path := range writtenFiles {
-		_ = os.Remove(path + ".tmp")
-	}
-}
-
-func (tx *transaction) LoadFile(path string) (*ast.File, error) {
+func (tx *transaction) LoadFile(ctx context.Context, path string) (*ast.File, error) {
 	if f, ok := tx.files[path]; ok {
 		return f, nil
 	}
 
-	f, err := parser.ParseFile(tx.fset, path, nil, parser.ParseComments)
+	data, err := tx.fs.ReadFile(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+
+	f, err := parser.ParseFile(tx.fset, path, data, parser.ParseComments)
 	if err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
 	}

--- a/internal/tools/analysis/refactor_manager.go
+++ b/internal/tools/analysis/refactor_manager.go
@@ -6,16 +6,18 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
 type refactorManager struct {
+	fs persistence.FileSystem
 	SP refactorSecurity
 }
 
-func newRefactorManager(sp refactorSecurity) *refactorManager {
-	return &refactorManager{SP: sp}
+func newRefactorManager(fs persistence.FileSystem, sp refactorSecurity) *refactorManager {
+	return &refactorManager{fs: fs, SP: sp}
 }
 
 func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
@@ -47,11 +49,11 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 	plan.SrcFile = resolvedSrc
 	plan.DstFile = resolvedDst
 
-	tx := newTransaction()
-	if _, err := tx.LoadFile(plan.SrcFile); err != nil {
+	tx := newTransactionWithFS(m.fs)
+	if _, err := tx.LoadFile(ctx, plan.SrcFile); err != nil {
 		return tools.ToolResult{}, fmt.Errorf("move definition load src %s: %w", plan.SrcFile, err)
 	}
-	if _, err := tx.LoadFile(plan.DstFile); err != nil {
+	if _, err := tx.LoadFile(ctx, plan.DstFile); err != nil {
 		return tools.ToolResult{}, fmt.Errorf("move definition load dst %s: %w", plan.DstFile, err)
 	}
 
@@ -69,7 +71,7 @@ func (m *refactorManager) MoveDefinition(ctx context.Context, args map[string]in
 // loadGoFilesForRename discovers all Go source files in resolvedDir, loads
 // them into a new transaction, and returns the file list and transaction.
 // Callers own the responsibility of adding transforms and committing.
-func (m *refactorManager) loadGoFilesForRename(resolvedDir string) ([]string, *transaction, error) {
+func (m *refactorManager) loadGoFilesForRename(ctx context.Context, resolvedDir string) ([]string, *transaction, error) {
 	goFiles, err := filepath.Glob(filepath.Join(resolvedDir, "*.go"))
 	if err != nil {
 		return nil, nil, fmt.Errorf("glob %s: %w", resolvedDir, err)
@@ -78,9 +80,9 @@ func (m *refactorManager) loadGoFilesForRename(resolvedDir string) ([]string, *t
 		return nil, nil, fmt.Errorf("no .go files found in %s", resolvedDir)
 	}
 
-	tx := newTransaction()
+	tx := newTransactionWithFS(m.fs)
 	for _, f := range goFiles {
-		if _, err := tx.LoadFile(f); err != nil {
+		if _, err := tx.LoadFile(ctx, f); err != nil {
 			return nil, nil, fmt.Errorf("load %s: %w", filepath.Base(f), err)
 		}
 	}
@@ -108,7 +110,7 @@ func (m *refactorManager) RenameSymbol(ctx context.Context, args map[string]inte
 	}
 
 	// Discover and load all Go source files into a transaction.
-	goFiles, tx, err := m.loadGoFilesForRename(resolvedDir)
+	goFiles, tx, err := m.loadGoFilesForRename(ctx, resolvedDir)
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("rename symbol %s→%s: %w", params.OldName, params.NewName, err)
 	}

--- a/internal/tools/analysis/refactor_manager_test.go
+++ b/internal/tools/analysis/refactor_manager_test.go
@@ -68,7 +68,7 @@ func TestMoveDefinition(t *testing.T) {
 				return "", fmt.Errorf("error")
 			},
 		}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"symbol":   "MyFunc",
 			"src_file": "src.go",
@@ -168,7 +168,7 @@ func setupMoveWorkspace(t *testing.T, files map[string]string) (*refactorManager
 	}
 
 	sp := &refactorMockSecurityProvider{}
-	return newRefactorManager(sp), tmpDir
+	return newRefactorManager(defaultFS, sp), tmpDir
 }
 
 func verifyFileContent(t *testing.T, path string, expectedContains []string, expectedAbsent []string) {
@@ -307,7 +307,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 	t.Run("UnmarshalArgs error", func(t *testing.T) {
 		t.Parallel()
 		sp := &refactorMockSecurityProvider{}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		_, err := mgr.MoveDefinition(ctx, map[string]interface{}{"symbol": make(chan int)}, nil)
 		require.Error(t, err)
 	})
@@ -324,7 +324,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 				return path, nil
 			},
 		}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"symbol":   "MyFunc",
 			"src_file": "src.go",
@@ -339,7 +339,7 @@ func TestMoveDefinition_ErrorPaths(t *testing.T) {
 	t.Run("src file load error", func(t *testing.T) {
 		t.Parallel()
 		sp := &refactorMockSecurityProvider{}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"symbol":   "MyFunc",
 			"src_file": "/nonexistent/src.go",
@@ -377,7 +377,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 	t.Run("UnmarshalArgs error", func(t *testing.T) {
 		t.Parallel()
 		sp := &refactorMockSecurityProvider{}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		_, err := mgr.RenameSymbol(ctx, map[string]interface{}{"old_name": make(chan int)}, nil)
 		require.Error(t, err)
 	})
@@ -389,7 +389,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 				return "", fmt.Errorf("path not writable")
 			},
 		}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"old_name": "Foo",
 			"new_name": "Bar",
@@ -406,7 +406,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 		t.Parallel()
 		emptyDir := t.TempDir()
 		sp := &refactorMockSecurityProvider{}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"old_name": "Foo",
 			"new_name": "Bar",
@@ -427,7 +427,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(brokenPath, []byte("package test\nfunc broken() {"), 0644))
 
 		sp := &refactorMockSecurityProvider{}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"old_name": "Foo",
 			"new_name": "Bar",
@@ -451,7 +451,7 @@ func TestRenameSymbol_ErrorPaths(t *testing.T) {
 				return dir, nil
 			},
 		}
-		mgr := newRefactorManager(sp)
+		mgr := newRefactorManager(defaultFS, sp)
 		args := map[string]interface{}{
 			"old_name": "Foo",
 			"new_name": "Bar",
@@ -488,10 +488,10 @@ func TestLoadGoFilesForRename_GlobError(t *testing.T) {
 	t.Parallel()
 
 	sp := &refactorMockSecurityProvider{}
-	mgr := newRefactorManager(sp)
+	mgr := newRefactorManager(defaultFS, sp)
 
 	// Use a path with unclosed glob metacharacter to trigger Glob error
-	_, _, err := mgr.loadGoFilesForRename("/tmp/[invalid")
+	_, _, err := mgr.loadGoFilesForRename(context.Background(), "/tmp/[invalid")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "glob")
 }

--- a/internal/tools/analysis/refactor_test.go
+++ b/internal/tools/analysis/refactor_test.go
@@ -19,15 +19,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// createErrorFS wraps a persistence.FileSystem and overrides OpenFile to
-// return an error, simulating a file-creation failure without OS-specific
-// tricks like os.Chmod(0500).
-type createErrorFS struct {
+// atomicWriteErrorFS wraps a persistence.FileSystem and overrides
+// AtomicWrite to return an error, simulating an atomic-write failure
+// without OS-specific tricks like os.Chmod(0500).
+type atomicWriteErrorFS struct {
 	persistence.FileSystem
 }
 
-func (f *createErrorFS) OpenFile(ctx context.Context, name string, flag int, perm os.FileMode) (persistence.File, error) {
-	return nil, fs.ErrPermission
+func (f *atomicWriteErrorFS) AtomicWrite(ctx context.Context, name string, data []byte, perm os.FileMode) error {
+	return fs.ErrPermission
 }
 
 type mockTransform struct {
@@ -48,7 +48,7 @@ func TestTransaction_Commit(t *testing.T) {
 	}
 
 	tx := newTransaction()
-	_, err := tx.LoadFile(path)
+	_, err := tx.LoadFile(context.Background(), path)
 	if err != nil {
 		t.Fatalf("LoadFile failed: %v", err)
 	}
@@ -79,24 +79,10 @@ func TestTransaction_Commit(t *testing.T) {
 	}
 }
 
-func TestTransaction_Rollback(t *testing.T) {
-	t.Parallel()
-	tx := newTransaction()
-	path := filepath.Join(t.TempDir(), "test_rollback.txt")
-	_ = os.WriteFile(path+".tmp", []byte("temp"), 0644)
-	defer func() { _ = os.Remove(path + ".tmp") }()
-
-	tx.rollback([]string{path})
-
-	if _, err := os.Stat(path + ".tmp"); !os.IsNotExist(err) {
-		t.Error("expected temp file to be removed after rollback")
-	}
-}
-
 func TestTransaction_LoadFile_Error(t *testing.T) {
 	t.Parallel()
 	tx := newTransaction()
-	_, err := tx.LoadFile("non_existent.go")
+	_, err := tx.LoadFile(context.Background(), "non_existent.go")
 	if err == nil {
 		t.Error("expected error loading non-existent file")
 	}
@@ -107,18 +93,18 @@ func TestTransaction_LoadFile_CachedReturn(t *testing.T) {
 	tx := newTransaction()
 
 	// First call: parses the file
-	f1, err := tx.LoadFile("testdata/valid.go")
+	f1, err := tx.LoadFile(context.Background(), "testdata/valid.go")
 	// If testdata/valid.go doesn't exist, create a temp file
 	if err != nil {
 		// Use a temp file instead
 		tmpDir := t.TempDir()
 		path := tmpDir + "/valid.go"
 		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
-		f1, err = tx.LoadFile(path)
+		f1, err = tx.LoadFile(context.Background(), path)
 		require.NoError(t, err)
 
 		// Second call with same path: should return cached file
-		f2, err := tx.LoadFile(path)
+		f2, err := tx.LoadFile(context.Background(), path)
 		require.NoError(t, err)
 		if f1 != f2 {
 			t.Error("LoadFile must return the same *ast.File pointer on cache hit")
@@ -128,7 +114,7 @@ func TestTransaction_LoadFile_CachedReturn(t *testing.T) {
 	require.NoError(t, err)
 
 	// Second call with same path: should return cached file (same pointer)
-	f2, err := tx.LoadFile("testdata/valid.go")
+	f2, err := tx.LoadFile(context.Background(), "testdata/valid.go")
 	require.NoError(t, err)
 
 	if f1 != f2 {
@@ -145,7 +131,7 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
 
 		tx := newTransaction()
-		_, err := tx.LoadFile(path)
+		_, err := tx.LoadFile(context.Background(), path)
 		require.NoError(t, err)
 
 		// Corrupt AST so format.Node fails
@@ -181,7 +167,7 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
 
 		tx := newTransaction()
-		_, err := tx.LoadFile(path)
+		_, err := tx.LoadFile(context.Background(), path)
 		require.NoError(t, err)
 
 		tx.Add(&mockTransform{
@@ -201,7 +187,7 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 
 		err = tx.Commit(context.Background())
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to finalize")
+		assert.Contains(t, err.Error(), "failed to rename temp file")
 
 		// .tmp cleaned (rollback)
 		_, statErr := os.Stat(path + ".tmp")
@@ -215,7 +201,7 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
 
 		tx := newTransaction()
-		_, err := tx.LoadFile(path)
+		_, err := tx.LoadFile(context.Background(), path)
 		require.NoError(t, err)
 
 		tx.Add(&mockTransform{
@@ -230,15 +216,20 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		assert.Contains(t, err.Error(), "simulated transform failure")
 	})
 
-	t.Run("create_temp_file_error_is_wrapped", func(t *testing.T) {
+	t.Run("atomic_write_error_is_wrapped", func(t *testing.T) {
 		t.Parallel()
-		tmpDir := t.TempDir()
-		path := filepath.Join(tmpDir, "test.go")
-		require.NoError(t, os.WriteFile(path, []byte("package p\n\nfunc F() {}\n"), 0644))
+		ctx := context.Background()
+		path := filepath.Join(t.TempDir(), "test.go")
+		content := []byte("package p\n\nfunc F() {}\n")
+
+		// LoadFile reads through the injected FS, so the mock must hold
+		// the source before the AtomicWrite failure is exercised.
+		mfs := persistence.NewMockFileSystem()
+		require.NoError(t, mfs.WriteFile(ctx, path, content, 0644))
 
 		tx := newTransaction()
-		tx.fs = &createErrorFS{FileSystem: persistence.NewMockFileSystem()}
-		_, err := tx.LoadFile(path)
+		tx.fs = &atomicWriteErrorFS{FileSystem: mfs}
+		_, err := tx.LoadFile(ctx, path)
 		require.NoError(t, err)
 
 		tx.Add(&mockTransform{
@@ -247,10 +238,9 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 			},
 		})
 
-		err = tx.Commit(context.Background())
+		err = tx.Commit(ctx)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "create temp file")
-		assert.Contains(t, err.Error(), ".tmp")
+		assert.Contains(t, err.Error(), "atomic write")
 	})
 
 	t.Run("load_file_parse_error_is_wrapped", func(t *testing.T) {
@@ -260,7 +250,7 @@ func TestTransaction_Commit_ErrorPaths(t *testing.T) {
 		require.NoError(t, os.WriteFile(path, []byte("not valid go {{{"), 0644))
 
 		tx := newTransaction()
-		_, err := tx.LoadFile(path)
+		_, err := tx.LoadFile(context.Background(), path)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "parse")
 		assert.Contains(t, err.Error(), "broken.go")

--- a/internal/tools/analysis/transaction_memoryfs_test.go
+++ b/internal/tools/analysis/transaction_memoryfs_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"context"
+	"go/ast"
+	"go/token"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTransaction_MemoryFS_LoadTransformCommit is the PROOF PROPERTY for
+// issue #1295 PR1: the transaction's read and write paths must be fully
+// routed through the injected persistence.FileSystem port.
+//
+// Against pre-change code this test FAILS: LoadFile parses the real disk,
+// so the in-memory path cannot be read (the transaction was OS-bound).
+// Post-change, LoadFile reads via tx.fs.ReadFile and Commit writes via
+// tx.fs.AtomicWrite, so the full Load -> Transform -> Commit cycle runs
+// against the in-memory filesystem. Scope is the transaction unit only —
+// NOT the tools (RenameSymbol/MoveDefinition stay OS-bound via Glob).
+func TestTransaction_MemoryFS_LoadTransformCommit(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mfs := persistence.NewMockFileSystem()
+	tx := newTransactionWithFS(mfs)
+
+	const path = "memory:/src/main.go"
+	const content = "package main\n\nfunc main() {}\n"
+	require.NoError(t, mfs.WriteFile(ctx, path, []byte(content), 0644))
+
+	// Read path: must come from the injected FS, not the OS.
+	f, err := tx.LoadFile(ctx, path)
+	require.NoError(t, err, "LoadFile must parse through the injected FileSystem")
+	require.NotNil(t, f)
+
+	// Transform: no-op that succeeds (round-trips the parsed file).
+	tx.Add(&mockTransform{
+		applyFn: func(ctx context.Context, fset *token.FileSet, files map[string]*ast.File) error {
+			return nil
+		},
+	})
+
+	// Write path: must go through tx.fs.AtomicWrite, not OpenFile on the OS.
+	require.NoError(t, tx.Commit(ctx), "Commit must write through the injected FileSystem")
+
+	got, err := mfs.ReadFile(ctx, path)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), "package main")
+	assert.Contains(t, string(got), "func main()")
+}
+
+// TestNewTransactionWithFS_NilPanics pins the contract-violation guard on
+// the injection seam (ADR-055: use newTransaction() for the default).
+func TestNewTransactionWithFS_NilPanics(t *testing.T) {
+	t.Parallel()
+	require.PanicsWithValue(t,
+		"nil FileSystem to newTransactionWithFS: use newTransaction() for the default",
+		func() { newTransactionWithFS(nil) },
+	)
+}


### PR DESCRIPTION
Part of #1295 — **PR1: analysis path** (PR2 = workspace convention + verify-tools-adapter-import gate, lands separately).

## Summary
The DI thread already existed end-to-end (`ToolRegistrationParams.FileSystem` → `NewDomainFS` → `analysis.Register`); the defect was a dropped parameter: `newAnalysisManager` → `newRefactorManager(sp)` → `newTransaction()` self-constructed the OS adapter. This PR port-routes the analysis transaction's read/write paths through the injected domain port.

**Changes:**
- `transaction.Commit` → buffers + `tx.fs.AtomicWrite(ctx, path, buf.Bytes(), 0644)`; `rollback()`, `writtenFiles`, and all `.tmp`-litter cleanup deleted. Write semantics improve: perms 0666→0644 (deliberate, matches tools precedent), fsync, retry w/ backoff, EXDEV fallback, Windows transient-rename retry, context-cancellation abort.
- `transaction.LoadFile(ctx, path)` reads via `tx.fs.ReadFile`.
- `newTransactionWithFS(fs)` seam (nil → actionable panic); zero-arg `newTransaction()` survives delegating to `defaultFS` (all 9 test sites untouched).
- `internal/tools/analysis/default_fs.go` — the single sanctioned adapter construction site in the package.
- `fs` threaded through `newRefactorManager(fs, sp)` (manager.go:90).
- **ADR-055** (`docs/adr/2026-08-tools-filesystem-injection.md`, drafted with PR1, indexed, SOP boundary rule in `architecture_and_packages.md` §3).
- Memory-FS proof test (`TestTransaction_MemoryFS_LoadTransformCommit`): **failed pre-change** (RED captured: `parse memory:/src/main.go: no such file`), green post-change — proves the port-routing.

## Verification
| Check | Status |
|-------|--------|
| `refactor.go` has no `os` import; adapter import confined to `default_fs.go` (grep-verified) | PASS |
| RED→GREEN proof test | PASS |
| `go test ./internal/tools/analysis/...` | PASS |
| `make verify-adr-index` | PASS |
| make check-full (all 10 steps incl. race) | PASS |
| Scope: analysis + docs only; workspace untouched (PR2) | PASS |

## Notes
- Non-goals honored: `filepath.Glob` discovery stays OS-bound; Shape B (processExecutor port-routing) rejected.
- The `verify-tools-adapter-import` gate lands in PR2 (file-name allowlist requires both `default_fs.go` files to exist).
- Zero runtime delta to callers — signature of the tools unchanged.