### PR TITLE
Refactor: clear remaining complexity alerts (buildE2EBinary, TestFormatMetricsLine)

### DIFF
--- a/internal/domain/ports/metrics_format_test.go
+++ b/internal/domain/ports/metrics_format_test.go
@@ -33,37 +33,26 @@ func fullMetricsStatus() events.TurnStatus {
 	}
 }
 
-func TestFormatMetricsLine(t *testing.T) {
+// TestFormatMetricsLine_NilMetrics covers the nil-Metrics case: an empty
+// TurnStatus renders to an empty string.
+func TestFormatMetricsLine_NilMetrics(t *testing.T) {
 	t.Run("nil metrics returns empty string", func(t *testing.T) {
 		got := FormatMetricsLine(events.TurnStatus{})
 		if got != "" {
 			t.Errorf("FormatMetricsLine() with nil Metrics = %q; want empty", got)
 		}
 	})
+}
 
+// TestFormatMetricsLine_FullRender covers the exact full line and the
+// provider-identification segment: provider used as-is, provider falls back
+// to model, and the bracket is omitted when both are empty.
+func TestFormatMetricsLine_FullRender(t *testing.T) {
 	t.Run("renders full metrics line", func(t *testing.T) {
 		got := FormatMetricsLine(fullMetricsStatus())
 		want := "[14:30:00] [deepseek-pro] M: 200 H: 800 C: 50 Th: 120 ($0.0012) [7.00s (ΣT: 1.50s)]"
 		if got != want {
 			t.Errorf("FormatMetricsLine() = %q; want %q", got, want)
-		}
-	})
-
-	t.Run("omits thinking tokens when zero", func(t *testing.T) {
-		ts := fullMetricsStatus()
-		ts.Metrics.ThinkingTokens = 0
-		got := FormatMetricsLine(ts)
-		if strings.Contains(got, "Th:") {
-			t.Errorf("FormatMetricsLine() = %q; want no Th: segment", got)
-		}
-	})
-
-	t.Run("omits cost when zero", func(t *testing.T) {
-		ts := fullMetricsStatus()
-		ts.Metrics.Cost = 0
-		got := FormatMetricsLine(ts)
-		if strings.Contains(got, "($") {
-			t.Errorf("FormatMetricsLine() = %q; want no cost segment", got)
 		}
 	})
 
@@ -87,7 +76,36 @@ func TestFormatMetricsLine(t *testing.T) {
 			t.Errorf("FormatMetricsLine() = %q; want %q", got, want)
 		}
 	})
+}
 
+// TestFormatMetricsLine_OptionalSegments covers the zero-valued optional
+// segments: thinking tokens and cost are omitted when they are zero.
+func TestFormatMetricsLine_OptionalSegments(t *testing.T) {
+	t.Run("omits thinking tokens when zero", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.ThinkingTokens = 0
+		got := FormatMetricsLine(ts)
+		if strings.Contains(got, "Th:") {
+			t.Errorf("FormatMetricsLine() = %q; want no Th: segment", got)
+		}
+	})
+
+	t.Run("omits cost when zero", func(t *testing.T) {
+		ts := fullMetricsStatus()
+		ts.Metrics.Cost = 0
+		got := FormatMetricsLine(ts)
+		if strings.Contains(got, "($") {
+			t.Errorf("FormatMetricsLine() = %q; want no cost segment", got)
+		}
+	})
+}
+
+// TestFormatMetricsLine_SessionDuration covers the session duration segment:
+// it is omitted when StartTime is zero, appended with a per-turn average for
+// positive turn counts (structural regex, since time.Since is
+// non-deterministic), and appended without the average for non-positive
+// turn counts.
+func TestFormatMetricsLine_SessionDuration(t *testing.T) {
 	t.Run("zero StartTime omits session duration segment", func(t *testing.T) {
 		got := FormatMetricsLine(fullMetricsStatus())
 		if strings.Contains(got, " / ") {

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -18,8 +18,9 @@ import (
 // catalog: it recomputes the real complexity alerts against the LIVE repo and
 // cross-references them against the live docs/architect/INTENTIONAL_NON_FIXES.md
 // catalog (uncapped, mirroring bucketComplexityAlerts internals). Every
-// over-threshold function must be pinned by an ACCEPTED catalog entry — the
-// only allowed alert is the known genuine gap (buildE2EBinary, CC=12).
+// over-threshold function must be pinned by an ACCEPTED catalog entry. The
+// former known genuine gap (buildE2EBinary, CC=12) was refactored below
+// threshold in 2026-09 (fix/e2e-build-complexity), so zero alerts remain.
 //
 // The go test binary runs with its working directory set to the package
 // source directory, so the walk root and the catalog path are anchored to
@@ -90,5 +91,5 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)
-	require.Equal(t, []string{"buildE2EBinary"}, alerts)
+	require.Empty(t, alerts)
 }

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -39,6 +39,66 @@ func isShortMode() bool {
 	return false
 }
 
+// resolveE2EBinPath determines where the e2e binary lives and whether it is
+// in a temporary directory. It prefers a persistent cache directory under the
+// user cache dir so the binary survives across runs; if os.UserCacheDir()
+// fails it falls back to a fresh temporary directory. On failure it prints to
+// stderr and calls os.Exit(1).
+func resolveE2EBinPath() (binPath string, isTemp bool) {
+	exeSuffix := ""
+	if runtime.GOOS == "windows" {
+		exeSuffix = ".exe"
+	}
+
+	// Prefer a persistent cache directory so the binary survives across runs.
+	cacheDir, cacheErr := os.UserCacheDir()
+	if cacheErr == nil {
+		cacheDir = filepath.Join(cacheDir, "tell-me-go", "e2e-binary")
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create cache dir %s: %v\n", cacheDir, err)
+			os.Exit(1)
+		}
+		return filepath.Join(cacheDir, "tell-me-go"+exeSuffix), false
+	}
+
+	// Fallback: create a fresh temp directory (old behavior).
+	tempDir, err := os.MkdirTemp("", "tell-me-go-e2e")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to create temp dir: %v\n", err)
+		os.Exit(1)
+	}
+	return filepath.Join(tempDir, "tell-me-go"+exeSuffix), true
+}
+
+// e2eBinaryFresh reports whether the cached binary at binPath is newer than
+// the source at mainPath and therefore does not need to be rebuilt.
+func e2eBinaryFresh(binPath, mainPath string) bool {
+	binInfo, err := os.Stat(binPath)
+	if err != nil {
+		return false
+	}
+	srcInfo, err := os.Stat(mainPath)
+	if err != nil {
+		return false
+	}
+	return binInfo.ModTime().After(srcInfo.ModTime())
+}
+
+// buildE2EBinaryNow runs `go build -o binPath mainPath`. On failure it prints
+// the combined output to stderr, removes the binary's directory when it lives
+// in a temp dir (cache dir should persist), and calls os.Exit(1).
+func buildE2EBinaryNow(binPath, mainPath string) {
+	build := exec.Command("go", "build", "-o", binPath, mainPath)
+	if out, err := build.CombinedOutput(); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to build binary: %v\nOutput: %s\n", err, string(out))
+		// Only clean up if we used a temp dir (cache dir should persist).
+		if isTempBinDir {
+			_ = os.RemoveAll(filepath.Dir(binPath))
+		}
+		os.Exit(1)
+	}
+}
+
 // buildE2EBinary compiles cmd/tell-me-go into a persistent cache directory.
 // The cache lives at <UserCacheDir>/tell-me-go/e2e-binary/ so that rebuilds only
 // happen when cmd/tell-me-go/main.go is newer than the cached binary.
@@ -54,55 +114,15 @@ func buildE2EBinary() {
 	projectRoot = filepath.Dir(filepath.Dir(wd))
 	mainPath := filepath.Join(projectRoot, "cmd", "tell-me-go", "main.go")
 
-	exeSuffix := ""
-	if runtime.GOOS == "windows" {
-		exeSuffix = ".exe"
-	}
+	binPath, isTempBinDir = resolveE2EBinPath()
 
-	// Prefer a persistent cache directory so the binary survives across runs.
-	cacheDir, cacheErr := os.UserCacheDir()
-	if cacheErr == nil {
-		cacheDir = filepath.Join(cacheDir, "tell-me-go", "e2e-binary")
-		if err := os.MkdirAll(cacheDir, 0755); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create cache dir %s: %v\n", cacheDir, err)
-			os.Exit(1)
-		}
-		binPath = filepath.Join(cacheDir, "tell-me-go"+exeSuffix)
-		isTempBinDir = false
-	} else {
-		// Fallback: create a fresh temp directory (old behavior).
-		tempDir, err := os.MkdirTemp("", "tell-me-go-e2e")
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to create temp dir: %v\n", err)
-			os.Exit(1)
-		}
-		binPath = filepath.Join(tempDir, "tell-me-go"+exeSuffix)
-		isTempBinDir = true
-	}
-
-	needsBuild := true
-	if binInfo, err := os.Stat(binPath); err == nil {
-		if srcInfo, err := os.Stat(mainPath); err == nil {
-			if binInfo.ModTime().After(srcInfo.ModTime()) {
-				needsBuild = false
-			}
-		}
-	}
-
-	if needsBuild {
-		fmt.Printf("Building binary: %s from %s\n", binPath, mainPath)
-		build := exec.Command("go", "build", "-o", binPath, mainPath)
-		if out, err := build.CombinedOutput(); err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to build binary: %v\nOutput: %s\n", err, string(out))
-			// Only clean up if we used a temp dir (cache dir should persist).
-			if isTempBinDir {
-				_ = os.RemoveAll(filepath.Dir(binPath))
-			}
-			os.Exit(1)
-		}
-	} else {
+	if e2eBinaryFresh(binPath, mainPath) {
 		fmt.Printf("Using cached binary: %s\n", binPath)
+		return
 	}
+
+	fmt.Printf("Building binary: %s from %s\n", binPath, mainPath)
+	buildE2EBinaryNow(binPath, mainPath)
 }
 
 func TestMain(m *testing.M) {


### PR DESCRIPTION
## Summary

Architect-assigned fix: closes the last two open items in the quality model's `triage-loop-closed` invariant. **Merging this PR returns `dev` to green on the `verify-nonfix-catalog` gate.**

### 1. Refactor `buildE2EBinary` (CC 12 → 3)

`buildE2EBinary()` in `tests/e2e/e2e_test.go` was the only over-threshold function NOT pinned by an ACCEPTED catalog entry (the partition gate asserted it as the sole "genuine gap"). Fix chosen: **refactor** (the FIX path of the triage loop), not cataloging.

Decomposed into three cohesive unexported helpers, each ≤ CC 10:
- `resolveE2EBinPath()` (CC 5) — windows suffix, user-cache dir + `MkdirAll`, temp-dir fallback
- `e2eBinaryFresh(binPath, mainPath)` (CC 3) — stat + mtime freshness check (returns `false` on stat failure, preserving the original `needsBuild=true` default)
- `buildE2EBinaryNow(binPath, mainPath)` (CC 3) — `go build`, error handling, temp cleanup on failure

**Behavior exactly preserved** (the e2e suite depends on it): stdout messages (`Building binary: …`, `Using cached binary: …`), stderr messages and `os.Exit(1)` on all failure paths, package-var side effects (`binPath`, `projectRoot`, `isTempBinDir`), temp-dir cleanup semantics, ordering of observable side effects.

### 2. Fix the `dev`-red regression introduced by #1314: `TestFormatMetricsLine` (CC 12 → ≤ 6)

PR #1314's new test function `TestFormatMetricsLine` (`internal/domain/ports/metrics_format_test.go`) had CC 12 — the complexity analyzer counts subtest closures into the parent function — leaving `dev` RED on `verify-nonfix-catalog` (alerts = `[TestFormatMetricsLine, buildE2EBinary]`).

Split into four focused top-level test functions (all 9 subtests preserved verbatim — pure re-grouping, no assertion or expected-string changes):
- `TestFormatMetricsLine_NilMetrics` (CC 2)
- `TestFormatMetricsLine_FullRender` (CC 4) — full line, provider→model fallback, empty-provider bracket omission
- `TestFormatMetricsLine_OptionalSegments` (CC 3) — `Th:` / cost omission when zero
- `TestFormatMetricsLine_SessionDuration` (CC 6) — zero/nonzero StartTime (structural regex for non-deterministic `time.Since`), negative CurrentTurns

### 3. Partition gate updated

`internal/tools/analysis/real_nonfix_catalog_test.go`: `require.Equal(t, []string{"buildE2EBinary"}, alerts)` → `require.Empty(t, alerts)`. Doc comment updated; `expectedCataloged` (25 entries) **untouched**. The gate is now a regression tripwire: any future function exceeding CC 10 without a catalog pin fails the pipeline.

## Verification (all on the merged branch state)

- `go test -tags=arch -run TestVerifyNonFixCatalog ./internal/tools/analysis -count=1` — **passes** (alerts empty; RED→GREEN proven in TDD sequence)
- `go test -count=1 -tags=arch -run TestVerifyRealArchitecture ./internal/tools/analysis -args -strict-arch=true` — passes
- `go test -v -tags=arch -run TestVerifyTransitiveClosureGate ./internal/tools/analysis -args -transitive-gate-report-only=false` — passes
- `go build ./...` — passes
- `go test ./internal/domain/ports/... -count=1` — all 11 subtests pass (74 test runs)
- `go test ./tests/e2e/... -run TestVersionFlag -count=1` — passes (both refactored build branches exercised)
- `go vet` / `gofmt` / `git diff --check` — clean

Untouched: `docs/architect/INTENTIONAL_NON_FIXES.md` (FIX path — no catalog entry), `.modelith` files, generated Markdown.
