### PR TITLE
test: close uncataloged coverage gaps; align CC threshold policy

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -1196,4 +1196,20 @@ to reason about.
 
 ---
 
-*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056)*
+## Coverage Gaps (ACCEPTED — 2026-08 coverage/complexity hygiene)
+
+### domain/ports/logger.go — NoOpLogger and NoOpTurnsLogger no-op stubs at 0%
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: `NoOpLogger.Error/Warn/Info/Debug` (empty bodies) and `NoOpTurnsLogger.HandleEvent`/`Listen`/`Close` exist solely to satisfy the `Logger`/`TurnsLogger` interface contracts. All are already exercised by `logger_test.go` (`TestNoOpLogger`, `TestNoOpTurnsLogger_HandleEvent`, `TestNoOpTurnsLogger_Listen`, `TestNoOpTurnsLogger_Close`, `TestNoOpTurnsLogger_Listen_DeadlineExceeded`); Go's coverage instrumentation does not count empty method bodies as covered (blocks report `count=1` with zero statements). Same acceptance class as the cataloged `NoOpEventBus` and `auth.Invalidate` entries — `interface-stub`.
+- **See**: `internal/domain/ports/logger.go:36-39,62-64`, `internal/domain/ports/logger_test.go`
+
+### infrastructure/security/policy.go — BypassConfirmation success path and confirmAction error branch
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: The entire success path of `BypassConfirmation` (`SetBypassActive(true)` + `kv.Set("bypass_confirmation","true")` + `Warn` + success return, `policy.go:300-308`) and the `confirmAction` error branch (`policy.go:293-295`) are structurally unreachable: `confirmAction` never returns an error, and it returns `true` only when `sm.IsBypassActive()` is already true — which short-circuits at the entry check (`policy.go:287`). Both checks read the same `bypassActive` field (`manager.go:22,90-100`) under the same `TerminalLock`, so no interleaving exists. The tool can only ever report "already enabled" or auto-decline; bypass is actually enabled via `di/session_factory.go:82-86`. A skipped test already documents the kv.Set path (`policy_test.go:596`, `t.Skip("[UNREACHABLE] ...")`). Same acceptance class as `json.Marshal` on all-string structs — `structurally-unreachable`.
+- **See**: `internal/infrastructure/security/policy.go:283-308`, `internal/infrastructure/security/policy_test.go:596`
+
+---
+
+*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056; coverage hygiene: NoOpLogger + BypassConfirmation entries — 2026-08)*

--- a/docs/domain-model/quality.modelith.md
+++ b/docs/domain-model/quality.modelith.md
@@ -95,11 +95,11 @@ The cyclomatic complexity score per function produced by the complexity tooling.
 | --- | --- | --- |
 | `function` | string | The fully qualified function name being measured. |
 | `score` | integer | The cyclomatic complexity value. |
-| `threshold` | integer | The policy threshold — scores below 10 are acceptable without rationale. |
+| `threshold` | integer | The policy threshold — scores of 10 or below are acceptable without rationale. |
 
 **Invariants**
 
-- **complexity-threshold-policy** — A function with CC below 10 is acceptable by policy; CC at or above 10 requires either a refactor or a documented `IntentionalNonFix` entry.
+- **complexity-threshold-policy** — A function with CC of 10 or below is acceptable by policy; CC above 10 (11 or more) requires either a refactor or a documented `IntentionalNonFix` entry.
 
 ### `CoverageReport`
 
@@ -341,7 +341,7 @@ Complexity tooling reports CC=12 on a type-switch dispatch handler. The `Archite
 
 **Invariants touched**
 
-- **complexity-threshold-policy** — A function with CC below 10 is acceptable by policy; CC at or above 10 requires either a refactor or a documented `IntentionalNonFix` entry.
+- **complexity-threshold-policy** — A function with CC of 10 or below is acceptable by policy; CC above 10 (11 or more) requires either a refactor or a documented `IntentionalNonFix` entry.
 - **nonfix-has-acceptance-class** — Every `IntentionalNonFix` entry carries an acceptance class and a rationale; an entry without both is invalid.
 - **catalog-architect-curated** — Only the `Architect` records or removes `IntentionalNonFix` entries; an `Agent` never edits the catalog unilaterally.
 

--- a/docs/domain-model/quality.modelith.yaml
+++ b/docs/domain-model/quality.modelith.yaml
@@ -191,10 +191,10 @@ entities:
         description: The cyclomatic complexity value.
       - name: threshold
         type: integer
-        description: "The policy threshold — scores below 10 are acceptable without rationale."
+        description: "The policy threshold — scores of 10 or below are acceptable without rationale."
     invariants:
       - id: complexity-threshold-policy
-        statement: "A function with CC below 10 is acceptable by policy; CC at or above 10 requires either a refactor or a documented `IntentionalNonFix` entry."
+        statement: "A function with CC of 10 or below is acceptable by policy; CC above 10 (11 or more) requires either a refactor or a documented `IntentionalNonFix` entry."
 
   NonFixCatalog:
     definition: >

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -1381,6 +1381,7 @@ func TestBootstrapper_Getters(t *testing.T) {
 	assert.NotNil(t, b.GetHistoryBrowser())
 	assert.NotNil(t, b.GetUIRenderer())
 	assert.NotNil(t, b.GetHistoryRenderer())
+	assert.NotNil(t, b.GetSystemMetricsProvider())
 }
 
 func TestGetUnifiedHistoryProvider_SuccessPath(t *testing.T) {

--- a/internal/infrastructure/history/history_test.go
+++ b/internal/infrastructure/history/history_test.go
@@ -1526,3 +1526,40 @@ func TestGetModelTurn(t *testing.T) {
 		}
 	})
 }
+
+// captureLogger is a local stub implementing ports.Logger for
+// TestManager_WithLogger. It captures nothing — it exists only to verify
+// that WithLogger stores the injected logger. No new imports needed.
+type captureLogger struct{}
+
+func (l *captureLogger) Error(msg string, args ...any) {}
+func (l *captureLogger) Warn(msg string, args ...any)  {}
+func (l *captureLogger) Info(msg string, args ...any)  {}
+func (l *captureLogger) Debug(msg string, args ...any) {}
+
+func TestManager_WithLogger(t *testing.T) {
+	m := NewManager(infrapersistence.NewOSFileSystem(), filepath.Join(t.TempDir(), "h.json"), filepath.Join(t.TempDir(), "h.archive.jsonl"))
+
+	// Default logger is a NoOpLogger.
+	if _, ok := m.logger.(*ports.NoOpLogger); !ok {
+		t.Errorf("expected default logger *ports.NoOpLogger, got %T", m.logger)
+	}
+
+	// WithLogger(nil) is a nil-guard no-op and remains chainable.
+	got := m.WithLogger(nil)
+	if got != m {
+		t.Errorf("expected WithLogger(nil) to return the same manager, got %p", got)
+	}
+	if _, ok := m.logger.(*ports.NoOpLogger); !ok {
+		t.Errorf("expected logger to remain *ports.NoOpLogger after WithLogger(nil), got %T", m.logger)
+	}
+
+	// A real logger is stored and the method is chainable.
+	got = m.WithLogger(&captureLogger{})
+	if got != m {
+		t.Errorf("expected WithLogger(&captureLogger{}) to return the same manager, got %p", got)
+	}
+	if _, ok := m.logger.(*captureLogger); !ok {
+		t.Errorf("expected logger to be *captureLogger, got %T", m.logger)
+	}
+}

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -351,3 +351,53 @@ func (r *testAssetResolver) Resolve(ctx context.Context, assetID string) ([]byte
 	}
 	return d, nil
 }
+
+func TestPrepareMediaForTurn_ResolverError(t *testing.T) {
+	c := NewClient("", "test-model", &auth.BearerAuth{Token: "test"})
+	c.capabilities.SupportsVision = true
+
+	history := []*llm.Content{{
+		Role:  "user",
+		Parts: []*llm.Part{{AssetID: "asset-1"}},
+	}}
+
+	// The asset is missing from the resolver's data map, so Resolve fails.
+	ta, err := c.prepareMediaForTurn(context.Background(), history, &testAssetResolver{data: map[string][]byte{}})
+	if ta != nil {
+		t.Errorf("expected nil turnAssets on resolver error, got %v", ta)
+	}
+	if err == nil {
+		t.Error("expected error from resolver failure, got nil")
+	}
+}
+
+func TestPrepareMediaForTurn_SuccessAppliesParts(t *testing.T) {
+	c := NewClient("", "test-model", &auth.BearerAuth{Token: "test"})
+	c.capabilities.SupportsVision = true
+	c.capabilities.SupportsFileUpload = false
+
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte("x")}},
+		},
+	}}
+
+	// The part already carries InlineData.Data, so it is not a hydration
+	// candidate — no resolver is required.
+	ta, err := c.prepareMediaForTurn(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ta == nil {
+		t.Fatal("expected non-nil turnAssets")
+	}
+	if len(history[0].Parts) != 1 {
+		t.Fatalf("expected 1 part preserved, got %d", len(history[0].Parts))
+	}
+	if history[0].Parts[0].InlineData == nil ||
+		history[0].Parts[0].InlineData.MIMEType != "image/png" ||
+		string(history[0].Parts[0].InlineData.Data) != "x" {
+		t.Errorf("expected InlineData preserved, got %+v", history[0].Parts[0].InlineData)
+	}
+}

--- a/internal/tools/analysis/harvest_test.go
+++ b/internal/tools/analysis/harvest_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"go/token"
+	"go/types"
+	"testing"
+)
+
+// TestIsTestSymbol closes the 0.0% coverage gap on isTestSymbol
+// (harvest.go:49). The predicate is a single return of four
+// strings.HasPrefix checks, so any row exercising it covers the line;
+// the negative rows pin the exact-prefix semantics (e.g. lowercase
+// "testing" must NOT match the "Test" prefix).
+func TestIsTestSymbol(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"TestFoo", true},
+		{"BenchmarkFoo", true},
+		{"ExampleFoo", true},
+		{"FuzzFoo", true},
+		{"Test", true},     // exact prefix match
+		{"Foo", false},     // no test prefix
+		{"testing", false}, // lowercase 't' does not match "Test"
+		{"", false},        // empty name
+	}
+
+	for _, tt := range tests {
+		if got := analyzer.isTestSymbol(tt.input); got != tt.want {
+			t.Errorf("isTestSymbol(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+// TestIsEligibleForHarvest_RemainingBranches closes the remaining gaps on
+// isEligibleForHarvest (harvest.go:116-129): the Test-prefix rejection, the
+// export_test.go rejection, and the final happy-path `return true`. The
+// nil-object, nil-package and init branches are already covered by
+// TestIsEligibleForHarvest_EdgeCases (dead_code_test.go); they are repeated
+// here for completeness of the branch table (redundancy is intentional).
+func TestIsEligibleForHarvest_RemainingBranches(t *testing.T) {
+	t.Parallel()
+
+	analyzer := &defaultDeadCodeAnalyzer{}
+	pkg := types.NewPackage("example.com/pkg", "pkg")
+	sig := types.NewSignatureType(nil, nil, nil, nil, nil, false)
+
+	// export_test.go fset: the object's position must resolve inside THIS
+	// fset, otherwise isExportTestFile returns false and the row would
+	// wrongly take the happy path.
+	exportTestFset := token.NewFileSet()
+	exportTestFile := exportTestFset.AddFile("internal/foo/export_test.go", -1, 64)
+
+	tests := []struct {
+		name string
+		obj  types.Object
+		fset *token.FileSet
+		want bool
+	}{
+		{
+			name: "nil object",
+			obj:  nil,
+			fset: token.NewFileSet(),
+			want: false,
+		},
+		{
+			name: "nil package",
+			obj:  types.NewVar(token.NoPos, nil, "X", types.Typ[types.Int]),
+			fset: token.NewFileSet(),
+			want: false,
+		},
+		{
+			name: "unexported",
+			obj:  types.NewFunc(token.NoPos, pkg, "helper", sig),
+			fset: token.NewFileSet(),
+			want: false,
+		},
+		{
+			name: "init",
+			obj:  types.NewFunc(token.NoPos, pkg, "init", sig),
+			fset: token.NewFileSet(),
+			want: false,
+		},
+		{
+			name: "test symbol",
+			obj:  types.NewFunc(token.NoPos, pkg, "TestFoo", sig),
+			fset: token.NewFileSet(),
+			want: false,
+		},
+		{
+			name: "export_test.go file",
+			obj:  types.NewFunc(exportTestFile.Pos(1), pkg, "ExportedHelper", sig),
+			fset: exportTestFset, // must contain obj.Pos()
+			want: false,
+		},
+		{
+			name: "exported in normal file",
+			obj:  types.NewFunc(token.NoPos, pkg, "ExportedThing", sig),
+			fset: token.NewFileSet(),
+			want: true, // covers the final return true
+		},
+	}
+
+	for _, tt := range tests {
+		if got := analyzer.isEligibleForHarvest(tt.obj, tt.fset); got != tt.want {
+			t.Errorf("isEligibleForHarvest(%s) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}

--- a/internal/ui/tui/tasks_model_test.go
+++ b/internal/ui/tui/tasks_model_test.go
@@ -350,6 +350,56 @@ func TestTaskListModel_MoveSelection_Bounds(t *testing.T) {
 	}
 }
 
+func TestTaskListModel_CmdMoveDown(t *testing.T) {
+	m := &taskListModel{tasks: []ports.Task{{}, {}}, selected: 0}
+	cmd := m.cmdMoveDown()
+	if cmd != nil {
+		t.Errorf("expected nil cmd from cmdMoveDown, got %v", cmd)
+	}
+	if m.selected != 1 {
+		t.Errorf("expected selected 1 after move down, got %d", m.selected)
+	}
+}
+
+func TestTaskListModel_CmdMoveUp(t *testing.T) {
+	m := &taskListModel{tasks: []ports.Task{{}, {}}, selected: 1}
+	cmd := m.cmdMoveUp()
+	if cmd != nil {
+		t.Errorf("expected nil cmd from cmdMoveUp, got %v", cmd)
+	}
+	if m.selected != 0 {
+		t.Errorf("expected selected 0 after move up, got %d", m.selected)
+	}
+}
+
+func TestTaskListModel_CmdMoveDown_ClampedAtEnd(t *testing.T) {
+	m := &taskListModel{tasks: []ports.Task{{}, {}}, selected: 1}
+	m.cmdMoveDown()
+	if m.selected != 1 {
+		t.Errorf("expected selected 1 (clamped at end), got %d", m.selected)
+	}
+}
+
+func TestTaskListModel_CmdMoveUp_ClampedAtTop(t *testing.T) {
+	m := &taskListModel{tasks: []ports.Task{{}, {}}, selected: 0}
+	m.cmdMoveUp()
+	if m.selected != 0 {
+		t.Errorf("expected selected 0 (clamped at top), got %d", m.selected)
+	}
+}
+
+func TestTaskListModel_CmdMove_EmptyTasksNoOp(t *testing.T) {
+	m := &taskListModel{tasks: nil, selected: 5}
+	m.cmdMoveDown()
+	if m.selected != 5 {
+		t.Errorf("expected selected unchanged for empty tasks after move down, got %d", m.selected)
+	}
+	m.cmdMoveUp()
+	if m.selected != 5 {
+		t.Errorf("expected selected unchanged for empty tasks after move up, got %d", m.selected)
+	}
+}
+
 func TestTaskListModel_View_ErrorState(t *testing.T) {
 	m := &taskListModel{
 		err:   context.DeadlineExceeded,


### PR DESCRIPTION
Coverage/complexity hygiene pass (from the Orchestrator's audit of make test-coverage + the complexity gate against INTENTIONAL_NON_FIXES.md).

## Summary
**Commit 1 — actionable wins (tests + policy doc):**
- `tasks_model.go` `cmdMoveDown`/`cmdMoveUp` → 100% (5 tests incl. clamp/no-op)
- `history.go` `WithLogger` → 100% (default, nil-guard, chainable store via local stub — no new imports)
- `openai/chat.go` `prepareMediaForTurn` → 100% (resolver-error + success-apply branches)
- `di` `GetSystemMetricsProvider`/`ui_factory.SystemMetricsProvider` → 100% (one-line consistency fix in existing TestBootstrapper_Getters)
- `analysis/harvest.go` `isTestSymbol` + `isEligibleForHarvest` → 100% (new table-driven harvest_test.go — user chose coverage over cataloging)
- **Policy alignment**: quality.modelith.yaml threshold wording fixed — CC of 10 or below is acceptable; above 10 (11+) requires a refactor or entry. Gate code was already correct (>10); the doc was stale. modelith re-rendered.

**Commit 2 — catalog entries (architect-approved):**
- `NoOpLogger`/`NoOpTurnsLogger` — interface-stub class (already tested; empty-body instrumentation artifact)
- `BypassConfirmation` success path + `confirmAction` error branch — structurally-unreachable class (skipped test already documents it)

## Verification
| Check | Status |
|-------|--------|
| Coverage 96.6% → **96.7%**; all 8 targeted functions at 100% | PASS |
| go test (tui, history, openai, di, analysis) | PASS |
| make verify-nonfix-catalog (25-pin + buildE2EBinary canary intact) | PASS |
| make verify-transitive-gate (STRICT) | PASS |
| make check-full (all steps incl. race) | PASS |
| Scope: 5 test files + 1 new test file + 2 domain-model docs + 1 catalog doc; zero production .go changes | PASS |

Note: the product quirk surfaced during triage — the bypass tool can never actually enable bypass (only report/decline); enabled via di/session_factory.go. Recorded in the catalog entry; a separate look is warranted if desired.