### PR TITLE
Inject the Go toolchain runner into the tools layer (ToolchainRunner domain port, ADR-055-style)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ ifeq ($(OS),Windows_NT)
     endif
 endif
 
-.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import verify-no-test-sleep verify-architecture verify-exit-query verify-transitive-gate verify-nonfix-catalog verify-adr-index verify-no-context-window-cache lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
+.PHONY: build test test-race tidy fmt help verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import verify-tools-toolchain-import verify-no-test-sleep verify-architecture verify-exit-query verify-transitive-gate verify-nonfix-catalog verify-adr-index verify-no-context-window-cache lint vulncheck dead-code check check-full bench fuzz fuzz-smoke modelith-lint modelith-render modelith-check modelith-drift modelith-layers modelith-vocab
 
 help:
 	@echo "tell-me-go development tasks:"
@@ -45,6 +45,7 @@ help:
 	@echo "  make verify-nonfix-catalog - Verify the complexity-pin catalog partition (issue #1297)"
 	@echo "  make verify-no-test-sleep - Verify no time.Sleep for synchronization in tests"
 	@echo "  make verify-tools-adapter-import - Verify tools adapter imports are confined to default_fs.go (ADR-055)"
+	@echo "  make verify-tools-toolchain-import - Verify no infrastructure/toolchain imports in tools production files (issue #1325)"
 	@echo "  make verify-no-context-window-cache - Verify no context window cache references (ADR-057; part of make check/check-full)"
 	@echo "  make test-coverage - Run tests with coverage (excludes mocks/generated)"
 	@echo "  make tidy       - Tidy and vendor dependencies"
@@ -67,7 +68,7 @@ help:
 build:
 	go build -ldflags="-X 'main.version=$(VERSION)'" -o tell-me-go ./cmd/tell-me-go
 
-test: verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import
+test: verify-testutil-convention verify-no-testing-import verify-internal-bridge-brand verify-mock-pattern verify-session-provider-mock verify-tools-adapter-import verify-tools-toolchain-import
 	go test ./...
 
 # Verify ADR-021: no testutil packages (centralized test-double dump).
@@ -413,6 +414,70 @@ else
 	@echo "  ✓ Adapter imports confined to the two default_fs.go files."
 endif
 
+# Verify issue #1325: no internal/tools production file imports the
+# internal/infrastructure/toolchain adapter. The Go toolchain runner is
+# injected via the domain port (tools.ToolchainRunner) with a single
+# construction in internal/infrastructure/di/toolchain_factory.go.
+#
+# Predicate: "production files" = non-_test.go files under internal/tools/
+# OUTSIDE analysistest/ and toolstest/ (explicit path exclusions mirroring
+# verify-no-testing-import). Test-layer files are deliberately exempt: the 22
+# surviving toolchain.NewGoRunner constructions across coverage_parser_test.go,
+# health_test.go, real_nonfix_catalog_test.go, and architecture_bench_test.go
+# are the real-adapter-over-mock verification surface the e2e deferral depends
+# on. ANTI-EXTENSION DECISION (ADR-060): this gate must never be extended to
+# _test.go files — doing so would break those sites and destroy the
+# verification surface.
+verify-tools-toolchain-import:
+ifeq ($(IS_POSIX),true)
+	@echo "Checking for infrastructure/toolchain adapter imports in tools production files (issue #1325)..."
+	@VIOLATIONS="$$( grep -rn 'github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"' internal/tools/ --include='*.go' \
+		| grep -v '_test\.go:' \
+		| grep -v '^internal/tools/analysis/analysistest/' \
+		| grep -v '^internal/tools/toolstest/' )"; \
+	if [ -n "$$VIOLATIONS" ]; then \
+		echo ""; \
+		echo "❌ issue #1325 violation: infrastructure/toolchain import in a tools production file."; \
+		echo "   The Go toolchain runner must be injected via tools.ToolchainRunner (domain port,"; \
+		echo "   single construction in internal/infrastructure/di/toolchain_factory.go)."; \
+		echo "   See: docs/adr/2026-08-toolchain-runner-injection.md (ADR-060)"; \
+		echo ""; \
+		echo "Violating files:"; \
+		echo "$$VIOLATIONS"; \
+		echo ""; \
+		echo "Fix: delete the direct construction and thread the injected runner through"; \
+		echo "RegisterAll -> analysis.Register / developer.Register."; \
+		exit 1; \
+	fi
+	@echo "  ✓ No infrastructure/toolchain imports in tools production files."
+else
+	@echo "Checking for infrastructure/toolchain adapter imports in tools production files (issue #1325)..."
+	@powershell -Command " \
+		$$ErrorActionPreference = 'Stop'; \
+		$$violations = @(); \
+		Get-ChildItem -Path internal/tools -Recurse -Filter '*.go' | Where-Object { \
+			$$_.Name -notlike '*_test.go' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'internal/tools/analysis/analysistest/' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'internal/tools/toolstest/' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch '.git/' -and \
+			($$_.FullName.Replace('\', '/')) -notmatch 'vendor/' \
+		} | ForEach-Object { \
+			$$matches = Select-String -Path $$_.FullName -Pattern 'github\.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"'; \
+			if ($$matches) { foreach ($$m in $$matches) { $$violations += ('{0}:{1}' -f $$m.Path, $$m.LineNumber) } } \
+		}; \
+		if ($$violations.Count -gt 0) { \
+			Write-Host ''; \
+			Write-Host '❌ issue #1325 violation: infrastructure/toolchain import in a tools production file.'; \
+			Write-Host '   See: docs/adr/2026-08-toolchain-runner-injection.md (ADR-060)'; \
+			Write-Host ''; \
+			$$violations | Sort-Object -Unique | ForEach-Object { Write-Host $$_ }; \
+			Write-Host ''; \
+			exit 1 \
+		}; \
+		Write-Host '  ✓ No infrastructure/toolchain imports in tools production files.' \
+	"
+endif
+
 # Verify no time.Sleep for synchronization in test files (Issue #580 / ADR-036).
 # Legitimate I/O simulation and hardware observation sleeps are explicitly allow-listed.
 verify-no-test-sleep:
@@ -686,6 +751,8 @@ check: fmt tidy build
 	@$(MAKE) verify-session-provider-mock
 	@echo "=== verify-tools-adapter-import ==="
 	@$(MAKE) verify-tools-adapter-import
+	@echo "=== verify-tools-toolchain-import ==="
+	@$(MAKE) verify-tools-toolchain-import
 	@echo "=== verify-no-test-sleep ==="
 	@$(MAKE) verify-no-test-sleep
 	@echo "=== verify-adr-index ==="
@@ -726,6 +793,8 @@ check-full: fmt tidy build
 	@$(MAKE) verify-session-provider-mock
 	@echo "=== verify-tools-adapter-import ==="
 	@$(MAKE) verify-tools-adapter-import
+	@echo "=== verify-tools-toolchain-import ==="
+	@$(MAKE) verify-tools-toolchain-import
 	@echo "=== verify-no-test-sleep ==="
 	@$(MAKE) verify-no-test-sleep
 	@echo "=== verify-adr-index ==="

--- a/docs/adr/2026-08-toolchain-runner-injection.md
+++ b/docs/adr/2026-08-toolchain-runner-injection.md
@@ -1,0 +1,89 @@
+# ADR-060: Inject the Go Toolchain Runner into the Tools Layer (ToolchainRunner Domain Port)
+
+**Status:** Accepted
+**Date:** 2026-08
+**Related:** [Issue #1325](https://github.com/gosharplite/tell-me-go/issues/1325), [ADR-055](2026-08-tools-filesystem-injection.md), [ADR-056](2026-08-contract-home-and-transitive-closure-gate.md), [ADR-003](2026-01-domain-decomposition-strategy.md), [ADR-021](2026-04-test-doubles-in-pkgtest-subpackages.md), [ADR-017](2026-04-blackbox-integration-test-tree.md)
+
+## Context
+
+Five production files in `internal/tools/` leaked the `internal/infrastructure/toolchain` adapter across the tools layer, plus a second leaked symbol:
+
+- Two direct constructions: `toolchain.NewGoRunner(executor)` at `internal/tools/analysis/manager.go:81` (inside `newAnalysisManager`) and `toolchain.NewGoRunner(exec)` at `internal/tools/developer/registration.go:19`.
+- Three forced type leaks: `AnalysisGoRunner` (`manager.go:55`), the developer `goRunner` (`dev.go:32`), and `releaseGoRunner` (`release.go:27`) all returned `toolchain.CoverageReport`; `dev.go:221` (`var report toolchain.CoverageReport`) was the fifth touchpoint.
+- A second leaked symbol: `toolchain.ErrNoSupportedLinter`, consumed at `analysis/health.go` (`errors.Is(err, toolchain.ErrNoSupportedLinter)` in `runLint`).
+
+The edge was **invisible to both architectural gates**: the layer gate's `layerTools` rule forbids only `application` and `cmd` (infrastructure is not forbidden), and ADR-056's `familyOf()` returns `""` outside `internal/domain/`, so no whitelist row can express a tools→infrastructure edge. The edge passed CI not because it was adjudicated but because the instruments cannot see it — the same class ADR-055 addressed with a purpose-built grep gate.
+
+## Decision
+
+### 1. ADR-055-extension framing (not a naked ADR-003 Rule #1 deviation)
+
+`ToolchainRunner` homes in `internal/domain/tools` as an **extension of the ADR-055 precedent to the toolchain family**. ADR-055 ratified this exact seam shape one month earlier: a domain port (`persistence.FileSystem`), consumed by `internal/tools`, implemented by `internal/infrastructure/persistence`, concrete confined under a grep gate. The `ToolchainRunner` seam is the identical consumer/implementer pair applied to the Go toolchain. ADR-003 Rule #1's *intent* is satisfied — the consumer family defines the contract; the implementer does not dictate it; only the physical-location letter is superseded, consistent with ADR-055/ADR-056. Gate mechanics are the **enforcement consequence, not the primary reason**: a home in `internal/tools` would force `infrastructure/toolchain → internal/tools`, ballooning the implementer's closure to the whole tools tree; a new `internal/domain/toolchain` would add a tenth domain family to `derivedPortsFamilies` and split `CommandExecutor` from its consumer family; `domain/tools` is the only zero-closure-delta home and sits next to `CommandExecutor` at `internal/domain/tools/executor.go:12`.
+
+### 2. ADR-056 Decision 1 inapplicability
+
+ADR-056 Decision 1 (cross-layer contracts spanning non-importable layers) **never fires** for this seam: `tools` and `infrastructure` are importable layers (the layer rule forbids `layerTools` from importing only `application` and `cmd`; `layerInfrastructure` from importing only `application` and `cmd`). The ADR-055 precedent, not ADR-056, governs this seam.
+
+### 3. The three-home analysis
+
+- `internal/tools` home: would invert the dependency — `infrastructure/toolchain` would import the whole tools subpackage tree (a decision-required closure payer).
+- New `internal/domain/toolchain` family: adds a tenth family to `derivedPortsFamilies` and splits `CommandExecutor` from its consumer family.
+- `internal/domain/tools`: zero closure delta — `infra/toolchain` already imports `domain/tools` (for `CommandExecutor`), the tools production files already import `domain/tools`, and the di composition root already imports `infra_toolchain`. The graph delta of PR1 is purely the deletion of the five tools→infra edges plus the single di construction.
+
+### 4. Corrected infra/toolchain import surface + ports-hub derivation
+
+`internal/infrastructure/toolchain`'s module-internal import surface is **`{domain/ports, domain/tools}`**, not `{domain/tools}` alone: `toolchain_health.go` imports `domain/ports` (it implements `ports.HealthChecker` for `BuildHealthChecker`); `runner.go` imports `domain/tools` (for `CommandExecutor`, and post-PR1 the `ToolchainRunner` port). The implementer remains **self-justifying** under the ratified ADR-056 gate semantics: the BFS reaches `{toolchain, ports, tools}`; `collectReachableNodes` marks `ports` visited-but-not-expanded (hub rule) and `extractDomainFamilies` never attributes the ports family; `domain/tools` is a leaf family. Hence `Dom(infra/toolchain) = {tools} = direct` — approved-constant, no whitelist row before or after. The classification is contingent on the hub semantics; the false "only import is domain/tools" claim from grill round 1 is corrected here.
+
+### 5. Tool-boundary designed-nil guard criterion (verbatim) + per-field citations
+
+A `ToolRegistrationParams` field is **guarded** unless the tools layer defines a designed nil-mode *at the tool boundary*, evidenced by exactly one of: (i) a registration-time skip — the tool is absent from the registry when the field is nil; (ii) a tool-handler return of a sentinel degrade (`ErrNotImplemented`) on nil; (iii) a documented default-substitution in the tool's construction. An internal nil-check inside a private consumer helper is **not** a tool-boundary mode and does not exempt the field.
+
+Guards (8): `Registry`, `SecurityManager`, `WorkspacePolicy`, `FileSystem` (unconditional DI contract); `CommandExecutor` (no nil-mode anywhere; panics at `gitManager.Exec.Output`); `CommandValidator` (`shell.go:163` `if w.validator != nil && w.validator.HasBareNewline(command)` is a private Windows capability probe — internal-fallback non-exemption; the core contract `validateTestCommand → m.validator.Split` has no nil mode and panics); `EventBus` (`info.go:212` `if m.Events == nil` is a private side-effect skip — non-exemption; the dev/workspace publication contract — `dev.go:357`, `shell.go:467,471,479,543` raw `Publish` — has no nil mode and panics); `ToolchainRunner` (`health.go:272` `if m.Runner != nil` is a private repo-root fallback — non-exemption; every core port method panics on a nil interface).
+
+Exclusions (3): `SessionProvider` (registration skip, `tools.go` `if params.SessionProvider != nil`); `HealthManager` (registration skip, `workspace/registration.go:392` `if health != nil`); `Client` (sentinel degrade `media.go:60,232` `ErrNotImplemented`; default substitution `network.go:36`, `teams.go:31`, `atlassian/jira.go:30` `&http.Client{Timeout: 30s}`; `integrations/registration.go` never populates `HTTPClient`).
+
+`TestRegisterAll_Errors` gained exactly 4 rows (CommandExecutor, CommandValidator, EventBus, ToolchainRunner) — not 5 (the Client row was retracted in grill Q2).
+
+### 6. Drift status of PR1 symbols + sentinel contract + declaration-style pin
+
+Traced against `scripts/modelith-drift.sh` against the code model:
+
+| Symbol | Drift status |
+| --- | --- |
+| `ToolchainRunner` | **Escapes** — only via the `Tool`-substring false-negative (the entity-substring loop matches `"ToolchainRunner"` against the modeled entity `Tool`). An accidental escape, not model coverage; the gate is too weak to be decision-relevant. |
+| `CoverageSummary` | **TRIPS** — accepted advisory; the DTO is a port data shape like `CommandExecutor`/`ToolResult`/`Schema`/`Registry` (all in `domain/tools`, none modeled). No model edit. |
+| `ErrNoSupportedLinter` | **Escapes** — deterministic via the pinned single-line declaration `var ErrNoSupportedLinter = errors.New(...)` (a `var (...)` block would trip). The pin is part of the sentinel contract. |
+
+The DTO choice rests on the verified 4-field consumer union (`PassedCount`, `NoGoFiles`, `CoveragePct`, `SummaryOutput` consumed at `dev.go` `getCoverage` and `health.go` `runTestsAndCoverage`) and `TestOutput`'s zero assertion consumers — not on drift (both DTO and report trip identically). Sentinel contract: couplings to *our* wording are typed (`errors.Is`); couplings to stdlib wording (`"exit status 1"`) are documented, not converted; semantics are "detection; severity consumer-decided" (health SKIP vs release FAIL).
+
+### 7. Per-destination wiring-test contract
+
+Six runner-consuming fields receive the `ToolchainRunner`: `dependencyAnalyzer.Runner`, `infoManager.Runner`, `architectureManager.Runner`, `healthManager.Runner` (assigned inside `newAnalysisManager`), `devManager.runner`, `releaseManager.runner` (assigned inside `developer.Register`). Every field must have either a behavioral probe asserting the injected fake was reached (identity + exact method) or a white-box construction assertion. Assignment is proven by the wiring tests; the 12-method *behavioral* surface is proven by the infra adapter's own tests (`runner_test.go`) — neither surface covers the other. A dropped assignment compiles (nil satisfies the interface), so per-destination coverage is the enforcement, not review.
+
+### 8. toolstest fake home + stub accounting
+
+One canonical `toolstest.FakeToolchainRunner` (ADR-021 locality — the common ancestor of the three consumer sub-trees; ADR-056 canonical-mock-home; coverage-excluded). Stub accounting: **6 exercised** by probes — `GetGoDoc` (go_doc), `RunTestsWithCoverage` (get_coverage), `RunLinter`/`RunTests`/`BuildCode` (verify_release_readiness), `CheckGovulncheck` (seam capture); **6 compile-time-only** — `GetPackageList`, `GetModulePath`, `GetModuleDir`, `RunBenchmarks`, `RunModTidy`, `FormatCode`. All 12 record to the call log, so a probe that unexpectedly reaches the wrong method fails its identity assertion with the recorded call in hand.
+
+### 9. Surviving test-layer construction census + anti-extension decision + the promise's three conditions
+
+22 test-file `toolchain.NewGoRunner(...)` constructions survive by design across 4 files: `coverage_parser_test.go` ×17, `health_test.go` ×2, `real_nonfix_catalog_test.go` ×2, `architecture_bench_test.go` ×1. They are the **real-adapter-over-mock-executor verification surface** — the actual parsing/consumption paths fed with realistic `go test`/`go tool cover -func=` output through the real runner — which is precisely the substitute the e2e deferral names. **Anti-extension decision**: `verify-tools-toolchain-import` must never be extended to `_test.go` files; doing so would break the 22 sites and destroy the verification the deferral depends on. The "future go-tooling tools copy this pattern without fresh adjudication" promise has three conditions: (1) consumer side — `domain/tools` port, single di construction, production-file confinement gate; (2) implementer side — domain imports stay within the ports hub plus the consumer family, keeping the implementer self-justifying; (3) test layer — direct adapter construction remains legitimate in tools `_test.go` files per ADR-021 and the issue's own "test files may continue importing" language; the gate is not extended to test files.
+
+### 10. e2e known-gap + seam-capture probe rationale
+
+The real-adapter e2e boundary at the `di/toolchain_factory.go` construction line is deliberately deferred. Trigger, verbatim from the maintainer decision: **"Fund real-adapter e2e in the blackbox integration tree (`tests/integration/`, per ADR-017) when a Go toolchain output-format change breaks the parsers in the field** — i.e., when `go test` / `go tool cover -func=` output drift is reported (or a Go release notes change in test/cover output formats) rather than preemptively."
+
+The unit-level verification is the **seam-capture probe** (`TestBuildRegistry_PopulatesToolchainRunner`): capture `ToolRegistrationParams` via the injectable `RegisterAllTools`, assert `ToolchainRunner` non-nil, then call `CheckGovulncheck` directly on the captured port (lookPath-only, no subprocess). Handler-level probing is forbidden: `check_vulnerabilities` falls through to a real `govulncheck ./...` via the non-injectable `devManager.executor` (dev.go), and `make check` guarantees govulncheck is installed — a handler-level probe would spawn a real subprocess and be environment-dependent, contradicting the deferral rationale.
+
+### 11. Follow-ups
+
+- `verify-tools-adapter-import` predicate harmonization: align its predicate to the same non-`_test.go` + `*test/`-path-exclusion form as `verify-tools-toolchain-import` when next touched.
+- Five raw `eventBus.Publish` sites (`dev.go:357`, `shell.go:467,471,479,543`): nil-guard vs. `SafePublish` conversion (the latter adds a 2s-timeout wrapper nuance) — architect's choice, documented follow-up.
+- `devManager.executor` non-injectability: a `withExecutor` devOption would enable handler-level tests later; recorded residual, out of #1325 scope.
+
+## Consequences
+
+- **Positive**: single runner construction at the composition root; direct-construction class eliminated from production and mechanically gated; per-destination wiring proven by tests; zero mock growth (narrow consumer interfaces survive per ADR-003 Rule #2 and the MockEstimator ruling).
+- **Regression-visible**: none — PR1 is zero-runtime-delta by design; the value is the boundary rule, its gate, and its verification.
+- **Accepted advisory**: `CoverageSummary` trips `modelith-drift`; no model edit (port data shape, consistent with `CommandExecutor`).
+- **Known-gap**: real-adapter e2e deferred with the trigger above.
+- **Issue-closure mapping**: the "clean up the ADR-056 whitelist" criterion is satisfied as a documented non-change — no whitelist row ever existed for the edge (the gate's unit of measurement has no slot for an infrastructure edge); the ADR/index criterion is satisfied by this record plus `verify-adr-index`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -65,6 +65,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-057** | Remove the Context Window Cache | 2026-08 | Accepted | [2026-08-remove-context-window-cache.md](2026-08-remove-context-window-cache.md) |
 | **ADR-058** | Accept the Per-Round GetWindow Deep Clone (F2 Evaluation — Candidate 3) | 2026-08 | Accepted | [2026-08-getwindow-clone-evaluation.md](2026-08-getwindow-clone-evaluation.md) |
 | **ADR-059** | Overflow Signal into Prepare (Effective-Budget Reduction on Recovery) | 2026-08 | Accepted | [2026-08-overflow-signal-into-prepare.md](2026-08-overflow-signal-into-prepare.md) |
+| **ADR-060** | Inject the Go Toolchain Runner into the Tools Layer (ToolchainRunner Domain Port) | 2026-08 | Accepted | [2026-08-toolchain-runner-injection.md](2026-08-toolchain-runner-injection.md) |
 
 ## How to Create a New ADR
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -1166,6 +1166,18 @@ to reason about.
 - **Rationale**: Single-scenario test pinning via model message ID in a plain user→model text turn to close the `contentHasFunctionCall` false-return gap. CC=12 is entirely error-checking boilerplate: `t.Fatalf` on `AddContent`, `GetWindow`, and `SetPinned` calls, plus pin/unpin assertions. Same acceptance class as `TestGetModelTurn` (CC=16) and `TestHistoryManager_SetPinned_WithFunctionCall` (CC=21).
 - **See**: `internal/infrastructure/history/history_test.go:493`
 
+### internal/tools/toolstest/fake_toolchain_runner_test.go — TestFakeToolchainRunner_PresetValues (CC=28)
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Table-driven test with 12 subtests (one per ToolchainRunner method) asserting preset-Func returns, call-log recording, and last-Call identity via the assertCallLog helper. CC=28 comes from subtest enumeration and assertion boilerplate, not branching business logic — each subtest is a one-liner closure. Same acceptance class as `TestGetModelTurn` (CC=16) and `TestHistoryManager_SetPinned_WithFunctionCall` (CC=21).
+- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:35`
+
+### internal/tools/toolstest/fake_toolchain_runner_test.go — TestFakeToolchainRunner_ZeroDefaults (CC=38)
+
+- **Status**: ACCEPTED (2026-08)
+- **Rationale**: Table-driven test with 12 subtests (one per ToolchainRunner method) asserting exact zero-value defaults and call-log recording on an unset-Func fake. CC=38 comes from subtest enumeration and assertion boilerplate, not branching business logic. Same acceptance class as `TestFakeToolchainRunner_PresetValues` (CC=28) and `TestHistoryManager_SetPinned_WithFunctionCall` (CC=21).
+- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:248`
+
 ---
 
 ## Coverage Gaps (ACCEPTED — 2026-08 pricing-file removal follow-up)
@@ -1220,4 +1232,4 @@ to reason about.
 
 ---
 
-*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056; coverage hygiene: NoOpLogger + BypassConfirmation entries — 2026-08)*
+*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056; coverage hygiene: NoOpLogger + BypassConfirmation entries — 2026-08; test-complexity catalog additions: TestFakeToolchainRunner_PresetValues (CC=28) and TestFakeToolchainRunner_ZeroDefaults (CC=38) — issue #1325 toolstest fake)*

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -1170,13 +1170,13 @@ to reason about.
 
 - **Status**: ACCEPTED (2026-08)
 - **Rationale**: Table-driven test with 12 subtests (one per ToolchainRunner method) asserting preset-Func returns, call-log recording, and last-Call identity via the assertCallLog helper. CC=28 comes from subtest enumeration and assertion boilerplate, not branching business logic — each subtest is a one-liner closure. Same acceptance class as `TestGetModelTurn` (CC=16) and `TestHistoryManager_SetPinned_WithFunctionCall` (CC=21).
-- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:35`
+- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:36`
 
 ### internal/tools/toolstest/fake_toolchain_runner_test.go — TestFakeToolchainRunner_ZeroDefaults (CC=38)
 
 - **Status**: ACCEPTED (2026-08)
 - **Rationale**: Table-driven test with 12 subtests (one per ToolchainRunner method) asserting exact zero-value defaults and call-log recording on an unset-Func fake. CC=38 comes from subtest enumeration and assertion boilerplate, not branching business logic. Same acceptance class as `TestFakeToolchainRunner_PresetValues` (CC=28) and `TestHistoryManager_SetPinned_WithFunctionCall` (CC=21).
-- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:248`
+- **See**: `internal/tools/toolstest/fake_toolchain_runner_test.go:249`
 
 ---
 

--- a/internal/domain/tools/toolchain.go
+++ b/internal/domain/tools/toolchain.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package tools
+
+import (
+	"context"
+	"errors"
+)
+
+// ToolchainRunner defines the Go toolchain capabilities consumed by the tools
+// layer. It is the union of the consumer narrowing interfaces
+// (analysis.AnalysisGoRunner, the developer goRunner, and the developer
+// releaseGoRunner) and is the static type of the DI thread only — consumer
+// fields keep their narrow views per ADR-003 Rule #2. Each method appears in
+// at least one consumer narrow interface (zero dead members). Implemented by
+// internal/infrastructure/toolchain.
+type ToolchainRunner interface {
+	GetPackageList(ctx context.Context, path string) ([]byte, error)
+	GetGoDoc(ctx context.Context, symbol string) ([]byte, error)
+	GetModulePath(ctx context.Context) (string, error)
+	GetModuleDir(ctx context.Context) (string, error)
+	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (CoverageSummary, error)
+	RunLinter(ctx context.Context) (string, string, error)
+	RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error)
+	CheckGovulncheck(ctx context.Context) error
+	RunModTidy(ctx context.Context) ([]byte, error)
+	FormatCode(ctx context.Context, path string) ([]byte, error)
+	RunTests(ctx context.Context, path string) ([]byte, error)
+	BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error)
+}
+
+// CoverageSummary is the tools-layer view of a coverage run: the verified
+// 4-field consumer union of the infrastructure toolchain.CoverageReport
+// (TestOutput is intentionally absent — it has zero assertion consumers; see
+// ADR-060). Full report stays infrastructure-internal.
+type CoverageSummary struct {
+	PassedCount   int
+	NoGoFiles     bool
+	CoveragePct   string // e.g. "85.0%"
+	SummaryOutput string
+}
+
+// ErrNoSupportedLinter is returned when neither golangci-lint nor staticcheck is found.
+var ErrNoSupportedLinter = errors.New("no supported linter found (golangci-lint or staticcheck)")

--- a/internal/domain/tools/toolchain.go
+++ b/internal/domain/tools/toolchain.go
@@ -31,7 +31,7 @@ type ToolchainRunner interface {
 }
 
 // CoverageSummary is the tools-layer view of a coverage run: the verified
-// 4-field consumer union of the infrastructure toolchain.CoverageReport
+// 4-field consumer union of the infrastructure-internal CoverageReport
 // (TestOutput is intentionally absent — it has zero assertion consumers; see
 // ADR-060). Full report stays infrastructure-internal.
 type CoverageSummary struct {

--- a/internal/infrastructure/di/toolchain_factory.go
+++ b/internal/infrastructure/di/toolchain_factory.go
@@ -87,15 +87,12 @@ func (f *defaultToolchainFactory) BuildRegistry(params toolchainParams) (tools.R
 		WorkspacePolicy:  f.WorkspacePolicy,
 	}
 
-	// Single production construction of the runner (issue #1325: the
-	// direct-construction class in tools is eliminated; only the di
-	// composition root constructs). toolchainRunnerAdapter bridges the
-	// infrastructure goRunner's CoverageReport return to the port's
-	// CoverageSummary (TestOutput deliberately absent per ADR-060); it can be
-	// replaced by a plain assignment once the infrastructure toolchain
-	// satisfies tools.ToolchainRunner directly.
-	runner := infra_toolchain.NewGoRunner(regParams.CommandExecutor)
-	regParams.ToolchainRunner = toolchainRunnerAdapter{toolchainRunnerCore: runner}
+	// Single production construction of the runner (issue #1325, ADR-060):
+	// the direct-construction class in tools is eliminated; only the di
+	// composition root constructs. Reuses the &exec.RealExecutor{} from the
+	// literal above; *toolchain.goRunner satisfies tools.ToolchainRunner
+	// directly (CoverageSummary boundary).
+	regParams.ToolchainRunner = infra_toolchain.NewGoRunner(regParams.CommandExecutor)
 
 	if err := f.RegisterAllTools(regParams); err != nil {
 		return nil, fmt.Errorf("%w: failed to register core tools: %w", errInfraInit, err)
@@ -141,47 +138,4 @@ func (f *defaultToolchainFactory) BuildHealthChecker() ports.HealthChecker {
 		[]string{"git", "go"}, // required binaries
 		[]string{"make"},      // optional binaries
 	)
-}
-
-// toolchainRunnerCore is the concrete method set of infra_toolchain.NewGoRunner:
-// the 12 ToolchainRunner operations with the infrastructure CoverageReport
-// return on RunTestsWithCoverage. It exists so toolchainRunnerAdapter can embed
-// (and thus promote) every method except the one whose signature differs from
-// the port. Satisfied by *infra_toolchain.goRunner.
-type toolchainRunnerCore interface {
-	GetPackageList(ctx context.Context, path string) ([]byte, error)
-	GetGoDoc(ctx context.Context, symbol string) ([]byte, error)
-	GetModulePath(ctx context.Context) (string, error)
-	GetModuleDir(ctx context.Context) (string, error)
-	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (infra_toolchain.CoverageReport, error)
-	RunLinter(ctx context.Context) (string, string, error)
-	RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error)
-	CheckGovulncheck(ctx context.Context) error
-	RunModTidy(ctx context.Context) ([]byte, error)
-	FormatCode(ctx context.Context, path string) ([]byte, error)
-	RunTests(ctx context.Context, path string) ([]byte, error)
-	BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error)
-}
-
-// toolchainRunnerAdapter bridges infra_toolchain's goRunner to the
-// tools.ToolchainRunner port. The only signature difference is
-// RunTestsWithCoverage: the infrastructure implementation returns its full
-// CoverageReport while the port requires the tools-layer CoverageSummary
-// (TestOutput intentionally absent — it has zero assertion consumers per
-// ADR-060). All other methods are promoted from the embedded interface. Once
-// the infrastructure toolchain returns tools.CoverageSummary directly
-// (issue #1325 follow-up tasks), this adapter can be deleted and the plain
-// assignment restored.
-type toolchainRunnerAdapter struct {
-	toolchainRunnerCore
-}
-
-func (a toolchainRunnerAdapter) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
-	report, err := a.toolchainRunnerCore.RunTestsWithCoverage(ctx, path, short, profilePath)
-	return tools.CoverageSummary{
-		PassedCount:   report.PassedCount,
-		NoGoFiles:     report.NoGoFiles,
-		CoveragePct:   report.CoveragePct,
-		SummaryOutput: report.SummaryOutput,
-	}, err
 }

--- a/internal/infrastructure/di/toolchain_factory.go
+++ b/internal/infrastructure/di/toolchain_factory.go
@@ -87,6 +87,16 @@ func (f *defaultToolchainFactory) BuildRegistry(params toolchainParams) (tools.R
 		WorkspacePolicy:  f.WorkspacePolicy,
 	}
 
+	// Single production construction of the runner (issue #1325: the
+	// direct-construction class in tools is eliminated; only the di
+	// composition root constructs). toolchainRunnerAdapter bridges the
+	// infrastructure goRunner's CoverageReport return to the port's
+	// CoverageSummary (TestOutput deliberately absent per ADR-060); it can be
+	// replaced by a plain assignment once the infrastructure toolchain
+	// satisfies tools.ToolchainRunner directly.
+	runner := infra_toolchain.NewGoRunner(regParams.CommandExecutor)
+	regParams.ToolchainRunner = toolchainRunnerAdapter{toolchainRunnerCore: runner}
+
 	if err := f.RegisterAllTools(regParams); err != nil {
 		return nil, fmt.Errorf("%w: failed to register core tools: %w", errInfraInit, err)
 	}
@@ -131,4 +141,47 @@ func (f *defaultToolchainFactory) BuildHealthChecker() ports.HealthChecker {
 		[]string{"git", "go"}, // required binaries
 		[]string{"make"},      // optional binaries
 	)
+}
+
+// toolchainRunnerCore is the concrete method set of infra_toolchain.NewGoRunner:
+// the 12 ToolchainRunner operations with the infrastructure CoverageReport
+// return on RunTestsWithCoverage. It exists so toolchainRunnerAdapter can embed
+// (and thus promote) every method except the one whose signature differs from
+// the port. Satisfied by *infra_toolchain.goRunner.
+type toolchainRunnerCore interface {
+	GetPackageList(ctx context.Context, path string) ([]byte, error)
+	GetGoDoc(ctx context.Context, symbol string) ([]byte, error)
+	GetModulePath(ctx context.Context) (string, error)
+	GetModuleDir(ctx context.Context) (string, error)
+	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (infra_toolchain.CoverageReport, error)
+	RunLinter(ctx context.Context) (string, string, error)
+	RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error)
+	CheckGovulncheck(ctx context.Context) error
+	RunModTidy(ctx context.Context) ([]byte, error)
+	FormatCode(ctx context.Context, path string) ([]byte, error)
+	RunTests(ctx context.Context, path string) ([]byte, error)
+	BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error)
+}
+
+// toolchainRunnerAdapter bridges infra_toolchain's goRunner to the
+// tools.ToolchainRunner port. The only signature difference is
+// RunTestsWithCoverage: the infrastructure implementation returns its full
+// CoverageReport while the port requires the tools-layer CoverageSummary
+// (TestOutput intentionally absent — it has zero assertion consumers per
+// ADR-060). All other methods are promoted from the embedded interface. Once
+// the infrastructure toolchain returns tools.CoverageSummary directly
+// (issue #1325 follow-up tasks), this adapter can be deleted and the plain
+// assignment restored.
+type toolchainRunnerAdapter struct {
+	toolchainRunnerCore
+}
+
+func (a toolchainRunnerAdapter) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+	report, err := a.toolchainRunnerCore.RunTestsWithCoverage(ctx, path, short, profilePath)
+	return tools.CoverageSummary{
+		PassedCount:   report.PassedCount,
+		NoGoFiles:     report.NoGoFiles,
+		CoveragePct:   report.CoveragePct,
+		SummaryOutput: report.SummaryOutput,
+	}, err
 }

--- a/internal/infrastructure/di/toolchain_factory_seam_test.go
+++ b/internal/infrastructure/di/toolchain_factory_seam_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package di
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
+	"github.com/gosharplite/tell-me-go/internal/domain/security"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
+	infra_tools "github.com/gosharplite/tell-me-go/internal/tools"
+)
+
+// TestBuildRegistry_PopulatesToolchainRunner is the per-destination wiring
+// verification for the di composition root (issue #1325, ADR-060 seam
+// capture): BuildRegistry must populate ToolchainRunner on the
+// ToolRegistrationParams handed to RegisterAllTools.
+func TestBuildRegistry_PopulatesToolchainRunner(t *testing.T) {
+	sm := new(mockConfigurableSecurityManager)
+	sm.RegisterPolicyToolsFunc = func(r tools.Registry, kv ports.KVStore) error { return nil }
+
+	factory := newToolchainFactory(t.TempDir(), nil, sm, nil, nil, nil).(*defaultToolchainFactory)
+
+	var captured infra_tools.ToolRegistrationParams
+	factory.RegisterAllTools = func(params infra_tools.ToolRegistrationParams) error {
+		captured = params
+		return nil
+	}
+	factory.RegisterMetrics = func(r tools.Registry, sm security.Manager, logFile, traceFile, model, mode string, pricingOverrides map[string]pricing.ModelPricing) error {
+		return nil
+	}
+
+	mockSP := &testfixtures.MockSessionProvider{
+		GetSettingsFn: func() ports.KVStore { return &mockKVStore{} },
+	}
+	params := toolchainParams{
+		Paths:           &persistence.Paths{},
+		SessionProvider: mockSP,
+	}
+
+	if _, err := factory.BuildRegistry(params); err != nil {
+		t.Fatalf("BuildRegistry failed: %v", err)
+	}
+
+	if captured.ToolchainRunner == nil {
+		t.Fatal("ToolchainRunner was not populated on ToolRegistrationParams")
+	}
+
+	// Direct port call — never through the registry handler: check_vulnerabilities
+	// falls through to a real govulncheck ./... via the non-injectable
+	// devManager.executor (dev.go:327-331). CheckGovulncheck is lookPath-only;
+	// the assertion is NO-PANIC — a NewGoRunner(nil-exec) construction typo
+	// panics on the nil executor interface. Deterministic whether or not
+	// govulncheck is installed (ADR-060 seam-capture rationale).
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("CheckGovulncheck panicked (runner constructed with nil executor?): %v", r)
+			}
+		}()
+		_ = captured.ToolchainRunner.CheckGovulncheck(context.Background())
+	}()
+}

--- a/internal/infrastructure/toolchain/runner.go
+++ b/internal/infrastructure/toolchain/runner.go
@@ -2,7 +2,6 @@ package toolchain
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"regexp"
@@ -11,9 +10,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
-
-// ErrNoSupportedLinter is returned when neither golangci-lint nor staticcheck is found.
-var ErrNoSupportedLinter = errors.New("no supported linter found (golangci-lint or staticcheck)")
 
 // CoverageReport is the infrastructure-internal parse container for coverage runs; the boundary type is tools.CoverageSummary (see ADR-060).
 type CoverageReport struct {
@@ -198,7 +194,7 @@ func (r *goRunner) RunLinter(ctx context.Context) (output string, toolUsed strin
 		out, err := r.combinedOutput(ctx, "staticcheck", "./...")
 		return string(out), "staticcheck", err
 	}
-	return "", "", ErrNoSupportedLinter
+	return "", "", tools.ErrNoSupportedLinter
 }
 
 // RunTests runs project tests using the standard Go test tool.

--- a/internal/infrastructure/toolchain/runner.go
+++ b/internal/infrastructure/toolchain/runner.go
@@ -15,7 +15,7 @@ import (
 // ErrNoSupportedLinter is returned when neither golangci-lint nor staticcheck is found.
 var ErrNoSupportedLinter = errors.New("no supported linter found (golangci-lint or staticcheck)")
 
-// CoverageReport encapsulates the result of running tests with coverage.
+// CoverageReport is the infrastructure-internal parse container for coverage runs; the boundary type is tools.CoverageSummary (see ADR-060).
 type CoverageReport struct {
 	TestOutput    string
 	SummaryOutput string
@@ -82,8 +82,9 @@ func (r *goRunner) applyTimeout(ctx context.Context) (context.Context, context.C
 	return context.WithTimeout(ctx, r.defaultTimeout)
 }
 
-// RunTestsWithCoverage executes tests with coverage and returns a parsed report.
-func (r *goRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (CoverageReport, error) {
+// RunTestsWithCoverage executes tests with coverage and returns the boundary
+// CoverageSummary (CoverageReport stays internal to this package).
+func (r *goRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 	ctx, cancel := r.applyTimeout(ctx)
 	defer cancel()
 
@@ -93,7 +94,7 @@ func (r *goRunner) RunTestsWithCoverage(ctx context.Context, path string, short 
 	if tempName == "" {
 		f, err := r.createTemp("", "coverage-*.out")
 		if err != nil {
-			return report, fmt.Errorf("failed to create temp coverage file: %w", err)
+			return tools.CoverageSummary{}, fmt.Errorf("failed to create temp coverage file: %w", err)
 		}
 		tempName = f.Name()
 		// Safe to ignore: immediate closure to prepare file for OS write by child process.
@@ -116,9 +117,9 @@ func (r *goRunner) RunTestsWithCoverage(ctx context.Context, path string, short 
 		if r.isNoGoFiles(outStr) {
 			report.NoGoFiles = true
 			report.CoveragePct = "0.0%"
-			return report, nil
+			return tools.CoverageSummary{NoGoFiles: true, CoveragePct: "0.0%"}, nil
 		}
-		return report, fmt.Errorf("test execution failed: %w (output: %s)", testErr, outStr)
+		return tools.CoverageSummary{}, fmt.Errorf("test execution failed: %w (output: %s)", testErr, outStr)
 	}
 
 	report.PassedCount = r.countPassedPackages(outStr)
@@ -126,13 +127,18 @@ func (r *goRunner) RunTestsWithCoverage(ctx context.Context, path string, short 
 	// Get summary
 	sumOut, summaryErr := r.combinedOutput(ctx, "go", "tool", "cover", "-func="+tempName)
 	if summaryErr != nil {
-		return report, fmt.Errorf("coverage summary execution failed: %w", summaryErr)
+		return tools.CoverageSummary{}, fmt.Errorf("coverage summary execution failed: %w", summaryErr)
 	}
 
 	report.SummaryOutput = string(sumOut)
 	report.CoveragePct = r.parseCoveragePct(report.SummaryOutput)
 
-	return report, nil
+	return tools.CoverageSummary{
+		PassedCount:   report.PassedCount,
+		NoGoFiles:     report.NoGoFiles,
+		CoveragePct:   report.CoveragePct,
+		SummaryOutput: report.SummaryOutput,
+	}, nil
 }
 
 func (r *goRunner) countPassedPackages(output string) int {

--- a/internal/infrastructure/toolchain/runner_test.go
+++ b/internal/infrastructure/toolchain/runner_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
 
 type mockExecutor struct {
@@ -341,7 +343,7 @@ func TestGoRunner_RunLinter(t *testing.T) {
 					return "", errors.New("not found")
 				}
 			},
-			wantErr: ErrNoSupportedLinter,
+			wantErr: tools.ErrNoSupportedLinter,
 		},
 	}
 

--- a/internal/tools/analysis/common_test.go
+++ b/internal/tools/analysis/common_test.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -213,7 +213,7 @@ type mockAnalysisGoRunner struct {
 	getGoDocFunc             func(ctx context.Context, symbol string) ([]byte, error)
 	getModulePathFunc        func(ctx context.Context) (string, error)
 	getModuleDirFunc         func(ctx context.Context) (string, error)
-	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 	runLinterFunc            func(ctx context.Context) (string, string, error)
 }
 
@@ -245,11 +245,11 @@ func (m *mockAnalysisGoRunner) GetModuleDir(ctx context.Context) (string, error)
 	return "", nil
 }
 
-func (m *mockAnalysisGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+func (m *mockAnalysisGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 	if m.runTestsWithCoverageFunc != nil {
 		return m.runTestsWithCoverageFunc(ctx, path, short, profilePath)
 	}
-	return toolchain.CoverageReport{}, nil
+	return tools.CoverageSummary{}, nil
 }
 
 func (m *mockAnalysisGoRunner) RunLinter(ctx context.Context) (string, string, error) {

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 	"golang.org/x/sync/errgroup"
 )
@@ -234,7 +233,7 @@ func (m *healthManager) runLint(ctx context.Context) (string, string) {
 	outStr, tool, err := m.Runner.RunLinter(ctx)
 	var exitErr *exec.ExitError
 	if err != nil && !errors.As(err, &exitErr) {
-		if errors.Is(err, toolchain.ErrNoSupportedLinter) {
+		if errors.Is(err, tools.ErrNoSupportedLinter) {
 			return "SKIP", "No linter found"
 		}
 		return "ERROR", err.Error()

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -36,7 +36,7 @@ func (m *mockDeadCodeAnalyzer) FindOrphanedSymbols(ctx context.Context, args map
 }
 
 type mockGoRunner struct {
-	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 	runBenchmarksFunc        func(ctx context.Context, path string, benchRegex string) (string, error)
 	runLinterFunc            func(ctx context.Context) (string, string, error)
 	runModTidyFunc           func(ctx context.Context) ([]byte, error)
@@ -48,14 +48,13 @@ type mockGoRunner struct {
 	getModuleDirFunc         func(ctx context.Context) (string, error)
 }
 
-func (m *mockGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+func (m *mockGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 	if m.runTestsWithCoverageFunc != nil {
 		return m.runTestsWithCoverageFunc(ctx, path, short, profilePath)
 	}
-	return toolchain.CoverageReport{
+	return tools.CoverageSummary{
 		PassedCount:   2,
 		CoveragePct:   "82.5%",
-		TestOutput:    "ok package1\nok package2",
 		SummaryOutput: "total: (statements) 82.5%",
 	}, nil
 }
@@ -444,12 +443,12 @@ func TestHealthManager_GetDetailedCoverage(t *testing.T) {
 	t.Parallel()
 	mockExec := &coverageMockExecutor{t: t}
 	mockRunner := &mockGoRunner{
-		runTestsWithCoverageFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+		runTestsWithCoverageFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 			content := "mode: set\ngithub.com/gosharplite/tell-me-go/internal/domain/events/events.go:1.1,2.1 1 0\n"
 			if err := os.WriteFile(profilePath, []byte(content), 0644); err != nil {
 				t.Errorf("failed to write mock coverage file: %v", err)
 			}
-			return toolchain.CoverageReport{}, nil
+			return tools.CoverageSummary{}, nil
 		},
 	}
 	hea := &healthManager{Exec: mockExec, Runner: mockRunner}
@@ -774,7 +773,7 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 	tests := []struct {
 		name             string
 		ctxFunc          func() (context.Context, func())
-		runnerFunc       func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+		runnerFunc       func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 		wantTestStatus   string
 		wantTestContains string
 		wantCovStatus    string
@@ -786,8 +785,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 				ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Hour))
 				return ctx, cancel
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{}, context.DeadlineExceeded
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{}, context.DeadlineExceeded
 			},
 			wantTestStatus:   "TIMEOUT",
 			wantTestContains: "timed out",
@@ -801,8 +800,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 				cancel() // ctx.Err() returns context.Canceled
 				return ctx, cancel
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{}, context.Canceled
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{}, context.Canceled
 			},
 			wantTestStatus:   "CANCELLED",
 			wantTestContains: "cancelled",
@@ -814,8 +813,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 			ctxFunc: func() (context.Context, func()) {
 				return context.Background(), func() {}
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{}, errors.New("exit status 1")
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{}, errors.New("exit status 1")
 			},
 			wantTestStatus:   "FAIL",
 			wantTestContains: "failed",
@@ -827,8 +826,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 			ctxFunc: func() (context.Context, func()) {
 				return context.Background(), func() {}
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{CoveragePct: "N/A", PassedCount: 3}, nil
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{CoveragePct: "N/A", PassedCount: 3}, nil
 			},
 			wantTestStatus:   "PASS",
 			wantTestContains: "3 packages passed",
@@ -840,8 +839,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 			ctxFunc: func() (context.Context, func()) {
 				return context.Background(), func() {}
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{NoGoFiles: true, PassedCount: 0}, nil
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{NoGoFiles: true, PassedCount: 0}, nil
 			},
 			wantTestStatus:   "PASS",
 			wantTestContains: "0 packages passed",
@@ -853,8 +852,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 			ctxFunc: func() (context.Context, func()) {
 				return context.Background(), func() {}
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{CoveragePct: "", PassedCount: 1}, nil
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{CoveragePct: "", PassedCount: 1}, nil
 			},
 			wantTestStatus:   "PASS",
 			wantTestContains: "1 packages passed",
@@ -866,8 +865,8 @@ func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 			ctxFunc: func() (context.Context, func()) {
 				return context.Background(), func() {}
 			},
-			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-				return toolchain.CoverageReport{CoveragePct: "85.0%", PassedCount: 5}, nil
+			runnerFunc: func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+				return tools.CoverageSummary{CoveragePct: "85.0%", PassedCount: 5}, nil
 			},
 			wantTestStatus:   "PASS",
 			wantTestContains: "5 packages passed",

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -149,7 +149,7 @@ func TestHealthManager_GetCodeHealth(t *testing.T) {
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
 	mockDead := &mockDeadCodeAnalyzer{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), mockDead)
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, &toolstest.FakeToolchainRunner{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), mockDead)
 	hea := &healthManager{SP: sm, complexity: ana.complexity, deadCode: mockDead, Exec: mockExec, Runner: mockRunner}
 
 	ctx := context.Background()
@@ -182,7 +182,7 @@ func TestHealthManager_GetCodeHealth_Cancelled(t *testing.T) {
 	cache := newASTCache(".")
 	mockExec := &mockHealthExecutor{}
 	mockRunner := &mockGoRunner{}
-	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), &mockDeadCodeAnalyzer{})
+	ana := newAnalysisManager(idx, cache, sm, nil, mockExec, &toolstest.FakeToolchainRunner{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), &mockDeadCodeAnalyzer{})
 	hea := &healthManager{SP: sm, complexity: ana.complexity, deadCode: &mockDeadCodeAnalyzer{}, Exec: mockExec, Runner: mockRunner}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -913,7 +913,7 @@ func TestRunLint_ErrorPaths(t *testing.T) {
 		{
 			name: "no linter found",
 			runLinterFn: func(ctx context.Context) (string, string, error) {
-				return "", "", toolchain.ErrNoSupportedLinter
+				return "", "", tools.ErrNoSupportedLinter
 			},
 			wantStatus:   "SKIP",
 			wantContains: "No linter found",

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -11,7 +11,6 @@ import (
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 )
 
@@ -77,8 +76,7 @@ type analysisManager struct {
 	arch   *architectureManager
 }
 
-func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy, dc deadCodeAnalyzer) *analysisManager {
-	runner := toolchain.NewGoRunner(executor)
+func newAnalysisManager(idx symbolIndex, cache *astCache, sp domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, runner tools.ToolchainRunner, fs persistence.FileSystem, wp services.WorkspacePolicy, dc deadCodeAnalyzer) *analysisManager {
 	m := &analysisManager{
 		complexity: newComplexityAnalyzer(cache, sp, fs),
 		dependency: newDependencyAnalyzer(runner, sp, bus, wp, fs),

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -52,7 +52,7 @@ type AnalysisGoRunner interface {
 	GetGoDoc(ctx context.Context, symbol string) ([]byte, error)
 	GetModulePath(ctx context.Context) (string, error)
 	GetModuleDir(ctx context.Context) (string, error)
-	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 	RunLinter(ctx context.Context) (string, string, error)
 }
 

--- a/internal/tools/analysis/manager_test.go
+++ b/internal/tools/analysis/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 )
 
 func setupAnalysisManager(t *testing.T) (*analysisManager, string) {
@@ -26,7 +27,7 @@ func setupAnalysisManager(t *testing.T) (*analysisManager, string) {
 	cache := newASTCache(".")
 	sp := &mockSecurityProvider{}
 
-	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), newDeadCodeAnalyzer(sp, idx))
+	m := newAnalysisManager(idx, cache, sp, nil, &mockHealthExecutor{}, &toolstest.FakeToolchainRunner{}, persistencetest.NewPlainOSFileSystem(), infra_persistence.NewWorkspacePolicy(), newDeadCodeAnalyzer(sp, idx))
 	return m, tmpDir
 }
 

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -92,6 +92,8 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"(*renderer).makeSubscriber":                      {Line: 48, Complexity: 11, FilePath: "internal/ui/tui/progress/renderer.go"},
 		"TestMediaBlocks":                                 {Line: 18, Complexity: 11, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
 		"TestRunCommand_NonExitErrorWaitPath":             {Line: 817, Complexity: 11, FilePath: "internal/tools/workspace/process_executor_stream_test.go"},
+		"TestFakeToolchainRunner_PresetValues":            {Line: 35, Complexity: 28, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
+		"TestFakeToolchainRunner_ZeroDefaults":            {Line: 248, Complexity: 38, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -92,8 +92,8 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"(*renderer).makeSubscriber":                      {Line: 48, Complexity: 11, FilePath: "internal/ui/tui/progress/renderer.go"},
 		"TestMediaBlocks":                                 {Line: 18, Complexity: 11, FilePath: "internal/infrastructure/llm/openai/client_vision_test.go"},
 		"TestRunCommand_NonExitErrorWaitPath":             {Line: 817, Complexity: 11, FilePath: "internal/tools/workspace/process_executor_stream_test.go"},
-		"TestFakeToolchainRunner_PresetValues":            {Line: 35, Complexity: 28, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
-		"TestFakeToolchainRunner_ZeroDefaults":            {Line: 248, Complexity: 38, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
+		"TestFakeToolchainRunner_PresetValues":            {Line: 36, Complexity: 28, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
+		"TestFakeToolchainRunner_ZeroDefaults":            {Line: 249, Complexity: 38, FilePath: "internal/tools/toolstest/fake_toolchain_runner_test.go"},
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -15,10 +15,10 @@ import (
 )
 
 // Register adds all consolidated analysis tools to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, fs persistence.FileSystem, wp services.WorkspacePolicy) (tools.ToolFunc, error) {
+func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus, executor tools.CommandExecutor, runner tools.ToolchainRunner, fs persistence.FileSystem, wp services.WorkspacePolicy) (tools.ToolFunc, error) {
 	idx, _ := newIndexer(".")
 	cache := newASTCache(".")
-	m := newAnalysisManager(idx, cache, sm, bus, executor, fs, wp, newDeadCodeAnalyzer(sm, idx))
+	m := newAnalysisManager(idx, cache, sm, bus, executor, runner, fs, wp, newDeadCodeAnalyzer(sm, idx))
 
 	type toolSpec struct {
 		decl    *tools.ToolDeclaration

--- a/internal/tools/analysis/registration_test.go
+++ b/internal/tools/analysis/registration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -134,7 +135,7 @@ func TestRegister_ErrorWrapping(t *testing.T) {
 		fs := &stubFileSystem{}
 		wp := &stubWorkspacePolicy{}
 
-		_, err := Register(r, sp, bus, exec, fs, wp)
+		_, err := Register(r, sp, bus, exec, &toolstest.FakeToolchainRunner{}, fs, wp)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "register tool")
 		// First tool with opts is "verify_architecture"
@@ -154,7 +155,7 @@ func TestRegister_ErrorWrapping(t *testing.T) {
 		fs := &stubFileSystem{}
 		wp := &stubWorkspacePolicy{}
 
-		_, err := Register(r, sp, bus, exec, fs, wp)
+		_, err := Register(r, sp, bus, exec, &toolstest.FakeToolchainRunner{}, fs, wp)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "register tool")
 		// First tool without opts is "list_symbols"
@@ -173,7 +174,7 @@ func TestRegister_Success(t *testing.T) {
 	fs := &stubFileSystem{}
 	wp := &stubWorkspacePolicy{}
 
-	result, err := Register(r, sp, bus, exec, fs, wp)
+	result, err := Register(r, sp, bus, exec, &toolstest.FakeToolchainRunner{}, fs, wp)
 	require.NoError(t, err)
 	require.NotNil(t, result, "expected a non-nil handler (VerifyArchitecture) on success")
 }

--- a/internal/tools/analysis/toolchain_wiring_test.go
+++ b/internal/tools/analysis/toolchain_wiring_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+)
+
+// TestNewAnalysisManager_WiresRunnerIntoAllConsumers is a white-box
+// construction assertion: the runner injected into newAnalysisManager must
+// reach every consumer field (info, arch, health, dependency). No tool
+// execution, no subprocesses.
+func TestNewAnalysisManager_WiresRunnerIntoAllConsumers(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte("module test\ngo 1.25"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "test.go"), []byte("package test\nfunc F(){}\nvar _ = F"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	idx, _ := newIndexer(tmpDir)
+	idx.knownModulePath = "test"
+	cache := newASTCache(".")
+	sp := &mockSecurityProvider{}
+	mockExec := &mockHealthExecutor{}
+	fs := persistencetest.NewPlainOSFileSystem()
+	wp := infra_persistence.NewWorkspacePolicy()
+	dc := newDeadCodeAnalyzer(sp, idx)
+
+	fake := &toolstest.FakeToolchainRunner{}
+	m := newAnalysisManager(idx, cache, sp, nil, mockExec, fake, fs, wp, dc)
+
+	if m.info.Runner == nil {
+		t.Error("infoManager.Runner is nil; runner not wired")
+	}
+	if m.arch.Runner == nil {
+		t.Error("architectureManager.Runner is nil; runner not wired")
+	}
+	if m.health.Runner == nil {
+		t.Error("healthManager.Runner is nil; runner not wired")
+	}
+	dep, ok := m.dependency.(*defaultDependencyAnalyzer)
+	if !ok {
+		t.Fatalf("dependency field is %T, want *defaultDependencyAnalyzer", m.dependency)
+	}
+	if dep.Runner == nil {
+		t.Error("dependencyAnalyzer.Runner is nil; runner not wired")
+	}
+}

--- a/internal/tools/developer/dev.go
+++ b/internal/tools/developer/dev.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/pkg/stringsutil"
 	"github.com/gosharplite/tell-me-go/internal/pkg/telemetry"
 )
@@ -29,7 +28,7 @@ func withHeartbeatInterval(d time.Duration) devOption {
 }
 
 type goRunner interface {
-	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 	RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error)
 	RunLinter(ctx context.Context) (string, string, error)
 	CheckGovulncheck(ctx context.Context) error
@@ -218,7 +217,7 @@ func (m *devManager) getCoverage(ctx context.Context, args map[string]interface{
 
 	// Prompt user for authorization
 	command := fmt.Sprintf("Run coverage on %s", path)
-	var report toolchain.CoverageReport
+	var report tools.CoverageSummary
 	err := m.runWithHeartbeat(ctx, hb, "get_coverage", command, "Getting test coverage summary", func() error {
 		var err error
 		report, err = m.runner.RunTestsWithCoverage(ctx, path, false, "")

--- a/internal/tools/developer/dev_test.go
+++ b/internal/tools/developer/dev_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -52,7 +52,7 @@ func (mv *mockValidator) IsSafe(command string) (bool, string) {
 }
 
 type mockGoRunner struct {
-	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
+	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
 	runBenchmarksFunc        func(ctx context.Context, path string, benchRegex string) (string, error)
 	runLinterFunc            func(ctx context.Context) (string, string, error)
 	checkGovulncheckFunc     func(ctx context.Context) error
@@ -61,11 +61,11 @@ type mockGoRunner struct {
 	runTestsFunc             func(ctx context.Context, path string) ([]byte, error)
 }
 
-func (m *mockGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+func (m *mockGoRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 	if m.runTestsWithCoverageFunc != nil {
 		return m.runTestsWithCoverageFunc(ctx, path, short, profilePath)
 	}
-	return toolchain.CoverageReport{}, nil
+	return tools.CoverageSummary{}, nil
 }
 
 func (m *mockGoRunner) RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error) {
@@ -216,17 +216,17 @@ func TestCheckVulnerabilities(t *testing.T) {
 
 func setupCoverageMock(t *testing.T, m *devManager, executeErr error, summaryOut string, tempErr error, noGoFiles bool) {
 	runner := m.runner.(*mockGoRunner)
-	runner.runTestsWithCoverageFunc = func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
+	runner.runTestsWithCoverageFunc = func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
 		if tempErr != nil {
-			return toolchain.CoverageReport{}, tempErr
+			return tools.CoverageSummary{}, tempErr
 		}
 		if executeErr != nil {
-			return toolchain.CoverageReport{}, executeErr
+			return tools.CoverageSummary{}, executeErr
 		}
 		if noGoFiles {
-			return toolchain.CoverageReport{NoGoFiles: true}, nil
+			return tools.CoverageSummary{NoGoFiles: true}, nil
 		}
-		return toolchain.CoverageReport{SummaryOutput: summaryOut}, nil
+		return tools.CoverageSummary{SummaryOutput: summaryOut}, nil
 	}
 }
 

--- a/internal/tools/developer/registration.go
+++ b/internal/tools/developer/registration.go
@@ -11,12 +11,10 @@ import (
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
 
 // Register adds all development workflow and release tools to the registry.
-func Register(r tools.Registry, sm domain_security.Manager, exec tools.CommandExecutor, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, archVerify tools.ToolFunc, eventBus events.EventBus) error {
-	runner := toolchain.NewGoRunner(exec)
+func Register(r tools.Registry, sm domain_security.Manager, runner tools.ToolchainRunner, validator domain_security.CommandValidator, fs persistence.FileSystem, wp services.WorkspacePolicy, archVerify tools.ToolFunc, eventBus events.EventBus) error {
 	dev := newDevManager(sm, eventBus, validator, runner)
 
 	if err := r.RegisterWithOptions(&tools.ToolDeclaration{

--- a/internal/tools/developer/registration_test.go
+++ b/internal/tools/developer/registration_test.go
@@ -47,41 +47,14 @@ func (m *mockToolRegistry) GetDeclarations() []*tools.ToolDeclaration {
 	return nil
 }
 
-type mockToolchainExecutor struct {
-	runFunc      func(ctx context.Context, name string, args ...string) ([]byte, error)
-	lookPathFunc func(file string) (string, error)
-}
-
-func (m *mockToolchainExecutor) Output(ctx context.Context, name string, args ...string) ([]byte, error) {
-	if m.runFunc != nil {
-		return m.runFunc(ctx, name, args...)
-	}
-	return []byte(""), nil
-}
-
-func (m *mockToolchainExecutor) CombinedOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	if m.runFunc != nil {
-		return m.runFunc(ctx, name, args...)
-	}
-	return []byte(""), nil
-}
-
-func (m *mockToolchainExecutor) LookPath(file string) (string, error) {
-	if m.lookPathFunc != nil {
-		return m.lookPathFunc(file)
-	}
-	return "/usr/bin/" + file, nil
-}
-
 func TestRegister(t *testing.T) {
 	t.Parallel()
 	registry := &mockToolRegistry{}
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 	fs := persistence.NewMockFileSystem()
-	exec := &mockToolchainExecutor{}
 
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
+	if err := Register(registry, sm, &toolstest.FakeToolchainRunner{}, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("Register failed: %v", err)
 	}
 
@@ -162,9 +135,8 @@ func TestRegister_PartialFailure(t *testing.T) {
 			sm := &toolstest.MockSecurityManager{AllowAll: true}
 			validator := &toolstest.MockCommandValidator{}
 			fs := persistence.NewMockFileSystem()
-			exec := &mockToolchainExecutor{}
 
-			err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{})
+			err := Register(registry, sm, &toolstest.FakeToolchainRunner{}, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{})
 
 			if err == nil {
 				t.Fatal("expected error, got nil")
@@ -191,10 +163,9 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	sm := &toolstest.MockSecurityManager{AllowAll: true}
 	validator := &toolstest.MockCommandValidator{}
 	fs := persistence.NewMockFileSystem()
-	exec := &mockToolchainExecutor{}
 
 	// First registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
+	if err := Register(registry, sm, &toolstest.FakeToolchainRunner{}, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("first Register failed: %v", err)
 	}
 
@@ -213,7 +184,7 @@ func TestRegister_DuplicateRegistration(t *testing.T) {
 	}
 
 	// Second registration
-	if err := Register(registry, sm, exec, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
+	if err := Register(registry, sm, &toolstest.FakeToolchainRunner{}, validator, fs, infra_persistence.NewWorkspacePolicy(), nil, &events.NoOpEventBus{}); err != nil {
 		t.Fatalf("second Register failed: %v", err)
 	}
 

--- a/internal/tools/developer/release.go
+++ b/internal/tools/developer/release.go
@@ -5,6 +5,7 @@ package developer
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -20,11 +21,9 @@ import (
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/services"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 )
 
 type releaseGoRunner interface {
-	RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
 	RunLinter(ctx context.Context) (string, string, error)
 	RunTests(ctx context.Context, path string) ([]byte, error)
 	BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error)
@@ -314,7 +313,7 @@ func (c *linterChecker) Name() string { return "Linter Verification" }
 func (c *linterChecker) Run(ctx context.Context) checkResult {
 	out, tool, err := c.runner.RunLinter(ctx)
 	if err != nil {
-		if strings.Contains(err.Error(), "no supported linter found") {
+		if errors.Is(err, tools.ErrNoSupportedLinter) {
 			return checkResult{OK: false, Message: "No linter found (golangci-lint or staticcheck)."}
 		}
 		// If it's an exit status 1, it usually means issues found, but we should check output.

--- a/internal/tools/developer/release_test.go
+++ b/internal/tools/developer/release_test.go
@@ -15,17 +15,15 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/toolchain"
 	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 type mockReleaseRunner struct {
-	runLinterFunc            func(ctx context.Context) (string, string, error)
-	runTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error)
-	runTestsFunc             func(ctx context.Context, path string) ([]byte, error)
-	buildCodeFunc            func(ctx context.Context, outputBinary, path string) ([]byte, error)
+	runLinterFunc func(ctx context.Context) (string, string, error)
+	runTestsFunc  func(ctx context.Context, path string) ([]byte, error)
+	buildCodeFunc func(ctx context.Context, outputBinary, path string) ([]byte, error)
 }
 
 func (m *mockReleaseRunner) RunLinter(ctx context.Context) (string, string, error) {
@@ -33,13 +31,6 @@ func (m *mockReleaseRunner) RunLinter(ctx context.Context) (string, string, erro
 		return m.runLinterFunc(ctx)
 	}
 	return "", "mock-linter", nil
-}
-
-func (m *mockReleaseRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (toolchain.CoverageReport, error) {
-	if m.runTestsWithCoverageFunc != nil {
-		return m.runTestsWithCoverageFunc(ctx, path, short, profilePath)
-	}
-	return toolchain.CoverageReport{PassedCount: 1, CoveragePct: "100.0%"}, nil
 }
 
 func (m *mockReleaseRunner) RunTests(ctx context.Context, path string) ([]byte, error) {
@@ -228,7 +219,7 @@ func TestLinterChecker_Fallbacks(t *testing.T) {
 			setupRunner: func() *mockReleaseRunner {
 				return &mockReleaseRunner{
 					runLinterFunc: func(ctx context.Context) (string, string, error) {
-						return "", "", toolchain.ErrNoSupportedLinter
+						return "", "", tools.ErrNoSupportedLinter
 					},
 				}
 			},
@@ -679,7 +670,7 @@ func TestLinterChecker_NoSupportedLinter(t *testing.T) {
 	t.Parallel()
 	runner := &mockReleaseRunner{
 		runLinterFunc: func(ctx context.Context) (string, string, error) {
-			return "", "", toolchain.ErrNoSupportedLinter
+			return "", "", tools.ErrNoSupportedLinter
 		},
 	}
 	c := &linterChecker{runner: runner}

--- a/internal/tools/developer/toolchain_wiring_test.go
+++ b/internal/tools/developer/toolchain_wiring_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package developer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/infrastructure/registry"
+	"github.com/gosharplite/tell-me-go/internal/tools/toolstest"
+)
+
+// TestRegister_GetCoverage_ReachesFakeRunner proves devManager.runner is
+// wired through the real handler dispatch (issue #1325, ADR-060): the fake
+// ToolchainRunner's RunTestsWithCoverage must be reached via
+// registry.Execute("get_coverage", ...). Zero subprocesses — the fake
+// returns an empty CoverageSummary and the handler completes.
+func TestRegister_GetCoverage_ReachesFakeRunner(t *testing.T) {
+	fake := &toolstest.FakeToolchainRunner{}
+	archVerify := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "ok"}, nil
+	}
+	reg := registry.New()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	if err := Register(reg, sm, fake, &toolstest.MockCommandValidator{}, persistence.NewMockFileSystem(), infra_persistence.NewWorkspacePolicy(), archVerify, &events.NoOpEventBus{}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	hb := make(chan struct{})
+	if _, err := reg.Execute(context.Background(), "get_coverage", map[string]interface{}{"path": "./..."}, hb); err != nil {
+		t.Fatalf("get_coverage failed: %v", err)
+	}
+	if !fake.Called("RunTestsWithCoverage") {
+		t.Error("fake runner RunTestsWithCoverage was not reached through the get_coverage handler")
+	}
+}
+
+// TestRegister_VerifyReleaseReadiness_ReachesFakeRunner proves
+// releaseManager.runner is wired through the real handler dispatch: the fake
+// ToolchainRunner's RunLinter/RunTests/BuildCode must be reached via
+// registry.Execute("verify_release_readiness", ...). All six checks run
+// concurrently; the remaining checks run against the mock FS and stub
+// verifier — their PASS/FAIL is irrelevant, only the three runner
+// assertions matter. Zero subprocesses.
+func TestRegister_VerifyReleaseReadiness_ReachesFakeRunner(t *testing.T) {
+	fake := &toolstest.FakeToolchainRunner{}
+	archVerify := func(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: "ok"}, nil
+	}
+	reg := registry.New()
+	sm := &toolstest.MockSecurityManager{AllowAll: true}
+	if err := Register(reg, sm, fake, &toolstest.MockCommandValidator{}, persistence.NewMockFileSystem(), infra_persistence.NewWorkspacePolicy(), archVerify, &events.NoOpEventBus{}); err != nil {
+		t.Fatalf("Register failed: %v", err)
+	}
+	hb := make(chan struct{})
+	if _, err := reg.Execute(context.Background(), "verify_release_readiness", nil, hb); err != nil {
+		t.Fatalf("verify_release_readiness failed: %v", err)
+	}
+	for _, method := range []string{"RunLinter", "RunTests", "BuildCode"} {
+		if !fake.Called(method) {
+			t.Errorf("fake runner %s was not reached through verify_release_readiness", method)
+		}
+	}
+}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -86,7 +86,7 @@ func RegisterAll(params ToolRegistrationParams) error {
 			return fmt.Errorf("workspace.RegisterPersistence: %w", err)
 		}
 	}
-	archVerify, err := analysis.Register(params.Registry, params.SecurityManager, params.EventBus, params.CommandExecutor, params.FileSystem, params.WorkspacePolicy)
+	archVerify, err := analysis.Register(params.Registry, params.SecurityManager, params.EventBus, params.CommandExecutor, params.ToolchainRunner, params.FileSystem, params.WorkspacePolicy)
 	if err != nil {
 		return fmt.Errorf("analysis.Register: %w", err)
 	}

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -90,7 +90,7 @@ func RegisterAll(params ToolRegistrationParams) error {
 	if err != nil {
 		return fmt.Errorf("analysis.Register: %w", err)
 	}
-	if err := developer.Register(params.Registry, params.SecurityManager, params.CommandExecutor, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify, params.EventBus); err != nil {
+	if err := developer.Register(params.Registry, params.SecurityManager, params.ToolchainRunner, params.CommandValidator, params.FileSystem, params.WorkspacePolicy, archVerify, params.EventBus); err != nil {
 		return fmt.Errorf("developer.Register: %w", err)
 	}
 	if err := integrations.RegisterAll(params.Registry, params.FileSystem, params.SecurityManager, params.Client, params.AssetsDir); err != nil {

--- a/internal/tools/tools.go
+++ b/internal/tools/tools.go
@@ -28,6 +28,7 @@ type ToolRegistrationParams struct {
 	SecurityManager  domain_security.Manager
 	CommandExecutor  tools.CommandExecutor
 	CommandValidator domain_security.CommandValidator
+	ToolchainRunner  tools.ToolchainRunner
 	SessionProvider  ports.SessionProvider
 	LogFile          string
 	TraceFile        string
@@ -56,6 +57,18 @@ func validateRegistrationParams(params ToolRegistrationParams) error {
 	}
 	if params.FileSystem == nil {
 		return fmt.Errorf("RegisterAll: FileSystem is required and must not be nil")
+	}
+	if params.CommandExecutor == nil {
+		return fmt.Errorf("RegisterAll: CommandExecutor is required and must not be nil")
+	}
+	if params.CommandValidator == nil {
+		return fmt.Errorf("RegisterAll: CommandValidator is required and must not be nil")
+	}
+	if params.EventBus == nil {
+		return fmt.Errorf("RegisterAll: EventBus is required and must not be nil")
+	}
+	if params.ToolchainRunner == nil {
+		return fmt.Errorf("RegisterAll: ToolchainRunner is required and must not be nil")
 	}
 	return nil
 }

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -381,3 +381,24 @@ func (m *MockRegistry) GetDeclarationsByToolkits(toolkits []string) []*domaintoo
 func (m *MockRegistry) ListAvailableToolkits() []string {
 	return []string{"core"}
 }
+
+// TestRegisterAll_GoDoc_ReachesFakeRunner proves infoManager.Runner is wired
+// through RegisterAll (issue #1325, ADR-060): the fake ToolchainRunner's
+// GetGoDoc must be reached via registry.Execute("go_doc", ...). Zero
+// subprocesses — the fake returns no output and the handler completes.
+// hb nil is safe: GoDoc's heartbeat goroutine guards `if hb != nil`.
+func TestRegisterAll_GoDoc_ReachesFakeRunner(t *testing.T) {
+	t.Parallel()
+	fake := &toolstest.FakeToolchainRunner{}
+	params := newTestParams()
+	params.ToolchainRunner = fake
+	if err := tools.RegisterAll(params); err != nil {
+		t.Fatalf("RegisterAll failed: %v", err)
+	}
+	if _, err := params.Registry.Execute(context.Background(), "go_doc", map[string]interface{}{"symbol": "fmt.Println"}, nil); err != nil {
+		t.Fatalf("go_doc failed: %v", err)
+	}
+	if !fake.Called("GetGoDoc") {
+		t.Error("fake runner GetGoDoc was not reached through the go_doc handler")
+	}
+}

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/gosharplite/tell-me-go/internal/domain/events/eventstest"
 	domaintools "github.com/gosharplite/tell-me-go/internal/domain/tools"
 	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence/persistencetest"
@@ -21,69 +22,65 @@ import (
 
 func TestNewToolRegistry(t *testing.T) {
 	t.Parallel()
-	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := registry.New()
-	if err := tools.RegisterAll(tools.ToolRegistrationParams{
-		HealthManager:   nil,
-		Registry:        r,
-		SecurityManager: sm,
-		LogFile:         "tokens.log",
-		Model:           "model",
-		Mode:            "mode",
-		AssetsDir:       t.TempDir(),
-		FileSystem:      persistencetest.NewPlainOSFileSystem(),
-		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-	}); err != nil {
+	params := newTestParams()
+	params.LogFile = "tokens.log"
+	params.Model = "model"
+	params.Mode = "mode"
+	params.AssetsDir = t.TempDir()
+	if err := tools.RegisterAll(params); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
 
-	if len(r.GetDeclarations()) == 0 {
+	if len(params.Registry.GetDeclarations()) == 0 {
 		t.Error("expected registered tools, got none")
+	}
+}
+
+// newTestParams returns a ToolRegistrationParams with every guarded field set
+// (8-guard table per issue #1325 / ADR-060) and a real non-failing registry.
+// Tests override individual fields to exercise specific paths. Client,
+// SessionProvider, and HealthManager stay unset (documented exclusions).
+func newTestParams() tools.ToolRegistrationParams {
+	return tools.ToolRegistrationParams{
+		Registry:         registry.New(),
+		SecurityManager:  &toolstest.MockSecurityManager{AllowAll: true},
+		WorkspacePolicy:  infra_persistence.NewWorkspacePolicy(),
+		FileSystem:       persistencetest.NewPlainOSFileSystem(),
+		CommandExecutor:  &toolstest.MockExecutor{},
+		CommandValidator: &toolstest.MockCommandValidator{},
+		EventBus:         &eventstest.TestEventBus{},
+		ToolchainRunner:  &toolstest.FakeToolchainRunner{},
 	}
 }
 
 func TestRegisterAll_WithSessionProvider(t *testing.T) {
 	t.Parallel()
-	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := registry.New()
 	sp := &testfixtures.MockSessionProvider{}
-	if err := tools.RegisterAll(tools.ToolRegistrationParams{
-		HealthManager:   nil,
-		Registry:        r,
-		SecurityManager: sm,
-		SessionProvider: sp,
-		LogFile:         "tokens.log",
-		Model:           "model",
-		Mode:            "mode",
-		AssetsDir:       t.TempDir(),
-		FileSystem:      persistencetest.NewPlainOSFileSystem(),
-		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-	}); err != nil {
+	params := newTestParams()
+	params.SessionProvider = sp
+	params.LogFile = "tokens.log"
+	params.Model = "model"
+	params.Mode = "mode"
+	params.AssetsDir = t.TempDir()
+	if err := tools.RegisterAll(params); err != nil {
 		t.Fatalf("RegisterAll with SessionProvider failed: %v", err)
 	}
 }
 
 func TestToolExecution(t *testing.T) {
 	t.Parallel()
-	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := registry.New()
-	if err := tools.RegisterAll(tools.ToolRegistrationParams{
-		HealthManager:   nil,
-		Registry:        r,
-		SecurityManager: sm,
-		LogFile:         "tokens.log",
-		Model:           "model",
-		Mode:            "mode",
-		AssetsDir:       t.TempDir(),
-		FileSystem:      persistencetest.NewPlainOSFileSystem(),
-		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-	}); err != nil {
+	params := newTestParams()
+	params.LogFile = "tokens.log"
+	params.Model = "model"
+	params.Mode = "mode"
+	params.AssetsDir = t.TempDir()
+	if err := tools.RegisterAll(params); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
 
 	ctx := context.Background()
 	// list_files is registered by workspace.Register
-	_, err := r.Execute(ctx, "list_files", map[string]interface{}{"path": "."}, nil)
+	_, err := params.Registry.Execute(ctx, "list_files", map[string]interface{}{"path": "."}, nil)
 	if err != nil {
 		t.Errorf("failed to execute list_files: %v", err)
 	}
@@ -91,19 +88,12 @@ func TestToolExecution(t *testing.T) {
 
 func TestGenerateMermaidDiagram(t *testing.T) {
 	t.Parallel()
-	sm := &toolstest.MockSecurityManager{AllowAll: true}
-	r := registry.New()
-	if err := tools.RegisterAll(tools.ToolRegistrationParams{
-		HealthManager:   nil,
-		Registry:        r,
-		SecurityManager: sm,
-		LogFile:         "tokens.log",
-		Model:           "model",
-		Mode:            "mode",
-		AssetsDir:       t.TempDir(),
-		FileSystem:      persistencetest.NewPlainOSFileSystem(),
-		WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-	}); err != nil {
+	params := newTestParams()
+	params.LogFile = "tokens.log"
+	params.Model = "model"
+	params.Mode = "mode"
+	params.AssetsDir = t.TempDir()
+	if err := tools.RegisterAll(params); err != nil {
 		t.Fatalf("RegisterAll failed: %v", err)
 	}
 
@@ -113,7 +103,7 @@ func TestGenerateMermaidDiagram(t *testing.T) {
 		"pkg2": []string{"pkg3"},
 	}
 
-	res, err := r.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{"graph": graph}, nil)
+	res, err := params.Registry.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{"graph": graph}, nil)
 	if err != nil {
 		t.Fatalf("failed to execute generate_mermaid_diagram: %v", err)
 	}
@@ -123,7 +113,7 @@ func TestGenerateMermaidDiagram(t *testing.T) {
 	}
 
 	// Test invalid graph
-	res, err = r.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{"graph": 123}, nil)
+	res, err = params.Registry.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{"graph": 123}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -132,7 +122,7 @@ func TestGenerateMermaidDiagram(t *testing.T) {
 	}
 
 	// Test missing graph
-	res, err = r.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{}, nil)
+	res, err = params.Registry.Execute(ctx, "generate_mermaid_diagram", map[string]interface{}{}, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -177,46 +167,74 @@ func TestRegisterAll_Errors(t *testing.T) {
 
 	t.Run("nil Registry returns error", func(t *testing.T) {
 		t.Parallel()
-		err := tools.RegisterAll(tools.ToolRegistrationParams{
-			Registry:        nil,
-			SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
-			WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-		})
+		params := newTestParams()
+		params.Registry = nil
+		err := tools.RegisterAll(params)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "Registry is required")
 	})
 
 	t.Run("nil SecurityManager returns error", func(t *testing.T) {
 		t.Parallel()
-		err := tools.RegisterAll(tools.ToolRegistrationParams{
-			Registry:        new(MockRegistry),
-			SecurityManager: nil,
-			WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-		})
+		params := newTestParams()
+		params.SecurityManager = nil
+		err := tools.RegisterAll(params)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "SecurityManager is required")
 	})
 
 	t.Run("nil WorkspacePolicy returns error", func(t *testing.T) {
 		t.Parallel()
-		err := tools.RegisterAll(tools.ToolRegistrationParams{
-			Registry:        new(MockRegistry),
-			SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
-			WorkspacePolicy: nil,
-		})
+		params := newTestParams()
+		params.WorkspacePolicy = nil
+		err := tools.RegisterAll(params)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "WorkspacePolicy is required")
 	})
 
 	t.Run("nil FileSystem returns error", func(t *testing.T) {
 		t.Parallel()
-		err := tools.RegisterAll(tools.ToolRegistrationParams{
-			Registry:        new(MockRegistry),
-			SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
-			WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-		})
+		params := newTestParams()
+		params.FileSystem = nil
+		err := tools.RegisterAll(params)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "FileSystem is required")
+	})
+
+	t.Run("nil CommandExecutor returns error", func(t *testing.T) {
+		t.Parallel()
+		params := newTestParams()
+		params.CommandExecutor = nil
+		err := tools.RegisterAll(params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CommandExecutor is required")
+	})
+
+	t.Run("nil CommandValidator returns error", func(t *testing.T) {
+		t.Parallel()
+		params := newTestParams()
+		params.CommandValidator = nil
+		err := tools.RegisterAll(params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "CommandValidator is required")
+	})
+
+	t.Run("nil EventBus returns error", func(t *testing.T) {
+		t.Parallel()
+		params := newTestParams()
+		params.EventBus = nil
+		err := tools.RegisterAll(params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "EventBus is required")
+	})
+
+	t.Run("nil ToolchainRunner returns error", func(t *testing.T) {
+		t.Parallel()
+		params := newTestParams()
+		params.ToolchainRunner = nil
+		err := tools.RegisterAll(params)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "ToolchainRunner is required")
 	})
 
 	tests := []struct {
@@ -262,14 +280,8 @@ func TestRegisterAll_Errors(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			mockReg := &MockRegistry{failAfter: tt.failAfter}
-			params := tools.ToolRegistrationParams{
-				HealthManager:   nil,
-				Registry:        mockReg,
-				SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
-				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-				FileSystem:      persistencetest.NewPlainOSFileSystem(),
-			}
+			params := newTestParams()
+			params.Registry = &MockRegistry{failAfter: tt.failAfter}
 			if tt.setup != nil {
 				tt.setup(&params)
 			}
@@ -333,14 +345,8 @@ func TestRegisterAll_ErrorWrapping(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			mockReg := &MockRegistry{failAfter: tt.failAfter}
-			params := tools.ToolRegistrationParams{
-				Registry:        mockReg,
-				SecurityManager: &toolstest.MockSecurityManager{AllowAll: true},
-				WorkspacePolicy: infra_persistence.NewWorkspacePolicy(),
-				HealthManager:   nil,
-				FileSystem:      persistencetest.NewPlainOSFileSystem(),
-			}
+			params := newTestParams()
+			params.Registry = &MockRegistry{failAfter: tt.failAfter}
 			if tt.setup != nil {
 				tt.setup(&params)
 			}

--- a/internal/tools/toolstest/fake_toolchain_runner.go
+++ b/internal/tools/toolstest/fake_toolchain_runner.go
@@ -5,6 +5,7 @@ package toolstest
 
 import (
 	"context"
+	"sync"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 )
@@ -29,12 +30,17 @@ type FakeToolchainRunner struct {
 	RunTestsFunc             func(ctx context.Context, path string) ([]byte, error)
 	BuildCodeFunc            func(ctx context.Context, outputBinary, path string) ([]byte, error)
 
-	// Calls records every invocation as the method name, in call order.
+	// mu guards Calls for concurrent access: the release pipeline
+	// (verify_release_readiness) invokes runner methods concurrently, so
+	// the call log must be race-safe (issue #1325).
+	mu    sync.Mutex
 	Calls []string
 }
 
 // Called reports whether the named method was invoked at least once.
 func (f *FakeToolchainRunner) Called(method string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	for _, c := range f.Calls {
 		if c == method {
 			return true
@@ -44,7 +50,9 @@ func (f *FakeToolchainRunner) Called(method string) bool {
 }
 
 func (f *FakeToolchainRunner) GetPackageList(ctx context.Context, path string) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "GetPackageList")
+	f.mu.Unlock()
 	if f.GetPackageListFunc != nil {
 		return f.GetPackageListFunc(ctx, path)
 	}
@@ -52,7 +60,9 @@ func (f *FakeToolchainRunner) GetPackageList(ctx context.Context, path string) (
 }
 
 func (f *FakeToolchainRunner) GetGoDoc(ctx context.Context, symbol string) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "GetGoDoc")
+	f.mu.Unlock()
 	if f.GetGoDocFunc != nil {
 		return f.GetGoDocFunc(ctx, symbol)
 	}
@@ -60,7 +70,9 @@ func (f *FakeToolchainRunner) GetGoDoc(ctx context.Context, symbol string) ([]by
 }
 
 func (f *FakeToolchainRunner) GetModulePath(ctx context.Context) (string, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "GetModulePath")
+	f.mu.Unlock()
 	if f.GetModulePathFunc != nil {
 		return f.GetModulePathFunc(ctx)
 	}
@@ -68,7 +80,9 @@ func (f *FakeToolchainRunner) GetModulePath(ctx context.Context) (string, error)
 }
 
 func (f *FakeToolchainRunner) GetModuleDir(ctx context.Context) (string, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "GetModuleDir")
+	f.mu.Unlock()
 	if f.GetModuleDirFunc != nil {
 		return f.GetModuleDirFunc(ctx)
 	}
@@ -76,7 +90,9 @@ func (f *FakeToolchainRunner) GetModuleDir(ctx context.Context) (string, error) 
 }
 
 func (f *FakeToolchainRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "RunTestsWithCoverage")
+	f.mu.Unlock()
 	if f.RunTestsWithCoverageFunc != nil {
 		return f.RunTestsWithCoverageFunc(ctx, path, short, profilePath)
 	}
@@ -84,7 +100,9 @@ func (f *FakeToolchainRunner) RunTestsWithCoverage(ctx context.Context, path str
 }
 
 func (f *FakeToolchainRunner) RunLinter(ctx context.Context) (string, string, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "RunLinter")
+	f.mu.Unlock()
 	if f.RunLinterFunc != nil {
 		return f.RunLinterFunc(ctx)
 	}
@@ -92,7 +110,9 @@ func (f *FakeToolchainRunner) RunLinter(ctx context.Context) (string, string, er
 }
 
 func (f *FakeToolchainRunner) RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "RunBenchmarks")
+	f.mu.Unlock()
 	if f.RunBenchmarksFunc != nil {
 		return f.RunBenchmarksFunc(ctx, path, benchRegex)
 	}
@@ -100,7 +120,9 @@ func (f *FakeToolchainRunner) RunBenchmarks(ctx context.Context, path string, be
 }
 
 func (f *FakeToolchainRunner) CheckGovulncheck(ctx context.Context) error {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "CheckGovulncheck")
+	f.mu.Unlock()
 	if f.CheckGovulncheckFunc != nil {
 		return f.CheckGovulncheckFunc(ctx)
 	}
@@ -108,7 +130,9 @@ func (f *FakeToolchainRunner) CheckGovulncheck(ctx context.Context) error {
 }
 
 func (f *FakeToolchainRunner) RunModTidy(ctx context.Context) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "RunModTidy")
+	f.mu.Unlock()
 	if f.RunModTidyFunc != nil {
 		return f.RunModTidyFunc(ctx)
 	}
@@ -116,7 +140,9 @@ func (f *FakeToolchainRunner) RunModTidy(ctx context.Context) ([]byte, error) {
 }
 
 func (f *FakeToolchainRunner) FormatCode(ctx context.Context, path string) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "FormatCode")
+	f.mu.Unlock()
 	if f.FormatCodeFunc != nil {
 		return f.FormatCodeFunc(ctx, path)
 	}
@@ -124,7 +150,9 @@ func (f *FakeToolchainRunner) FormatCode(ctx context.Context, path string) ([]by
 }
 
 func (f *FakeToolchainRunner) RunTests(ctx context.Context, path string) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "RunTests")
+	f.mu.Unlock()
 	if f.RunTestsFunc != nil {
 		return f.RunTestsFunc(ctx, path)
 	}
@@ -132,7 +160,9 @@ func (f *FakeToolchainRunner) RunTests(ctx context.Context, path string) ([]byte
 }
 
 func (f *FakeToolchainRunner) BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error) {
+	f.mu.Lock()
 	f.Calls = append(f.Calls, "BuildCode")
+	f.mu.Unlock()
 	if f.BuildCodeFunc != nil {
 		return f.BuildCodeFunc(ctx, outputBinary, path)
 	}

--- a/internal/tools/toolstest/fake_toolchain_runner.go
+++ b/internal/tools/toolstest/fake_toolchain_runner.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package toolstest
+
+import (
+	"context"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// FakeToolchainRunner is a test double for tools.ToolchainRunner. It follows
+// the MockExecutor shape: pre-set return values via <Method>Func fields plus
+// a call log recording every invocation as the method name, in call order.
+// All 12 methods record to the log; a method without its Func set returns
+// zero values. This is the canonical tools-family runner double per ADR-021
+// locality and ADR-056 canonical-mock-home discipline (issue #1325, ADR-060).
+type FakeToolchainRunner struct {
+	GetPackageListFunc       func(ctx context.Context, path string) ([]byte, error)
+	GetGoDocFunc             func(ctx context.Context, symbol string) ([]byte, error)
+	GetModulePathFunc        func(ctx context.Context) (string, error)
+	GetModuleDirFunc         func(ctx context.Context) (string, error)
+	RunTestsWithCoverageFunc func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error)
+	RunLinterFunc            func(ctx context.Context) (string, string, error)
+	RunBenchmarksFunc        func(ctx context.Context, path string, benchRegex string) (string, error)
+	CheckGovulncheckFunc     func(ctx context.Context) error
+	RunModTidyFunc           func(ctx context.Context) ([]byte, error)
+	FormatCodeFunc           func(ctx context.Context, path string) ([]byte, error)
+	RunTestsFunc             func(ctx context.Context, path string) ([]byte, error)
+	BuildCodeFunc            func(ctx context.Context, outputBinary, path string) ([]byte, error)
+
+	// Calls records every invocation as the method name, in call order.
+	Calls []string
+}
+
+// Called reports whether the named method was invoked at least once.
+func (f *FakeToolchainRunner) Called(method string) bool {
+	for _, c := range f.Calls {
+		if c == method {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *FakeToolchainRunner) GetPackageList(ctx context.Context, path string) ([]byte, error) {
+	f.Calls = append(f.Calls, "GetPackageList")
+	if f.GetPackageListFunc != nil {
+		return f.GetPackageListFunc(ctx, path)
+	}
+	return nil, nil
+}
+
+func (f *FakeToolchainRunner) GetGoDoc(ctx context.Context, symbol string) ([]byte, error) {
+	f.Calls = append(f.Calls, "GetGoDoc")
+	if f.GetGoDocFunc != nil {
+		return f.GetGoDocFunc(ctx, symbol)
+	}
+	return nil, nil
+}
+
+func (f *FakeToolchainRunner) GetModulePath(ctx context.Context) (string, error) {
+	f.Calls = append(f.Calls, "GetModulePath")
+	if f.GetModulePathFunc != nil {
+		return f.GetModulePathFunc(ctx)
+	}
+	return "", nil
+}
+
+func (f *FakeToolchainRunner) GetModuleDir(ctx context.Context) (string, error) {
+	f.Calls = append(f.Calls, "GetModuleDir")
+	if f.GetModuleDirFunc != nil {
+		return f.GetModuleDirFunc(ctx)
+	}
+	return "", nil
+}
+
+func (f *FakeToolchainRunner) RunTestsWithCoverage(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+	f.Calls = append(f.Calls, "RunTestsWithCoverage")
+	if f.RunTestsWithCoverageFunc != nil {
+		return f.RunTestsWithCoverageFunc(ctx, path, short, profilePath)
+	}
+	return tools.CoverageSummary{}, nil
+}
+
+func (f *FakeToolchainRunner) RunLinter(ctx context.Context) (string, string, error) {
+	f.Calls = append(f.Calls, "RunLinter")
+	if f.RunLinterFunc != nil {
+		return f.RunLinterFunc(ctx)
+	}
+	return "", "", nil
+}
+
+func (f *FakeToolchainRunner) RunBenchmarks(ctx context.Context, path string, benchRegex string) (string, error) {
+	f.Calls = append(f.Calls, "RunBenchmarks")
+	if f.RunBenchmarksFunc != nil {
+		return f.RunBenchmarksFunc(ctx, path, benchRegex)
+	}
+	return "", nil
+}
+
+func (f *FakeToolchainRunner) CheckGovulncheck(ctx context.Context) error {
+	f.Calls = append(f.Calls, "CheckGovulncheck")
+	if f.CheckGovulncheckFunc != nil {
+		return f.CheckGovulncheckFunc(ctx)
+	}
+	return nil
+}
+
+func (f *FakeToolchainRunner) RunModTidy(ctx context.Context) ([]byte, error) {
+	f.Calls = append(f.Calls, "RunModTidy")
+	if f.RunModTidyFunc != nil {
+		return f.RunModTidyFunc(ctx)
+	}
+	return nil, nil
+}
+
+func (f *FakeToolchainRunner) FormatCode(ctx context.Context, path string) ([]byte, error) {
+	f.Calls = append(f.Calls, "FormatCode")
+	if f.FormatCodeFunc != nil {
+		return f.FormatCodeFunc(ctx, path)
+	}
+	return nil, nil
+}
+
+func (f *FakeToolchainRunner) RunTests(ctx context.Context, path string) ([]byte, error) {
+	f.Calls = append(f.Calls, "RunTests")
+	if f.RunTestsFunc != nil {
+		return f.RunTestsFunc(ctx, path)
+	}
+	return nil, nil
+}
+
+func (f *FakeToolchainRunner) BuildCode(ctx context.Context, outputBinary, path string) ([]byte, error) {
+	f.Calls = append(f.Calls, "BuildCode")
+	if f.BuildCodeFunc != nil {
+		return f.BuildCodeFunc(ctx, outputBinary, path)
+	}
+	return nil, nil
+}

--- a/internal/tools/toolstest/fake_toolchain_runner_test.go
+++ b/internal/tools/toolstest/fake_toolchain_runner_test.go
@@ -1,0 +1,436 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package toolstest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// Compile-time assertion: FakeToolchainRunner implements the full 12-method
+// tools.ToolchainRunner port (issue #1325, ADR-060).
+var _ tools.ToolchainRunner = (*FakeToolchainRunner)(nil)
+
+// assertCallLog verifies the method was recorded in the Calls log and is the
+// most recent entry. This is the fake's identity assertion: a probe that
+// unexpectedly reaches the wrong method fails here with the recorded call in
+// hand.
+func assertCallLog(t *testing.T, f *FakeToolchainRunner, method string) {
+	t.Helper()
+	if !f.Called(method) {
+		t.Errorf("Called(%q) = false; want true", method)
+	}
+	if len(f.Calls) == 0 {
+		t.Fatalf("Calls is empty; want last element %q", method)
+	}
+	if got := f.Calls[len(f.Calls)-1]; got != method {
+		t.Errorf("last Call = %q; want %q", got, method)
+	}
+}
+
+func TestFakeToolchainRunner_PresetValues(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, f *FakeToolchainRunner)
+	}{
+		{
+			name: "GetPackageList",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.GetPackageListFunc = func(ctx context.Context, path string) ([]byte, error) {
+					return []byte("pkgs"), nil
+				}
+				got, err := f.GetPackageList(ctx, ".")
+				if err != nil {
+					t.Fatalf("GetPackageList() returned error: %v", err)
+				}
+				if string(got) != "pkgs" {
+					t.Errorf("GetPackageList() = %q; want %q", got, "pkgs")
+				}
+				assertCallLog(t, f, "GetPackageList")
+			},
+		},
+		{
+			name: "GetGoDoc",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.GetGoDocFunc = func(ctx context.Context, symbol string) ([]byte, error) {
+					return []byte("doc"), nil
+				}
+				got, err := f.GetGoDoc(ctx, "fmt.Println")
+				if err != nil {
+					t.Fatalf("GetGoDoc() returned error: %v", err)
+				}
+				if string(got) != "doc" {
+					t.Errorf("GetGoDoc() = %q; want %q", got, "doc")
+				}
+				assertCallLog(t, f, "GetGoDoc")
+			},
+		},
+		{
+			name: "GetModulePath",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.GetModulePathFunc = func(ctx context.Context) (string, error) {
+					return "module/path", nil
+				}
+				got, err := f.GetModulePath(ctx)
+				if err != nil {
+					t.Fatalf("GetModulePath() returned error: %v", err)
+				}
+				if got != "module/path" {
+					t.Errorf("GetModulePath() = %q; want %q", got, "module/path")
+				}
+				assertCallLog(t, f, "GetModulePath")
+			},
+		},
+		{
+			name: "GetModuleDir",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.GetModuleDirFunc = func(ctx context.Context) (string, error) {
+					return "/module/dir", nil
+				}
+				got, err := f.GetModuleDir(ctx)
+				if err != nil {
+					t.Fatalf("GetModuleDir() returned error: %v", err)
+				}
+				if got != "/module/dir" {
+					t.Errorf("GetModuleDir() = %q; want %q", got, "/module/dir")
+				}
+				assertCallLog(t, f, "GetModuleDir")
+			},
+		},
+		{
+			name: "RunTestsWithCoverage",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.RunTestsWithCoverageFunc = func(ctx context.Context, path string, short bool, profilePath string) (tools.CoverageSummary, error) {
+					return tools.CoverageSummary{PassedCount: 3, NoGoFiles: true, CoveragePct: "85.0%", SummaryOutput: "total:"}, nil
+				}
+				want := tools.CoverageSummary{PassedCount: 3, NoGoFiles: true, CoveragePct: "85.0%", SummaryOutput: "total:"}
+				got, err := f.RunTestsWithCoverage(ctx, ".", false, "coverage.out")
+				if err != nil {
+					t.Fatalf("RunTestsWithCoverage() returned error: %v", err)
+				}
+				if got != want {
+					t.Errorf("RunTestsWithCoverage() = %+v; want %+v", got, want)
+				}
+				assertCallLog(t, f, "RunTestsWithCoverage")
+			},
+		},
+		{
+			name: "RunLinter",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.RunLinterFunc = func(ctx context.Context) (string, string, error) {
+					return "out", "golangci-lint", errors.New("lint err")
+				}
+				out, name, err := f.RunLinter(ctx)
+				if out != "out" {
+					t.Errorf("RunLinter() output = %q; want %q", out, "out")
+				}
+				if name != "golangci-lint" {
+					t.Errorf("RunLinter() name = %q; want %q", name, "golangci-lint")
+				}
+				if err == nil || err.Error() != "lint err" {
+					t.Errorf("RunLinter() err = %v; want %q", err, "lint err")
+				}
+				assertCallLog(t, f, "RunLinter")
+			},
+		},
+		{
+			name: "RunBenchmarks",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.RunBenchmarksFunc = func(ctx context.Context, path string, benchRegex string) (string, error) {
+					return "bench", nil
+				}
+				got, err := f.RunBenchmarks(ctx, ".", "Benchmark.*")
+				if err != nil {
+					t.Fatalf("RunBenchmarks() returned error: %v", err)
+				}
+				if got != "bench" {
+					t.Errorf("RunBenchmarks() = %q; want %q", got, "bench")
+				}
+				assertCallLog(t, f, "RunBenchmarks")
+			},
+		},
+		{
+			name: "CheckGovulncheck",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.CheckGovulncheckFunc = func(ctx context.Context) error {
+					return errors.New("not installed")
+				}
+				err := f.CheckGovulncheck(ctx)
+				if err == nil || err.Error() != "not installed" {
+					t.Errorf("CheckGovulncheck() err = %v; want %q", err, "not installed")
+				}
+				assertCallLog(t, f, "CheckGovulncheck")
+			},
+		},
+		{
+			name: "RunModTidy",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.RunModTidyFunc = func(ctx context.Context) ([]byte, error) {
+					return []byte("tidy"), nil
+				}
+				got, err := f.RunModTidy(ctx)
+				if err != nil {
+					t.Fatalf("RunModTidy() returned error: %v", err)
+				}
+				if string(got) != "tidy" {
+					t.Errorf("RunModTidy() = %q; want %q", got, "tidy")
+				}
+				assertCallLog(t, f, "RunModTidy")
+			},
+		},
+		{
+			name: "FormatCode",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.FormatCodeFunc = func(ctx context.Context, path string) ([]byte, error) {
+					return []byte("fmt"), nil
+				}
+				got, err := f.FormatCode(ctx, ".")
+				if err != nil {
+					t.Fatalf("FormatCode() returned error: %v", err)
+				}
+				if string(got) != "fmt" {
+					t.Errorf("FormatCode() = %q; want %q", got, "fmt")
+				}
+				assertCallLog(t, f, "FormatCode")
+			},
+		},
+		{
+			name: "RunTests",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.RunTestsFunc = func(ctx context.Context, path string) ([]byte, error) {
+					return []byte("PASS"), nil
+				}
+				got, err := f.RunTests(ctx, "./internal/tools/...")
+				if err != nil {
+					t.Fatalf("RunTests() returned error: %v", err)
+				}
+				if string(got) != "PASS" {
+					t.Errorf("RunTests() = %q; want %q", got, "PASS")
+				}
+				assertCallLog(t, f, "RunTests")
+			},
+		},
+		{
+			name: "BuildCode",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				f.BuildCodeFunc = func(ctx context.Context, outputBinary, path string) ([]byte, error) {
+					return []byte("built"), nil
+				}
+				got, err := f.BuildCode(ctx, "/tmp/bin", ".")
+				if err != nil {
+					t.Fatalf("BuildCode() returned error: %v", err)
+				}
+				if string(got) != "built" {
+					t.Errorf("BuildCode() = %q; want %q", got, "built")
+				}
+				assertCallLog(t, f, "BuildCode")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := &FakeToolchainRunner{}
+			tt.run(t, f)
+		})
+	}
+}
+
+func TestFakeToolchainRunner_ZeroDefaults(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		run  func(t *testing.T, f *FakeToolchainRunner)
+	}{
+		{
+			name: "GetPackageList",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.GetPackageList(ctx, ".")
+				if got != nil || err != nil {
+					t.Errorf("GetPackageList() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("GetPackageList") {
+					t.Error("GetPackageList not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "GetGoDoc",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.GetGoDoc(ctx, "fmt.Println")
+				if got != nil || err != nil {
+					t.Errorf("GetGoDoc() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("GetGoDoc") {
+					t.Error("GetGoDoc not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "GetModulePath",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.GetModulePath(ctx)
+				if got != "" || err != nil {
+					t.Errorf("GetModulePath() = (%q, %v); want (\"\", nil)", got, err)
+				}
+				if !f.Called("GetModulePath") {
+					t.Error("GetModulePath not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "GetModuleDir",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.GetModuleDir(ctx)
+				if got != "" || err != nil {
+					t.Errorf("GetModuleDir() = (%q, %v); want (\"\", nil)", got, err)
+				}
+				if !f.Called("GetModuleDir") {
+					t.Error("GetModuleDir not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "RunTestsWithCoverage",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.RunTestsWithCoverage(ctx, ".", false, "coverage.out")
+				if got != (tools.CoverageSummary{}) || err != nil {
+					t.Errorf("RunTestsWithCoverage() = (%+v, %v); want (%+v, nil)", got, err, tools.CoverageSummary{})
+				}
+				if !f.Called("RunTestsWithCoverage") {
+					t.Error("RunTestsWithCoverage not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "RunLinter",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				out, name, err := f.RunLinter(ctx)
+				if out != "" || name != "" || err != nil {
+					t.Errorf("RunLinter() = (%q, %q, %v); want (\"\", \"\", nil)", out, name, err)
+				}
+				if !f.Called("RunLinter") {
+					t.Error("RunLinter not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "RunBenchmarks",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.RunBenchmarks(ctx, ".", "Benchmark.*")
+				if got != "" || err != nil {
+					t.Errorf("RunBenchmarks() = (%q, %v); want (\"\", nil)", got, err)
+				}
+				if !f.Called("RunBenchmarks") {
+					t.Error("RunBenchmarks not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "CheckGovulncheck",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				err := f.CheckGovulncheck(ctx)
+				if err != nil {
+					t.Errorf("CheckGovulncheck() = %v; want nil", err)
+				}
+				if !f.Called("CheckGovulncheck") {
+					t.Error("CheckGovulncheck not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "RunModTidy",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.RunModTidy(ctx)
+				if got != nil || err != nil {
+					t.Errorf("RunModTidy() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("RunModTidy") {
+					t.Error("RunModTidy not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "FormatCode",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.FormatCode(ctx, ".")
+				if got != nil || err != nil {
+					t.Errorf("FormatCode() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("FormatCode") {
+					t.Error("FormatCode not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "RunTests",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.RunTests(ctx, "./internal/tools/...")
+				if got != nil || err != nil {
+					t.Errorf("RunTests() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("RunTests") {
+					t.Error("RunTests not recorded in Calls")
+				}
+			},
+		},
+		{
+			name: "BuildCode",
+			run: func(t *testing.T, f *FakeToolchainRunner) {
+				got, err := f.BuildCode(ctx, "/tmp/bin", ".")
+				if got != nil || err != nil {
+					t.Errorf("BuildCode() = (%v, %v); want (nil, nil)", got, err)
+				}
+				if !f.Called("BuildCode") {
+					t.Error("BuildCode not recorded in Calls")
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			f := &FakeToolchainRunner{}
+			tt.run(t, f)
+		})
+	}
+}
+
+func TestFakeToolchainRunner_CallOrder(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	f := &FakeToolchainRunner{}
+
+	if _, err := f.RunTestsWithCoverage(ctx, ".", false, "coverage.out"); err != nil {
+		t.Fatalf("RunTestsWithCoverage() returned error: %v", err)
+	}
+	if _, _, err := f.RunLinter(ctx); err != nil {
+		t.Fatalf("RunLinter() returned error: %v", err)
+	}
+	if _, err := f.GetGoDoc(ctx, "fmt.Println"); err != nil {
+		t.Fatalf("GetGoDoc() returned error: %v", err)
+	}
+
+	want := []string{"RunTestsWithCoverage", "RunLinter", "GetGoDoc"}
+	if len(f.Calls) != len(want) {
+		t.Fatalf("len(Calls) = %d; want %d", len(f.Calls), len(want))
+	}
+	for i, c := range f.Calls {
+		if c != want[i] {
+			t.Errorf("Calls[%d] = %q; want %q", i, c, want[i])
+		}
+	}
+}

--- a/internal/tools/toolstest/fake_toolchain_runner_test.go
+++ b/internal/tools/toolstest/fake_toolchain_runner_test.go
@@ -6,6 +6,7 @@ package toolstest
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
@@ -431,6 +432,40 @@ func TestFakeToolchainRunner_CallOrder(t *testing.T) {
 	for i, c := range f.Calls {
 		if c != want[i] {
 			t.Errorf("Calls[%d] = %q; want %q", i, c, want[i])
+		}
+	}
+}
+
+func TestFakeToolchainRunner_ConcurrentAppends(t *testing.T) {
+	f := &FakeToolchainRunner{}
+	const goroutines = 16
+	const callsPerGoroutine = 50
+	var wg sync.WaitGroup
+	ctx := context.Background()
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			for i := 0; i < callsPerGoroutine; i++ {
+				switch (seed + i) % 3 {
+				case 0:
+					_, _, _ = f.RunLinter(ctx)
+				case 1:
+					_, _ = f.RunTests(ctx, "./...")
+				case 2:
+					_, _ = f.BuildCode(ctx, "/tmp/out", "./cmd/tell-me-go")
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	// All goroutines joined: reading Calls is now safe.
+	if len(f.Calls) != goroutines*callsPerGoroutine {
+		t.Errorf("Calls length = %d; want %d", len(f.Calls), goroutines*callsPerGoroutine)
+	}
+	for _, method := range []string{"RunLinter", "RunTests", "BuildCode"} {
+		if !f.Called(method) {
+			t.Errorf("Called(%q) = false; want true after concurrent appends", method)
 		}
 	}
 }


### PR DESCRIPTION
Closes #1325.

## Summary

Injects the Go toolchain runner into the tools layer via a domain port, eliminating the direct `tools → infrastructure/toolchain` construction class (ADR-055-style). Produced by the Architect + Coder task loop, pressure-tested by two architecture grill rounds.

- **Port**: 12-method `tools.ToolchainRunner` (zero dead members), 4-field `CoverageSummary` DTO (no `TestOutput` — zero assertion consumers), `ErrNoSupportedLinter` sentinel in a pinned single-line declaration — all in `internal/domain/tools`.
- **Migration**: the 5-file leak (2 direct constructions + 3 type leaks + the sentinel) eliminated; zero production `toolchain.NewGoRunner` constructions under `internal/tools/`; single construction at the di composition root (`di/toolchain_factory.go`), reusing the existing executor; narrow consumer interfaces survive as field types (compile-time assignability, zero mock growth); `releaseGoRunner` trimmed to 3 methods; `linterChecker` on typed `errors.Is` with the sentinel unified across infra and both consumers.
- **Guard table**: `validateRegistrationParams` = 8 guards / 3 exclusions per the tool-boundary designed-nil criterion (documented in ADR-060 with per-field citations).
- **Enforcement**: new `verify-tools-toolchain-import` Makefile gate (POSIX + Windows, production-only predicate with `analysistest/`/`toolstest/` exclusions; anti-extension decision recorded — never extended to `_test.go`), wired into `make test`, `check`, and `check-full`.
- **Verification**: per-destination wiring proven (white-box assertion for the 4 analysis fields, behavioral probes for dev/release/info, seam-capture for the di construction — no-panic direct-port call, never through the handler); canonical `toolstest.FakeToolchainRunner` (mutex-guarded, 6/6 stub accounting); the 22 test-layer constructions survive by design as the real-adapter-over-mock verification surface; `verify-nonfix-catalog` partition updated to 27-cataloged / 0-alert.
- **Governance**: ADR-060 records the full corrected record — ADR-055-extension framing, Decision 1 inapplicability, three-home analysis, corrected import surface + ports-hub derivation, the guard criterion verbatim, the drift table (CoverageSummary trips — accepted advisory; no model edit), the sentinel style pin, the per-destination wiring contract, the 22-site census + anti-extension decision + the promise's three conditions, the e2e known-gap trigger verbatim, and three follow-ups. Indexed; `verify-adr-index` green.

## Acceptance criteria mapping (issue #1325)

- [x] No production `.go` file under `internal/tools/` imports `internal/infrastructure/toolchain` — enforced by the new gate; verified by grep
- [x] `ToolRegistrationParams` carries the injected runner — `ToolchainRunner` field, threaded through `RegisterAll` → `analysis.Register`/`developer.Register`
- [x] `CoverageReport` no longer leaks into consumer-facing signatures — infra-internal parse container only; boundary type is `tools.CoverageSummary`
- [x] `make test` passes, including the new `verify-tools-toolchain-import` gate (negative path proven with a scratch file, then reverted)
- [x] `make verify-architecture` and `make verify-transitive-gate` pass — the ADR-056 whitelist is a documented non-change (no row ever existed; the edge was invisible to the gate's unit of measurement)
- [x] New ADR (060) written, indexed, and `verify-adr-index` passes

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (full pipeline including race detection) | **PASS** — "All checks passed (including race detection)" |
| `make check` | **PASS** |
| `go test ./...` | PASS (79 packages) |
| `go test -race ./internal/tools/...` (incl. the developer package that previously raced) | PASS |
| `make verify-nonfix-catalog` | PASS (27 cataloged / 0 alerts) |
| `make modelith-check` / `verify-adr-index` / `modelith-drift` | PASS / PASS / advisory only (`CoverageSummary` trips — accepted, no model edit) |

## Notes

- Two grill rounds (Griller vs. Architect) corrected several premises before implementation; the plan and the ADR do **not** inherit any falsified round-1 rationale. Transcripts: [round 1](https://gist.github.com/gosharplite/5067c5d4ce305599f5cbc26a92eac875) · [round 2](https://gist.github.com/gosharplite/9758bdeb0b8612f9bdd943e7c392c676).
- Known residuals (documented in ADR-060 §11 and the e2e trigger): real-adapter e2e deferred with the maintainer's trigger; five raw `eventBus.Publish` sites and `verify-tools-adapter-import` predicate harmonization as follow-ups; `devManager.executor` non-injectability recorded. None block merge.
- Implemented via the Architect–Coder task loop per `docs/sop/lifecycle/issue_to_pr_orchestration.md`; 12 atomic commits on `fix/issue-1325-toolchain-runner-injection`.
