### PR TITLE
chore(analysis): ratify transitive-gate whitelist; flip gate to strict (#1300)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -471,19 +471,19 @@ else
 	@$(MAKE) modelith-layers
 endif
 
-# Verify the ADR-056 transitive closure gate (issue #1300): prints the v1
+# Verify the ADR-056 transitive closure gate (issue #1300): prints the
 # report separating "decision required" rows from "approved constant" rows.
 # -v is required so go test surfaces the report's stdout on a passing run.
-# The explicit -transitive-gate-report-only=true documents the v1
-# report-first posture (default non-failing per the issue's implementation
-# detail); flipping to strict post-ratification = change the flag to
-# -transitive-gate-report-only=false. Deliberately NOT wired into
-# verify-architecture — v1 keeps passing as today.
+# STRICT since the 2026-08 ratification (39/39 whitelist entries accepted):
+# any consumer whose closure exceeds its whitelist or direct imports now
+# FAILS the gate — new closure growth must be adjudicated. Flip back to
+# report-only (-transitive-gate-report-only=true) only for diagnosis.
+# Deliberately NOT wired into verify-architecture.
 verify-transitive-gate:
 ifeq ($(IS_POSIX),true)
-	@go test -v -tags=arch -run TestVerifyTransitiveClosureGate ./internal/tools/analysis -args -transitive-gate-report-only=true
+	@go test -v -tags=arch -run TestVerifyTransitiveClosureGate ./internal/tools/analysis -args -transitive-gate-report-only=false
 else
-	@go test -v -tags=arch -run TestVerifyTransitiveClosureGate ./internal/tools/analysis -args -transitive-gate-report-only=true
+	@go test -v -tags=arch -run TestVerifyTransitiveClosureGate ./internal/tools/analysis -args -transitive-gate-report-only=false
 endif
 
 # Verify the complexity-pin catalog partition (issue #1297): runs the real

--- a/docs/adr/2026-08-contract-home-and-transitive-closure-gate.md
+++ b/docs/adr/2026-08-contract-home-and-transitive-closure-gate.md
@@ -115,3 +115,24 @@ The context-pipeline family leaves `internal/domain/ports`:
 
 - [Issue #1299](https://github.com/gosharplite/tell-me-go/issues/1299): the `*sessctx.Manager` coupling is an accepted cost — it is agent-layer and satisfies the cross-layer criterion.
 - [Issue #1297](https://github.com/gosharplite/tell-me-go/issues/1297): merged; orthogonal to the closure ledger.
+
+### Post-ratification record (2026-08, follow-up)
+
+- **Closure semantics ratified**: merged (prod+test) closure is canonical. The gate
+  classifies each package's compiled footprint (test binaries compile prod+test
+  together); test-edge excess is explicitly annotated in whitelist rationales.
+  V2: report annotates prod vs test-edge excess; family-level whitelists collapse
+  the P1/P2/P5 patterns.
+- **Gate ratification**: 39/39 decision-required rows accepted (whitelist additions
+  with per-row rationales); 0 splits — every excess traced to the recorded
+  events→telemetry decision, domain-internal hub coupling (llm↔events↔tools),
+  infra→domain inversion reach, or test-double coupling. Gate flipped to strict.
+- **Exit-query adjudication (7 candidates)**: 1 realign (SessionConfig →
+  internal/agent/session — the only candidate whose full consumer+implementer set
+  including di is single-layer) / 6 keep. The six stays are full-criterion
+  cross-layer: Capturer (di signature), HistoryBrowser/HistoryEditor/UIRenderer
+  (di uiFactory binding), SessionFinalizer (di-implemented sessionDeps),
+  HistoryRenderer (di + telemetry — recorded stay confirmed; the query's
+  composition-root-excluded single-layer status is realignment-eligibility, not an
+  exit). Realignment-strike stay-rationales enumerated above.
+- **SessionConfig realignment** tracked as follow-up work (not a non-fix).

--- a/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
+++ b/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
@@ -2,10 +2,23 @@
 
 Architect-curated. The architect owns whitelist maintenance: every consumer-level
 closure edge in this list is a recorded decision, and no entry is added, removed,
-or edited except by the architect. The transitive-closure gate (v1, report-only)
-reads this file at verification time. Family-level whitelists are deferred — no
+or edited except by the architect. The transitive-closure gate reads this file at
+verification time; since the 2026-08 ratification the gate is STRICT (failing):
+new closure growth must be adjudicated. Family-level whitelists are deferred — no
 schema exists for them yet; until one exists, only consumer-level entries are
 recognized.
+
+Closure semantics (ratified 2026-08): the gate measures the MERGED (prod+test)
+compiled footprint — `go test` compiles prod+test binaries together, so the merged
+closure is the real coupling surface. Test-edge excess is explicitly tagged with
+`# P4` in the per-entry rationale.
+
+Rationale legend:
+- P1 = events→telemetry (recorded decision, domain/events/types.go)
+- P2 = domain-internal hub (llm↔events↔tools cross-edges, legal domain→domain)
+- P3 = infra→domain dependency-inversion reach
+- P4 = test-double coupling (merged closure)
+- P5 = services via domain/tools (WorkspacePolicy leg)
 
 ## decision: events → telemetry
 
@@ -14,11 +27,122 @@ First recorded decision: the `events` family legitimately depends on `telemetry`
 whose closure reaches `events` is justified in also reaching `telemetry`. This
 edge is why the derived constant spans 9 families.
 
-## consumer: internal/ui/tui
-allowed: llm
-
+## consumer: cmd/deadcode
+allowed: events, llm, persistence, security, services, telemetry, tools
+# P2+P1: analysis/security toolchain surface; telemetry via events (recorded decision)
+## consumer: cmd/tell-me-go
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P2+P5: full hub surface via agent/analysis/cli deps
+## consumer: internal/agent
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P5+P1: services via tools; telemetry via events
+## consumer: internal/agent/agentinternal
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# test-access bridge mirrors agent's domain surface
+## consumer: internal/agent/agenttest
+allowed: events, llm, persistence, pricing, security, skills, telemetry, tools
+# P1+P4: canonical test-double surface; telemetry via events
+## consumer: internal/agent/orchestrator
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P2+P5: engine/session deps
+## consumer: internal/agent/orchestrator/orchestratortest
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P4: test harness mirrors orchestrator surface
+## consumer: internal/agent/session
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P2+P5: lifecycle deps
 ## consumer: internal/agent/session/context
-allowed: llm, tools, events, telemetry
-
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# AMENDED: config prod (strategy/gatekeeper); persistence/pricing/security/services/skills test-edge (P4)
+## consumer: internal/agent/session/ui
+allowed: events, llm, persistence, pricing, security, skills, telemetry, tools
+# P1+P2+P4: UI subpackage deps
+## consumer: internal/agent/skills
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P2+P5: skill-injection deps
+## consumer: internal/cli
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P2+P5: CLI command deps
+## consumer: internal/cli/clitest
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P4: test package mirroring CLI surface
+## consumer: internal/domain/config
+allowed: events, llm, pricing, telemetry, tools
+# P1+P2: llm/telemetry/tools via events
+## consumer: internal/domain/config/configtest
+allowed: config, events, llm, pricing, telemetry, tools
+# P4: test package
+## consumer: internal/domain/events/eventstest
+allowed: events, llm, telemetry, tools
+# P1+P2: events' own surface
+## consumer: internal/domain/pricing
+allowed: llm, tools
+# P2: tools via llm→events→tools
+## consumer: internal/infrastructure/auth
+allowed: persistence, services
+# P3: via infrastructure/persistence (imports domain/persistence + domain/services)
+## consumer: internal/infrastructure/config
+allowed: config, events, llm, pricing, telemetry, tools
+# P1+P2: via config+events deps
+## consumer: internal/infrastructure/di
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P3: composition root; telemetry via events
+## consumer: internal/infrastructure/factory
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P5+P1: services via tools; telemetry via events
+## consumer: internal/infrastructure/history
+allowed: llm, persistence, services, tools
+# P2+P3+P5: domain deps
+## consumer: internal/infrastructure/llm
+allowed: config, events, llm, persistence, pricing, services, telemetry, tools
+# P1+P3: adapter deps
+## consumer: internal/infrastructure/llm/anthropic
+allowed: llm, persistence, services, tools
+# P3: adapter deps
+## consumer: internal/infrastructure/llm/gemini
+allowed: events, llm, persistence, services, telemetry, tools
+# P1+P3: adapter deps
+## consumer: internal/infrastructure/llm/llmerr
+allowed: llm, tools
+# P2: tools via llm
+## consumer: internal/infrastructure/llm/openai
+allowed: llm, persistence, services, tools
+# P3: adapter deps
+## consumer: internal/infrastructure/logging
+allowed: events, llm, persistence, services, telemetry, tools
+# P1+P2+P3: via events/llm deps
+## consumer: internal/infrastructure/telemetry
+allowed: config, events, llm, pricing, security, telemetry, tools
+# P2+P3: config via events/telemetry deps
+## consumer: internal/tools
+allowed: events, llm, persistence, pricing, security, services, telemetry, tools
+# P1: telemetry via events
+## consumer: internal/tools/analysis
+allowed: events, llm, persistence, security, services, telemetry, tools
+# P1+P2: llm/telemetry via events
+## consumer: internal/tools/analysis/analysistest
+allowed: events, llm, persistence, security, services, telemetry, tools
+# P4: test package
+## consumer: internal/tools/developer
+allowed: events, llm, persistence, security, services, telemetry, tools
+# P1+P2: llm/telemetry
+## consumer: internal/tools/integrations/ado
+allowed: llm, persistence, security, tools
+# P2+P3: tool deps
+## consumer: internal/tools/integrations/atlassian
+allowed: llm, persistence, security, tools
+# P2+P3: tool deps
+## consumer: internal/tools/workspace
+allowed: events, llm, persistence, security, services, telemetry, tools
+# P1+P2: llm/telemetry
+## consumer: internal/ui
+allowed: config, events, llm, persistence, pricing, security, services, telemetry, tools
+# P1+P2+P5: UI deps
+## consumer: internal/ui/tui
+allowed: llm, security, tools
+# AMENDED: security prod (prompt_capturer UserInteractor); tools test-edge (P4)
+## consumer: internal/ui/tui/progress
+allowed: config, events, llm, persistence, pricing, security, services, telemetry, tools
+# P1+P2+P5: progress deps
 ## consumer: internal/domain/ports
 allowed: <derived>


### PR DESCRIPTION
Implements the ratified #1300 follow-up (Architect adjudication package, human-approved).

## Summary
The transitive-closure gate shipped report-only (v1 posture). This PR ratifies the deferred decisions and flips the gate to **strict**:

1. **Closure-semantics ruling**: merged (prod+test) closure is canonical — the gate measures the real compiled footprint; test-edge excess explicitly tagged (P4) in rationales.
2. **39/39 decision-required rows ACCEPTED, 0 splits** — every excess traced to a layer-legal mechanism (P1 events→telemetry recorded decision; P2 domain hub llm↔events↔tools; P3 infra→domain inversion; P4 test-double coupling; P5 services-via-tools). `TRANSITIVE_IMPORT_WHITELIST.md` rewritten with all 39 consumer entries (2 amended: sessctx, ui/tui) + per-entry rationale lines.
3. **Gate flipped to strict** (`-transitive-gate-report-only=false`) — future closure growth now FAILS the gate and must be adjudicated.
4. **ADR-056 post-ratification record** appended (closure ruling, gate ratification, exit-query adjudication: 1 REALIGN SessionConfig / 6 KEEP, HistoryRenderer stay confirmed).

## Verification
| Check | Status |
|-------|--------|
| `make verify-transitive-gate` (STRICT) — 0 decision-required, all whitelisted/self-justifying | PASS |
| `make verify-nonfix-catalog` | PASS |
| `make verify-adr-index` | PASS |
| `go test ./internal/tools/analysis/` | PASS |

## Follow-up (tracked separately)
- **SessionConfig realignment** to `internal/agent/session` — the exit criterion's first enforced outcome (bounded mechanical move, no di signature change); filed as follow-up work.
- Exit-query stay-rationales for the 6 KEEPs recorded in ADR-056.