### PR TITLE
Fix: cataloged coverage gaps no longer rank as actionable

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -249,14 +249,15 @@ catalog a new gap no one reviewed. Policy:
 ### agent/session/context/manager.go — capBestBlock non-capped return
 
 - **Status**: ACCEPTED (2026-07)
-- **Rationale**: The final return in `capBestBlock` (`manager.go:582`) is reached
+- **Rationale**: The final return in `capBestBlock` (`manager.go:590`) is reached
   when `best.count >= minViable` but `groupTurns` returns ≤1 turn for the
   sub-slice. With the default `contiguousUnpinnedSelector` (MinViableBlock=2),
   `best.count >= 2` and the sub-slice spans ≥2 turns, so `groupTurns` always
   returns ≥2 turns. This return is a defensive fallthrough for degenerate
   message sequences. Same acceptance class as defensive nil/empty guards on
-  internal pipeline state (2026-07 Batch Triage).
-- **See**: `internal/agent/session/context/manager.go:582`
+  internal pipeline state (2026-07 Batch Triage). Re-anchored 2026-09: the
+  return drifted from line 582 to 590 as the acceptance comment block grew.
+- **See**: `internal/agent/session/context/manager.go:590`
 
 ### agent/session/session_manager.go — tuiCleanup and setupUIRendering TUI branches
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -232,7 +232,7 @@ catalog a new gap no one reviewed. Policy:
   slice between validation and this call site. Structurally unreachable — same
   acceptance class as `json.Marshal` on all-string structs in
   `global_prompt_tracker.go`.
-- **See**: `internal/agent/session/context/manager.go`
+- **See**: `internal/agent/session/context/manager.go:574-576`
   (architect-acceptance comment at the `groupTurns` call site in `capBestBlock`)
 
 ### context/manager.go — capBestBlock error propagation in checkWindowSize
@@ -243,7 +243,7 @@ catalog a new gap no one reviewed. Policy:
   already-validated sub-slice is structurally unreachable (see previous entry),
   this error-handling branch is equally unreachable. Both gaps share the same root
   cause and acceptance rationale.
-- **See**: `internal/agent/session/context/manager.go`
+- **See**: `internal/agent/session/context/manager.go:619-621`
   (architect-acceptance comment at the `capBestBlock` call site in `checkWindowSize`)
 
 ### agent/session/context/manager.go — capBestBlock non-capped return
@@ -655,7 +655,7 @@ catalog a new gap no one reviewed. Policy:
   `store.Append`). Testing a pass-through method provides no value — same
   acceptance class as `domainFS.Chmod`, `mockFileSystem.Chmod`,
   `plainOSFS.Chmod`, and `OSFileSystem.Chmod`.
-- **See**: `internal/domain/services/task_service.go:95-97`
+- **See**: `internal/domain/services/task_service.go:101-103`
 
 ### agent/service.go — EditLastTurn delegation wrapper
 

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -604,8 +604,8 @@ func (m *healthManager) getDetailedCoverageJSON(ctx context.Context, packagePath
 		return "", err
 	}
 
-	// Tag ACCEPTED catalog gaps (additive). The catalog_title field is exposed
-	// to JSON callers; no filtering change here — callers may filter. A load
+	// Tag ACCEPTED catalog gaps, then exclude them from the priority-filtered
+	// JSON output (mirroring the report path's aggregateCoverageStats). A load
 	// failure degrades gracefully: all gaps stay actionable.
 	entries := m.loadNonFixEntries()
 	applyCatalogTitles(blocks, entries)
@@ -622,6 +622,12 @@ func (m *healthManager) getDetailedCoverageJSON(ctx context.Context, packagePath
 	return jsonStr, nil
 }
 
+// formatDetailedCoverageJSON renders the uncovered blocks as indented JSON,
+// filtered by minPriority. Blocks covered by an ACCEPTED catalog entry are
+// excluded from the filtered output — they are accepted gaps, not actionable
+// ones, and remain visible via the catalog itself. This mirrors the report
+// path (aggregateCoverageStats), which also excludes CatalogTitle != "" from
+// the High/Medium buckets.
 func formatDetailedCoverageJSON(blocks []uncoveredBlock, minPriority string) (string, error) {
 	priorityMap := map[string]int{
 		"High":   3,
@@ -632,6 +638,11 @@ func formatDetailedCoverageJSON(blocks []uncoveredBlock, minPriority string) (st
 	minP := priorityMap[minPriority]
 	var filtered []uncoveredBlock
 	for _, b := range blocks {
+		// Cataloged (ACCEPTED) gaps are already-accepted: they must never rank
+		// as actionable. They remain visible via the catalog itself.
+		if b.CatalogTitle != "" {
+			continue
+		}
 		if priorityMap[b.Priority] >= minP {
 			filtered = append(filtered, b)
 		}

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1233,6 +1234,8 @@ func TestGetDetailedCoverageJSON_PriorityFiltering(t *testing.T) {
 			return []byte("ok"), nil
 		},
 	}
+	// catalogPath is the zero value → behaves like a missing catalog, so the
+	// block is NOT tagged ACCEPTED and stays actionable.
 	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
 	// Block is in temp dir → classified as OTHER/Low priority
@@ -1257,6 +1260,66 @@ func TestGetDetailedCoverageJSON_PriorityFiltering(t *testing.T) {
 	}
 	if !strings.Contains(jsonStr, "test_file.go") {
 		t.Errorf("expected JSON data with file name for Low filter, got: %q", jsonStr)
+	}
+}
+
+func TestGetDetailedCoverageJSON_PriorityFiltering_ExcludesCataloged(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	_, goFile := setupMockGoFile(t, "package analysis\nfunc F() { if true {} }\n")
+
+	mock := &mockExecutor{
+		OutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("github.com/user/repo"), nil
+		},
+		CombinedOutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-coverprofile=") {
+					path := strings.TrimPrefix(arg, "-coverprofile=")
+					coverageContent := fmt.Sprintf("mode: set\n%s:1.0,2.0 1 0\n", goFile)
+					if err := os.WriteFile(path, []byte(coverageContent), 0644); err != nil {
+						t.Errorf("failed to write mock coverage file: %v", err)
+					}
+				}
+			}
+			return []byte("ok"), nil
+		},
+	}
+
+	// A catalog entry pinning the block's bare basename (`test_file.go:1-2`)
+	// marks the gap ACCEPTED, so it must be excluded from the priority-filtered
+	// JSON output even under the "Low" filter.
+	catalogPath := filepath.Join(t.TempDir(), "INTENTIONAL_NON_FIXES.md")
+	catalogMD := "# Intentional Non-Fixes\n\n### test_file.go — accepted gap\n\n- **Status**: ACCEPTED (2026-07)\n- **See**: `test_file.go:1-2`\n"
+	if err := os.WriteFile(catalogPath, []byte(catalogMD), 0644); err != nil {
+		t.Fatalf("failed to write catalog fixture: %v", err)
+	}
+	hea := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock), catalogPath: catalogPath}
+
+	jsonStr, err := hea.getDetailedCoverageJSON(ctx, ".", "Low", nil)
+	if err != nil {
+		t.Fatalf("getDetailedCoverageJSON with Low filter and catalog failed: %v", err)
+	}
+	if strings.Contains(jsonStr, "test_file.go") {
+		t.Errorf("expected cataloged block excluded from JSON output, got: %q", jsonStr)
+	}
+}
+
+func TestFormatDetailedCoverageJSON_ExcludesCataloged(t *testing.T) {
+	t.Parallel()
+	blocks := []uncoveredBlock{
+		{File: "file1.go", Start: 1, End: 2, Category: "BUSINESS_LOGIC", Priority: "High", Code: "code1"},
+		{File: "file2.go", Start: 1, End: 2, Category: "ERROR_HANDLING", Priority: "High", Code: "code2", CatalogTitle: "accepted entry"},
+	}
+	jsonStr, err := formatDetailedCoverageJSON(blocks, "Low")
+	if err != nil {
+		t.Fatalf("formatDetailedCoverageJSON failed: %v", err)
+	}
+	if !strings.Contains(jsonStr, "file1.go") {
+		t.Error("expected uncataloged block in JSON output")
+	}
+	if strings.Contains(jsonStr, "file2.go") {
+		t.Error("expected cataloged block excluded from JSON output")
 	}
 }
 

--- a/internal/tools/analysis/nonfix_catalog.go
+++ b/internal/tools/analysis/nonfix_catalog.go
@@ -42,6 +42,13 @@ var backtickRef = regexp.MustCompile("`([^`]+)`")
 type pendingEntry struct {
 	entry  nonFixEntry
 	status string
+	// lastSeeFile is the file component of the most recent file-bearing
+	// reference in this entry's See block. It lets a bare `:line` reference
+	// (empty file component) inherit the file of the preceding reference —
+	// e.g. "`config.go:224-229` (definition), `:249-251` (call-site error
+	// branch)". It is scoped to the entry's See block because parseSeeRefs
+	// only mutates it for See bullets and their indented continuations.
+	lastSeeFile string
 }
 
 // loadNonFixCatalog reads and parses the Intentional Non-Fixes catalog at
@@ -135,10 +142,18 @@ func filterAcceptedEntries(pending []pendingEntry) []nonFixEntry {
 
 // parseSeeRefs extracts every backticked reference from a See bullet line (or
 // an indented continuation) and appends the valid fileRange values to the
-// pending entry.
+// pending entry. The most recent file-bearing reference in the entry's See
+// block is remembered on cur.lastSeeFile so a bare `:line` continuation ref
+// inherits its file. Refs that resolve to no range (commit hashes, prose,
+// file-only refs, malformed locations) do not update the inherited file.
 func parseSeeRefs(line string, cur *pendingEntry) {
 	for _, m := range backtickRef.FindAllStringSubmatch(line, -1) {
-		cur.entry.Refs = append(cur.entry.Refs, parseCatalogRef(m[1])...)
+		ranges := parseCatalogRefInherited(m[1], cur.lastSeeFile)
+		if len(ranges) == 0 {
+			continue
+		}
+		cur.lastSeeFile = ranges[0].File
+		cur.entry.Refs = append(cur.entry.Refs, ranges...)
 	}
 }
 
@@ -146,16 +161,35 @@ func parseSeeRefs(line string, cur *pendingEntry) {
 // reference into one or more fileRange values. A comma-separated location
 // list (`file.go:162,431,558` or `file.go:142-144,237-240`) expands into
 // multiple ranges. Refs that are not `<path>:<line>` shaped (commit hashes,
-// plain paths, prose) are ignored.
+// plain paths, prose) are ignored. A ref with an empty file component
+// (`:249-251`) is dropped — it only resolves when an inherited file is
+// supplied via parseCatalogRefInherited.
 func parseCatalogRef(ref string) []fileRange {
+	return parseCatalogRefInherited(ref, "")
+}
+
+// parseCatalogRefInherited parses one backticked reference with an inherited
+// default file. A ref shaped `:249-251` (empty file component, non-empty
+// location) resolves against inheritedFile, producing
+// {File: inheritedFile, Start: 249, End: 251}; with no inherited file the
+// ref is dropped. All other behavior matches parseCatalogRef: comma lists
+// expand, commit hashes and prose are ignored, and plain file refs with no
+// line spec are dropped.
+func parseCatalogRefInherited(ref, inheritedFile string) []fileRange {
 	colonIdx := strings.LastIndex(ref, ":")
 	if colonIdx == -1 {
 		return nil
 	}
 	file := strings.TrimSpace(ref[:colonIdx])
 	locSpec := strings.TrimSpace(ref[colonIdx+1:])
-	if file == "" || locSpec == "" {
+	if locSpec == "" {
 		return nil
+	}
+	if file == "" {
+		if inheritedFile == "" {
+			return nil
+		}
+		file = inheritedFile
 	}
 
 	var ranges []fileRange

--- a/internal/tools/analysis/nonfix_catalog_test.go
+++ b/internal/tools/analysis/nonfix_catalog_test.go
@@ -294,6 +294,185 @@ func TestParseCatalogRef(t *testing.T) {
 	}
 }
 
+// continuationCatalog exercises the See-block file-inheritance rules: a bare
+// `:line` continuation ref inherits the file of the most recent file-bearing
+// ref in the same See block (within one bullet and across indented
+// continuation lines); a bare `:line` ref with no preceding file-bearing ref
+// is dropped; file-only refs are dropped and do not feed inheritance.
+const continuationCatalog = `# Intentional Non-Fixes
+
+## Coverage Gaps (ACCEPTED)
+
+### domain/config/config.go — validateProviderUniqueness
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Structural invariant.
+- **See**: ` + "`internal/domain/config/config.go:224-229`" + ` (definition), ` + "`:249-251`" + ` (call-site error branch, covered by this entry)
+
+### domain/services/task_service.go — AppendTask delegation wrapper
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Delegation wrapper.
+- **See**: ` + "`internal/domain/services/task_service.go:95-97`" + ` (old anchor),
+  ` + "`:101-103`" + ` (drifted body)
+
+### agent/session/context/manager.go — bare ref with no inherited file
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: No file-bearing ref precedes the bare ref.
+- **See**: ` + "`:574-576`" + `
+
+### tools/workspace/shell.go — comma list after inherited file
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: Comma lists keep expanding under inheritance.
+- **See**: ` + "`internal/tools/workspace/shell.go:162`" + `,
+  ` + "`:431,558`" + ` (inherits the file)
+
+### ui/tui/progress/model.go — file-only ref does not feed inheritance
+
+- **Status**: ACCEPTED (2026-07)
+- **Rationale**: File-only refs are dropped and do not become inherited files.
+- **See**: ` + "`internal/ui/tui/progress/model.go`" + `
+  (file only), ` + "`:338`" + ` (must still be dropped)
+
+---
+
+*Last Updated: 2026-08 (catalog hygiene)*
+`
+
+func TestParseNonFixCatalog_ColonContinuationRefs(t *testing.T) {
+	t.Parallel()
+	entries := parseNonFixCatalog(continuationCatalog)
+
+	if len(entries) != 5 {
+		t.Fatalf("parseNonFixCatalog() = %d entries, want 5", len(entries))
+	}
+
+	tests := []struct {
+		name  string
+		entry int
+		want  []fileRange
+	}{
+		{
+			name:  "bare range inherits file within one See bullet",
+			entry: 0,
+			want: []fileRange{
+				{File: "internal/domain/config/config.go", Start: 224, End: 229},
+				{File: "internal/domain/config/config.go", Start: 249, End: 251},
+			},
+		},
+		{
+			name:  "bare range inherits file across indented continuation lines",
+			entry: 1,
+			want: []fileRange{
+				{File: "internal/domain/services/task_service.go", Start: 95, End: 97},
+				{File: "internal/domain/services/task_service.go", Start: 101, End: 103},
+			},
+		},
+		{
+			name:  "bare ref with no preceding file-bearing ref is dropped",
+			entry: 2,
+			want:  nil,
+		},
+		{
+			name:  "comma list continues to expand under inherited file",
+			entry: 3,
+			want: []fileRange{
+				{File: "internal/tools/workspace/shell.go", Start: 162, End: 162},
+				{File: "internal/tools/workspace/shell.go", Start: 431, End: 431},
+				{File: "internal/tools/workspace/shell.go", Start: 558, End: 558},
+			},
+		},
+		{
+			name:  "file-only ref does not feed inheritance",
+			entry: 4,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := entries[tt.entry].Refs
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("entries[%d].Refs = %+v, want %+v", tt.entry, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCatalogRefInherited(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name          string
+		ref           string
+		inheritedFile string
+		want          []fileRange
+	}{
+		{
+			name:          "bare range inherits file",
+			ref:           ":249-251",
+			inheritedFile: "internal/domain/config/config.go",
+			want:          []fileRange{{File: "internal/domain/config/config.go", Start: 249, End: 251}},
+		},
+		{
+			name:          "bare single line inherits file",
+			ref:           ":431",
+			inheritedFile: "internal/tools/workspace/shell.go",
+			want:          []fileRange{{File: "internal/tools/workspace/shell.go", Start: 431, End: 431}},
+		},
+		{
+			name:          "bare comma list inherits file",
+			ref:           ":431,558",
+			inheritedFile: "internal/tools/workspace/shell.go",
+			want: []fileRange{
+				{File: "internal/tools/workspace/shell.go", Start: 431, End: 431},
+				{File: "internal/tools/workspace/shell.go", Start: 558, End: 558},
+			},
+		},
+		{
+			name:          "bare ref with no inherited file dropped",
+			ref:           ":249-251",
+			inheritedFile: "",
+			want:          nil,
+		},
+		{
+			name:          "full ref ignores inherited file",
+			ref:           "internal/other.go:10-12",
+			inheritedFile: "internal/domain/config/config.go",
+			want:          []fileRange{{File: "internal/other.go", Start: 10, End: 12}},
+		},
+		{
+			name:          "file-only ref still dropped with inherited file",
+			ref:           "internal/ui/tui/progress/model.go",
+			inheritedFile: "internal/domain/config/config.go",
+			want:          nil,
+		},
+		{
+			name:          "commit hash still ignored with inherited file",
+			ref:           "0f882423",
+			inheritedFile: "internal/domain/config/config.go",
+			want:          nil,
+		},
+		{
+			name:          "empty location still ignored",
+			ref:           "file.go:",
+			inheritedFile: "internal/domain/config/config.go",
+			want:          nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseCatalogRefInherited(tt.ref, tt.inheritedFile)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCatalogRefInherited(%q, %q) = %+v, want %+v", tt.ref, tt.inheritedFile, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadNonFixCatalog_MissingFile(t *testing.T) {
 	t.Parallel()
 	entries, err := loadNonFixCatalog(filepath.Join(t.TempDir(), "does-not-exist.md"))

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -7,10 +7,14 @@ package analysis
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/exec"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -129,4 +133,53 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 			require.NotEmpty(t, title, "range %s:%d-%d must be matched by an ACCEPTED catalog entry", tt.file, tt.start, tt.end)
 		})
 	}
+}
+
+// TestDetailedCoverageReport_CatalogedGapsNotActionable is the end-to-end
+// regression for the FULL detailed-coverage report path: real `go test
+// -coverprofile` subprocess → profile parse → applyCatalogTitles against the
+// LIVE catalog → report format. It pins the REPORT OUTPUT, not just the
+// matcher: the formerly-HIGH config.go:249-251 gap must appear under
+// [CATALOGED GAPS (ACCEPTED)] and never under [HIGH PRIORITY GAPS]. This test
+// is RED on the pre-fix parser (the `:249-251` continuation ref is dropped,
+// so config.go:249-251 surfaces as HIGH) and GREEN on the fixed code — it is
+// the self-verification that future agents' get_detailed_coverage output
+// agrees with the catalog.
+func TestDetailedCoverageReport_CatalogedGapsNotActionable(t *testing.T) {
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	// The report path shells out to the real `go` binary; run it from the
+	// module root so the coverage profile records repo-relative paths (catalog
+	// refs are repo-relative). The test binary's working directory is the
+	// package source dir, so chdir here and restore on cleanup. All arch-tagged
+	// tests are sequential, so the chdir cannot race a parallel test.
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	// Mirror production wiring (manager.go newAnalysisManager): the real `go`
+	// executor feeds both the runner and Exec; the catalog is the default live
+	// catalog; SP is the test mock (unused on this path).
+	executor := &exec.RealExecutor{}
+	m := &healthManager{
+		SP:          &mockSecurityProvider{},
+		Exec:        executor,
+		Runner:      toolchain.NewGoRunner(executor),
+		clk:         clock.RealClock{},
+		catalogPath: defaultNonFixCatalogPath,
+	}
+
+	report, err := m.getDetailedCoverageReport(context.Background(), "./internal/domain/config", nil, nil)
+	require.NoError(t, err)
+
+	// The cataloged gap must never rank as actionable: with the fix, config's
+	// only uncovered block (config.go:249-251) is ACCEPTED, so the report
+	// emits no HIGH PRIORITY GAPS section at all.
+	require.NotContains(t, report, "[HIGH PRIORITY GAPS]")
+	// ... and the formerly-HIGH block is reported as an ACCEPTED cataloged gap.
+	require.Contains(t, report, "[CATALOGED GAPS (ACCEPTED)]")
+	require.Contains(t, report, "config.go (Lines 249-251)")
+	require.Contains(t, report, "validateProviderUniqueness")
 }

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -133,6 +133,15 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 			require.NotEmpty(t, title, "range %s:%d-%d must be matched by an ACCEPTED catalog entry", tt.file, tt.start, tt.end)
 		})
 	}
+
+	// The capBestBlock non-capped return pin (re-anchored 2026-09 from 582 to
+	// 590 as the acceptance comment block grew) must resolve to its catalog
+	// entry — previously it surfaced as an uncataloged MEDIUM gap.
+	t.Run("manager.go_capBestBlock_non_capped_return", func(t *testing.T) {
+		title := catalogTitleForRange(entries, "internal/agent/session/context/manager.go", 590, 590)
+		require.NotEmpty(t, title, "range manager.go:590 must be matched by an ACCEPTED catalog entry")
+		require.Contains(t, title, "capBestBlock non-capped return")
+	})
 }
 
 // TestDetailedCoverageReport_CatalogedGapsNotActionable is the end-to-end
@@ -182,4 +191,45 @@ func TestDetailedCoverageReport_CatalogedGapsNotActionable(t *testing.T) {
 	require.Contains(t, report, "[CATALOGED GAPS (ACCEPTED)]")
 	require.Contains(t, report, "config.go (Lines 249-251)")
 	require.Contains(t, report, "validateProviderUniqueness")
+}
+
+// TestDetailedCoverageReport_ContextPackageCataloged is the end-to-end
+// behavioral check for the re-anchored capBestBlock non-capped return pin:
+// the formerly-MEDIUM manager.go:590 gap must appear under
+// [CATALOGED GAPS (ACCEPTED)] with its ACCEPTED title, and must not surface
+// as actionable in the High or Medium buckets. Same full report path as
+// TestDetailedCoverageReport_CatalogedGapsNotActionable, scoped to the
+// context package (~0.5s subprocess).
+func TestDetailedCoverageReport_ContextPackageCataloged(t *testing.T) {
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	// Run from the module root so the coverage profile records repo-relative
+	// paths; restore on cleanup (all arch-tagged tests are sequential).
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	// Mirror production wiring (manager.go newAnalysisManager).
+	executor := &exec.RealExecutor{}
+	m := &healthManager{
+		SP:          &mockSecurityProvider{},
+		Exec:        executor,
+		Runner:      toolchain.NewGoRunner(executor),
+		clk:         clock.RealClock{},
+		catalogPath: defaultNonFixCatalogPath,
+	}
+
+	report, err := m.getDetailedCoverageReport(context.Background(), "./internal/agent/session/context", nil, nil)
+	require.NoError(t, err)
+
+	// The re-anchored 590 gap must be cataloged, not actionable: it is listed
+	// under [CATALOGED GAPS (ACCEPTED)] with the capBestBlock title ...
+	require.Contains(t, report, "[CATALOGED GAPS (ACCEPTED)]")
+	require.Contains(t, report, "manager.go (Lines 590-590)")
+	require.Contains(t, report, "capBestBlock non-capped return")
+	// ... and the High/Medium buckets are empty.
+	require.Contains(t, report, "- High Priority (Architectural): 0")
+	require.Contains(t, report, "- Medium Priority (Technical Debt): 0")
 }

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -93,3 +93,40 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 	require.Equal(t, expectedCataloged, cataloged)
 	require.Empty(t, alerts)
 }
+
+// TestVerifyCoveragePinsMatchLiveCatalog is the coverage-pin regression gate
+// for the catalog matcher: it asserts the four formerly-HIGH coverage gaps
+// (config.go:249-251, task_service.go:101-103, manager.go:574-576,
+// manager.go:619-621) are matched by the LIVE catalog after the continuation
+// ref parser fix and the 2026-09 re-anchors. A cataloged gap surfacing as
+// actionable in the detailed coverage report is the exact regression this
+// test prevents. Coverage pins have no name axis to verify against (ADR-054),
+// so interval-overlap matching against the live catalog is the enforcement
+// boundary.
+func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	entries, err := loadNonFixCatalog(filepath.Join(repoRoot, defaultNonFixCatalogPath))
+	require.NoError(t, err)
+	require.NotEmpty(t, entries, "live catalog must contain ACCEPTED entries")
+
+	tests := []struct {
+		name  string
+		file  string
+		start int
+		end   int
+	}{
+		{"config.go call-site error branch", "internal/domain/config/config.go", 249, 251},
+		{"task_service.go AppendTask body", "internal/domain/services/task_service.go", 101, 103},
+		{"manager.go groupTurns error branch", "internal/agent/session/context/manager.go", 574, 576},
+		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 619, 621},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			title := catalogTitleForRange(entries, tt.file, tt.start, tt.end)
+			require.NotEmpty(t, title, "range %s:%d-%d must be matched by an ACCEPTED catalog entry", tt.file, tt.start, tt.end)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Architect-assigned fix (Item 1): **cataloged (ACCEPTED) coverage gaps must never rank above genuinely open ones.**

The detailed coverage report surfaced 4 HIGH-PRIORITY gaps that are all covered by ACCEPTED entries in `docs/architect/INTENTIONAL_NON_FIXES.md` — they ranked as actionable because the catalog matcher failed to tag them at runtime. Three root causes, all fixed:

### 1. Parser: bare `:line` continuation refs now inherit the file (`internal/tools/analysis/nonfix_catalog.go`)
The config.go entry pins "`` `config.go:224-229` `` (definition), `` `:249-251` `` (call-site error branch, covered by this entry)" — the `:249-251` continuation ref was **dropped** (empty file component). `parseSeeRefs` now tracks the most recent file-bearing ref (`pendingEntry.lastSeeFile`) across a See bullet and its indented continuations; `parseCatalogRefInherited` resolves bare `:line` refs against it. `parseCatalogRef` keeps its 1-arg API. Refs with no file and no inheritance, file-only refs, commit hashes, and prose remain dropped.

### 2. JSON path: cataloged blocks excluded from priority-filtered output (`internal/tools/analysis/coverage_parser.go`)
`formatDetailedCoverageJSON` filtered only by priority and surfaced cataloged blocks as actionable; it now skips `CatalogTitle != ""`, mirroring the report path's `aggregateCoverageStats`.

### 3. Catalog re-anchors (architect-authorized, per the catalog's Drift Policy)
- `task_service.go — AppendTask delegation wrapper`: `:95-97` → `:101-103` (code drifted ~6 lines)
- `context/manager.go — groupTurns error in capBestBlock`: file-only ref → `:574-576`
- `context/manager.go — capBestBlock error propagation in checkWindowSize`: file-only ref → `:619-621`

`config.go` needed no catalog edit — its continuation ref resolves via fix 1.

### Regression tests
- `TestParseNonFixCatalog_ColonContinuationRefs` / `TestParseCatalogRefInherited` — parser inheritance (within bullet, across continuations, standalone `:line` still dropped, comma/basename/full-path forms intact)
- `TestGetDetailedCoverageJSON_PriorityFiltering_ExcludesCataloged` + `TestFormatDetailedCoverageJSON_ExcludesCataloged` — JSON path
- `TestVerifyCoveragePinsMatchLiveCatalog` — matcher-level: all 4 ranges resolve via the **live** catalog
- **`TestDetailedCoverageReport_CatalogedGapsNotActionable`** — end-to-end: real `go test -coverprofile` subprocess → full report path against the **live** catalog; asserts no `[HIGH PRIORITY GAPS]` and the block appears under `[CATALOGED GAPS (ACCEPTED)]` with the `validateProviderUniqueness` title. Proven RED on the pre-fix parser, GREEN on the fix.

## Verification
- `go test ./internal/tools/analysis/... -count=1` — PASS
- `go test -tags=arch -run TestVerifyNonFixCatalog ./internal/tools/analysis -count=1` — PASS (25 complexity pins untouched; no partition-test edit needed — re-anchored entries are coverage pins)
- `go test -count=1 -tags=arch -run TestVerifyRealArchitecture ./internal/tools/analysis -args -strict-arch=true` — PASS
- `go build ./...` — OK; `gofmt`/`go vet`/`git diff --check` — clean

## Behavioral result
After the fix, the detailed coverage report for the three affected packages shows **High Priority (Architectural): 0**; `config.go (249-251)`, `task_service.go (101-103)`, `manager.go (574-576)`, `manager.go (619-621)` all appear under `[CATALOGED GAPS (ACCEPTED)]` with their acceptance titles.

## Follow-up (not in this PR)
`manager.go:590` (the `capBestBlock` non-capped return, MEDIUM priority) still surfaces uncataloged — its catalog entry pins `:582` while the code drifted to `:590`. Same drift class; warrants a future re-anchor.

---

## Follow-up (commit 4fbc2375): re-anchor manager.go:590 drift

After review, the flagged MEDIUM-priority drift was resolved: the `capBestBlock` non-capped return pin (`manager.go:582`) had drifted to line 590 as the acceptance comment block grew. Re-anchored per the catalog Drift Policy:
- **See** `manager.go:582` → `manager.go:590`; rationale line updated; drift note recorded in the entry.
- `TestVerifyCoveragePinsMatchLiveCatalog` extended with a 5th subtest (`manager.go:590` → "capBestBlock non-capped return").
- New e2e `TestDetailedCoverageReport_ContextPackageCataloged`: full report path for the context package asserts `manager.go (Lines 590-590)` appears under `[CATALOGED GAPS (ACCEPTED)]` and **Medium Priority: 0** (formerly 1).
- All gates green (partition, arch, transitive, analysis suite, build).

Now the catalog is fully self-consistent: zero stale file:line refs (`grep "manager.go:582"` = 0).