### PR TITLE
fix(agent): comment fixes + ChatServiceConfig refactor (#1332)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -565,7 +565,7 @@ verify-exit-query:
 
 # Verify the complexity-pin catalog partition (issue #1297): runs the real
 # GatherComplexities against the live INTENTIONAL_NON_FIXES.md catalog and
-# asserts the post-fix 25-cataloged / 1-alert partition by name (line +
+# asserts the post-fix 27-cataloged / 0-alert partition by name (line +
 # recorded CC). RED-first: the gate must fail against a drifted catalog —
 # never weaken it to land green.
 verify-nonfix-catalog:

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -670,7 +670,7 @@ catalog a new gap no one reviewed. Policy:
   no value. Same acceptance class as `AppendTask`, `domainFS.Chmod`,
   `mockFileSystem.Chmod`, `plainOSFS.Chmod`, and `HasBareNewline` — all
   delegation wrappers already documented in this file.
-- **See**: `internal/agent/service.go:226-228`
+- **See**: `internal/agent/service.go:221-223`
 
 ### persistence/state.go — NewSessionStateFromEnv thin entry point at 0%
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -43,7 +43,7 @@ type agent struct {
 	ctxManager    *sessctx.Manager
 	configWatcher domain_config.ConfigWatcher
 	strategy      *sessctx.Strategy
-	executor      *executor.Dispatcher
+	executor      *executor.Dispatcher // write-only: assigned in initComponents; the dispatcher value is consumed by NewEngine via the local
 	events        events.EventBus
 	tracker       domain_pricing.CostTracker
 	turnsLogger   ports.TurnsLogger

--- a/internal/agent/service.go
+++ b/internal/agent/service.go
@@ -32,15 +32,25 @@ type LogFileOpener interface {
 	Open(ctx context.Context, name string) (persistence.File, error)
 }
 
-// ChatServiceOption configures a chatService during construction.
-type ChatServiceOption func(*chatService)
+// ChatServiceConfig configures a chatService during construction.
+type ChatServiceConfig struct {
+	HomeDir string
+	Version string
+	Stdout  io.Writer
+	Stderr  io.Writer
+	SM      domain_security.Manager
 
-// WithPathResolver overrides the default path resolution function.
-// The default is persistence.ResolvePaths.
-func WithPathResolver(resolver func(homeDir, mode string) *persistence.Paths) ChatServiceOption {
-	return func(s *chatService) {
-		s.resolvePaths = resolver
-	}
+	LifecycleManager SessionLifecycleManager
+	ChatterFactory   ports.ChatterFactory
+	UIRenderer       ports.UIRenderer
+	HistoryRenderer  ports.HistoryRenderer
+	HistoryBrowser   ports.HistoryBrowser
+	HistoryEditor    ports.HistoryEditor
+	LogOpener        LogFileOpener
+
+	// ResolvePaths resolves session filesystem paths. Defaults to persistence.ResolvePaths.
+	// Injectable for testing the empty-path defensive guard in StreamTurnsLog.
+	ResolvePaths func(homeDir, mode string) *persistence.Paths
 }
 
 type chatService struct {
@@ -64,40 +74,25 @@ type chatService struct {
 }
 
 // NewChatService creates a new concrete implementation of ChatService with explicit dependency injection.
-func NewChatService(
-	homeDir, version string,
-	stdout, stderr io.Writer,
-	sm domain_security.Manager,
-	lifecycleManager SessionLifecycleManager,
-	chatterFactory ports.ChatterFactory,
-	uiRenderer ports.UIRenderer,
-	historyRenderer ports.HistoryRenderer,
-	historyBrowser ports.HistoryBrowser,
-	historyEditor ports.HistoryEditor,
-	logOpener LogFileOpener,
-	opts ...ChatServiceOption,
-) ChatService {
-	svc := &chatService{
-		HomeDir:          homeDir,
-		Version:          version,
-		Stdout:           stdout,
-		Stderr:           stderr,
-		SM:               sm,
-		LifecycleManager: lifecycleManager,
-		ChatterFactory:   chatterFactory,
-		UIRenderer:       uiRenderer,
-		HistoryRenderer:  historyRenderer,
-		HistoryBrowser:   historyBrowser,
-		HistoryEditor:    historyEditor,
-		LogOpener:        logOpener,
-		resolvePaths:     persistence.ResolvePaths, // default
+func NewChatService(cfg ChatServiceConfig) ChatService {
+	if cfg.ResolvePaths == nil {
+		cfg.ResolvePaths = persistence.ResolvePaths
 	}
-
-	for _, opt := range opts {
-		opt(svc)
+	return &chatService{
+		HomeDir:          cfg.HomeDir,
+		Version:          cfg.Version,
+		Stdout:           cfg.Stdout,
+		Stderr:           cfg.Stderr,
+		SM:               cfg.SM,
+		LifecycleManager: cfg.LifecycleManager,
+		ChatterFactory:   cfg.ChatterFactory,
+		UIRenderer:       cfg.UIRenderer,
+		HistoryRenderer:  cfg.HistoryRenderer,
+		HistoryBrowser:   cfg.HistoryBrowser,
+		HistoryEditor:    cfg.HistoryEditor,
+		LogOpener:        cfg.LogOpener,
+		resolvePaths:     cfg.ResolvePaths,
 	}
-
-	return svc
 }
 
 // GetLastUserMessage implements ChatService.

--- a/internal/agent/service_test.go
+++ b/internal/agent/service_test.go
@@ -24,6 +24,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// newTestChatService builds a ChatService with default test wiring; callers
+// override individual config fields via the variadic functional overrides.
+func newTestChatService(t *testing.T, overrides ...func(*agent.ChatServiceConfig)) agent.ChatService {
+	t.Helper()
+	cfg := agent.ChatServiceConfig{
+		HomeDir: "home",
+		Version: "v1",
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+	}
+	for _, o := range overrides {
+		o(&cfg)
+	}
+	return agent.NewChatService(cfg)
+}
+
 // newProcessMessageFixtures creates the 7 mocks, chatterFactory, and ChatService
 // instance used by all TestProcessMessage_* sub-functions. Callers set per-case
 // expectations on the returned mocks and then invoke service.ProcessMessage.
@@ -54,10 +70,15 @@ func newProcessMessageFixtures(
 		return agentMock, nil
 	})
 
-	service = agent.NewChatService(
-		"home", "v1", io.Discard, stderr, sm,
-		sf, chatterFactory, &agenttest.StubUIRenderer{}, &agenttest.StubHistoryRenderer{}, &agenttest.StubHistoryBrowser{}, nil, nil,
-	)
+	service = newTestChatService(t, func(c *agent.ChatServiceConfig) {
+		c.Stderr = stderr
+		c.SM = sm
+		c.LifecycleManager = sf
+		c.ChatterFactory = chatterFactory
+		c.UIRenderer = &agenttest.StubUIRenderer{}
+		c.HistoryRenderer = &agenttest.StubHistoryRenderer{}
+		c.HistoryBrowser = &agenttest.StubHistoryBrowser{}
+	})
 
 	return
 }
@@ -478,10 +499,9 @@ func TestGetLastUserMessage(t *testing.T) {
 
 	mockHM := &mockHistoryManagerForRetry{msg: "last message", turns: 1}
 
-	service := agent.NewChatService(
-		"home", "v1", io.Discard, io.Discard, sm,
-		nil, nil, &agenttest.StubUIRenderer{}, &agenttest.StubHistoryRenderer{}, &agenttest.StubHistoryBrowser{}, nil, nil,
-	)
+	service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+		c.SM = sm
+	})
 
 	msg, turns, err := service.GetLastUserMessage(ctx, mockHM)
 
@@ -648,10 +668,10 @@ func TestStreamTurnsLog(t *testing.T) {
 				tt.setupMock(mFS)
 			}
 
-			service := agent.NewChatService(
-				homeDir, "v1", io.Discard, io.Discard, nil,
-				nil, nil, nil, nil, nil, nil, mFS,
-			)
+			service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+				c.HomeDir = homeDir
+				c.LogOpener = mFS
+			})
 
 			var out bytes.Buffer
 			err := service.StreamTurnsLog(ctx, &config.Config{Mode: tt.mode}, &out)
@@ -793,7 +813,7 @@ func TestRunDiagnostics(t *testing.T) {
 
 				// Construct a report with an un-marshalable Details field.
 				// json.MarshalIndent cannot serialize a channel, so the defensive
-				// guard at service.go:258-260 is exercised.
+				// guard is exercised.
 				unmarshalableReport := &ports.HealthReport{
 					OverallStatus: ports.StatusHealthy,
 					Components: map[ports.Component]ports.ComponentReport{
@@ -894,10 +914,11 @@ func TestRunDiagnostics(t *testing.T) {
 			}
 
 			var stdout bytes.Buffer
-			service := agent.NewChatService(
-				"home", "v1", &stdout, io.Discard, nil,
-				sf, nil, uir, nil, nil, nil, nil,
-			)
+			service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+				c.Stdout = &stdout
+				c.LifecycleManager = sf
+				c.UIRenderer = uir
+			})
 
 			cfg := &config.Config{Mode: "assistant"}
 			err := service.RunDiagnostics(ctx, cfg, "config.yaml", tt.jsonOutput)
@@ -969,10 +990,9 @@ func TestBrowseHistory(t *testing.T) {
 				return tt.browseErr
 			}
 
-			service := agent.NewChatService(
-				"home", "v1", io.Discard, io.Discard, nil,
-				nil, nil, nil, nil, browser, nil, nil,
-			)
+			service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+				c.HistoryBrowser = browser
+			})
 
 			err := service.BrowseHistory(ctx, nil, mockHM)
 
@@ -1052,10 +1072,7 @@ func TestGetToolNames(t *testing.T) {
 			ctx := context.Background()
 			reg := &mockToolRegistry{declarations: tt.declarations}
 
-			service := agent.NewChatService(
-				"home", "v1", io.Discard, io.Discard, nil,
-				nil, nil, nil, nil, nil, nil, nil,
-			)
+			service := newTestChatService(t)
 
 			names, err := service.GetToolNames(ctx, reg)
 
@@ -1071,17 +1088,17 @@ func TestChatService_StreamTurnsLog_EmptyMode(t *testing.T) {
 	// Verifies that an empty Config.Mode falls back to "default" mode in path
 	// resolution.  The call proceeds to LogOpener.Open for the default-mode
 	// path, which fails with os.ErrNotExist, yielding a graceful "No turns log
-	// found" message.  (The empty-path guard — service.go:214 — is tested
-	// separately in TestChatService_StreamTurnsLog_EmptyPath.)
+	// found" message.  (The empty-path guard is tested separately in
+	// TestChatService_StreamTurnsLog_EmptyPath.)
 	mFS := new(mockFileSystemStream)
 	mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
 		return nil, os.ErrNotExist
 	}
 
-	service := agent.NewChatService(
-		"/nonexistent", "v1", io.Discard, io.Discard, nil,
-		nil, nil, nil, nil, nil, nil, mFS,
-	)
+	service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+		c.HomeDir = "/nonexistent"
+		c.LogOpener = mFS
+	})
 
 	var out bytes.Buffer
 	cfg := &config.Config{Mode: ""}
@@ -1095,21 +1112,20 @@ func TestChatService_StreamTurnsLog_EmptyMode(t *testing.T) {
 func TestChatService_StreamTurnsLog_EmptyPath(t *testing.T) {
 	ctx := context.Background()
 
-	// Inject a resolvePaths stub via WithPathResolver that returns a
-	// zero-value Paths struct (all fields empty, including TurnsLogPath).
-	// This exercises the defensive guard at service.go:214 which is
-	// otherwise unreachable through the real persistence.ResolvePaths.
+	// Inject a resolvePaths stub via the ResolvePaths config field that returns
+	// a zero-value Paths struct (all fields empty, including TurnsLogPath).
+	// This exercises the defensive guard which is otherwise unreachable through
+	// the real persistence.ResolvePaths.
 	emptyPathResolver := func(homeDir, mode string) *persistence.Paths {
 		return &persistence.Paths{}
 	}
 
 	// LogOpener must not be called — the guard should short-circuit before Open.
 	// Passing nil for LogOpener proves this: if Open is reached, the test panics.
-	service := agent.NewChatService(
-		"/test", "v1", io.Discard, io.Discard, nil,
-		nil, nil, nil, nil, nil, nil, nil,
-		agent.WithPathResolver(emptyPathResolver),
-	)
+	service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+		c.HomeDir = "/test"
+		c.ResolvePaths = emptyPathResolver
+	})
 
 	var out bytes.Buffer
 	cfg := &config.Config{Mode: "assistant"}
@@ -1119,13 +1135,29 @@ func TestChatService_StreamTurnsLog_EmptyPath(t *testing.T) {
 	assert.Equal(t, "turns log path not available", err.Error())
 }
 
+func TestChatService_ResolvePathsDefault(t *testing.T) {
+	ctx := context.Background()
+	mFS := new(mockFileSystemStream)
+	var gotName string
+	mFS.OpenFunc = func(ctx context.Context, name string) (persistence.File, error) {
+		gotName = name
+		return nil, os.ErrNotExist // graceful: proves Open was reached with the resolved path
+	}
+	service := newTestChatService(t, func(c *agent.ChatServiceConfig) { c.LogOpener = mFS })
+	var out bytes.Buffer
+	err := service.StreamTurnsLog(ctx, &config.Config{Mode: "assistant"}, &out)
+	assert.NoError(t, err)
+	assert.Equal(t, "No turns log found for this session yet.\n", out.String())
+	want := persistence.ResolvePaths("home", "assistant").TurnsLogPath
+	assert.Equal(t, want, gotName)
+}
+
 func TestUpdateLastTurn(t *testing.T) {
 	ctx := context.Background()
 
-	service := agent.NewChatService(
-		"home", "v1", io.Discard, io.Discard, &agenttest.MockServiceSecurityManager{},
-		nil, nil, &agenttest.StubUIRenderer{}, &agenttest.StubHistoryRenderer{}, &agenttest.StubHistoryBrowser{}, nil, nil,
-	)
+	service := newTestChatService(t, func(c *agent.ChatServiceConfig) {
+		c.SM = &agenttest.MockServiceSecurityManager{}
+	})
 
 	t.Run("delete when text is empty", func(t *testing.T) {
 		hm := &agenttest.MockHistoryManager{}

--- a/internal/cli/chat_integration_test.go
+++ b/internal/cli/chat_integration_test.go
@@ -78,16 +78,20 @@ func TestChatCommand_NewSessionIntegration(t *testing.T) {
 	}
 
 	loader := &config.YAMLConfigLoader{Finder: config.NewDefaultConfigFinder()}
-	chatService := agent.NewChatService(
-		tmpDir, "1.0.0", &stdout, &stderr, sm,
-		container,
-		container.GetAgentFactory(),
-		container.GetUIRenderer(),
-		container.GetHistoryRenderer(),
-		container.GetHistoryBrowser(),
-		nil,
-		infra_persistence.NewOSFileSystem(),
-	)
+	chatService := agent.NewChatService(agent.ChatServiceConfig{
+		HomeDir:          tmpDir,
+		Version:          "1.0.0",
+		Stdout:           &stdout,
+		Stderr:           &stderr,
+		SM:               sm,
+		LifecycleManager: container,
+		ChatterFactory:   container.GetAgentFactory(),
+		UIRenderer:       container.GetUIRenderer(),
+		HistoryRenderer:  container.GetHistoryRenderer(),
+		HistoryBrowser:   container.GetHistoryBrowser(),
+		HistoryEditor:    nil,
+		LogOpener:        infra_persistence.NewOSFileSystem(),
+	})
 
 	cmdCtx := &cli.Context{
 		Version:      "1.0.0",

--- a/internal/infrastructure/di/chat_factory.go
+++ b/internal/infrastructure/di/chat_factory.go
@@ -46,18 +46,18 @@ func (f *defaultChatFactory) AgentFactory() ports.ChatterFactory {
 }
 
 func (f *defaultChatFactory) ChatService() agent.ChatService {
-	return agent.NewChatService(
-		f.HomeDir,
-		f.Version,
-		f.Stdout,
-		f.Stderr,
-		f.SM,
-		f.LifecycleManager,
-		f.AgentFactory(),
-		f.UIFact.UIRenderer(),
-		f.UIFact.HistoryRenderer(),
-		f.UIFact.HistoryBrowser(),
-		f.UIFact.HistoryEditor(),
-		infra_persistence.NewDomainFS(f.FileSystem),
-	)
+	return agent.NewChatService(agent.ChatServiceConfig{
+		HomeDir:          f.HomeDir,
+		Version:          f.Version,
+		Stdout:           f.Stdout,
+		Stderr:           f.Stderr,
+		SM:               f.SM,
+		LifecycleManager: f.LifecycleManager,
+		ChatterFactory:   f.AgentFactory(),
+		UIRenderer:       f.UIFact.UIRenderer(),
+		HistoryRenderer:  f.UIFact.HistoryRenderer(),
+		HistoryBrowser:   f.UIFact.HistoryBrowser(),
+		HistoryEditor:    f.UIFact.HistoryEditor(),
+		LogOpener:        infra_persistence.NewDomainFS(f.FileSystem),
+	})
 }

--- a/tests/integration/agent/service_integration_test.go
+++ b/tests/integration/agent/service_integration_test.go
@@ -44,10 +44,16 @@ func TestChatService_Initialization_Failures(t *testing.T) {
 				tt.setup(mockSF)
 			}
 
-			service := agent.NewChatService(
-				"home", "v1", io.Discard, io.Discard, nil,
-				mockSF, nil, &agenttest.StubUIRenderer{}, &agenttest.StubHistoryRenderer{}, &agenttest.StubHistoryBrowser{}, nil, nil,
-			)
+			service := agent.NewChatService(agent.ChatServiceConfig{
+				HomeDir:          "home",
+				Version:          "v1",
+				Stdout:           io.Discard,
+				Stderr:           io.Discard,
+				LifecycleManager: mockSF,
+				UIRenderer:       &agenttest.StubUIRenderer{},
+				HistoryRenderer:  &agenttest.StubHistoryRenderer{},
+				HistoryBrowser:   &agenttest.StubHistoryBrowser{},
+			})
 
 			// 3. Attempt ProcessMessage
 			cfg := &config.Config{}


### PR DESCRIPTION
Closes #1332.

## Summary

Implements **T1 + T2** from issue #1332 (scoped from #1331 — the grill-adjudicated architecture review). **R2 (measure-first benchmark + ADR) and R3 (Design Rejections catalog entry) are follow-ups, not in this PR.**

**T1 — comment fixes (clarity-only, zero net lines):**
- `internal/agent/agent.go:46` — trailing comment on the write-only `executor` field (assigned in `initComponents`, never read via the field; the value is consumed by `NewEngine` via the local `exec`). In-line only — catalog pins `agent.go:39,44,104-149` and `:382-383` stay on-symbol, no re-anchors.
- `Makefile:568` — corrected the stale "25-cataloged / 1-alert" comment to the live **27-cataloged / 0-alert** partition asserted by `verify-nonfix-catalog`.

**T2 — `ChatServiceConfig` full replacement of `NewChatService`:**
- `ChatServiceConfig` struct replaces the 12 positional params + `opts ...ChatServiceOption`; `ChatServiceOption`/`WithPathResolver`/opts loop **deleted** (the options mechanism had exactly one production use — a test injection).
- `ResolvePaths` defaults to `persistence.ResolvePaths` when nil; new `TestChatService_ResolvePathsDefault` covers it.
- All 12 call sites rewritten (9 in `service_test.go` collapsed via a shared `newTestChatService` helper; 3 direct struct literals incl. the `di` composition root).
- Catalog `EditLastTurn` `See:` re-anchored `service.go:226-228` → `221-223` (drift obligation, same PR; scoped coordination-rule reading — no partition-test edit, verified `service.go` appears in neither partition map).
- Stale test-comment line refs (`service.go:214`, `:258-260`) de-numbered.

## Acceptance criteria mapping

- [x] T1: trailing comment on `executor` (agent.go:46) + `Makefile:568` corrected; catalog pins `agent.go:39,44,104-149` and `:382-383` verified still on-symbol (lines 40/103/383 unchanged)
- [x] T2: `ChatServiceConfig` in place; `ChatServiceOption`/`WithPathResolver`/opts loop deleted (0 matches repo-wide); 12 call sites rewritten (9 via `newTestChatService`); `ResolvePaths` default applied when nil
- [x] `EditLastTurn` catalog entry re-anchored to post-change `service.go` position in the same PR
- [x] `make check-full` green (incl. `test-race`)
- [x] PR body carries the note: implements T1+T2 from #1331; R2/R3 are follow-ups

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-*, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, test-race) | PASS |
| `go test ./internal/agent/... ./internal/cli/... ./internal/infrastructure/di/... ./tests/integration/agent/...` | PASS |
| `go test -tags=arch -run 'TestVerifyNonFixCatalog\|TestVerifyCoveragePinsMatchLiveCatalog' ./internal/tools/analysis` | PASS |
| `gofmt -l` on all touched files | clean |
| `git diff -- internal/tools/analysis/real_nonfix_catalog_test.go` | empty (partition test untouched) |
| `grep -rn "ChatServiceOption\|WithPathResolver" internal/` | 0 matches |
