### PR TITLE
Refactor: move metrics formatters from ui/tui/progress to domain/ports

### DIFF
--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -17,7 +17,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
-	"github.com/gosharplite/tell-me-go/internal/ui/tui/progress"
 )
 
 // sessionManager manages the session lifecycle and agent execution.
@@ -297,14 +296,14 @@ func (o *sessionManager) renderPostTUISummary(ts events.TurnStatus, sd ports.Cha
 			ts.MaxHistoryTokens,
 			ts.Mode, ts.Model)
 	}
-	if metricsLine := progress.FormatMetricsLine(ts); metricsLine != "" {
+	if metricsLine := ports.FormatMetricsLine(ts); metricsLine != "" {
 		_, _ = fmt.Fprintf(o.Stdout, "%s\n", metricsLine)
 	}
 	turnCost := 0.0
 	if ts.Metrics != nil {
 		turnCost = ts.Metrics.Cost
 	}
-	_, _ = fmt.Fprintf(o.Stdout, "%s\n", progress.FormatFinalLine(ts, turnCost))
+	_, _ = fmt.Fprintf(o.Stdout, "%s\n", ports.FormatFinalLine(ts, turnCost))
 }
 
 func (o *sessionManager) applyConfiguration(ctx context.Context, chatAgent ports.Chatter, sCfg SessionConfig, sd ports.ChatterComposer, capturer ports.Capturer, tuiOutput bool) (*ui.Bridge, error) {

--- a/internal/domain/ports/metrics_format.go
+++ b/internal/domain/ports/metrics_format.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ports
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+)
+
+// FormatMetricsLine renders a single-line post-call metrics summary from
+// a TurnStatus. Returns an empty string if Metrics is nil.
+func FormatMetricsLine(ts events.TurnStatus) string {
+	if ts.Metrics == nil {
+		return ""
+	}
+	miss := ts.Metrics.PromptTokens - ts.Metrics.CachedTokens
+	var parts []string
+
+	parts = append(parts, fmt.Sprintf("[%s]", ts.Timestamp.Format("15:04:05")))
+
+	display := ts.Metrics.Provider
+	if display == "" {
+		display = ts.Metrics.Model
+	}
+	if display != "" {
+		parts = append(parts, fmt.Sprintf("[%s]", display))
+	}
+
+	parts = append(parts, fmt.Sprintf("M: %d H: %d C: %d",
+		miss, ts.Metrics.CachedTokens, ts.Metrics.ResponseTokens))
+
+	if ts.Metrics.ThinkingTokens > 0 {
+		parts = append(parts, fmt.Sprintf("Th: %d", ts.Metrics.ThinkingTokens))
+	}
+
+	if ts.Metrics.Cost > 0 {
+		parts = append(parts, fmt.Sprintf("($%.4f)", ts.Metrics.Cost))
+	}
+
+	totalLatency := ts.Metrics.Duration + ts.Metrics.ToolDuration
+	timing := fmt.Sprintf("[%.2fs (ΣT: %.2fs)]",
+		totalLatency, ts.Metrics.CumulativeToolDuration)
+	if !ts.StartTime.IsZero() {
+		sessionDur := time.Since(ts.StartTime).Seconds()
+		turns := ts.CurrentTurns + 1
+		if turns > 0 {
+			timing = fmt.Sprintf("%s / %.2fs (%.2f)",
+				timing, sessionDur, sessionDur/float64(turns))
+		} else {
+			timing = fmt.Sprintf("%s / %.2fs", timing, sessionDur)
+		}
+	}
+	parts = append(parts, timing)
+
+	return strings.Join(parts, " ")
+}
+
+// FormatFinalLine renders the "Ready" summary line when the session is
+// complete. turnCost is the cost of the current turn (from Metrics.Cost).
+func FormatFinalLine(ts events.TurnStatus, turnCost float64) string {
+	hitRate := 0.0
+	if total := ts.TotalM + ts.TotalH; total > 0 {
+		hitRate = float64(ts.TotalH) / float64(total) * 100
+	}
+	return fmt.Sprintf("╰─⠿ Ready ($%.4f $%.4f $%.4f M: %d H: %d %.1f%% O: %d)",
+		turnCost, ts.TaskCost, ts.SessionCost,
+		ts.TotalM, ts.TotalH, hitRate, ts.TotalO)
+}

--- a/internal/domain/ports/metrics_format_test.go
+++ b/internal/domain/ports/metrics_format_test.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package ports
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+)
+
+// fullMetricsStatus returns a TurnStatus exercising every optional part of
+// FormatMetricsLine (provider, thinking tokens, cost, timing) with a zero
+// StartTime so the output is fully deterministic.
+func fullMetricsStatus() events.TurnStatus {
+	return events.TurnStatus{
+		Timestamp: time.Date(2026, 1, 15, 14, 30, 0, 0, time.UTC),
+		Metrics: &llm.Metrics{
+			PromptTokens:           1000,
+			CachedTokens:           800,
+			ResponseTokens:         50,
+			ThinkingTokens:         120,
+			Cost:                   0.0012,
+			Duration:               5.0,
+			ToolDuration:           2.0,
+			CumulativeToolDuration: 1.5,
+			Provider:               "deepseek-pro",
+		},
+	}
+}
+
+func TestFormatMetricsLine(t *testing.T) {
+	t.Run("nil metrics returns empty string", func(t *testing.T) {
+		got := FormatMetricsLine(events.TurnStatus{})
+		if got != "" {
+			t.Errorf("FormatMetricsLine() with nil Metrics = %q; want empty", got)
+		}
+	})
+
+	t.Run("renders full metrics line", func(t *testing.T) {
+		got := FormatMetricsLine(fullMetricsStatus())
+		want := "[14:30:00] [deepseek-pro] M: 200 H: 800 C: 50 Th: 120 ($0.0012) [7.00s (ΣT: 1.50s)]"
+		if got != want {
+			t.Errorf("FormatMetricsLine() = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("omits thinking tokens when zero", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.ThinkingTokens = 0
+		got := FormatMetricsLine(ts)
+		if strings.Contains(got, "Th:") {
+			t.Errorf("FormatMetricsLine() = %q; want no Th: segment", got)
+		}
+	})
+
+	t.Run("omits cost when zero", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.Cost = 0
+		got := FormatMetricsLine(ts)
+		if strings.Contains(got, "($") {
+			t.Errorf("FormatMetricsLine() = %q; want no cost segment", got)
+		}
+	})
+
+	t.Run("provider falls back to model", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.Provider = ""
+		ts.Metrics.Model = "deepseek-v4-pro"
+		got := FormatMetricsLine(ts)
+		if !strings.Contains(got, "[deepseek-v4-pro]") {
+			t.Errorf("FormatMetricsLine() = %q; want model fallback [deepseek-v4-pro]", got)
+		}
+	})
+
+	t.Run("omits provider bracket when both empty", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.Provider = ""
+		ts.Metrics.Model = ""
+		got := FormatMetricsLine(ts)
+		want := "[14:30:00] M: 200 H: 800 C: 50 Th: 120 ($0.0012) [7.00s (ΣT: 1.50s)]"
+		if got != want {
+			t.Errorf("FormatMetricsLine() = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("zero StartTime omits session duration segment", func(t *testing.T) {
+		got := FormatMetricsLine(fullMetricsStatus())
+		if strings.Contains(got, " / ") {
+			t.Errorf("FormatMetricsLine() = %q; want no session duration segment when StartTime is zero", got)
+		}
+	})
+
+	t.Run("nonzero StartTime appends session duration with per-turn average", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.StartTime = ts.Timestamp.Add(-10 * time.Second)
+		ts.CurrentTurns = 4 // turns = 5 → includes per-turn average
+		got := FormatMetricsLine(ts)
+		prefix := "[14:30:00] [deepseek-pro] M: 200 H: 800 C: 50 Th: 120 ($0.0012) [7.00s (ΣT: 1.50s)] / "
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("FormatMetricsLine() = %q; want prefix %q", got, prefix)
+		}
+		// Tail: "<sessionDur>s (<sessionDur>/5)" — time.Since makes it non-deterministic,
+		// so assert the structural shape instead of byte equality.
+		tailRe := regexp.MustCompile(`^\d+\.\d{2}s \(\d+\.\d{2}\)$`)
+		if !tailRe.MatchString(got[len(prefix):]) {
+			t.Errorf("FormatMetricsLine() tail = %q; want shape <seconds>s (<seconds>)", got[len(prefix):])
+		}
+	})
+
+	t.Run("negative CurrentTurns appends session duration without average", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.StartTime = ts.Timestamp.Add(-10 * time.Second)
+		ts.CurrentTurns = -1 // turns = 0 → no per-turn average
+		got := FormatMetricsLine(ts)
+		prefix := "[14:30:00] [deepseek-pro] M: 200 H: 800 C: 50 Th: 120 ($0.0012) [7.00s (ΣT: 1.50s)] / "
+		if !strings.HasPrefix(got, prefix) {
+			t.Errorf("FormatMetricsLine() = %q; want prefix %q", got, prefix)
+		}
+		tailRe := regexp.MustCompile(`^\d+\.\d{2}s$`)
+		if !tailRe.MatchString(got[len(prefix):]) {
+			t.Errorf("FormatMetricsLine() tail = %q; want shape <seconds>s", got[len(prefix):])
+		}
+	})
+}
+
+func TestFormatFinalLine(t *testing.T) {
+	t.Run("renders ready summary line", func(t *testing.T) {
+		ts := events.TurnStatus{
+			TaskCost:    0.0012,
+			SessionCost: 0.1505,
+			TotalM:      116386,
+			TotalH:      15172096,
+			TotalO:      51607,
+		}
+		got := FormatFinalLine(ts, 0.0010)
+		want := "╰─⠿ Ready ($0.0010 $0.0012 $0.1505 M: 116386 H: 15172096 99.2% O: 51607)"
+		if got != want {
+			t.Errorf("FormatFinalLine() = %q; want %q", got, want)
+		}
+	})
+
+	t.Run("zero totals render zero hit rate", func(t *testing.T) {
+		got := FormatFinalLine(events.TurnStatus{}, 0)
+		want := "╰─⠿ Ready ($0.0000 $0.0000 $0.0000 M: 0 H: 0 0.0% O: 0)"
+		if got != want {
+			t.Errorf("FormatFinalLine() = %q; want %q", got, want)
+		}
+	})
+}

--- a/internal/ui/tui/progress/model.go
+++ b/internal/ui/tui/progress/model.go
@@ -409,14 +409,14 @@ func (m *model) handleTurnStatus(e events.TurnStatusEvent) tea.Cmd {
 	if e.Status.IsPostCall && e.Status.Metrics != nil {
 		s := e.Status
 		m.postCallStatus = &s
-		m.postCallMetricsLine = FormatMetricsLine(s)
+		m.postCallMetricsLine = ports.FormatMetricsLine(s)
 	}
 	if e.Status.IsFinal {
 		turnCost := 0.0
 		if e.Status.Metrics != nil {
 			turnCost = e.Status.Metrics.Cost
 		}
-		m.finalCostLine = FormatFinalLine(e.Status, turnCost)
+		m.finalCostLine = ports.FormatFinalLine(e.Status, turnCost)
 	}
 	if m.spinner.active() {
 		m.spinner.clear()
@@ -585,66 +585,6 @@ func (m *model) extractToolCallsFromResponse(content *llm.Content) {
 	for _, fc := range toolCalls {
 		m.logToolCall(fc)
 	}
-}
-
-// FormatMetricsLine renders a single-line post-call metrics summary from
-// a TurnStatus. Returns an empty string if Metrics is nil.
-func FormatMetricsLine(ts events.TurnStatus) string {
-	if ts.Metrics == nil {
-		return ""
-	}
-	miss := ts.Metrics.PromptTokens - ts.Metrics.CachedTokens
-	var parts []string
-
-	parts = append(parts, fmt.Sprintf("[%s]", ts.Timestamp.Format("15:04:05")))
-
-	display := ts.Metrics.Provider
-	if display == "" {
-		display = ts.Metrics.Model
-	}
-	if display != "" {
-		parts = append(parts, fmt.Sprintf("[%s]", display))
-	}
-
-	parts = append(parts, fmt.Sprintf("M: %d H: %d C: %d",
-		miss, ts.Metrics.CachedTokens, ts.Metrics.ResponseTokens))
-
-	if ts.Metrics.ThinkingTokens > 0 {
-		parts = append(parts, fmt.Sprintf("Th: %d", ts.Metrics.ThinkingTokens))
-	}
-
-	if ts.Metrics.Cost > 0 {
-		parts = append(parts, fmt.Sprintf("($%.4f)", ts.Metrics.Cost))
-	}
-
-	totalLatency := ts.Metrics.Duration + ts.Metrics.ToolDuration
-	timing := fmt.Sprintf("[%.2fs (ΣT: %.2fs)]",
-		totalLatency, ts.Metrics.CumulativeToolDuration)
-	if !ts.StartTime.IsZero() {
-		sessionDur := time.Since(ts.StartTime).Seconds()
-		turns := ts.CurrentTurns + 1
-		if turns > 0 {
-			timing = fmt.Sprintf("%s / %.2fs (%.2f)",
-				timing, sessionDur, sessionDur/float64(turns))
-		} else {
-			timing = fmt.Sprintf("%s / %.2fs", timing, sessionDur)
-		}
-	}
-	parts = append(parts, timing)
-
-	return strings.Join(parts, " ")
-}
-
-// FormatFinalLine renders the "Ready" summary line when the session is
-// complete. turnCost is the cost of the current turn (from Metrics.Cost).
-func FormatFinalLine(ts events.TurnStatus, turnCost float64) string {
-	hitRate := 0.0
-	if total := ts.TotalM + ts.TotalH; total > 0 {
-		hitRate = float64(ts.TotalH) / float64(total) * 100
-	}
-	return fmt.Sprintf("╰─⠿ Ready ($%.4f $%.4f $%.4f M: %d H: %d %.1f%% O: %d)",
-		turnCost, ts.TaskCost, ts.SessionCost,
-		ts.TotalM, ts.TotalH, hitRate, ts.TotalO)
 }
 
 // View renders the progress model as three viewport zones.

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -406,7 +407,7 @@ func TestModel_View(t *testing.T) {
 			},
 			StartTime: time.Date(2026, 1, 15, 14, 28, 0, 0, time.UTC),
 		}
-		m.postCallMetricsLine = FormatMetricsLine(*m.postCallStatus)
+		m.postCallMetricsLine = ports.FormatMetricsLine(*m.postCallStatus)
 
 		out := m.View()
 		assert.Contains(t, out, "M: 200 H: 800 C: 50")


### PR DESCRIPTION
## Summary

Architect-assigned fix ([Finding 1]): removes the application→presentation concrete import edge.

`internal/agent/session/session_manager.go` (application layer) imported the concrete presentation package `internal/ui/tui/progress` solely to call two pure string formatters (`FormatMetricsLine`, `FormatFinalLine`). The TUI renderer itself was already correctly injected via `ports.ProgressRenderer`; only these two formatters leaked across the layer boundary.

## Changes

- **Move** `FormatMetricsLine` / `FormatFinalLine` **verbatim** (behavior-identical) from `internal/ui/tui/progress/model.go` → new `internal/domain/ports/metrics_format.go` (shared kernel; `ports` already imports `events`, no new edges).
- **Update call sites** to `ports.FormatMetricsLine` / `ports.FormatFinalLine` in:
  - `internal/ui/tui/progress/model.go` (`handleTurnStatus`)
  - `internal/agent/session/session_manager.go` (`renderPostTUISummary`)
- **Remove** the `internal/ui/tui/progress` import from `session_manager.go`. The agent layer now has **zero** imports of any `internal/ui/...` package.
- **Tests**: new `internal/domain/ports/metrics_format_test.go` — 11 subtests covering every branch (nil metrics, full render, optional-segment omission, provider→model fallback, session-duration variants, zero totals). The prior `model_test.go` line-409 usage was an indirect call inside `TestModel_View` (not a dedicated test), so it was updated in place rather than moved.

## Verification

- `go build ./...` — passes (no import cycle)
- `go test ./internal/domain/ports/... ./internal/ui/tui/progress/... ./internal/agent/session/...` — all `ok`
- `go test ./...` — all packages pass
- `grep -rn "internal/ui/tui/progress" internal/agent/` — no matches (verified; stronger claim: no `internal/ui/` imports at all)
- Strict architecture gate: `go test -tags=arch -run TestVerifyRealArchitecture ./internal/tools/analysis -args -strict-arch=true` — passes
- `gofmt`/`go vet` clean on touched packages

## Impact

Removes the only application→presentation concrete edge. UI implementation becomes fully swappable behind `ports.ProgressRenderer`. Output format of both functions is unchanged (byte-identical strings).
