### PR TITLE
refactor(session): realign SessionConfig to agent/session per ADR-056 exit criterion

### DIFF
--- a/docs/adr/2026-08-contract-home-and-transitive-closure-gate.md
+++ b/docs/adr/2026-08-contract-home-and-transitive-closure-gate.md
@@ -136,3 +136,7 @@ The context-pipeline family leaves `internal/domain/ports`:
   composition-root-excluded single-layer status is realignment-eligibility, not an
   exit). Realignment-strike stay-rationales enumerated above.
 - **SessionConfig realignment** tracked as follow-up work (not a non-fix).
+
+### SessionConfig realignment completed (2026-08)
+
+**SessionConfig realignment completed** — interface moved to `internal/agent/session` per ADR-003 Rule #1; `ports.SessionConfig` deleted; move is edge-neutral for the transitive gate (no whitelist change).

--- a/internal/agent/session/export_test.go
+++ b/internal/agent/session/export_test.go
@@ -21,11 +21,11 @@ type SessionConfigInternal = sessionConfig
 // renaming churns ~15 test sites for zero production value.
 type SessionDependenciesInternal = agenttest.StubChatterComposer
 
-func (o *sessionManager) ApplyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.ChatterComposer, capturer ports.Capturer, tuiOutput bool) (*ui.Bridge, error) {
+func (o *sessionManager) ApplyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg SessionConfig, sd ports.ChatterComposer, capturer ports.Capturer, tuiOutput bool) (*ui.Bridge, error) {
 	return o.applyConfiguration(ctx, chatAgent, sCfg, sd, capturer, tuiOutput)
 }
 
-func (o *sessionManager) RenderPostTUISummary(ts events.TurnStatus, sd ports.ChatterComposer, sc ports.SessionConfig, ic ports.Capturer) {
+func (o *sessionManager) RenderPostTUISummary(ts events.TurnStatus, sd ports.ChatterComposer, sc SessionConfig, ic ports.Capturer) {
 	o.renderPostTUISummary(ts, sd, sc, ic)
 }
 

--- a/internal/agent/session/interfaces.go
+++ b/internal/agent/session/interfaces.go
@@ -6,6 +6,7 @@ package session
 import (
 	"context"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 )
 
@@ -14,9 +15,38 @@ type Capturer interface {
 	ports.Capturer
 }
 
+// SessionConfig defines the configuration interface for a session.
+// It lives in the consuming package per ADR-003 Rule #1
+// (consumer-defined interfaces) — the ADR-056 exit-criterion realignment.
+type SessionConfig interface {
+	// GetPrompt returns the user's input prompt for the current turn.
+	GetPrompt() string
+
+	// GetLastN returns the number of recent history entries to display.
+	GetLastN() int
+
+	// IsLastNSet returns true if -l was explicitly passed by the user.
+	// When false, GetLastN() returns 0 (default).
+	IsLastNSet() bool
+
+	// GetBackN returns the number of turns to roll back when processing
+	// a history navigation command.
+	GetBackN() int
+
+	// GetRawOutput returns true if markdown rendering should be disabled
+	// and output should be displayed as plain text.
+	GetRawOutput() bool
+
+	// GetConfigPath returns the filesystem path to the main configuration file.
+	GetConfigPath() string
+
+	// GetConfig returns the full application configuration.
+	GetConfig() *config.Config
+}
+
 // SessionManager defines the entry point for running a chat session.
 type SessionManager interface {
-	Run(ctx context.Context, sc ports.SessionConfig, sd ports.ChatterComposer, ic ports.Capturer, tuiOutput bool) error
-	Rollback(ctx context.Context, sc ports.SessionConfig, sd ports.ChatterComposer) error
-	RenderHistory(hManager ports.HistoryManager, sCfg ports.SessionConfig, isTTY bool)
+	Run(ctx context.Context, sc SessionConfig, sd ports.ChatterComposer, ic ports.Capturer, tuiOutput bool) error
+	Rollback(ctx context.Context, sc SessionConfig, sd ports.ChatterComposer) error
+	RenderHistory(hManager ports.HistoryManager, sCfg SessionConfig, isTTY bool)
 }

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -57,7 +57,7 @@ func (c *sessionConfig) GetConfigPath() string     { return c.ConfigPath }
 func (c *sessionConfig) GetConfig() *config.Config { return c.Config }
 
 // NewSessionConfig creates a new sessionConfig with required parameters.
-func NewSessionConfig(configPath string, newSession bool, lastN int, lastNSet bool, backN int, rawOutput bool, prompt string, cfg *config.Config) ports.SessionConfig {
+func NewSessionConfig(configPath string, newSession bool, lastN int, lastNSet bool, backN int, rawOutput bool, prompt string, cfg *config.Config) SessionConfig {
 	return &sessionConfig{
 		ConfigPath: configPath,
 		NewSession: newSession,
@@ -110,7 +110,7 @@ func NewSessionManager(homeDir, version string, sm domain_security.Manager, stdo
 }
 
 // Run executes the session orchestration.
-func (o *sessionManager) Run(ctx context.Context, sc ports.SessionConfig, sd ports.ChatterComposer, ic ports.Capturer, tuiOutput bool) (err error) {
+func (o *sessionManager) Run(ctx context.Context, sc SessionConfig, sd ports.ChatterComposer, ic ports.Capturer, tuiOutput bool) (err error) {
 	cfg := sc.GetConfig()
 	paths := sd.GetPaths()
 	activeModel := cfg.GetActiveProvider().Model
@@ -185,7 +185,7 @@ func (o *sessionManager) teardownSession(
 	finalTurnStatus events.TurnStatus,
 	hasFinalTurnStatus bool,
 	sd ports.ChatterComposer,
-	sc ports.SessionConfig,
+	sc SessionConfig,
 	ic ports.Capturer,
 ) error {
 	var errs error
@@ -233,7 +233,7 @@ func (o *sessionManager) generateSessionID() string {
 }
 
 // Rollback deletes the specified number of turns from history.
-func (o *sessionManager) Rollback(ctx context.Context, sc ports.SessionConfig, sd ports.ChatterComposer) error {
+func (o *sessionManager) Rollback(ctx context.Context, sc SessionConfig, sd ports.ChatterComposer) error {
 	if sc.GetBackN() <= 0 {
 		return nil
 	}
@@ -254,7 +254,7 @@ func (o *sessionManager) Rollback(ctx context.Context, sc ports.SessionConfig, s
 }
 
 // RenderHistory renders the last N messages from history.
-func (o *sessionManager) RenderHistory(hManager ports.HistoryManager, sCfg ports.SessionConfig, isTTY bool) {
+func (o *sessionManager) RenderHistory(hManager ports.HistoryManager, sCfg SessionConfig, isTTY bool) {
 	cfg := sCfg.GetConfig()
 	o.HistoryRenderer.Render(o.Stdout, hManager, sCfg.GetLastN(), ports.HistoryRenderOptions{
 		Raw:          sCfg.GetRawOutput(),
@@ -267,7 +267,7 @@ func (o *sessionManager) RenderHistory(hManager ports.HistoryManager, sCfg ports
 // renderPostTUISummary writes a header, the last turn from history, and a
 // footer to stdout after the TUI exits. This ensures the user sees a summary
 // when the TUI auto-closes instead of an empty terminal.
-func (o *sessionManager) renderPostTUISummary(ts events.TurnStatus, sd ports.ChatterComposer, sc ports.SessionConfig, ic ports.Capturer) {
+func (o *sessionManager) renderPostTUISummary(ts events.TurnStatus, sd ports.ChatterComposer, sc SessionConfig, ic ports.Capturer) {
 	isTTY := ic.IsTTY(o.Stdout)
 	cfg := sc.GetConfig()
 
@@ -307,7 +307,7 @@ func (o *sessionManager) renderPostTUISummary(ts events.TurnStatus, sd ports.Cha
 	_, _ = fmt.Fprintf(o.Stdout, "%s\n", progress.FormatFinalLine(ts, turnCost))
 }
 
-func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg ports.SessionConfig, sd ports.ChatterComposer, capturer ports.Capturer, tuiOutput bool) (*ui.Bridge, error) {
+func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg SessionConfig, sd ports.ChatterComposer, capturer ports.Capturer, tuiOutput bool) (*ui.Bridge, error) {
 	cfg := sCfg.GetConfig()
 	paths := sd.GetPaths()
 	logger := sd.GetLogger()

--- a/internal/domain/ports/doc.go
+++ b/internal/domain/ports/doc.go
@@ -10,7 +10,7 @@
 //
 // Agent Lifecycle & Configuration:
 //   - Chatter / ChatterFactory / ChatExecutor / ChatConfigurator / ChatEventSource
-//   - ChatterComposer / SessionConfig / Session
+//   - ChatterComposer / Session
 //
 // Conversation Persistence:
 //   - HistoryManager / HistoryReader / HistoryWriter / HistoryModifier

--- a/internal/domain/ports/session.go
+++ b/internal/domain/ports/session.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -100,33 +99,6 @@ type ChatterConfig struct {
 
 // ChatterFactory defines the functional signature for creating a Chatter instance.
 type ChatterFactory func(ctx context.Context, deps ChatterComposer, cfg ChatterConfig) (Chatter, error)
-
-// SessionConfig defines the configuration interface for a session.
-type SessionConfig interface {
-	// GetPrompt returns the user's input prompt for the current turn.
-	GetPrompt() string
-
-	// GetLastN returns the number of recent history entries to display.
-	GetLastN() int
-
-	// IsLastNSet returns true if -l was explicitly passed by the user.
-	// When false, GetLastN() returns 0 (default).
-	IsLastNSet() bool
-
-	// GetBackN returns the number of turns to roll back when processing
-	// a history navigation command.
-	GetBackN() int
-
-	// GetRawOutput returns true if markdown rendering should be disabled
-	// and output should be displayed as plain text.
-	GetRawOutput() bool
-
-	// GetConfigPath returns the filesystem path to the main configuration file.
-	GetConfigPath() string
-
-	// GetConfig returns the full application configuration.
-	GetConfig() *config.Config
-}
 
 // ChatterComposer defines the dependencies required to construct a Chatter
 // via a ChatterFactory. It is the narrowest interface needed by


### PR DESCRIPTION
Implements the ratified #1300 follow-up: the exit criterion's first enforced outcome.

## Summary
ADR-056 Decision 1 (cross-layer criterion) + the exit-query adjudication identified `SessionConfig` as the only ports seam whose full consumer+implementer set (including di) is single-layer — an exit candidate. This PR realigns it:

- **`SessionConfig` interface moved** from `internal/domain/ports/session.go` to `internal/agent/session/interfaces.go` (after `Capturer`, per ADR-003 Rule #1: interfaces defined where consumed) — with an ADR-056/ADR-003 doc comment
- **All 11 references updated** (3 SessionManager signatures, 7 session_manager.go sites, 2 export_test wrappers) — all were already inside the package
- **`ports.SessionConfig` deleted** (+ unused `domain/config` import); `ports/doc.go` family list updated
- Impl `sessionConfig` kept unexported (matches the `SessionManager`/`sessionManager` package precedent); `SessionConfigInternal` alias intact
- **ADR-056 completion note** added (architect-approved)

## Verification
| Check | Status |
|-------|--------|
| go build ./... | PASS |
| go test ./internal/agent/... (10 pkgs) + ./internal/cli/... (2 pkgs) | PASS |
| verify-architecture | PASS |
| verify-transitive-gate (STRICT) — 74 consumers / 0 decision-required (edge-neutral, whitelist untouched) | PASS |
| verify-nonfix-catalog / verify-adr-index | PASS |
| make check-full (all steps incl. race) | PASS |
| Residual `ports.SessionConfig` references | 0 |

No whitelist entry, no catalog touch, no domain-model change — confirmed unnecessary by the Architect.