### PR TITLE
refactor(workspace): inject persistence.FileSystem; add verify-tools-adapter-import gate (#1295, PR2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(OS),Windows_NT)
     endif
 endif
 
-.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-no-test-sleep verify-architecture verify-nonfix-catalog verify-adr-index lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
+.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import verify-no-test-sleep verify-architecture verify-nonfix-catalog verify-adr-index lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
 
 help:
 	@echo "tell-me-go development tasks:"
@@ -42,6 +42,7 @@ help:
 	@echo "  make verify-architecture - Verify Clean/Hexagonal Architecture layer discipline"
 	@echo "  make verify-nonfix-catalog - Verify the complexity-pin catalog partition (issue #1297)"
 	@echo "  make verify-no-test-sleep - Verify no time.Sleep for synchronization in tests"
+	@echo "  make verify-tools-adapter-import - Verify tools adapter imports are confined to default_fs.go (ADR-055)"
 	@echo "  make test-coverage - Run tests with coverage (excludes mocks/generated)"
 	@echo "  make tidy       - Tidy and vendor dependencies"
 	@echo "  make fmt        - Format code"
@@ -63,7 +64,7 @@ help:
 build:
 	go build -ldflags="-X 'main.version=$(VERSION)'" -o tell-me-go ./cmd/tell-me-go
 
-test: verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock
+test: verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import
 	go test ./...
 
 # Verify ADR-021: no testutil packages (centralized test-double dump).
@@ -350,6 +351,65 @@ else
 	"
 endif
 
+# Verify ADR-055: the internal/infrastructure/persistence adapter import is
+# confined to the two sanctioned default_fs.go files in internal/tools/
+# (analysis, workspace). Every other tools-layer production file must use
+# the injected domain port (persistence.FileSystem).
+verify-tools-adapter-import:
+ifeq ($(IS_POSIX),true)
+	@echo "Checking for infrastructure/persistence adapter imports in tools production files (ADR-055)..."
+	@VIOLATIONS="$$( grep -rn 'github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"' internal/tools/ --include='*.go' \
+		| grep -v '_test\.go:' \
+		| grep -v '^internal/tools/analysis/default_fs\.go:' \
+		| grep -v '^internal/tools/workspace/default_fs\.go:' )"; \
+	if [ -n "$$VIOLATIONS" ]; then \
+		echo ""; \
+		echo "❌ ADR-055 violation: adapter import outside the sanctioned default_fs.go files."; \
+		echo "   internal/tools production files may import internal/infrastructure/persistence"; \
+		echo "   only in internal/tools/analysis/default_fs.go and"; \
+		echo "   internal/tools/workspace/default_fs.go (each holds its package's defaultFS fallback)."; \
+		echo "   Every live tool path must use the injected domain port (persistence.FileSystem)."; \
+		echo "   See: docs/adr/2026-08-tools-filesystem-injection.md"; \
+		echo ""; \
+		echo "Violating files:"; \
+		echo "$$VIOLATIONS"; \
+		echo ""; \
+		echo "Fix: route through the injected FileSystem (ToolRegistrationParams.FileSystem →"; \
+		echo "workspace.Register → registerSystem → newshellTool) and construct the adapter"; \
+		echo "only in the package's default_fs.go."; \
+		exit 1; \
+	fi
+	@echo "  ✓ Adapter imports confined to the two default_fs.go files."
+else
+	@echo "Checking for infrastructure/persistence adapter imports in tools production files (ADR-055)..."
+	@powershell -Command " \
+		$$ErrorActionPreference = 'Stop'; \
+		$$violations = @(); \
+		Get-ChildItem -Path internal/tools -Recurse -Filter '*.go' | Where-Object { \
+			$$_.Name -notlike '*_test.go' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'internal/tools/analysis/default_fs\.go$$' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'internal/tools/workspace/default_fs\.go$$' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch '.git/' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'vendor/' \
+		} | ForEach-Object { \
+			$$matches = Select-String -Path $$_.FullName -Pattern 'github\.com/gosharplite/tell-me-go/internal/infrastructure/persistence"'; \
+			if ($$matches) { foreach ($$m in $$matches) { $$violations += ('{0}:{1}' -f $$m.Path, $$m.LineNumber) } } \
+		}; \
+		if ($$violations.Count -gt 0) { \
+			Write-Host ''; \
+			Write-Host '❌ ADR-055 violation: adapter import outside the sanctioned default_fs.go files.'; \
+			Write-Host '   See: docs/adr/2026-08-tools-filesystem-injection.md'; \
+			Write-Host ''; \
+			$$violations | Sort-Object -Unique | ForEach-Object { Write-Host $$_ }; \
+			Write-Host ''; \
+			Write-Host 'Fix: route through the injected FileSystem and construct the adapter'; \
+			Write-Host 'only in the package default_fs.go.'; \
+			exit 1 \
+		} \
+	"
+	@echo "  ✓ Adapter imports confined to the two default_fs.go files."
+endif
+
 # Verify no time.Sleep for synchronization in test files (Issue #580 / ADR-036).
 # Legitimate I/O simulation and hardware observation sleeps are explicitly allow-listed.
 verify-no-test-sleep:
@@ -589,6 +649,8 @@ check: fmt tidy build
 	@$(MAKE) verify-mock-pattern
 	@echo "=== verify-session-provider-mock ==="
 	@$(MAKE) verify-session-provider-mock
+	@echo "=== verify-tools-adapter-import ==="
+	@$(MAKE) verify-tools-adapter-import
 	@echo "=== verify-no-test-sleep ==="
 	@$(MAKE) verify-no-test-sleep
 	@echo "=== verify-adr-index ==="
@@ -621,6 +683,8 @@ check-full: fmt tidy build
 	@$(MAKE) verify-mock-pattern
 	@echo "=== verify-session-provider-mock ==="
 	@$(MAKE) verify-session-provider-mock
+	@echo "=== verify-tools-adapter-import ==="
+	@$(MAKE) verify-tools-adapter-import
 	@echo "=== verify-no-test-sleep ==="
 	@$(MAKE) verify-no-test-sleep
 	@echo "=== verify-adr-index ==="

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -54,6 +54,9 @@ func validateRegistrationParams(params ToolRegistrationParams) error {
 	if params.WorkspacePolicy == nil {
 		return fmt.Errorf("RegisterAll: WorkspacePolicy is required and must not be nil")
 	}
+	if params.FileSystem == nil {
+		return fmt.Errorf("RegisterAll: FileSystem is required and must not be nil")
+	}
 	return nil
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -208,6 +208,17 @@ func TestRegisterAll_Errors(t *testing.T) {
 		assert.Contains(t, err.Error(), "WorkspacePolicy is required")
 	})
 
+	t.Run("nil FileSystem returns error", func(t *testing.T) {
+		t.Parallel()
+		err := tools.RegisterAll(tools.ToolRegistrationParams{
+			Registry:        new(MockRegistry),
+			SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
+			WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
+		})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "FileSystem is required")
+	})
+
 	tests := []struct {
 		name      string
 		failAfter int
@@ -257,6 +268,7 @@ func TestRegisterAll_Errors(t *testing.T) {
 				Registry:        mockReg,
 				SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
 				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
+				FileSystem:      persistencetest.NewPlainOSFileSystem(),
 			}
 			if tt.setup != nil {
 				tt.setup(&params)
@@ -327,6 +339,7 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 				SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
 				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
 				HealthManager:   nil,
+				FileSystem:      persistencetest.NewPlainOSFileSystem(),
 			}
 			if tt.setup != nil {
 				tt.setup(&params)

--- a/internal/tools/workspace/default_fs.go
+++ b/internal/tools/workspace/default_fs.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package workspace
+
+import (
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+// defaultFS is the single sanctioned construction site for the OS
+// filesystem adapter in this package (issue #1295, ADR-055). Every live
+// tool path uses the injected domain port (persistence.FileSystem); this
+// fallback exists so the zero-arg newprocessExecutor() keeps working for
+// call sites that predate injection. Do not add further
+// internal/infrastructure/persistence imports to production files in this
+// package — the verify-tools-adapter-import gate enforces the boundary.
+var defaultFS = infra_persistence.NewOSFileSystem()

--- a/internal/tools/workspace/process_executor.go
+++ b/internal/tools/workspace/process_executor.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/encoding"
-	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/pkg/filepathutil"
 )
 
@@ -58,11 +57,23 @@ type processExecutor struct {
 
 const maxScannerCapacity = 10 * 1024 * 1024
 
-// newprocessExecutor creates a new processExecutor.
+// newprocessExecutor creates a new processExecutor backed by the default
+// OS filesystem (defaultFS in default_fs.go — the package's single
+// sanctioned adapter construction site, ADR-055).
 func newprocessExecutor() *processExecutor {
-	return &processExecutor{
-		fs: infra_persistence.NewOSFileSystem(),
+	return newprocessExecutorWithFS(defaultFS)
+}
+
+// newprocessExecutorWithFS creates a processExecutor with an explicit
+// filesystem. A nil fs is a contract violation on a test-reachable seam:
+// in production the hub (validateRegistrationParams) guarantees non-nil.
+// Use the zero-arg newprocessExecutor() for the default OS filesystem
+// instead of passing nil here.
+func newprocessExecutorWithFS(fs persistence.FileSystem) *processExecutor {
+	if fs == nil {
+		panic("newprocessExecutorWithFS: nil fs — use newprocessExecutor() for the default OS filesystem")
 	}
+	return &processExecutor{fs: fs}
 }
 
 // RunCommand executes a single command.

--- a/internal/tools/workspace/registration.go
+++ b/internal/tools/workspace/registration.go
@@ -25,7 +25,7 @@ func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandEx
 	if err := registerFiles(r, sm, fs, exec, wp); err != nil {
 		return err
 	}
-	if err := registerSystem(r, sm, validator, health, eventBus); err != nil {
+	if err := registerSystem(r, sm, validator, health, eventBus, fs); err != nil {
 		return err
 	}
 	if err := registerGit(r, sm, exec); err != nil {
@@ -295,7 +295,7 @@ func registerFiles(r tools.Registry, sm domain_security.Manager, fs persistence.
 	return nil
 }
 
-func registerSystem(r tools.Registry, sm domain_security.Manager, validator domain_security.CommandValidator, health ports.HealthCheckManager, eventBus events.EventBus) error {
+func registerSystem(r tools.Registry, sm domain_security.Manager, validator domain_security.CommandValidator, health ports.HealthCheckManager, eventBus events.EventBus, fs persistence.FileSystem) error {
 	var translator commandTranslator
 	var wrapper shellWrapper
 	if runtime.GOOS == "windows" {
@@ -306,7 +306,7 @@ func registerSystem(r tools.Registry, sm domain_security.Manager, validator doma
 		wrapper = &posixShellWrapper{}
 	}
 
-	shell := newshellTool(sm, eventBus, validator, translator, wrapper)
+	shell := newshellTool(sm, eventBus, validator, translator, wrapper, fs)
 	diagnostic := newDiagnosticTool(health)
 
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{

--- a/internal/tools/workspace/registration_test.go
+++ b/internal/tools/workspace/registration_test.go
@@ -239,7 +239,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "execute_command",
 		}
-		err := registerSystem(registry, sm, validator, nil, nil)
+		err := registerSystem(registry, sm, validator, nil, nil, persistencetest.NewPlainOSFileSystem())
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -253,7 +253,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			mockToolRegistry: &mockToolRegistry{},
 			failOnTool:       "pipe_commands",
 		}
-		err := registerSystem(registry, sm, validator, nil, nil)
+		err := registerSystem(registry, sm, validator, nil, nil, persistencetest.NewPlainOSFileSystem())
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -268,7 +268,7 @@ func TestRegisterSystem_PartialFailure(t *testing.T) {
 			failOnTool:       "check_system_health",
 		}
 		mockHealth := &mockHealthCheckManager{}
-		err := registerSystem(registry, sm, validator, mockHealth, nil)
+		err := registerSystem(registry, sm, validator, mockHealth, nil, persistencetest.NewPlainOSFileSystem())
 		if err == nil {
 			t.Fatal("expected error from registerSystem")
 		}
@@ -430,7 +430,7 @@ func TestRegister_SystemToolsOnly(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	reg := registry.New()
 	// Register only system tools (skip git/files)
-	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), nil, nil)
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), nil, nil, persistencetest.NewPlainOSFileSystem())
 	if err != nil {
 		t.Fatalf("registerSystem failed: %v", err)
 	}
@@ -457,7 +457,7 @@ func TestRegister_WithHealth(t *testing.T) {
 		Components:    map[ports.Component]ports.ComponentReport{},
 		Timestamp:     time.Now(),
 	}}
-	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), mockHealth, nil)
+	err := registerSystem(reg, sm, security.NewCommandValidator(sm, nil), mockHealth, nil, persistencetest.NewPlainOSFileSystem())
 	if err != nil {
 		t.Fatalf("registerSystem failed: %v", err)
 	}
@@ -479,7 +479,7 @@ func TestRegisterSystem_HealthNil(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 
-	err := registerSystem(reg, sm, validator, nil, nil)
+	err := registerSystem(reg, sm, validator, nil, nil, persistencetest.NewPlainOSFileSystem())
 	if err != nil {
 		t.Fatalf("registerSystem with nil health failed: %v", err)
 	}

--- a/internal/tools/workspace/shell.go
+++ b/internal/tools/workspace/shell.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
@@ -203,12 +204,12 @@ type shellTool struct {
 	heartbeatInterval time.Duration // zero means default (2s)
 }
 
-func newshellTool(sm shellSecurity, eventBus events.EventBus, validator domain_security.CommandValidator, translator commandTranslator, wrapper shellWrapper) *shellTool {
+func newshellTool(sm shellSecurity, eventBus events.EventBus, validator domain_security.CommandValidator, translator commandTranslator, wrapper shellWrapper, fs persistence.FileSystem) *shellTool {
 	return &shellTool{
 		sm:         sm,
 		eventBus:   eventBus,
 		validator:  validator,
-		executor:   newprocessExecutor(),
+		executor:   newprocessExecutorWithFS(fs),
 		translator: translator,
 		wrapper:    wrapper,
 		maxOutput:  50000,

--- a/internal/tools/workspace/shell_posix_test.go
+++ b/internal/tools/workspace/shell_posix_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -18,7 +19,7 @@ func TestShellTool_ExecuteCommand_Validation_POSIX(t *testing.T) {
 	}
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{}, persistencetest.NewPlainOSFileSystem())
 	ctx := context.Background()
 
 	tests := []struct {

--- a/internal/tools/workspace/shell_structured_test.go
+++ b/internal/tools/workspace/shell_structured_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -19,7 +20,7 @@ func TestShellTool_ExecuteCommand_Structured(t *testing.T) {
 	}
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	sm.SetBypassActive(true)
-	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, security.NewCommandValidator(sm, nil), &posixTranslator{}, &posixShellWrapper{}, persistencetest.NewPlainOSFileSystem())
 	ctx := context.Background()
 
 	t.Run("Structured args (no shell)", func(t *testing.T) {

--- a/internal/tools/workspace/shell_test.go
+++ b/internal/tools/workspace/shell_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/security"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
@@ -91,7 +92,7 @@ func newTestShellTool(sm shellSecurity, validator domain_security.CommandValidat
 		translator = &windowsTranslator{}
 		wrapper = &windowsShellWrapper{validator: validator}
 	}
-	return newshellTool(sm, &events.NoOpEventBus{}, validator, translator, wrapper)
+	return newshellTool(sm, &events.NoOpEventBus{}, validator, translator, wrapper, persistencetest.NewPlainOSFileSystem())
 }
 
 func setupTruncationTest(t *testing.T) (*shellTool, context.Context, map[string]interface{}) {
@@ -771,7 +772,7 @@ func TestShellTool_PrepareCommand_ShellSelection(t *testing.T) {
 	sm.SetBypassActive(true)
 	validator := &toolstest.MockCommandValidator{}
 	wrapper := &windowsShellWrapper{}
-	_ = newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, wrapper)
+	_ = newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, wrapper, persistencetest.NewPlainOSFileSystem())
 
 	t.Run("PowerShell indicators", func(t *testing.T) {
 		tests := []struct {
@@ -1485,7 +1486,7 @@ func TestShellTool_PrepareCommand_SplitError(t *testing.T) {
 			return nil, fmt.Errorf("split: mock failure")
 		},
 	}
-	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{}, persistencetest.NewPlainOSFileSystem())
 
 	parts, err := tool.prepareCommand("any command")
 
@@ -1516,7 +1517,7 @@ func TestShellTool_PrepareCommand_ValidateStructureError(t *testing.T) {
 			return fmt.Errorf("validate: structure rejected")
 		},
 	}
-	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{})
+	tool := newshellTool(sm, &events.NoOpEventBus{}, validator, &posixTranslator{}, &posixShellWrapper{}, persistencetest.NewPlainOSFileSystem())
 
 	parts, err := tool.prepareCommand("echo hello")
 


### PR DESCRIPTION
Part of #1295 — **PR2: workspace convention + gate** (completes the issue; PR1 was #1308).

## Summary
Completes the ADR-055 injection convention in the workspace package: direct adapter construction confined to a single sanctioned default_fs.go fallback; every live tool path uses the injected domain port.

**Changes:**
- workspace/default_fs.go — the package's single sanctioned adapter construction site (mirrors analysis PR1).
- newprocessExecutorWithFS(fs) seam (nil → actionable panic); zero-arg newprocessExecutor() survives delegating to defaultFS — **all 69 test call sites untouched**.
- fs threaded: Register → registerSystem → newshellTool → newprocessExecutorWithFS (production: 4 edit sites; tests: 6 + 6 sites updated).
- Hub nil-check: validateRegistrationParams rejects nil FileSystem (4th check, order preserves the 3 existing nil subtests); 10-subtest param-table churn + new 'nil FileSystem returns error' subtest.
- **verify-tools-adapter-import gate** — import-based, allowlists exactly the two default_fs.go files; wired into test: prerequisites, check/check-full, .PHONY, help.

## Verification
| Check | Status |
|-------|--------|
| Gate positive (final state) + negative (scratch blank-import file → FAIL → deleted → PASS) | PASS |
| go build ./... / go vet / go test ./internal/tools/... (11 packages) | PASS |
| make check-full (all 10 steps incl. race, gate runs twice) | PASS |
| Scope: 10 modified + 1 new file; zero runtime delta; no analysis files touched | PASS |

## Notes
- **Gate filter fix** (Architect-adjudicated, necessary): the end-anchored _test.go filter (correct for grep -rln) fails with grep -rn (lines end with the import string); fixed to the path-prefix anchor. Empirically verified positive AND negative.
- Zero-runtime-delta by design (ADR-055 Consequences): the value is the boundary rule + gate, not behavior.