### PR TITLE
test(app)+catalog: coverage fallback test, llm gap cataloging, pin re-anchors

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -323,7 +323,7 @@ catalog a new gap no one reviewed. Policy:
   would test the third-party uuid library, not project code. Same acceptance
   class as `RealClock` delegation wrappers in `pkg/clock/clock.go` and
   `mockFileSystem.Chmod`.
-- **See**: `internal/domain/llm/types.go:222-224`
+- **See**: `internal/domain/llm/types.go:234-236`
 
 ### domain/ports/repository.go — Task struct field accessors (GetID, GetStatus, GetCreatedAt)
 
@@ -333,7 +333,7 @@ catalog a new gap no one reviewed. Policy:
   interface constraint. They contain no branches and no business logic.
   Testing them would test Go struct field access. Same acceptance class as
   the interface-satisfying stubs in `agenttest/helpers.go`.
-- **See**: `internal/domain/ports/repository.go:105,108,111`
+- **See**: `internal/domain/ports/repository.go:112,116`
 
 ### agent/orchestrator/engine_phases.go — default case in RecoveryStep switch
 
@@ -767,6 +767,22 @@ catalog a new gap no one reviewed. Policy:
 
 - **See**: `internal/tools/integrations/skillssh/manager_impl.go`,
   `internal/tools/integrations/skillssh/tools.go`
+
+---
+
+## Coverage Gaps (ACCEPTED — 2026-09 catalog hygiene)
+
+### llm/failover.go — FailoverGateway.ExtractDocument delegation wrapper
+
+- **Status**: ACCEPTED (2026-09)
+- **Rationale**: one-line delegation to clients[0].Client.ExtractDocument; testing a pass-through provides no value — same acceptance class as AppendTask / domainFS.Chmod (delegation-wrapper).
+- **See**: `internal/infrastructure/llm/failover.go:131-133`
+
+### llm/provider_health.go — getPingEndpoint panic and buildRequest error branch (structurally unreachable)
+
+- **Status**: ACCEPTED (2026-09)
+- **Rationale**: getPingEndpoint's switch is exhaustive over the 3-value APIFamily (//exhaustive:enforce) — the trailing panic is unreachable; consequently buildRequest's `if err != nil` branch consuming getPingEndpoint's (never-returned) error is equally unreachable. Same acceptance class as llm/factory.go createAuthenticator default-case (structurally-unreachable).
+- **See**: `internal/infrastructure/llm/provider_health.go:238`, and the `if err != nil` branch at `provider_health.go:126-129`
 
 ---
 
@@ -1252,4 +1268,4 @@ to reason about.
 
 ---
 
-*Last Updated: 2026-08 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056; coverage hygiene: NoOpLogger + BypassConfirmation entries — 2026-08; test-complexity catalog additions: TestFakeToolchainRunner_PresetValues (CC=28) and TestFakeToolchainRunner_ZeroDefaults (CC=38) — issue #1325 toolstest fake; #1327: middleware.go catalog pins re-anchored to :213/:311 (per-turn Turn lifecycle refactor); catalog re-anchor: di/container.go skills.sh error branch (203-206) covered — See narrowed to :197-200; catalog re-anchor: history_test.go pins +1 (T1 import shift); catalog re-anchor: middleware.go detectLoop + session_manager.go TUI entry (line drift from renderPostTUISummary feature); catalog re-anchor: factory_test.go + files_test.go complexity pins (issue #1350 item 4, llm→auth import shift); catalog re-anchor: files_test.go complexity pin 378→379 + auth.go Invalidate no-op stub lines (issue #1358 auth/contract realignment); 2026-09 factory seams triage: coverage pins for chatter.go skills.sh graceful-degradation path + llm/factory.go createAuthenticator default-case)*
+*Last Updated: 2026-09 (ADR-053: get_cost_summary tool, DailyCost metric, and global cost ledger removed — issue #1291; coverage/complexity hygiene: event-type table test, shared markdown renderer, accepted mock stubs; catalog additions: ado/pipeline_crud.go json.Marshal unreachable entry, assertMissingKeysResult (CC=13), TestRecoveryStep_EmptyResponse_RetriesUpToLimit (CC=12), CC drift re-verification for (*indexer).snapshot (14), TestResolveCapabilities (13), TestFixtureIndexer_ConstructAndHarvest (13), design rejection: split internal/agent façade — issue #1299; #1302: emergencySave ghost-response guard entry — engine_phases.go; #1300: #1299 entry criterion renamed di-touch → cross-layer per ADR-056; coverage hygiene: NoOpLogger + BypassConfirmation entries — 2026-08; test-complexity catalog additions: TestFakeToolchainRunner_PresetValues (CC=28) and TestFakeToolchainRunner_ZeroDefaults (CC=38) — issue #1325 toolstest fake; #1327: middleware.go catalog pins re-anchored to :213/:311 (per-turn Turn lifecycle refactor); catalog re-anchor: di/container.go skills.sh error branch (203-206) covered — See narrowed to :197-200; catalog re-anchor: history_test.go pins +1 (T1 import shift); catalog re-anchor: middleware.go detectLoop + session_manager.go TUI entry (line drift from renderPostTUISummary feature); catalog re-anchor: factory_test.go + files_test.go complexity pins (issue #1350 item 4, llm→auth import shift); catalog re-anchor: files_test.go complexity pin 378→379 + auth.go Invalidate no-op stub lines (issue #1358 auth/contract realignment); 2026-09 factory seams triage: coverage pins for chatter.go skills.sh graceful-degradation path + llm/factory.go createAuthenticator default-case; 2026-09 catalog hygiene: coverage pins for llm/failover.go ExtractDocument delegation wrapper + llm/provider_health.go getPingEndpoint panic and buildRequest error branch (structurally unreachable); re-anchored NewID (222-224 → 234-236) and Task accessors (105,108,111 → 112,116); coverage test for BuildSuggestionService tracker fallback)*

--- a/internal/app/suggestions_test.go
+++ b/internal/app/suggestions_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package app
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/services"
+	infra_persistence "github.com/gosharplite/tell-me-go/internal/infrastructure/persistence"
+)
+
+// TestBuildSuggestionService_TrackerInitFailure verifies the graceful
+// degradation contract of BuildSuggestionService: when the global prompt
+// tracker cannot be initialized (MkdirAll on <homeDir>/output fails because
+// a plain file named "output" occupies the path), the function logs a
+// warning and substitutes history.NewNoOpTracker() instead of failing.
+//
+// The tracker-failure trigger reuses the proven real-FS technique from
+// TestNewGlobalPromptTracker_MkdirError (internal/infrastructure/history):
+// no custom FS double — a plain file blocks the MkdirAll.
+func TestBuildSuggestionService_TrackerInitFailure(t *testing.T) {
+	homeDir := t.TempDir()
+	conflictFile := filepath.Join(homeDir, "output")
+	if err := os.WriteFile(conflictFile, []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Real OS-backed filesystem adapter, constructed exactly as the production
+	// composition root does (internal/infrastructure/di/container.go:50).
+	fs := &infra_persistence.OSFileSystem{}
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, nil))
+
+	var wp services.WorkspacePolicy // zero value (nil interface) — unused on this path
+
+	service, err := BuildSuggestionService(context.Background(), fs, homeDir, io.Discard, logger, wp, nil)
+	if err != nil {
+		t.Fatalf("BuildSuggestionService must degrade gracefully on tracker init failure, got error: %v", err)
+	}
+	if service == nil {
+		t.Fatal("expected non-nil suggestion service")
+	}
+
+	if !strings.Contains(logBuf.String(), "failed to initialize global prompt tracker") {
+		t.Errorf("expected warning about tracker init failure, got log: %q", logBuf.String())
+	}
+}

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -127,6 +127,11 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		{"task_service.go AppendTask body", "internal/domain/services/task_service.go", 101, 103},
 		{"manager.go groupTurns error branch", "internal/agent/session/context/manager.go", 526, 528},
 		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 571, 573},
+		{"failover.go ExtractDocument body", "internal/infrastructure/llm/failover.go", 131, 133},
+		{"provider_health.go buildRequest error branch", "internal/infrastructure/llm/provider_health.go", 126, 128},
+		{"provider_health.go getPingEndpoint panic", "internal/infrastructure/llm/provider_health.go", 238, 238},
+		{"types.go NewID", "internal/domain/llm/types.go", 234, 236},
+		{"repository.go Task accessors", "internal/domain/ports/repository.go", 112, 116},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Architect-recommended coverage & complexity hygiene (2026-09 triage). Coverage is 95.7% with zero uncataloged over-threshold complexity; this PR closes the remaining real coverage gap and the catalog bookkeeping:

- **New coverage test**: `TestBuildSuggestionService_TrackerInitFailure` covers the graceful-degradation fallback in `BuildSuggestionService` (tracker init failure → `NoOpTracker` + warning) — the one genuinely reachable non-cataloged gap found in triage.
- **Catalog additions** (`docs/architect/INTENTIONAL_NON_FIXES.md`): `failoverGateway.ExtractDocument` (delegation-wrapper) and `provider_health.go` panic + `buildRequest` error branch (structurally-unreachable) — formally closing the triage loop for those sites.
- **Pin re-anchors** (drift policy): `NewID` (`222-224` → `234-236`) and `Task` accessors (`105,108,111` → `112,116`), grep -n-verified against the committed tree.
- **Regression gate**: `TestVerifyCoveragePinsMatchLiveCatalog` extended with 5 cases (coordination rule — catalog change + partition-test update in the same commit).

## Acceptance criteria mapping

- [x] `TestBuildSuggestionService_TrackerInitFailure` added (real-FS trigger, ADR-036 deterministic, no testify/mock)
- [x] 2 new catalog entries with acceptance classes + rationale
- [x] 2 drifted pins re-anchored against the committed tree
- [x] Coverage-pin regression gate extended (5 cases)
- [x] Complexity partition (`TestVerifyNonFixCatalog`) untouched — still green

## Verification

| Gate | Result |
| --- | --- |
| `go test ./internal/app/...` | PASS |
| `go test -tags=arch -run 'TestVerifyCoveragePinsMatchLiveCatalog\|TestVerifyNonFixCatalog' ./internal/tools/analysis` | PASS |
| `go build ./...` | PASS |
| `make verify-nonfix-catalog` | PASS |

**Note**: `make check-full` (including race detection) is recommended before merge — this change is test/docs-only and the targeted gates are green.
