### PR TITLE
refactor(history): introduce domain AssetStore port, inject at DI root (#1350)

### DIFF
--- a/internal/domain/persistence/asset_store.go
+++ b/internal/domain/persistence/asset_store.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package persistence
+
+import "context"
+
+// AssetStore manages binary blobs in content-addressable storage.
+//
+// It is the domain port that the infrastructure/history adapter depends on
+// to offload binary InlineData parts. The concrete implementation lives in
+// internal/infrastructure/persistence; this interface keeps history decoupled
+// from that concrete type (issue #1350, item 5).
+type AssetStore interface {
+	Put(ctx context.Context, data []byte) (string, error)
+	Get(ctx context.Context, id string) ([]byte, error)
+}

--- a/internal/domain/persistence/paths.go
+++ b/internal/domain/persistence/paths.go
@@ -10,6 +10,7 @@ type Paths struct {
 	ModeDir            string
 	HistoryPath        string
 	HistoryArchivePath string
+	AssetsPath         string
 	LogPath            string
 	TracePath          string
 	CommandsLogPath    string
@@ -29,6 +30,7 @@ func ResolvePaths(homeDir string, mode string) *Paths {
 		ModeDir:            modeDir,
 		HistoryPath:        filepath.Join(modeDir, "history.jsonl"),
 		HistoryArchivePath: filepath.Join(modeDir, "history.archive.jsonl"),
+		AssetsPath:         filepath.Join(modeDir, "assets"),
 		LogPath:            filepath.Join(modeDir, "tokens.log"),
 		TracePath:          filepath.Join(modeDir, "tokens.trace.jsonl"),
 		CommandsLogPath:    filepath.Join(modeDir, "commands.log"),

--- a/internal/infrastructure/di/history_factory.go
+++ b/internal/infrastructure/di/history_factory.go
@@ -40,7 +40,9 @@ func (f *defaultHistoryFactory) BuildHistoryManager(ctx stdctx.Context, cfg *con
 		return nil, fmt.Errorf("%w: failed to ensure session directories for %s: %w", errInfraInit, cfg.Mode, err)
 	}
 
-	hManager := history.NewManager(infra_persistence.NewDomainFS(f.FileSystem), paths.HistoryPath, paths.HistoryArchivePath).WithLogger(f.Logger)
+	domainFS := infra_persistence.NewDomainFS(f.FileSystem)
+	assetStore := infra_persistence.NewAssetStore(domainFS, paths.AssetsPath)
+	hManager := history.NewManagerWithAssetStore(domainFS, assetStore, paths.HistoryPath, paths.HistoryArchivePath).WithLogger(f.Logger)
 	if err := hManager.Load(ctx); err != nil {
 		if !errors.Is(err, ports.ErrHistoryNotFound) {
 			return nil, fmt.Errorf("%w: failed to load history from %s: %w", errInfraInit, paths.HistoryPath, err)

--- a/internal/infrastructure/history/default_asset_store.go
+++ b/internal/infrastructure/history/default_asset_store.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package history
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
+	infrapersistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+// defaultAssetStore is the single sanctioned construction site for the
+// concrete infrastructure AssetStore in this package (issue #1350, item 5).
+// The production DI root injects the domain port via NewManagerWithAssetStore;
+// this fallback keeps the zero-churn NewManager / newJSONLStore constructors
+// working for the ~150 test/bench call sites that predate injection. Do not
+// construct infrapersistence.NewAssetStore anywhere else in this package.
+func defaultAssetStore(fs persistence.FileSystem, assetDir string) persistence.AssetStore {
+	return infrapersistence.NewAssetStore(fs, assetDir)
+}

--- a/internal/infrastructure/history/history.go
+++ b/internal/infrastructure/history/history.go
@@ -35,6 +35,19 @@ func NewManager(fs persistence.FileSystem, filePath string, archivePath string) 
 	}
 }
 
+// NewManagerWithAssetStore creates a new history manager with an injected
+// asset store (the domain persistence.AssetStore port). The DI root uses this
+// to inject the concrete infrastructure AssetStore built against the resolved
+// AssetsPath, inverting the adapter-to-adapter edge (issue #1350, item 5).
+func NewManagerWithAssetStore(fs persistence.FileSystem, assetStore persistence.AssetStore, filePath string, archivePath string) *Manager {
+	return &Manager{
+		store:    newJSONLStoreWithAssetStore(fs, assetStore, filePath, archivePath),
+		logger:   &ports.NoOpLogger{},
+		FilePath: filePath,
+		Contents: []*llm.Content{},
+	}
+}
+
 // WithLogger sets the logger for the Manager.
 func (m *Manager) WithLogger(l ports.Logger) *Manager {
 	if l != nil {

--- a/internal/infrastructure/history/store.go
+++ b/internal/infrastructure/history/store.go
@@ -15,7 +15,6 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	infrapersistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
 )
 
 // store defines the interface for history persistence.
@@ -42,17 +41,23 @@ type historyPatch struct {
 type jsonlStore struct {
 	filePath    string
 	archivePath string
-	assetStore  *infrapersistence.AssetStore
+	assetStore  persistence.AssetStore
+	assetDir    string
 	fs          persistence.FileSystem
 }
 
 // newJSONLStore creates a new jsonlStore.
 func newJSONLStore(fs persistence.FileSystem, filePath string, archivePath string) *jsonlStore {
 	assetDir := filepath.Join(filepath.Dir(filePath), "assets")
+	return newJSONLStoreWithAssetStore(fs, defaultAssetStore(fs, assetDir), filePath, archivePath)
+}
+
+func newJSONLStoreWithAssetStore(fs persistence.FileSystem, assetStore persistence.AssetStore, filePath string, archivePath string) *jsonlStore {
 	return &jsonlStore{
 		filePath:    filePath,
 		archivePath: archivePath,
-		assetStore:  infrapersistence.NewAssetStore(fs, assetDir),
+		assetDir:    filepath.Join(filepath.Dir(filePath), "assets"),
+		assetStore:  assetStore,
 		fs:          fs,
 	}
 }
@@ -60,7 +65,7 @@ func newJSONLStore(fs persistence.FileSystem, filePath string, archivePath strin
 // withFileSystem sets the filesystem implementation.
 func (s *jsonlStore) withFileSystem(fs persistence.FileSystem) *jsonlStore {
 	s.fs = fs
-	s.assetStore = infrapersistence.NewAssetStore(fs, s.assetStore.GetBaseDir())
+	s.assetStore = defaultAssetStore(fs, s.assetDir)
 	return s
 }
 

--- a/internal/infrastructure/persistence/assets.go
+++ b/internal/infrastructure/persistence/assets.go
@@ -94,8 +94,3 @@ func (s *AssetStore) getPath(id string) string {
 	}
 	return filepath.Join(s.baseDir, id[:2], id)
 }
-
-// GetBaseDir returns the base directory of the asset store.
-func (s *AssetStore) GetBaseDir() string {
-	return s.baseDir
-}

--- a/internal/infrastructure/persistence/assets_test.go
+++ b/internal/infrastructure/persistence/assets_test.go
@@ -171,13 +171,3 @@ func createTestAsset(t *testing.T, store *AssetStore, content []byte) string {
 	}
 	return id
 }
-
-func TestAssetStore_GetBaseDir(t *testing.T) {
-	tempDir := t.TempDir()
-	fs := NewOSFileSystem()
-	store := NewAssetStore(fs, tempDir)
-
-	if store.GetBaseDir() != tempDir {
-		t.Errorf("expected GetBaseDir() to return %s, got %s", tempDir, store.GetBaseDir())
-	}
-}


### PR DESCRIPTION
Refs #1350 (item 5) — the `history → persistence` lateral-edge inversion.

## Summary

`jsonlStore` now depends on the domain `persistence.AssetStore` port instead of the concrete `*infrapersistence.AssetStore` type.

- `internal/domain/persistence/asset_store.go` (new): `AssetStore` port — `Put(ctx, data []byte) (string, error)` + `Get(ctx, id string) ([]byte, error)` only (`GetBaseDir` excluded — it was a location/layout leak).
- `internal/domain/persistence/paths.go`: added `Paths.AssetsPath` (`filepath.Join(modeDir, "assets")`).
- `internal/infrastructure/history/store.go`: `jsonlStore.assetStore` widened to the port; added `assetDir` field; `newJSONLStore` delegates through `newJSONLStoreWithAssetStore` + `defaultAssetStore`; `withFileSystem` reads `s.assetDir` instead of `GetBaseDir`.
- `internal/infrastructure/history/default_asset_store.go` (new): the single sanctioned `infrapersistence.NewAssetStore` construction (ADR-055 fallback).
- `internal/infrastructure/history/history.go`: added `NewManagerWithAssetStore` (DI injection); `NewManager` unchanged (zero test churn).
- `internal/infrastructure/di/history_factory.go`: constructs `domainFS` + `assetStore` from `paths.AssetsPath` and injects via `NewManagerWithAssetStore`.
- `internal/infrastructure/persistence/assets.go` + `assets_test.go`: deleted the now-orphaned `GetBaseDir` method and its test.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (incl. race) | PASS |
| `go build ./...` | PASS |
| `go test ./internal/domain/persistence/... ./internal/infrastructure/persistence/... ./internal/infrastructure/history/... ./internal/infrastructure/di/...` | PASS |
| `go test ./internal/ui/... ./tests/integration/agent/... ./tests/e2e/...` | PASS |
| `go run ./cmd/deadcode` | `No dead code found.` |
| ADR-056 transitive gate | green (history `allowed:` already includes `persistence`; domain-closure-neutral) |

## Note

A pre-existing flaky test (`TestTimeoutKillsProcessTree` in `internal/tools/workspace`) failed once under load during the first `make check-full` run and passed on re-run — unrelated to this change (no `internal/tools/workspace` files touched). Flagging for visibility only.

This is item 5 of #1350. Only **item 6 (family-level gate schema extension)** remains.
