### PR TITLE
refactor(auth): inject persistence.FileSystem via defaultFS fallback (#1350)

### DIFF
--- a/internal/infrastructure/auth/auth.go
+++ b/internal/infrastructure/auth/auth.go
@@ -21,7 +21,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
@@ -44,6 +44,8 @@ type VertexAuth struct {
 	tokenCmdFunc func() ([]byte, error)
 	// CacheDir allows overriding the default cache location. Primarily for testing.
 	CacheDir string
+	// fs is the injected filesystem port used to persist the token cache.
+	fs persistence.FileSystem
 }
 
 // NewVertexAuth returns a VertexAuth wired with the production gcloud executor
@@ -54,6 +56,7 @@ func NewVertexAuth() *VertexAuth {
 		tokenCmdFunc: func() ([]byte, error) {
 			return execCommand("gcloud", "auth", "print-access-token").Output()
 		},
+		fs: defaultFS,
 	}
 }
 
@@ -119,7 +122,7 @@ func (a *VertexAuth) writeCacheFile(ctx context.Context, token string) {
 		log.Printf("failed to create auth cache directory: %v", err)
 		return
 	}
-	if err := persistence.AtomicWrite(ctx, &persistence.OSFileSystem{}, cacheFile, []byte(token), 0600); err != nil {
+	if err := a.fs.AtomicWrite(ctx, cacheFile, []byte(token), 0600); err != nil {
 		log.Printf("failed to write auth cache: %v", err)
 	}
 }

--- a/internal/infrastructure/auth/auth_test.go
+++ b/internal/infrastructure/auth/auth_test.go
@@ -133,6 +133,7 @@ func TestVertexAuth_GetToken(t *testing.T) {
 		ctx := context.Background()
 		auth := &VertexAuth{
 			CacheDir: t.TempDir(),
+			fs:       defaultFS,
 			tokenCmdFunc: func() ([]byte, error) {
 				return []byte("gcloud-token"), nil
 			},
@@ -200,6 +201,7 @@ func TestVertexAuth_Concurrency(t *testing.T) {
 
 	auth := &VertexAuth{
 		CacheDir: t.TempDir(),
+		fs:       defaultFS,
 		tokenCmdFunc: func() ([]byte, error) {
 			atomic.AddInt32(&calls, 1)
 			inFunc <- struct{}{}
@@ -630,6 +632,7 @@ func TestVertexAuth_GetToken_ExpiredCache(t *testing.T) {
 	tmpDir := t.TempDir()
 	auth := &VertexAuth{
 		CacheDir: tmpDir,
+		fs:       defaultFS,
 		tokenCmdFunc: func() ([]byte, error) {
 			return []byte("new-token"), nil
 		},
@@ -712,6 +715,7 @@ func TestVertexAuth_GetToken_AtomicWriteFailure(t *testing.T) {
 	// cache miss → gcloud → MkdirAll(succeeds) → AtomicWrite(fails)
 	auth2 := &VertexAuth{
 		CacheDir: tmpDir,
+		fs:       defaultFS,
 		tokenCmdFunc: func() ([]byte, error) {
 			return []byte("resilient-token"), nil
 		},
@@ -811,6 +815,7 @@ func TestVertexAuth_GetToken_CorruptCache(t *testing.T) {
 
 	auth := &VertexAuth{
 		CacheDir: tmpDir,
+		fs:       defaultFS,
 		tokenCmdFunc: func() ([]byte, error) {
 			return []byte("fresh-gcloud-token"), nil
 		},
@@ -1002,7 +1007,7 @@ func TestVertexAuth_ReadCacheFile_Unreadable(t *testing.T) {
 func TestVertexAuth_WriteCacheFile(t *testing.T) {
 	t.Run("successful write", func(t *testing.T) {
 		dir := t.TempDir()
-		auth := &VertexAuth{CacheDir: dir}
+		auth := &VertexAuth{CacheDir: dir, fs: defaultFS}
 		auth.writeCacheFile(context.Background(), "my-token")
 
 		cachePath := auth.getCachePath()
@@ -1036,7 +1041,7 @@ func TestVertexAuth_WriteCacheFile(t *testing.T) {
 			t.Skip("Chmod 0555 not reliable on Windows")
 		}
 		dir := t.TempDir()
-		auth := &VertexAuth{CacheDir: dir}
+		auth := &VertexAuth{CacheDir: dir, fs: defaultFS}
 		cachePath := auth.getCachePath()
 		cacheDir := filepath.Dir(cachePath)
 		if err := os.MkdirAll(cacheDir, 0700); err != nil {

--- a/internal/infrastructure/auth/default_fs.go
+++ b/internal/infrastructure/auth/default_fs.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package auth
+
+import (
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+// defaultFS is the single sanctioned construction site for the OS
+// filesystem adapter in this package (issue #1350, ADR-055). Every live
+// auth path uses the injected domain port (persistence.FileSystem); this
+// fallback exists so the zero-arg NewVertexAuth() keeps working for call
+// sites that predate injection. Do not add further
+// internal/infrastructure/persistence imports to production files in this
+// package.
+var defaultFS = infra_persistence.NewOSFileSystem()


### PR DESCRIPTION
Refs #1350 (item 3) — the `auth → persistence` lateral-edge inversion.

## Summary

`VertexAuth.writeCacheFile` no longer self-constructs the concrete infra adapter (`&persistence.OSFileSystem{}` + package-level `persistence.AtomicWrite`). It now writes through an injected domain `persistence.FileSystem` port.

- `internal/infrastructure/auth/auth.go`: import re-pointed to `domain/persistence`; `VertexAuth` gains an unexported `fs persistence.FileSystem` field; `NewVertexAuth()` defaults `fs: defaultFS`; `writeCacheFile` calls `a.fs.AtomicWrite(...)`.
- `internal/infrastructure/auth/default_fs.go` (new): single sanctioned adapter construction `var defaultFS = infra_persistence.NewOSFileSystem()` (ADR-055 confinement).
- `internal/infrastructure/auth/auth_test.go`: 7 white-box `VertexAuth` literals that reach `AtomicWrite` now inject `fs: defaultFS`.

Behavior-preserving. `llm/factory.go` constructs `NewVertexAuth()` (a non-DI site), so the fallback is the correct placement — not DI-threading.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (incl. race) | PASS |
| `go build ./internal/infrastructure/auth/` | PASS |
| `go test -race ./internal/infrastructure/auth/` | PASS |
| `go vet ./internal/infrastructure/auth/` | PASS |
| `go run ./cmd/deadcode` | `No dead code found.` |
| ADR-056 transitive gate | green (auth `allowed:` already includes `persistence`; domain-closure-neutral) |

## Note

This is item 3 of #1350. **Item 4 (`llm → auth`)** is the next, strictly-adjacent PR (both touch `auth/auth.go`); it will move `Authenticator`/`Request` to `domain/ports` and re-point the `llm` family.
