### PR TITLE
refactor(logging): invert logging→persistence adapter to domain port (#1350)

### DIFF
--- a/internal/infrastructure/di/telemetry_factory.go
+++ b/internal/infrastructure/di/telemetry_factory.go
@@ -83,7 +83,7 @@ func (f *defaultTelemetryFactory) BuildTelemetry(ctx stdctx.Context, paths *pers
 
 	var turnsLogger ports.TurnsLogger = &ports.NoOpTurnsLogger{}
 	if paths.TurnsLogPath != "" {
-		if tl, err := logging.NewAsyncTurnsLogger(ctx, f.FileSystem, paths.TurnsLogPath, f.Logger); err == nil {
+		if tl, err := logging.NewAsyncTurnsLogger(ctx, infra_persistence.NewDomainFS(f.FileSystem), paths.TurnsLogPath, f.Logger); err == nil {
 			turnsLogger = tl
 
 			origCleanup := cleanup

--- a/internal/infrastructure/logging/async_turns_logger.go
+++ b/internal/infrastructure/logging/async_turns_logger.go
@@ -15,15 +15,15 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 )
 
 const maxConsecutiveWarnBeforeError = 5
 
 type asyncTurnsLogger struct {
-	file                infra_persistence.File
+	file                persistence.File
 	ch                  chan string
 	wg                  sync.WaitGroup
 	logger              *slog.Logger
@@ -34,7 +34,7 @@ type asyncTurnsLogger struct {
 }
 
 // NewAsyncTurnsLogger creates a new ports.TurnsLogger that writes to a file asynchronously.
-func NewAsyncTurnsLogger(ctx context.Context, fs infra_persistence.FileSystem, filePath string, logger *slog.Logger) (ports.TurnsLogger, error) {
+func NewAsyncTurnsLogger(ctx context.Context, fs persistence.FileSystem, filePath string, logger *slog.Logger) (ports.TurnsLogger, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}

--- a/internal/infrastructure/logging/async_turns_logger_test.go
+++ b/internal/infrastructure/logging/async_turns_logger_test.go
@@ -37,7 +37,7 @@ func (m *mockClock) NewTicker(d time.Duration) clock.Ticker { return nil }
 func (m *mockClock) Jitter(base float64) float64            { return base }
 
 func TestAsyncTurnsLogger_Log(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "turns.log")
 	ctx := context.Background()
@@ -81,14 +81,14 @@ func TestAsyncTurnsLogger_Log(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_New_Error(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	ctx := context.Background()
 	_, err := NewAsyncTurnsLogger(ctx, fs, "/non/existent/path/to/logfile.log", slog.Default())
 	assert.Error(t, err)
 }
 
 func TestAsyncTurnsLogger_NilLogger(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "nil_logger.log")
 	ctx := context.Background()
@@ -111,7 +111,7 @@ func TestAsyncTurnsLogger_NilLogger(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_ListenAfterClose(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "listen_after_close.log")
 	ctx := context.Background()
@@ -128,7 +128,7 @@ func TestAsyncTurnsLogger_ListenAfterClose(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_ChannelCloseDuringListen(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "channel_close.log")
 	ctx := context.Background()
@@ -158,7 +158,7 @@ func TestAsyncTurnsLogger_ChannelCloseDuringListen(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_EmptyMessageGuard(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "empty_msg.log")
 	ctx := context.Background()
@@ -191,7 +191,7 @@ func TestAsyncTurnsLogger_EmptyMessageGuard(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_HandleEventAfterClose(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "after_close.log")
 	ctx := context.Background()
@@ -206,7 +206,7 @@ func TestAsyncTurnsLogger_HandleEventAfterClose(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_Concurrency(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "concurrency.log")
 	ctx := context.Background()
@@ -284,7 +284,7 @@ func (fs *errorSyncFS) OpenFile(ctx context.Context, _ string, _ int, _ os.FileM
 }
 
 func TestAsyncTurnsLogger_SyncError(t *testing.T) {
-	fs := &errorSyncFS{}
+	fs := infra_persistence.NewDomainFS(&errorSyncFS{})
 	handler := &slogHandler{}
 	logger := slog.New(handler)
 	ctx := context.Background()
@@ -324,7 +324,7 @@ func TestAsyncTurnsLogger_SyncError(t *testing.T) {
 }
 
 func TestAsyncTurnsLogger_Close_Twice(t *testing.T) {
-	fs := &infra_persistence.OSFileSystem{}
+	fs := infra_persistence.NewDomainFS(&infra_persistence.OSFileSystem{})
 	tmpDir := t.TempDir()
 	logFile := filepath.Join(tmpDir, "close_twice.log")
 	ctx := context.Background()
@@ -384,7 +384,7 @@ func (fs *blockingFS) OpenFile(ctx context.Context, name string, flag int, perm 
 func TestAsyncTurnsLogger_BufferFull(t *testing.T) {
 	block := make(chan struct{})
 	file := &blockingFile{block: block}
-	fs := &blockingFS{file: file}
+	fs := infra_persistence.NewDomainFS(&blockingFS{file: file})
 
 	handler := &slogHandler{}
 	logger := slog.New(handler)
@@ -459,7 +459,7 @@ func (fs *errorWriteFS) OpenFile(ctx context.Context, _ string, _ int, _ os.File
 }
 
 func TestAsyncTurnsLogger_WriteError(t *testing.T) {
-	fs := &errorWriteFS{}
+	fs := infra_persistence.NewDomainFS(&errorWriteFS{})
 	handler := &slogHandler{}
 	logger := slog.New(handler)
 	ctx := context.Background()
@@ -527,7 +527,7 @@ func (fs *spyFS) OpenFile(ctx context.Context, name string, flag int, perm os.Fi
 
 func TestAsyncTurnsLogger_CallsSync(t *testing.T) {
 	file := &spyFile{}
-	fs := &spyFS{file: file}
+	fs := infra_persistence.NewDomainFS(&spyFS{file: file})
 	ctx := context.Background()
 
 	tl, err := NewAsyncTurnsLogger(ctx, fs, "dummy", slog.Default())


### PR DESCRIPTION
Refs #1350 (item 2) — the `logging → persistence` lateral-edge inversion.

## Summary

Re-types `NewAsyncTurnsLogger` to depend on the **domain** persistence port instead of the infrastructure adapter, and adapts at the DI root.

- `internal/infrastructure/logging/async_turns_logger.go`: field `file` and constructor param `fs` re-typed from `infra_persistence.File`/`infra_persistence.FileSystem` to the domain `persistence.File`/`persistence.FileSystem`; import re-pointed.
- `internal/infrastructure/di/telemetry_factory.go`: wraps `f.FileSystem` with `infra_persistence.NewDomainFS(f.FileSystem)` at the single call site.
- `internal/infrastructure/logging/async_turns_logger_test.go`: 13 `fs :=` sites wrapped in `NewDomainFS(...)` (9 real-FS `OSFileSystem`, 4 custom error/behavior mocks). Mock type definitions unchanged — `NewDomainFS` adapts them because infra `File` is a method superset of domain `File`.

Behavior-preserving. `di` (a sanctioned composition root) remains the sole place that touches the infra adapter.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (incl. race) | PASS |
| `go build ./...` | PASS |
| `go vet ./internal/infrastructure/logging ./internal/infrastructure/di` | PASS |
| `go test ./internal/infrastructure/logging` | PASS |
| `go test -race ./internal/infrastructure/logging` | PASS |
| `go run ./cmd/deadcode` | `No dead code found.` |
| ADR-056 transitive gate | green (logging `allowed:` already includes `persistence`; domain-closure-neutral) |
