### PR TITLE
refactor(telemetry): point DefaultPricing at domain config (#1350)

### DIFF
--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
-	"github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/spf13/viper"
 )
 
@@ -232,11 +231,6 @@ func syncLegacyFields(cfg *domain_config.Config) {
 	if cfg.ThinkingLevel == "" {
 		cfg.ThinkingLevel = active.ThinkingLevel
 	}
-}
-
-// DefaultPricing returns the hardcoded fallback pricing data.
-func DefaultPricing() pricing.PricingData {
-	return domain_config.DefaultPricing()
 }
 
 // JSONSessionLoader implements domain_config.SessionLoader.

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -393,17 +393,6 @@ func TestYAMLConfigLoader_Load_AutoDiscovery(t *testing.T) {
 	})
 }
 
-func TestDefaultPricing(t *testing.T) {
-	p := DefaultPricing()
-	if len(p.Models) == 0 {
-		t.Error("expected non-empty pricing data")
-	}
-
-	if _, ok := p.Models["gpt-5"]; !ok {
-		t.Error("expected gpt-5 to be present in default pricing")
-	}
-}
-
 func TestLoad_ModelWithDots(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "test_dots.yaml")

--- a/internal/infrastructure/telemetry/metrics.go
+++ b/internal/infrastructure/telemetry/metrics.go
@@ -13,13 +13,13 @@ import (
 	"path/filepath"
 	"time"
 
+	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	domain_security "github.com/gosharplite/tell-me-go/internal/domain/security"
 	domain_telemetry "github.com/gosharplite/tell-me-go/internal/domain/telemetry"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/config"
 )
 
 type metricsManager struct {
@@ -119,7 +119,7 @@ func resolveUsageForSummary(ctx context.Context, sm domain_security.Manager, tra
 		return usage, totalCost, nil
 	}
 
-	pd := config.DefaultPricing()
+	pd := domain_config.DefaultPricing()
 	for k, v := range overrides {
 		pd.Models[k] = v
 	}

--- a/internal/infrastructure/telemetry/metrics_cost.go
+++ b/internal/infrastructure/telemetry/metrics_cost.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"strings"
 
+	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/config"
 )
 
 // applyPricingOverrides applies configured pricing overrides to the pricing data.
@@ -39,7 +39,7 @@ func (m *metricsManager) EstimateCost(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	pd := config.DefaultPricing()
+	pd := domain_config.DefaultPricing()
 	pd = m.applyPricingOverrides(pd)
 
 	// 1. Parse usage from log


### PR DESCRIPTION
Refs #1350 (item 1) — the `telemetry → config` lateral-edge inversion.

## Summary

Re-points the telemetry package's `DefaultPricing` dependency from the `internal/infrastructure/config` re-export shim to `internal/domain/config` directly, and removes the now-orphaned shim.

- `internal/infrastructure/telemetry/metrics.go` + `metrics_cost.go`: import `internal/domain/config` (aliased `domain_config`) instead of the infra shim; call `domain_config.DefaultPricing()` directly.
- `internal/infrastructure/config/config.go`: removed the now-dead `DefaultPricing` re-export shim and its now-unused `domain/pricing` import (its only consumers were the two telemetry files).
- `internal/infrastructure/config/config_test.go`: removed the orphaned white-box `TestDefaultPricing`.

Behavior-preserving: the infra symbol was a one-line shim returning `domain_config.DefaultPricing()`; `di/telemetry_factory.go` already used the domain function directly.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (incl. race) | PASS |
| `go build ./...` | PASS |
| `go test ./internal/infrastructure/telemetry/...` | PASS |
| `go test ./internal/infrastructure/config/...` | PASS |
| `go run ./cmd/deadcode` | `No dead code found.` |
| ADR-056 transitive gate | green (telemetry `allowed:` already includes `config`; domain-closure-neutral) |
