### PR TITLE
docs(adr): decouple ADR-064 Decision 7 forward-reference from ADR-065 (#1360)

### DIFF
--- a/docs/adr/2026-08-ports-shared-kernel-registry-gate.md
+++ b/docs/adr/2026-08-ports-shared-kernel-registry-gate.md
@@ -61,7 +61,7 @@ The composition-root exclusion is a property of the ADR-056 Decision 1 exit quer
 
 ### 7. Terminal-state contract
 
-PR-B (#1344) either ratifies the deferral (data appendix to this ADR) or upgrades to accept via **ADR-065** — a new ADR, never an amendment. Permanent deferral is a valid terminal state.
+PR-B (#1344) either ratifies the deferral (data appendix to this ADR) or upgrades to accept via a **new ADR** (next available number — note: ADR-065 was later assigned to the auth-seam contract-leaf rule, #1358) — never an amendment. Permanent deferral is a valid terminal state.
 
 ### 8. Evidence hygiene
 


### PR DESCRIPTION
Closes #1360.

## Summary

One-line, doc-only fix to ADR-064 **Decision 7 ("Terminal-state contract")**: decouples the deferred ports-split (PR-B, #1344) upgrade path from the literal "ADR-065" number, which has since been assigned to the auth-seam contract-leaf rule (#1358 / PR #1359).

Before:

> PR-B (#1344) either ratifies the deferral (data appendix to this ADR) or upgrades to accept via **ADR-065** — a new ADR, never an amendment.

After:

> PR-B (#1344) either ratifies the deferral (data appendix to this ADR) or upgrades to accept via a **new ADR** (next available number — note: ADR-065 was later assigned to the auth-seam contract-leaf rule, #1358) — never an amendment.

## Verification

| Check | Status |
|-------|--------|
| `make verify-adr-index` | ✅ PASS (`ADR index is consistent.`) |
| Scope | ✅ doc-only — no `.go` changes, no `docs/adr/README.md` change |
