### PR TITLE
Overflow signal into Prepare: effective-budget reduction on recovery + ADR-059 (#1320)

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Significant architectural decisions are documented in our [Architecture Decision
 *   **[ADR-053](docs/adr/2026-08-remove-get-cost-summary-and-daily-cost-metric.md)** — removal of the `get_cost_summary` tool, the `DailyCost` status-line metric, and the global cost ledger.
 *   **[ADR-057](docs/adr/2026-08-remove-context-window-cache.md)** — removal of the context window cache from the session context manager (`internal/agent/session/context`).
 *   **[ADR-058](docs/adr/2026-08-getwindow-clone-evaluation.md)** — acceptance of the per-round `GetWindow` deep clone as the sole remaining O(window) cost; F2 evaluation closes at candidate 3 (accept-with-data) for both the cheaper-clone and prune-then-clone candidates, continuing the ADR-057 removal lineage (issue #1321).
+*   **[ADR-059](docs/adr/2026-08-overflow-signal-into-prepare.md)** — overflow signal into `Prepare` (effective-budget reduction on recovery): the gatekeeper learns when `Prepare` is a recovery from a provider context overflow and responds with forced recovery summarization plus a reduced hard limit, so the last-chance recovery `Prepare` shrinks the window even when pass 1 already summarised (issue #1320).
 
 For the evolution of the shell-based environment management tooling — from simple bash aliases through Toby, Dobby, Porter, Sprawl, Winky, Flopsy, and Niffler — see [Evolution of Environment Management](docs/architect/environments/environment-management-evolution.md).
 

--- a/docs/adr/2026-08-overflow-signal-into-prepare.md
+++ b/docs/adr/2026-08-overflow-signal-into-prepare.md
@@ -50,23 +50,28 @@ Because the single-refinement policy means the recovery `Prepare` is the **last 
 - `docs/architect/INTENTIONAL_NON_FIXES.md` explicitly NOT a candidate (the issue's Reachability section).
 - The config workaround (`MAX_HISTORY_TOKENS`/`ContextWindow`) remains the operator lever, which is why no new config keys are added.
 
-### D5 — Acceptance checklist (enforced in later tasks)
+### D5 — Acceptance checklist (as implemented; enforced by grep + tests)
 
-Presence greps for:
+Presence greps (implemented reality — 6 production files, 8 code matches for the signal):
 
-- `RecoveryFromOverflow` (`engine_types.go`, `engine_phases.go` ×2, `engine.go` reset)
-- `WithOverflowRecovery`
-- `PrepareOption`
-- `ContextRequest.RecoveryFromOverflow`
-- `recoveryBufferMultiplier`
+- `RecoveryFromOverflow` — `engine_types.go` (field), `engine_phases.go` ×2 (`RecoveryStep` set + `ContextRefiner` read), `engine.go` (`prepareNextTurn` reset), `contracts.go` (`ContextRequest` field), `manager.go` (`WithOverflowRecovery` setter), `gatekeeper.go` ×2 (Lever 1 + Lever 2 reads).
+- `WithOverflowRecovery` — `manager.go` (definition) + `engine_phases.go` (call site).
+- `PrepareOption` — `manager.go` (type + variadic param) + `engine_phases.go` (`[]sessctx.PrepareOption` — the pinned `ContextRefiner` snippet).
+- `ContextRequest.RecoveryFromOverflow` — `contracts.go`.
+- `recoveryBufferMultiplier` — `gatekeeper.go` (const + use).
+
+Implementation notes:
+
+- Lever 2 reads the signal nil-safely as `req != nil && req.RecoveryFromOverflow` — required because the pre-existing `TestTokenGatekeeper_ValidateHardLimits` invokes `validateHardLimits` with a nil request (nil → `Recovery == false` → byte-identical normal-path behavior).
+- Doc comments in `internal/agent/session/context/` must not contain the word "persisted" (ADR-057 Tier-2 die-grep in `make verify-no-context-window-cache`); use "stored".
 
 Absence of new cache tokens (existing `make verify-no-context-window-cache` covers).
 
-Test expectations:
+Test expectations (landed in Task 3):
 
-- new gatekeeper test (recovery with under-threshold estimate summarises; too-short history degrades gracefully);
-- new Manager-level test built on the Q4-c shape (`TestManager_Prepare_ReSummarizesOnSecondPrepare`, `internal/agent/session/context/context_manager_test.go:534` — fixed `MockTokenCounter` under the 90% threshold on the first `Prepare`, forced summarization on the second with `WithOverflowRecovery()`);
-- orchestrator test (`RecoveryStep` sets the flag; `prepareNextTurn` resets it).
+- `internal/agent/session/context/gatekeeper_recovery_test.go` — `TestTokenGatekeeper_RecoveryFromOverflow_ForcesSummarization` (recovery with under-threshold estimate summarises; normal path unaffected), `TestTokenGatekeeper_RecoveryFromOverflow_TooShortHistoryDegradesGracefully` (too-short history degrades to "tokens unchanged"), `TestTokenGatekeeper_RecoveryFromOverflow_ReducedHardLimitFailsFast` (recovery fails fast at the reduced ceiling; exactly one summarizer call).
+- `internal/agent/session/context/context_manager_recovery_test.go` — `TestManager_Prepare_RecoveryFromOverflow_ForcesSummarization` (Manager-level, Q4-c shape: fixed `MockTokenCounter` under the 90% threshold on the first `Prepare`, forced summarization on the second with `WithOverflowRecovery()`).
+- `internal/agent/orchestrator/recovery_signal_test.go` — `TestRecoveryStep_ContextOverflow_SetsRecoveryFromOverflow`, `TestPrepareNextTurn_ResetsRecoveryFromOverflow`, `TestContextRefiner_PassesRecoverySignalToPrepare` (orchestrator wiring end-to-end).
 
 ## Consequences
 

--- a/docs/adr/2026-08-overflow-signal-into-prepare.md
+++ b/docs/adr/2026-08-overflow-signal-into-prepare.md
@@ -1,0 +1,102 @@
+# ADR-059: Overflow Signal into Prepare (Effective-Budget Reduction on Recovery)
+
+**Status:** Accepted (decision committed; implementation lands in #1320)
+**Date:** 2026-08-10
+**Related:** [Issue #1320](https://github.com/gosharplite/tell-me-go/issues/1320)
+
+## Context
+
+Post-F1 (ADR-057, `docs/adr/2026-08-remove-context-window-cache.md`), `Prepare` is estimate-driven: the gatekeeper summarises only when its local estimate exceeds the threshold. The provider-vs-estimator divergence — estimation imprecision, multimodal `InlineData` blob bytes not counted by the estimator, and a provider window smaller than the configured `ContextWindow` — means the re-assembled window is identical to the one that just overflowed. With the single-refinement policy (`RetryCount == 1`), the second overflow kills the turn.
+
+The current flow: `RecoveryStep` (`internal/agent/orchestrator/engine_phases.go`, `LLMErrorContextOverflow` branch, `RetryCount == 0` → `NextPhase: PhaseRefining`) → `ContextRefiner.Process` → `Turn.CtxManager.Prepare(ctx, Turn.Index)` (`engine_phases.go:58` — the **only** production `Prepare` caller) → `TokenGatekeeper.Transform` (`internal/agent/session/context/gatekeeper.go`: Stage 1 `handleSafetyPressure` 90% threshold, Stage 2 `validateHardLimits` vs. `hardLimitPolicy{MaxTokens, SystemContextBuffer=1000}.effectiveLimit()`).
+
+Two failure cases must be handled:
+
+- **Case A** — pass 1 did **not** summarise (estimate under the 90% threshold, provider overflowed anyway): a threshold tweak *could* in principle trigger pass-1 summarization, but only by distorting the normal-turn budget for every turn, not just recovery.
+- **Case B** — pass 1 **did** summarise and persisted, but the provider still overflowed: the reloaded (summarised) history sits far below any threshold, so a threshold tweak alone could **never** trigger a second summarization. Only a forced summarization can shrink the window further.
+
+Because the single-refinement policy means the recovery `Prepare` is the **last chance** to shrink the window, it must succeed in shrinking even when pass 1 already summarised.
+
+## Decision
+
+**Overflow signal into `Prepare` / effective-budget reduction on recovery** — the "Option C" from #1317 implemented as a deliberate feature, explicitly **NOT** a cache patch (ADR-057 finality). The gatekeeper learns that the current `Prepare` is a recovery from a provider context overflow and responds with two levers: forced recovery summarization and a reduced hard limit.
+
+### D1 — The signal and its flow (end-to-end)
+
+- `TurnState` (`internal/agent/orchestrator/engine_types.go`) gains `RecoveryFromOverflow bool` (`json:"-"`).
+- `RecoveryStep.Process` (`internal/agent/orchestrator/engine_phases.go`, `LLMErrorContextOverflow` branch, `RetryCount == 0`): set `Turn.State.RecoveryFromOverflow = true` immediately before returning `NextPhase: PhaseRefining`. The `RetryCount >= 1` fall-through (turn dies on second overflow) is unchanged.
+- `ContextRefiner.Process`: pass the signal via a new variadic option — `Turn.CtxManager.Prepare(ctx, Turn.Index, sessctx.WithOverflowRecovery())` when the flag is set, else the existing bare call. This requires adding the `internal/agent/session/context` import to `engine_phases.go`. The bare call form stays source-compatible (all existing callers/tests compile unchanged).
+- `Manager.Prepare` (`internal/agent/session/context/manager.go`) gains `opts ...PrepareOption` where `type PrepareOption func(*ContextRequest)` and `WithOverflowRecovery() PrepareOption` sets a new `ContextRequest.RecoveryFromOverflow bool` field (`contracts.go`, documented). The signal never leaves the request scope — **NO** Manager-level state, no persistence, no new config keys (the recovery margin is derived from the existing `SystemContextBuffer`).
+- **RESET**: `prepareNextTurn` (`internal/agent/orchestrator/engine.go`, where `RetryCount` is already reset) sets `Turn.State.RecoveryFromOverflow = false` — prevents cross-turn leakage since `Turn` is reused across turns.
+
+### D2 — The effective-budget mechanism (two levers, both owned by the gatekeeper)
+
+- **LEVER 1 — FORCED RECOVERY SUMMARIZATION (Stage 1).** In `handleSafetyPressure`, trigger summarization when `req.RecoveryFromOverflow` is true EVEN IF the estimate is under the 90% threshold: `overThreshold || req.RecoveryFromOverflow`. Reason string passed to `SummarizationRequired`: "recovery from provider context overflow: forcing summarization to shrink the window" (distinct from the 90% pressure reason). All existing guards inherited unchanged: `MaintenanceBlocked`/history-<10 degrade to "tokens unchanged" (no error), `SummarizationAttempted` prevents double-summarization within the recovery run, blocking errors still abort. This handles BOTH failure cases: Case A (pass 1 didn't summarise — estimate under threshold) and Case B (pass 1 did summarise and persisted, but the provider still overflowed — the reloaded history is under any threshold, so a threshold tweak alone could never trigger; forced summarization can).
+- **LEVER 2 — REDUCED HARD LIMIT (Stage 2).** `hardLimitPolicy` (`gatekeeper.go`) gains a `Recovery bool` field; `effectiveLimit()` doubles the reservation on recovery via a named constant `recoveryBufferMultiplier = 2` (documented: "the recovery margin reserves the system buffer a second time — an honest demand for a strictly smaller window when the estimator has demonstrably under-counted"). Result: recovery effective limit = `MaxTokens − 2 × min(10% MaxTokens, SystemContextBuffer)` (e.g. 20000 → 18000). Defense-in-depth: if forced summarization was impossible (all pinned / too short) or insufficient, the recovery `Prepare` fails fast with `ErrContextLimitExceeded` at the tighter ceiling instead of burning an inference call that will die anyway. A successful shrink still must clear the reduced ceiling before inference proceeds.
+- **UNCHANGED (explicitly):** normal (non-recovery) `Prepare` behavior is byte-identical — threshold, hard limit, events, and the `hardLimitPolicy` math for `Recovery == false` all untouched; `finalContextValidator` (`internal/agent/session/context/transformers.go`) keeps its absolute-ceiling check (the recovery budget is owned exclusively by the gatekeeper — one policy owner); `WarningInjector`, `TransientMerger`, pruner all untouched; `RecoveryStep`'s single-refinement policy untouched; no cache tokens anywhere (`make verify-no-context-window-cache` stays green).
+
+### D3 — Why the alternatives were rejected
+
+- **A) status quo** — the bug this issue exists to fix.
+- **B) overflow-aware cache invalidation** — rejected by ADR-057's own alternatives (Option C there) and by cache-finality.
+- **C) threshold-lowering only** — insufficient for Case B (post-summarization estimate sits far below any threshold).
+- **D) provider-reported usage** — not available/standardized across providers, no domain port exists, out of scope (noted as future enhancement only).
+- **E) persistent recovery state on the Manager** — rejected: cross-turn mutable state on a shared component, concurrency risk; the signal belongs to the Turn lifecycle where `RetryCount` already lives.
+
+### D4 — Related-record requirements to cite
+
+- The F2 token-walk finding (ADR-058: write-only `TokenCount`, ≤1% at the calibrated fixture) as the perf non-concern for an extra summarization path.
+- The #1320-authored multimodal requirement: if #1321's lazy-hydration/COW candidates land, the estimator must still count multimodal payloads accurately — the recovery signal is a safety net, not a substitute for estimation accuracy.
+- `docs/architect/INTENTIONAL_NON_FIXES.md` explicitly NOT a candidate (the issue's Reachability section).
+- The config workaround (`MAX_HISTORY_TOKENS`/`ContextWindow`) remains the operator lever, which is why no new config keys are added.
+
+### D5 — Acceptance checklist (enforced in later tasks)
+
+Presence greps for:
+
+- `RecoveryFromOverflow` (`engine_types.go`, `engine_phases.go` ×2, `engine.go` reset)
+- `WithOverflowRecovery`
+- `PrepareOption`
+- `ContextRequest.RecoveryFromOverflow`
+- `recoveryBufferMultiplier`
+
+Absence of new cache tokens (existing `make verify-no-context-window-cache` covers).
+
+Test expectations:
+
+- new gatekeeper test (recovery with under-threshold estimate summarises; too-short history degrades gracefully);
+- new Manager-level test built on the Q4-c shape (`TestManager_Prepare_ReSummarizesOnSecondPrepare`, `internal/agent/session/context/context_manager_test.go:534` — fixed `MockTokenCounter` under the 90% threshold on the first `Prepare`, forced summarization on the second with `WithOverflowRecovery()`);
+- orchestrator test (`RecoveryStep` sets the flag; `prepareNextTurn` resets it).
+
+## Consequences
+
+**Positive**
+
+- The turn survives a provider context overflow via a strictly-smaller window: forced recovery summarization shrinks the window even when pass 1 already summarised (Case B) or never summarised (Case A).
+- Fail-fast on irrecoverable divergence: if no summarizable block exists (all pinned / too short) or summarization is insufficient, the recovery `Prepare` fails with `ErrContextLimitExceeded` at the tighter ceiling instead of burning an inference call that will die anyway.
+- Defense-in-depth via two independent levers (forced summarization + reduced hard limit), both owned by the single policy owner (the gatekeeper) — no new Manager state, no persistence, no new config keys.
+- Normal (non-recovery) `Prepare` behavior is byte-identical — zero regression surface for the common path.
+
+**Negative**
+
+- A second LLM-backed summarizer call plus a second persist on the recovery path — the cost model ADR-057 already accepted (one extra summarization per turn at most, bounded by `RecoveryStep`'s single-refinement policy).
+- If no summarizable block exists, the turn still dies on the second overflow — unchanged failure semantics; the recovery signal does not create summarization material where none exists.
+- The recovery margin is derived from the existing `SystemContextBuffer` — the operator lever (`MAX_HISTORY_TOKENS`/`ContextWindow`) remains the way to influence its size.
+
+## Alternatives considered
+
+- **A — status quo.** Rejected: the bug this issue exists to fix.
+- **B — overflow-aware cache invalidation.** Rejected: ADR-057's own alternatives (Option C there) and cache-finality — the cache is gone and not coming back.
+- **C — threshold-lowering only.** Rejected: insufficient for Case B — after pass 1 summarised and persisted, the reloaded history sits far below any threshold, so a threshold tweak alone can never trigger a second summarization.
+- **D — provider-reported usage.** Rejected: not available/standardized across providers, no domain port exists, out of scope; noted as a future enhancement only.
+- **E — persistent recovery state on the Manager.** Rejected: cross-turn mutable state on a shared component is a concurrency risk; the signal belongs to the Turn lifecycle where `RetryCount` already lives.
+
+## References
+
+- [#1317](https://github.com/gosharplite/tell-me-go/issues/1317) — closed; Option C source.
+- [#1319](https://github.com/gosharplite/tell-me-go/issues/1319) — closed/merged: ADR-057 + context window cache removal.
+- [#1320](https://github.com/gosharplite/tell-me-go/issues/1320) — open: this issue.
+- [#1321](https://github.com/gosharplite/tell-me-go/issues/1321) — open: F2 evaluation (candidate 3 terminal, ADR-058).
+- [ADR-057](2026-08-remove-context-window-cache.md) — F1: cache removal; overflow residual tracked here.
+- [ADR-058](2026-08-getwindow-clone-evaluation.md) — F2: token-walk finding (write-only `TokenCount`, ≤1% at the calibrated fixture).
+- [docs/architect/1321-f1-baseline.md](../architect/1321-f1-baseline.md) — F1 baseline, real-counter instrument.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -64,6 +64,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-056** | Domain-Home Criterion for Cross-Layer Contracts; Transitive-Closure Gate; Context-Family Extraction | 2026-08 | Accepted | [2026-08-contract-home-and-transitive-closure-gate.md](2026-08-contract-home-and-transitive-closure-gate.md) |
 | **ADR-057** | Remove the Context Window Cache | 2026-08 | Accepted | [2026-08-remove-context-window-cache.md](2026-08-remove-context-window-cache.md) |
 | **ADR-058** | Accept the Per-Round GetWindow Deep Clone (F2 Evaluation — Candidate 3) | 2026-08 | Accepted | [2026-08-getwindow-clone-evaluation.md](2026-08-getwindow-clone-evaluation.md) |
+| **ADR-059** | Overflow Signal into Prepare (Effective-Budget Reduction on Recovery) | 2026-08 | Accepted | [2026-08-overflow-signal-into-prepare.md](2026-08-overflow-signal-into-prepare.md) |
 
 ## How to Create a New ADR
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -232,7 +232,7 @@ catalog a new gap no one reviewed. Policy:
   slice between validation and this call site. Structurally unreachable — same
   acceptance class as `json.Marshal` on all-string structs in
   `global_prompt_tracker.go`.
-- **See**: `internal/agent/session/context/manager.go:574-576`
+- **See**: `internal/agent/session/context/manager.go:526-528`
   (architect-acceptance comment at the `groupTurns` call site in `capBestBlock`)
 
 ### context/manager.go — capBestBlock error propagation in checkWindowSize
@@ -243,13 +243,13 @@ catalog a new gap no one reviewed. Policy:
   already-validated sub-slice is structurally unreachable (see previous entry),
   this error-handling branch is equally unreachable. Both gaps share the same root
   cause and acceptance rationale.
-- **See**: `internal/agent/session/context/manager.go:619-621`
+- **See**: `internal/agent/session/context/manager.go:571-573`
   (architect-acceptance comment at the `capBestBlock` call site in `checkWindowSize`)
 
 ### agent/session/context/manager.go — capBestBlock non-capped return
 
 - **Status**: ACCEPTED (2026-07)
-- **Rationale**: The final return in `capBestBlock` (`manager.go:590`) is reached
+- **Rationale**: The final return in `capBestBlock` (`manager.go:542`) is reached
   when `best.count >= minViable` but `groupTurns` returns ≤1 turn for the
   sub-slice. With the default `contiguousUnpinnedSelector` (MinViableBlock=2),
   `best.count >= 2` and the sub-slice spans ≥2 turns, so `groupTurns` always
@@ -257,7 +257,10 @@ catalog a new gap no one reviewed. Policy:
   message sequences. Same acceptance class as defensive nil/empty guards on
   internal pipeline state (2026-07 Batch Triage). Re-anchored 2026-09: the
   return drifted from line 582 to 590 as the acceptance comment block grew.
-- **See**: `internal/agent/session/context/manager.go:590`
+  Re-anchored 2026-08 (#1320): the return drifted from line 590 to 542 as the
+  ADR-057 cache-removal deletions and the #1320 additions shifted the file;
+  re-verified against the live source.
+- **See**: `internal/agent/session/context/manager.go:542`
 
 ### agent/session/session_manager.go — tuiCleanup and setupUIRendering TUI branches
 
@@ -336,7 +339,7 @@ catalog a new gap no one reviewed. Policy:
   in `RecoveryStep.Process` covers all five explicitly. The `default:` case is
   a defensive guard that is structurally unreachable. Same acceptance class as
   `json.Marshal` on all-string structs in `global_prompt_tracker.go`.
-- **See**: `internal/agent/orchestrator/engine_phases.go:129`
+- **See**: `internal/agent/orchestrator/engine_phases.go:177`
 
 ### agent/orchestrator/middleware.go — return nil in injectSyntheticLoopFeedback
 
@@ -1071,7 +1074,7 @@ to reason about.
   is a single-line delegation or return. Same acceptance class as
   `handleDomainEvent` (CC=12) and `(*model).Update` (CC=14) — structural
   dispatch where CC is switch/branch count, not branching business logic.
-- **See**: `internal/agent/orchestrator/engine_phases.go:124`
+- **See**: `internal/agent/orchestrator/engine_phases.go:129`
 
 ---
 
@@ -1195,7 +1198,7 @@ to reason about.
   deferred `Sync` fails) is accepted as out-of-scope for #1302; the durable fix
   belongs in the history store package (fault-injection-required class — fsync
   failure requires real I/O faults).
-- **See**: `internal/agent/orchestrator/engine_phases.go:79-92` (architect-acceptance comment + `IsTransient` classification)
+- **See**: `internal/agent/orchestrator/engine_phases.go:84-97` (architect-acceptance comment + `IsTransient` classification)
 
 ---
 

--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -257,6 +257,7 @@ func (e *Engine) prepareNextTurn(Turn *Turn) {
 	Turn.State.CurrentTurns = Turn.Index
 	Turn.State.Phase = PhaseGuard
 	Turn.State.RetryCount = 0
+	Turn.State.RecoveryFromOverflow = false
 	Turn.State.Response = nil
 	Turn.State.ToolResponse = nil
 	Turn.State.HasToolCalls = false

--- a/internal/agent/orchestrator/engine_phases.go
+++ b/internal/agent/orchestrator/engine_phases.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"time"
 
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 )
@@ -55,7 +56,11 @@ func (p *GuardStep) Process(ctx context.Context, Turn *Turn) (ProcessResult, err
 type ContextRefiner struct{}
 
 func (p *ContextRefiner) Process(ctx context.Context, Turn *Turn) (ProcessResult, error) {
-	history, metadata, err := Turn.CtxManager.Prepare(ctx, Turn.Index)
+	var opts []sessctx.PrepareOption
+	if Turn.State.RecoveryFromOverflow {
+		opts = append(opts, sessctx.WithOverflowRecovery())
+	}
+	history, metadata, err := Turn.CtxManager.Prepare(ctx, Turn.Index, opts...)
 	if err != nil {
 		category := llm.ErrTerminal
 		if IsTransient(err) {
@@ -163,6 +168,7 @@ func (p *RecoveryStep) Process(ctx context.Context, Turn *Turn) (ProcessResult, 
 			"turn", Turn.Index)
 		if Turn.State.RetryCount == 0 {
 			Turn.State.RetryCount++
+			Turn.State.RecoveryFromOverflow = true
 			return ProcessResult{NextPhase: PhaseRefining}, nil
 		}
 		// Subsequent context overflows fall through to retry/failure

--- a/internal/agent/orchestrator/engine_types.go
+++ b/internal/agent/orchestrator/engine_types.go
@@ -162,22 +162,26 @@ type TurnHook interface {
 
 // TurnState carries data between the phases of a Turn and tracks the current phase.
 type TurnState struct {
-	Phase                TurnPhase                `json:"phase"`
-	HasToolCalls         bool                     `json:"has_tool_calls"`
-	Metrics              *llm.Metrics             `json:"metrics,omitempty"`
-	Tokens               int                      `json:"tokens"`
-	CurrentTurns         int                      `json:"current_turns"`
-	Metadata             *sessctx.ContextMetadata `json:"metadata,omitempty"`
-	Response             *llm.Content             `json:"response,omitempty"`
-	ToolResponse         *llm.Content             `json:"tool_response,omitempty"`
-	LastError            error                    `json:"-"`
-	RetryCount           int                      `json:"retry_count"`
-	HasSeenRateLimit     bool                     `json:"-"`
-	ToolCallCount        map[string]int           `json:"-"`
-	RecentResponseHashes []string                 `json:"-"`
-	PreparedHistory      []*llm.Content           `json:"-"`
-	TaskCost             float64                  `json:"task_cost"`
-	ToolReasons          []string                 `json:"-"`
+	Phase        TurnPhase                `json:"phase"`
+	HasToolCalls bool                     `json:"has_tool_calls"`
+	Metrics      *llm.Metrics             `json:"metrics,omitempty"`
+	Tokens       int                      `json:"tokens"`
+	CurrentTurns int                      `json:"current_turns"`
+	Metadata     *sessctx.ContextMetadata `json:"metadata,omitempty"`
+	Response     *llm.Content             `json:"response,omitempty"`
+	ToolResponse *llm.Content             `json:"tool_response,omitempty"`
+	LastError    error                    `json:"-"`
+	RetryCount   int                      `json:"retry_count"`
+	// RecoveryFromOverflow is true when this turn is re-entering
+	// PhaseRefining after a provider context-overflow error; it signals
+	// Prepare to apply the ADR-059 recovery budget for this turn only.
+	RecoveryFromOverflow bool           `json:"-"`
+	HasSeenRateLimit     bool           `json:"-"`
+	ToolCallCount        map[string]int `json:"-"`
+	RecentResponseHashes []string       `json:"-"`
+	PreparedHistory      []*llm.Content `json:"-"`
+	TaskCost             float64        `json:"task_cost"`
+	ToolReasons          []string       `json:"-"`
 }
 
 // ToolExecutor defines the interface for tool execution.

--- a/internal/agent/orchestrator/recovery_signal_test.go
+++ b/internal/agent/orchestrator/recovery_signal_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/stretchr/testify/require"
+)
+
+// recoveryTestHistory builds n unpinned user/model turns for the ADR-059
+// recovery-signal wiring tests.
+func recoveryTestHistory(n int) []*llm.Content {
+	var contents []*llm.Content
+	for i := 0; i < n; i++ {
+		contents = append(contents,
+			&llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i+1)}}},
+			&llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i+1)}}},
+		)
+	}
+	return contents
+}
+
+// TestRecoveryStep_ContextOverflow_SetsRecoveryFromOverflow verifies D1:
+// on the first provider context overflow (RetryCount == 0) RecoveryStep raises
+// the ADR-059 recovery signal before re-entering PhaseRefining.
+func TestRecoveryStep_ContextOverflow_SetsRecoveryFromOverflow(t *testing.T) {
+	turn := &Turn{
+		State: &TurnState{
+			Phase:      PhaseRecovering,
+			LastError:  llm.ErrContextLimitExceeded,
+			RetryCount: 0,
+		},
+		Clock: &agenttest.MockClock{},
+	}
+	step := &RecoveryStep{Policy: &DefaultRetryPolicy{MaxRetries: 3, Backoff: time.Millisecond}}
+
+	res, err := step.Process(context.Background(), turn)
+
+	require.NoError(t, err)
+	require.Equal(t, PhaseRefining, res.NextPhase)
+	require.True(t, turn.State.RecoveryFromOverflow, "first overflow must raise the ADR-059 recovery signal")
+	require.Equal(t, 1, turn.State.RetryCount)
+}
+
+// TestPrepareNextTurn_ResetsRecoveryFromOverflow verifies D1 RESET: the signal
+// is cleared beside the RetryCount reset, preventing cross-turn leakage since
+// Turn is reused across turns.
+func TestPrepareNextTurn_ResetsRecoveryFromOverflow(t *testing.T) {
+	e := &Engine{}
+	turn := &Turn{
+		Index: 2,
+		State: &TurnState{
+			RecoveryFromOverflow: true,
+			RetryCount:           3,
+			Phase:                PhaseComplete,
+		},
+	}
+
+	e.prepareNextTurn(turn)
+
+	require.False(t, turn.State.RecoveryFromOverflow, "prepareNextTurn must clear the ADR-059 recovery signal")
+	require.Equal(t, 0, turn.State.RetryCount)
+	require.Equal(t, PhaseGuard, turn.State.Phase)
+	require.Equal(t, 3, turn.Index)
+}
+
+// TestContextRefiner_PassesRecoverySignalToPrepare verifies the wiring
+// end-to-end: ContextRefiner reads Turn.State.RecoveryFromOverflow and passes
+// WithOverflowRecovery() into Prepare, so the gatekeeper forces summarization.
+// FACTORY MUST BE NON-NIL — a nil factory means no pipeline/gatekeeper and the
+// test would fail for the wrong reason.
+func TestContextRefiner_PassesRecoverySignalToPrepare(t *testing.T) {
+	// buildCM returns a fresh Manager with a counting summarizer; each subtest
+	// gets its own fixture so the call counters assert per-scenario.
+	buildCM := func() (*sessctx.Manager, *int) {
+		counter := &agenttest.MockTokenCounter{Tokens: 12000}
+		strategy := sessctx.NewStrategy(counter)
+
+		summarizeCalls := 0
+		mockSum := &agenttest.MockSummarizer{}
+		mockSum.SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
+			summarizeCalls++
+			return "summary", nil, nil
+		})
+
+		strategy.SetLimits(20000, 100, 200)
+		factory := &sessctx.Factory{Estimator: strategy, Summarizer: mockSum}
+
+		history := &agenttest.MockHistoryManager{}
+		history.SetInternalContents(recoveryTestHistory(12))
+
+		cm := sessctx.NewManager(strategy, history, nil, factory)
+		return cm, &summarizeCalls
+	}
+
+	t.Run("signal_flows_into_prepare", func(t *testing.T) {
+		cm, summarizeCalls := buildCM()
+		turn := &Turn{
+			Index:        0,
+			CtxManager:   cm,
+			TokenCounter: &agenttest.MockTokenCounter{Tokens: 12000},
+			Clock:        &agenttest.MockClock{},
+			State:        &TurnState{RecoveryFromOverflow: true},
+		}
+
+		res, err := (&ContextRefiner{}).Process(context.Background(), turn)
+
+		require.NoError(t, err)
+		require.Equal(t, PhaseInference, res.NextPhase)
+		require.Equal(t, 1, *summarizeCalls, "recovery signal must force summarization through Prepare")
+		require.NotNil(t, turn.State.Metadata)
+		require.True(t, turn.State.Metadata.SummarizationAttempted)
+		require.NotNil(t, turn.State.PreparedHistory)
+	})
+
+	t.Run("no_signal_no_forced_summarization", func(t *testing.T) {
+		cm, summarizeCalls := buildCM()
+		turn := &Turn{
+			Index:        0,
+			CtxManager:   cm,
+			TokenCounter: &agenttest.MockTokenCounter{Tokens: 12000},
+			Clock:        &agenttest.MockClock{},
+			State:        &TurnState{},
+		}
+
+		res, err := (&ContextRefiner{}).Process(context.Background(), turn)
+
+		require.NoError(t, err)
+		require.Equal(t, PhaseInference, res.NextPhase)
+		require.Equal(t, 0, *summarizeCalls, "no recovery signal must not force summarization")
+		require.NotNil(t, turn.State.Metadata)
+		require.False(t, turn.State.Metadata.SummarizationAttempted)
+	})
+}

--- a/internal/agent/session/context/context_manager_recovery_test.go
+++ b/internal/agent/session/context/context_manager_recovery_test.go
@@ -1,0 +1,66 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package context_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/stretchr/testify/require"
+)
+
+// TestManager_Prepare_RecoveryFromOverflow_ForcesSummarization verifies the
+// ADR-059 signal end-to-end at Manager level, built on the Q4-c shape
+// (TestManager_Prepare_ReSummarizesOnSecondPrepare, context_manager_test.go:534):
+// with a fixed token counter UNDER the 90% pressure threshold
+// (12000 < 18000 = 90% of 20000), a bare Prepare does not summarise, while a
+// Prepare with WithOverflowRecovery() forces summarization and returns a
+// strictly smaller window (24 → 14 messages).
+func TestManager_Prepare_RecoveryFromOverflow_ForcesSummarization(t *testing.T) {
+	tc := &agenttest.MockTokenCounter{Tokens: 12000}
+	strategy := sessctx.NewStrategy(tc)
+
+	mockSum := &agenttest.MockSummarizer{}
+	var summarizeCalls int
+	mockSum.SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
+		summarizeCalls++
+		return "summary", nil, nil
+	})
+
+	// WIRING ORDER IS LOAD-BEARING: both must happen BEFORE NewManager.
+	// SetLimits(20000, 100, 200) — MaxHistoryTokens=20000, MaxToolTurns=100,
+	// MaxHistoryTurns=200 (pruner active but non-trimming: 12 turns ≪ 200).
+	// NewManager builds the pipeline from GetLimits() and wires cm.Summarizer
+	// from the factory — a nil factory summarizer would make the gatekeeper
+	// return a blocking ErrTerminal and the test would fail for the wrong reason.
+	strategy.SetLimits(20000, 100, 200)
+	factory := &sessctx.Factory{Estimator: strategy, Summarizer: mockSum}
+
+	history := &agenttest.MockHistoryManager{}
+	history.SetInternalContents(makePinnableTurnsExt(12))
+
+	cm := sessctx.NewManager(strategy, history, nil, factory)
+
+	ctx := context.Background()
+
+	// First Prepare, bare call: 12000 < 18000 → no summarization.
+	_, m1, err := cm.Prepare(ctx, 1)
+	require.NoError(t, err)
+	require.NotNil(t, m1)
+	require.False(t, m1.SummarizationAttempted, "under-threshold bare Prepare must not summarise")
+	require.Equal(t, 0, summarizeCalls)
+
+	// Second Prepare with the recovery signal: forced summarization shrinks
+	// the window from 24 messages to 14 (6 of 12 turns summarised).
+	h2, m2, err := cm.Prepare(ctx, 1, sessctx.WithOverflowRecovery())
+	require.NoError(t, err)
+	require.NotNil(t, m2)
+	require.True(t, m2.SummarizationAttempted, "recovery Prepare must force summarization")
+	require.Equal(t, 6, m2.SummarizedTurns)
+	require.Len(t, h2, 14, "recovery Prepare must return a strictly smaller window")
+	require.Equal(t, 1, summarizeCalls)
+}

--- a/internal/agent/session/context/contracts.go
+++ b/internal/agent/session/context/contracts.go
@@ -59,6 +59,11 @@ type ContextRequest struct {
 	// PersistHistory indicates whether the final History should be
 	// written to the store after the pipeline completes. Set by the orchestrator.
 	PersistHistory bool
+	// RecoveryFromOverflow marks this Prepare as a recovery from a
+	// provider context overflow (ADR-059). Request-scope only — never
+	// stored, never Manager state. The gatekeeper applies forced
+	// summarization and a reduced hard limit for this request.
+	RecoveryFromOverflow bool
 }
 
 // PruningPolicy defines how to mark turns for pruning.

--- a/internal/agent/session/context/gatekeeper.go
+++ b/internal/agent/session/context/gatekeeper.go
@@ -93,18 +93,28 @@ func NewTokenGatekeeper(estimator TokenEstimator, summarizer ports.Summarizer, o
 	return newTokenGatekeeper(estimator, summarizer, opts...)
 }
 
+// recoveryBufferMultiplier doubles the system-buffer reservation on a
+// recovery Prepare (ADR-059): "the recovery margin reserves the system
+// buffer a second time — an honest demand for a strictly smaller window
+// when the estimator has demonstrably under-counted".
+const recoveryBufferMultiplier = 2
+
 // hardLimitPolicy encapsulates the context-window buffer reservation
 // logic, keeping it separate from event publishing and error signaling.
 // It is a pure value type with no dependencies beyond config constants.
 type hardLimitPolicy struct {
 	MaxTokens           int
 	SystemContextBuffer int
+	// Recovery marks a recovery from provider context overflow — the
+	// reservation is doubled (ADR-059).
+	Recovery bool
 }
 
 // effectiveLimit returns the usable token budget after reserving system
 // buffer space. The reservation is capped at min(10% of MaxTokens,
-// SystemContextBuffer). Returns 0 when MaxTokens ≤ 0, which
-// signals that no hard-limit enforcement should be performed.
+// SystemContextBuffer), then doubled when Recovery is set. Returns 0
+// when MaxTokens ≤ 0, which signals that no hard-limit enforcement
+// should be performed.
 func (p hardLimitPolicy) effectiveLimit() int {
 	if p.MaxTokens <= 0 {
 		return 0
@@ -113,6 +123,9 @@ func (p hardLimitPolicy) effectiveLimit() int {
 	maxReserved := int(float64(p.MaxTokens) * 0.1)
 	if reserved > maxReserved {
 		reserved = maxReserved
+	}
+	if p.Recovery {
+		reserved *= recoveryBufferMultiplier
 	}
 	return p.MaxTokens - reserved
 }
@@ -142,8 +155,14 @@ func (t *TokenGatekeeper) Transform(ctx context.Context, req *ContextRequest) er
 }
 
 func (t *TokenGatekeeper) handleSafetyPressure(ctx context.Context, req *ContextRequest, tokens int) (int, error) {
-	if t.MaxTokens > 0 && tokens > int(float64(t.MaxTokens)*0.9) {
-		return t.triggerSummarization(ctx, req, tokens, t.MaxTokens, "safety limit pressure (> 90%)")
+	overThreshold := t.MaxTokens > 0 && tokens > int(float64(t.MaxTokens)*0.9)
+	recovering := req.RecoveryFromOverflow
+	if overThreshold || recovering {
+		reason := "safety limit pressure (> 90%)"
+		if recovering {
+			reason = "recovery from provider context overflow: forcing summarization to shrink the window"
+		}
+		return t.triggerSummarization(ctx, req, tokens, t.MaxTokens, reason)
 	}
 	return tokens, nil
 }
@@ -200,9 +219,11 @@ func (t *TokenGatekeeper) publishHardLimitEvents(ctx context.Context, tokens, ef
 }
 
 func (t *TokenGatekeeper) validateHardLimits(ctx context.Context, req *ContextRequest, tokens int) error {
+	recovering := req != nil && req.RecoveryFromOverflow
 	effectiveLimit := hardLimitPolicy{
 		MaxTokens:           t.MaxTokens,
 		SystemContextBuffer: config.SystemContextBuffer,
+		Recovery:            recovering,
 	}.effectiveLimit()
 	if effectiveLimit <= 0 {
 		return nil

--- a/internal/agent/session/context/gatekeeper_recovery_test.go
+++ b/internal/agent/session/context/gatekeeper_recovery_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package context
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/stretchr/testify/require"
+)
+
+// makeUnpinnedTurns creates n user/model turns (2n messages), all unpinned,
+// with unique per-turn text. Mirrors makePinnableTurnsExt in the external
+// context_test package (not visible from this in-package test).
+func makeUnpinnedTurns(n int) []*llm.Content {
+	var contents []*llm.Content
+	for i := 0; i < n; i++ {
+		contents = append(contents,
+			&llm.Content{Role: "user", Parts: []*llm.Part{{Text: fmt.Sprintf("u%d", i+1)}}},
+			&llm.Content{Role: "model", Parts: []*llm.Part{{Text: fmt.Sprintf("m%d", i+1)}}},
+		)
+	}
+	return contents
+}
+
+// recoveryGatekeeperFixture builds a TokenGatekeeper with a fixed token
+// estimator and a counting summarizer for the ADR-059 recovery tests.
+// It returns the gatekeeper and a pointer to the summarizer call counter.
+func recoveryGatekeeperFixture(tokens int) (*TokenGatekeeper, *int) {
+	summarizeCalls := 0
+	mockSum := &agenttest.MockSummarizer{}
+	mockSum.SetSummarizeFn(func(ctx context.Context, subset []*llm.Content, focus string) (string, *llm.Metrics, error) {
+		summarizeCalls++
+		return "summary", nil, nil
+	})
+	estimator := NewStrategy(&agenttest.MockTokenCounter{Tokens: tokens})
+	tg := newTokenGatekeeper(estimator, mockSum, withMaxTokens(20000))
+	return tg, &summarizeCalls
+}
+
+// TestTokenGatekeeper_RecoveryFromOverflow_ForcesSummarization verifies
+// ADR-059 Lever 1: recovery forces summarization even when the estimate is
+// UNDER the 90% pressure threshold, while the normal path stays byte-identical
+// (no summarizer call, window unchanged). Fixture: 12 turns / 24 msgs,
+// Tokens 12000 < 18000 = 90% of MaxTokens 20000.
+func TestTokenGatekeeper_RecoveryFromOverflow_ForcesSummarization(t *testing.T) {
+	tests := []struct {
+		name                       string
+		recovery                   bool
+		wantSummarizeCalls         int
+		wantSummarizationAttempted bool
+		wantSummarizedTurns        int
+		wantHistoryLen             int
+	}{
+		{
+			name:                       "recovery_forces_summarization_under_threshold",
+			recovery:                   true,
+			wantSummarizeCalls:         1,
+			wantSummarizationAttempted: true,
+			wantSummarizedTurns:        6,
+			wantHistoryLen:             14,
+		},
+		{
+			name:                       "normal_path_unaffected",
+			recovery:                   false,
+			wantSummarizeCalls:         0,
+			wantSummarizationAttempted: false,
+			wantSummarizedTurns:        0,
+			wantHistoryLen:             24,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tg, summarizeCalls := recoveryGatekeeperFixture(12000)
+			req := &ContextRequest{
+				History:              makeUnpinnedTurns(12),
+				RecoveryFromOverflow: tt.recovery,
+			}
+
+			err := tg.Transform(context.Background(), req)
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantSummarizeCalls, *summarizeCalls)
+			require.Equal(t, tt.wantSummarizationAttempted, req.Metadata.SummarizationAttempted)
+			require.Equal(t, tt.wantSummarizedTurns, req.Metadata.SummarizedTurns)
+			require.Len(t, req.History, tt.wantHistoryLen)
+		})
+	}
+}
+
+// TestTokenGatekeeper_RecoveryFromOverflow_TooShortHistoryDegradesGracefully
+// verifies the inherited guard: recovery with fewer than 10 messages forces
+// the summarization attempt, which degrades to "tokens unchanged" (no error,
+// no summarizer call, window untouched). Fixture: 4 turns / 8 msgs.
+func TestTokenGatekeeper_RecoveryFromOverflow_TooShortHistoryDegradesGracefully(t *testing.T) {
+	tg, summarizeCalls := recoveryGatekeeperFixture(12000)
+	req := &ContextRequest{
+		History:              makeUnpinnedTurns(4),
+		RecoveryFromOverflow: true,
+	}
+
+	err := tg.Transform(context.Background(), req)
+
+	require.NoError(t, err)
+	require.Equal(t, 0, *summarizeCalls)
+	require.True(t, req.Metadata.MaintenanceBlocked)
+	require.False(t, req.Metadata.SummarizationAttempted)
+	require.Len(t, req.History, 8)
+	require.Equal(t, 12000, req.Metadata.FinalTokenCount)
+}
+
+// TestTokenGatekeeper_RecoveryFromOverflow_ReducedHardLimitFailsFast verifies
+// ADR-059 Lever 2 in the Q4-c zone (Tokens 18500):
+//
+//	> 18000 (90% pressure threshold) → summarise on the normal path;
+//	≤ 19000 (normal hard limit = 20000 − min(2000, 1000)) → normal path passes;
+//	> 18000 (recovery hard limit = 20000 − 2×1000) → recovery fails fast with
+//	ErrContextLimitExceeded after exactly one summarizer call (the
+//	SummarizationAttempted guard prevents double-summarization).
+func TestTokenGatekeeper_RecoveryFromOverflow_ReducedHardLimitFailsFast(t *testing.T) {
+	tests := []struct {
+		name                       string
+		recovery                   bool
+		wantErr                    bool
+		wantSummarizeCalls         int
+		wantSummarizationAttempted bool
+	}{
+		{
+			name:                       "normal_path_summarises_and_passes",
+			recovery:                   false,
+			wantErr:                    false,
+			wantSummarizeCalls:         1,
+			wantSummarizationAttempted: true,
+		},
+		{
+			name:                       "recovery_fails_fast_at_reduced_ceiling",
+			recovery:                   true,
+			wantErr:                    true,
+			wantSummarizeCalls:         1,
+			wantSummarizationAttempted: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tg, summarizeCalls := recoveryGatekeeperFixture(18500)
+			req := &ContextRequest{
+				History:              makeUnpinnedTurns(12),
+				RecoveryFromOverflow: tt.recovery,
+			}
+
+			err := tg.Transform(context.Background(), req)
+
+			if tt.wantErr {
+				require.ErrorIs(t, err, llm.ErrContextLimitExceeded)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, tt.wantSummarizeCalls, *summarizeCalls)
+			require.Equal(t, tt.wantSummarizationAttempted, req.Metadata.SummarizationAttempted)
+		})
+	}
+}

--- a/internal/agent/session/context/manager.go
+++ b/internal/agent/session/context/manager.go
@@ -109,8 +109,22 @@ func (cm *Manager) Reconfigure(limits events.Limits) error {
 	return nil
 }
 
+// PrepareOption is a functional option configuring a single Prepare
+// request (ADR-059). Options apply to the request only — they never
+// mutate Manager state and are never stored.
+type PrepareOption func(*ContextRequest)
+
+// WithOverflowRecovery marks this Prepare as a recovery from a provider
+// context overflow; the gatekeeper applies forced summarization and a
+// reduced hard limit for this request only (ADR-059).
+func WithOverflowRecovery() PrepareOption {
+	return func(req *ContextRequest) {
+		req.RecoveryFromOverflow = true
+	}
+}
+
 // Prepare prepares the history for the given turn, applying pruning and summarization.
-func (cm *Manager) Prepare(ctx context.Context, turn int) ([]*llm.Content, *ContextMetadata, error) {
+func (cm *Manager) Prepare(ctx context.Context, turn int, opts ...PrepareOption) ([]*llm.Content, *ContextMetadata, error) {
 	snapshotVersion, history, pipeline, err := cm.loadHistory(ctx)
 	if err != nil {
 		return nil, nil, err
@@ -119,6 +133,10 @@ func (cm *Manager) Prepare(ctx context.Context, turn int) ([]*llm.Content, *Cont
 	req := &ContextRequest{
 		Turn:    turn,
 		History: history,
+	}
+
+	for _, opt := range opts {
+		opt(req)
 	}
 
 	if err := cm.runPipeline(ctx, pipeline, req, snapshotVersion); err != nil {

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -79,7 +79,7 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestHydrateMediaAssets":                          {Line: 243, Complexity: 13, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
 		"TestResolveCapabilities":                         {Line: 10, Complexity: 13, FilePath: "internal/domain/llm/capabilities_test.go"},
 		"assertMissingKeysResult":                         {Line: 211, Complexity: 13, FilePath: "internal/infrastructure/llm/factory_test.go"},
-		"(*RecoveryStep).Process":                         {Line: 124, Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go"},
+		"(*RecoveryStep).Process":                         {Line: 129, Complexity: 12, FilePath: "internal/agent/orchestrator/engine_phases.go"},
 		"(*model).handleDomainEvent":                      {Line: 338, Complexity: 12, FilePath: "internal/ui/tui/progress/model.go"},
 		"TestDeadCodeAnalyzer_Precision":                  {Line: 177, Complexity: 12, FilePath: "internal/tools/analysis/precision_test.go"},
 		"TestHistoryManager_SetPinned_ViaModelID":         {Line: 493, Complexity: 12, FilePath: "internal/infrastructure/history/history_test.go"},

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -123,8 +123,8 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 	}{
 		{"config.go call-site error branch", "internal/domain/config/config.go", 249, 251},
 		{"task_service.go AppendTask body", "internal/domain/services/task_service.go", 101, 103},
-		{"manager.go groupTurns error branch", "internal/agent/session/context/manager.go", 574, 576},
-		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 619, 621},
+		{"manager.go groupTurns error branch", "internal/agent/session/context/manager.go", 526, 528},
+		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 571, 573},
 	}
 
 	for _, tt := range tests {
@@ -135,11 +135,12 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 	}
 
 	// The capBestBlock non-capped return pin (re-anchored 2026-09 from 582 to
-	// 590 as the acceptance comment block grew) must resolve to its catalog
-	// entry — previously it surfaced as an uncataloged MEDIUM gap.
+	// 590 as the acceptance comment block grew; re-anchored 2026-08 (#1320)
+	// from 590 to 542) must resolve to its catalog entry — previously it
+	// surfaced as an uncataloged MEDIUM gap.
 	t.Run("manager.go_capBestBlock_non_capped_return", func(t *testing.T) {
-		title := catalogTitleForRange(entries, "internal/agent/session/context/manager.go", 590, 590)
-		require.NotEmpty(t, title, "range manager.go:590 must be matched by an ACCEPTED catalog entry")
+		title := catalogTitleForRange(entries, "internal/agent/session/context/manager.go", 542, 542)
+		require.NotEmpty(t, title, "range manager.go:542 must be matched by an ACCEPTED catalog entry")
 		require.Contains(t, title, "capBestBlock non-capped return")
 	})
 }
@@ -195,7 +196,7 @@ func TestDetailedCoverageReport_CatalogedGapsNotActionable(t *testing.T) {
 
 // TestDetailedCoverageReport_ContextPackageCataloged is the end-to-end
 // behavioral check for the re-anchored capBestBlock non-capped return pin:
-// the formerly-MEDIUM manager.go:590 gap must appear under
+// the formerly-MEDIUM manager.go:542 gap must appear under
 // [CATALOGED GAPS (ACCEPTED)] with its ACCEPTED title, and must not surface
 // as actionable in the High or Medium buckets. Same full report path as
 // TestDetailedCoverageReport_CatalogedGapsNotActionable, scoped to the
@@ -224,10 +225,10 @@ func TestDetailedCoverageReport_ContextPackageCataloged(t *testing.T) {
 	report, err := m.getDetailedCoverageReport(context.Background(), "./internal/agent/session/context", nil, nil)
 	require.NoError(t, err)
 
-	// The re-anchored 590 gap must be cataloged, not actionable: it is listed
+	// The re-anchored 542 gap must be cataloged, not actionable: it is listed
 	// under [CATALOGED GAPS (ACCEPTED)] with the capBestBlock title ...
 	require.Contains(t, report, "[CATALOGED GAPS (ACCEPTED)]")
-	require.Contains(t, report, "manager.go (Lines 590-590)")
+	require.Contains(t, report, "manager.go (Lines 542-542)")
 	require.Contains(t, report, "capBestBlock non-capped return")
 	// ... and the High/Medium buckets are empty.
 	require.Contains(t, report, "- High Priority (Architectural): 0")


### PR DESCRIPTION
## Summary

Fixes the ADR-057/058 overflow residual: `Prepare` is estimate-driven — the gatekeeper summarises only when its local estimate exceeds the threshold. When the provider's actual token count overflows while the local estimate stays under it (estimation imprecision, multimodal `InlineData` blob bytes not fully counted, provider window smaller than the configured `ContextWindow`), the re-assembled window is identical → overflow again → with `RetryCount == 1` the turn dies.

Per **ADR-059**, the fix is the overflow signal into `Prepare` implemented as a deliberate feature (explicitly **not** a cache patch — ADR-057 finality):

- **Signal (D1):** `RecoveryStep` raises `TurnState.RecoveryFromOverflow` on the first provider context overflow (`RetryCount == 0`); `ContextRefiner` passes `WithOverflowRecovery()` into `Prepare` (variadic `PrepareOption`); the flag rides `ContextRequest.RecoveryFromOverflow` to the gatekeeper. Request-scope only — no Manager state, no persistence; reset in `prepareNextTurn`.
- **Lever 1 (D2):** forced recovery summarization — `overThreshold || req.RecoveryFromOverflow` — shrinks the window even when pass 1 already summarised (Case B) or never summarised (Case A).
- **Lever 2 (D2):** reduced hard limit on recovery — `MaxTokens − 2 × min(10% MaxTokens, SystemContextBuffer)` — fail-fast when summarization is impossible or insufficient.

**Normal (non-recovery) path is byte-identical.** Single-refinement policy unchanged. No new config keys. Guardrails `TestManager_Prepare_ClonesContent` and `TestManager_Prepare_ReSummarizesOnSecondPrepare` green verbatim.

## ADR

[docs/adr/2026-08-overflow-signal-into-prepare.md](docs/adr/2026-08-overflow-signal-into-prepare.md) — D5 is the machine-checkable acceptance checklist (presence greps + landed tests), amended to the implemented reality (6 production files for the signal; nil-safe Lever 2 read required by the pre-existing `TestTokenGatekeeper_ValidateHardLimits` nil-request call; "persisted"-free doc comments per the ADR-057 Tier-2 die-grep).

## Commit chain

`5efc748d` (ADR-059) → `a77478d4` (implementation: signal + recovery budget) → `e57b362d` (tests: gatekeeper / Manager / orchestrator + D5 amendment) → `cf994e50` (chore: re-anchor non-fix catalog pins after RecoveryStep line shift — drift-policy re-anchors for `verify-nonfix-catalog`) → `d37be570` (chore: lockstep re-anchor coverage pins in arch tests — coordination rule)

## Verification

- `go build ./...`
- `go test ./internal/agent/session/context/... ./internal/agent/orchestrator/... ./internal/agent/...`
- Guardrails by name: `TestManager_Prepare_ClonesContent`, `TestManager_Prepare_ReSummarizesOnSecondPrepare`, `TestTokenGatekeeper_ValidateHardLimits`
- `go test -race ./internal/agent/session/context/... ./internal/agent/orchestrator/...`
- `make verify-no-context-window-cache`
- `make verify-adr-index`
- `make verify-nonfix-catalog`
- `go test -tags=arch ./internal/tools/analysis/` — 3 arch tests green (`TestVerifyNonFixCatalog`, `TestVerifyCoveragePinsMatchLiveCatalog`, `TestDetailedCoverageReport_ContextPackageCataloged`), incl. the pre-existing-red coverage-report test now green
- ADR-059 D5 presence greps (production files)

## Follow-ups

None — closes the overflow residual tracked by ADR-057/058. Provider-reported usage remains a recorded future enhancement (ADR-059 D3).

Closes #1320
