### PR TITLE
feat(security): allow mcp_ tool prefix in security whitelist

### DIFF
--- a/docs/adr/2026-08-mcp-client-architecture.md
+++ b/docs/adr/2026-08-mcp-client-architecture.md
@@ -170,6 +170,38 @@ endpoints, credentials, or auth modes — requires starting a new session; MCP
 servers are excluded from mid-turn hot-reload, which remains scoped to the
 subset of configuration the per-turn config watcher manages.
 
+### 11. Tool Authorization — `mcp_` Prefix Allowance (Amendment 2026-10)
+
+1. **Decision:** MCP-discovered tools — namespaced `mcp_<server>_<tool>` per
+   §5 — are now permitted by the tool authorizer. Discovered-but-undenied
+   tools are dispatchable end-to-end: the #1378/#1379 schema fix made them
+   discoverable; this amendment makes them authorizable.
+2. **Implementation:** `domain.Policy.AllowedCommandPrefixes` (default
+   `["mcp_"]`) and `domain.Policy.IsToolAllowed(name)` (exact allowlist match
+   OR prefix match) in `internal/domain/security/policy.go`; enforced via
+   `Manager.IsToolAllowed` (`internal/infrastructure/security/manager.go`
+   delegation) in `securityAuthorizer.Authorize`
+   (`internal/agent/executor/authorizer.go`). `Policy.IsCommandAllowed`
+   remains **exact-match** (fail-closed) — shell command validation
+   (`SafetyService.IsCommandSafe` → `command_validator.go`) is byte-identical
+   and unaffected.
+3. **Consent unchanged:** the whitelist gate is separate from consent (per the
+   original §8). Consent remains per-tool via `RequiresConsent`; readonly
+   endpoints default `requiresConsent: false` — so `mcp_github_*` tools
+   dispatch without prompting, a deliberate, recorded posture consequence —
+   while non-readonly servers still prompt. `AutoApprovableCommands` is
+   untouched: `mcp_` tools are not auto-approvable.
+4. **Security rationale:** the `mcp_` prefix is a reserved namespace produced
+   only by `FormatToolName` (ADR-067 §5 — server keys
+   `^[a-z0-9-]{1,24}$`, tool names from server discovery); built-in tool
+   names never start with `mcp_`, so there is no collision; matching is
+   case-sensitive; every other name remains fail-closed.
+5. **Accepted trade-off:** the prefix check is a string-prefix allowance, not
+   a proof of MCP provenance — any in-process plugin registering a `mcp_*`
+   name would also pass, which is accepted because plugins are trusted
+   in-process code and the alternative (provenance tracking) adds registry
+   coupling disproportionate to the threat model.
+
 ## Consequences
 
 **Positive:** the SDK is fully isolated behind `tools.MCPClient`, so the

--- a/internal/agent/agenttest/helpers.go
+++ b/internal/agent/agenttest/helpers.go
@@ -83,6 +83,7 @@ type mockServiceSecurityManager struct {
 	PromptFunc           func(message string)
 	WarnFunc             func(message string)
 	IsCommandAllowedFunc func(command string) bool
+	IsToolAllowedFunc    func(name string) bool
 	IsBypassActiveFunc   func() bool
 	CloseFunc            func() error
 
@@ -96,6 +97,7 @@ type mockServiceSecurityManager struct {
 	calledPrompt           int
 	calledWarn             int
 	calledIsCommandAllowed int
+	calledIsToolAllowed    int
 	calledIsBypassActive   int
 	calledClose            int
 
@@ -108,6 +110,7 @@ type mockServiceSecurityManager struct {
 	lastPrompt          string
 	lastWarn            string
 	lastCommand         string
+	lastTool            string
 }
 
 // snapshot returns a race-safe copy of all call counts.
@@ -124,6 +127,7 @@ func (m *mockServiceSecurityManager) snapshot() map[string]int {
 		"Prompt":           m.calledPrompt,
 		"Warn":             m.calledWarn,
 		"IsCommandAllowed": m.calledIsCommandAllowed,
+		"IsToolAllowed":    m.calledIsToolAllowed,
 		"IsBypassActive":   m.calledIsBypassActive,
 		"Close":            m.calledClose,
 	}
@@ -227,6 +231,18 @@ func (m *mockServiceSecurityManager) IsCommandAllowed(command string) bool {
 	m.mu.Unlock()
 	if fn != nil {
 		return fn(command)
+	}
+	return false
+}
+
+func (m *mockServiceSecurityManager) IsToolAllowed(name string) bool {
+	m.mu.Lock()
+	m.calledIsToolAllowed++
+	m.lastTool = name
+	fn := m.IsToolAllowedFunc
+	m.mu.Unlock()
+	if fn != nil {
+		return fn(name)
 	}
 	return false
 }

--- a/internal/agent/executor/authorizer.go
+++ b/internal/agent/executor/authorizer.go
@@ -42,7 +42,7 @@ func (a *securityAuthorizer) Authorize(ctx context.Context, tool *tools.ToolDecl
 	sm := a.sm
 	a.mu.RUnlock()
 
-	if sm != nil && !sm.IsCommandAllowed(call.Name) {
+	if sm != nil && !sm.IsToolAllowed(call.Name) {
 		msg := fmt.Sprintf("security policy: command %q is not allowed", call.Name)
 		return fmt.Errorf("%s: %w", msg, tools.ErrSecurityPolicy)
 	}

--- a/internal/agent/executor/authorizer_test.go
+++ b/internal/agent/executor/authorizer_test.go
@@ -5,6 +5,7 @@ package executor
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
@@ -54,6 +55,39 @@ func TestAuthorizationPanic(t *testing.T) {
 	err := auth.Authorize(context.Background(), &tools.ToolDeclaration{Name: "forbidden"}, &llm.FunctionCall{Name: "forbidden"})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "not allowed")
+}
+
+func TestAuthorize_AllowsMCPTool(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockToolRegistry{}
+	sm := &mockSecurityManager{AllowedCommands: map[string]bool{"allowed": true}}
+	auth := newSecurityAuthorizer(sm, reg, newToolResolutionService(reg))
+
+	call := &llm.FunctionCall{Name: "mcp_github_run_secret_scanning"}
+	tool := &tools.ToolDeclaration{Name: "mcp_github_run_secret_scanning"}
+
+	err := auth.Authorize(context.Background(), tool, call)
+	assert.NoError(t, err, "mcp_-prefixed tool names must be allowed by IsToolAllowed")
+}
+
+func TestAuthorize_DeniesUnknownNonMCPTool(t *testing.T) {
+	t.Parallel()
+
+	reg := &mockToolRegistry{}
+	sm := &mockSecurityManager{AllowedCommands: map[string]bool{"allowed": true}}
+	auth := newSecurityAuthorizer(sm, reg, newToolResolutionService(reg))
+
+	call := &llm.FunctionCall{Name: "unknown_tool"}
+	tool := &tools.ToolDeclaration{Name: "unknown_tool"}
+
+	err := auth.Authorize(context.Background(), tool, call)
+	if err == nil {
+		t.Fatal("expected error for unknown non-MCP tool")
+	}
+	if !strings.Contains(err.Error(), "not allowed") {
+		t.Errorf("error %q does not contain %q", err.Error(), "not allowed")
+	}
 }
 
 func TestRequestBatchConsent_BypassActive(t *testing.T) {

--- a/internal/agent/executor/mocks_test.go
+++ b/internal/agent/executor/mocks_test.go
@@ -5,6 +5,7 @@ package executor
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -95,6 +96,7 @@ func (m *mockEventBus) WaitStarted() {}
 type mockSecurityManager struct {
 	domain_security.Manager
 	AllowedCommands map[string]bool
+	AllowedPrefixes []string
 	AllowAll        bool
 }
 
@@ -103,6 +105,25 @@ func (m *mockSecurityManager) IsCommandAllowed(command string) bool {
 		return true
 	}
 	return m.AllowedCommands[command]
+}
+
+func (m *mockSecurityManager) IsToolAllowed(name string) bool {
+	if m.AllowAll {
+		return true
+	}
+	if m.AllowedCommands[name] {
+		return true
+	}
+	prefixes := m.AllowedPrefixes
+	if len(prefixes) == 0 {
+		prefixes = []string{"mcp_"}
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *mockSecurityManager) Close() error { return nil }
@@ -119,6 +140,11 @@ func (m *mockConsentSecurityManager) TerminalUnlock()      {}
 func (m *mockConsentSecurityManager) Confirm(ctx context.Context, msg string) (bool, error) {
 	return m.ConfirmResult, nil
 }
+
+// IsToolAllowed is consent-focused: this mock is only used to exercise
+// consent flows (RequestBatchConsent / IdentifyConsentItems); Authorize is
+// never exercised with it, so tool authorization is always denied.
+func (m *mockConsentSecurityManager) IsToolAllowed(name string) bool { return false }
 
 func (m *mockConsentSecurityManager) Close() error { return nil }
 

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -890,6 +890,7 @@ func (*noopSecurityManager) Warn(string)                                   {}
 func (*noopSecurityManager) Confirm(context.Context, string) (bool, error) { return true, nil }
 func (*noopSecurityManager) ReadLine(context.Context) (string, error)      { return "", nil }
 func (*noopSecurityManager) IsCommandAllowed(string) bool                  { return true }
+func (*noopSecurityManager) IsToolAllowed(string) bool                     { return true }
 func (*noopSecurityManager) IsBypassActive() bool                          { return false }
 
 func TestExecutionStep_PayloadValidation_GuardBranches(t *testing.T) {

--- a/internal/domain/security/interfaces.go
+++ b/internal/domain/security/interfaces.go
@@ -33,6 +33,10 @@ type TerminalController interface {
 
 type PolicyEvaluator interface {
 	IsCommandAllowed(command string) bool
+	// IsToolAllowed reports whether a tool name may be dispatched: exact
+	// allowlist membership OR membership in an allowed namespace prefix
+	// (e.g. "mcp_" for MCP-discovered tools). Fail-closed for everything else.
+	IsToolAllowed(name string) bool
 	IsBypassActive() bool
 }
 

--- a/internal/domain/security/policy.go
+++ b/internal/domain/security/policy.go
@@ -3,9 +3,12 @@
 
 package security
 
+import "strings"
+
 // Policy defines the security rules for the agent.
 type Policy struct {
 	AllowedCommands        map[string]bool
+	AllowedCommandPrefixes []string
 	AutoApprovableCommands map[string]bool
 	ForbiddenPatterns      []string
 	RestrictedPaths        []string
@@ -183,6 +186,7 @@ func DefaultPolicy() *Policy {
 			"read_video":    true,
 			"read_document": true,
 		},
+		AllowedCommandPrefixes: []string{"mcp_"},
 		AutoApprovableCommands: map[string]bool{
 			"grep": true, "ls": true, "pwd": true, "cat": true, "echo": true,
 			"head": true, "tail": true, "wc": true, "stat": true, "date": true,
@@ -221,6 +225,21 @@ func DefaultPolicy() *Policy {
 // IsCommandAllowed checks if a command is allowed.
 func (p *Policy) IsCommandAllowed(cmd string) bool {
 	return p.AllowedCommands[cmd]
+}
+
+// IsToolAllowed reports whether a tool name may be dispatched: exact
+// allowlist membership OR membership in an allowed namespace prefix
+// (e.g. "mcp_" for MCP-discovered tools). Fail-closed for everything else.
+func (p *Policy) IsToolAllowed(name string) bool {
+	if p.AllowedCommands[name] {
+		return true
+	}
+	for _, prefix := range p.AllowedCommandPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // isAutoApprovable checks if a command is auto-approvable.

--- a/internal/domain/security/policy_test.go
+++ b/internal/domain/security/policy_test.go
@@ -22,6 +22,10 @@ func TestDefaultPolicy(t *testing.T) {
 	if len(p.ForbiddenPatterns) == 0 {
 		t.Error("expected ForbiddenPatterns to be populated")
 	}
+
+	if len(p.AllowedCommandPrefixes) != 1 || p.AllowedCommandPrefixes[0] != "mcp_" {
+		t.Errorf("expected AllowedCommandPrefixes to be [\"mcp_\"], got %v", p.AllowedCommandPrefixes)
+	}
 }
 
 func TestPolicy_IsCommandAllowed(t *testing.T) {
@@ -37,6 +41,7 @@ func TestPolicy_IsCommandAllowed(t *testing.T) {
 		{"rm", "rm", true},
 		{"forbidden", "forbidden_cmd", false},
 		{"empty", "", false},
+		{"mcp_prefix_not_exact", "mcp_github_run_secret_scanning", false},
 	}
 
 	for _, tt := range tests {
@@ -69,6 +74,36 @@ func TestPolicy_isAutoApprovable(t *testing.T) {
 			t.Parallel()
 			if got := p.isAutoApprovable(tt.cmd); got != tt.want {
 				t.Errorf("isAutoApprovable(%q) = %v, want %v", tt.cmd, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPolicy_IsToolAllowed(t *testing.T) {
+	t.Parallel()
+	p := DefaultPolicy()
+	tests := []struct {
+		name string
+		cmd  string
+		want bool
+	}{
+		{"exact_command", "ls", true},
+		{"exact_tool", "read_files", true},
+		{"exact_execute", "execute_command", true},
+		{"mcp_github_tool", "mcp_github_run_secret_scanning", true},
+		{"mcp_github_list", "mcp_github_list_issues", true},
+		{"mcp_truncated_form", "mcp_github_some_very_long_tool_name_abcdef12", true},
+		{"unknown_non_mcp", "unknown_tool", false},
+		{"mcp_without_underscore", "mcp", false},
+		{"mcp_uppercase", "MCP_github_list_issues", false},
+		{"empty", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := p.IsToolAllowed(tt.cmd); got != tt.want {
+				t.Errorf("IsToolAllowed(%q) = %v, want %v", tt.cmd, got, tt.want)
 			}
 		})
 	}

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -196,6 +196,7 @@ type mockConfigurableSecurityManager struct {
 	confirmCalls              int
 	readLineCalls             int
 	isCommandAllowedCalls     int
+	isToolAllowedCalls        int
 	isBypassActiveCalls       int
 }
 
@@ -279,6 +280,11 @@ func (m *mockConfigurableSecurityManager) ReadLine(ctx context.Context) (string,
 
 func (m *mockConfigurableSecurityManager) IsCommandAllowed(command string) bool {
 	m.isCommandAllowedCalls++
+	return true
+}
+
+func (m *mockConfigurableSecurityManager) IsToolAllowed(command string) bool {
+	m.isToolAllowedCalls++
 	return true
 }
 

--- a/internal/infrastructure/security/manager.go
+++ b/internal/infrastructure/security/manager.go
@@ -105,6 +105,11 @@ func (sm *SecurityManager) IsCommandAllowed(command string) bool {
 	return sm.domainPolicy.IsCommandAllowed(command)
 }
 
+// IsToolAllowed checks if a tool name is allowed for dispatch (exact or allowed-prefix).
+func (sm *SecurityManager) IsToolAllowed(name string) bool {
+	return sm.domainPolicy.IsToolAllowed(name)
+}
+
 // TerminalLock locks the terminal.
 func (sm *SecurityManager) TerminalLock() {
 	sm.interaction.TerminalLock()

--- a/internal/infrastructure/security/manager_test.go
+++ b/internal/infrastructure/security/manager_test.go
@@ -53,6 +53,37 @@ func TestSecurityManager_IsCommandAllowed(t *testing.T) {
 	}
 }
 
+func TestSecurityManager_IsToolAllowed(t *testing.T) {
+	t.Parallel()
+	sm := NewSecurityManager(nil)
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"mcp_github_list_issues", true},
+		{"mcp_github_run_secret_scanning", true},
+		{"read_files", true},
+		{"unknown_tool", false},
+		{"mcp", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := sm.IsToolAllowed(tt.name); got != tt.want {
+				t.Errorf("IsToolAllowed(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+
+	// Exact-gate pin: IsCommandAllowed must remain exact-match and must NOT
+	// inherit the mcp_ prefix allowance granted by IsToolAllowed.
+	if sm.IsCommandAllowed("mcp_github_list_issues") {
+		t.Error("IsCommandAllowed must remain exact-match (no prefix allowance)")
+	}
+}
+
 func assertAuthorization(t *testing.T, name string, ok bool, err error, expectedOk bool) {
 	t.Helper()
 	if (err != nil) || (ok != expectedOk) {

--- a/internal/tools/analysis/analysistest/mock_security.go
+++ b/internal/tools/analysis/analysistest/mock_security.go
@@ -57,8 +57,9 @@ func (m *MockSecurityProvider) IsBypassActive() bool {
 func (m *MockSecurityProvider) IsCommandAllowed(command string) bool {
 	return true
 }
-func (m *MockSecurityProvider) Prompt(message string) {}
-func (m *MockSecurityProvider) Warn(message string)   {}
+func (m *MockSecurityProvider) IsToolAllowed(name string) bool { return true }
+func (m *MockSecurityProvider) Prompt(message string)          {}
+func (m *MockSecurityProvider) Warn(message string)            {}
 func (m *MockSecurityProvider) LogAudit(action string, args ...any) {
 }
 func (m *MockSecurityProvider) Authorize(ctx context.Context, label, detail, reason string, isSafe bool) (bool, error) {

--- a/internal/tools/analysis/common_test.go
+++ b/internal/tools/analysis/common_test.go
@@ -133,6 +133,7 @@ type mockSecurityProvider struct{}
 func (s *mockSecurityProvider) IsPathSafe(path string) (string, error)     { return path, nil }
 func (s *mockSecurityProvider) IsPathWritable(path string) (string, error) { return path, nil }
 func (s *mockSecurityProvider) IsCommandAllowed(command string) bool       { return true }
+func (s *mockSecurityProvider) IsToolAllowed(command string) bool          { return true }
 func (s *mockSecurityProvider) IsBypassActive() bool                       { return false }
 
 type mockExecutor struct {

--- a/internal/tools/integrations/fault_injection_test.go
+++ b/internal/tools/integrations/fault_injection_test.go
@@ -44,6 +44,7 @@ func (m *mockSecurityManager) Confirm(ctx context.Context, message string) (bool
 }
 func (m *mockSecurityManager) ReadLine(ctx context.Context) (string, error) { return "", nil }
 func (m *mockSecurityManager) IsCommandAllowed(command string) bool         { return true }
+func (m *mockSecurityManager) IsToolAllowed(command string) bool            { return true }
 func (m *mockSecurityManager) IsBypassActive() bool                         { return false }
 func (m *mockSecurityManager) Close() error                                 { return nil }
 

--- a/internal/tools/toolstest/mock_security_manager.go
+++ b/internal/tools/toolstest/mock_security_manager.go
@@ -70,6 +70,16 @@ func (m *MockSecurityManager) IsCommandAllowed(command string) bool {
 	return false
 }
 
+func (m *MockSecurityManager) IsToolAllowed(name string) bool {
+	if m.AllowAll || m.BypassActive {
+		return true
+	}
+	if m.AllowedCommands != nil {
+		return m.AllowedCommands[name]
+	}
+	return false
+}
+
 func (m *MockSecurityManager) IsBypassActive() bool {
 	return m.BypassActive
 }

--- a/internal/ui/common_test.go
+++ b/internal/ui/common_test.go
@@ -79,6 +79,7 @@ func (m *mockLocker) IsPathSafe(path string) (string, error)     { return path, 
 func (m *mockLocker) IsPathWritable(path string) (string, error) { return path, nil }
 func (m *mockLocker) IsBypassActive() bool                       { return false }
 func (m *mockLocker) IsCommandAllowed(command string) bool       { return true }
+func (m *mockLocker) IsToolAllowed(command string) bool          { return true }
 func (m *mockLocker) Prompt(message string)                      {}
 func (m *mockLocker) Warn(message string)                        {}
 func (m *mockLocker) ReadLine(ctx context.Context) (string, error) {


### PR DESCRIPTION
## Summary

MCP-discovered tools (`mcp_<server>_<tool>`, e.g. `mcp_github_list_issues`) are dynamically registered by the MCP client (ADR-067 §5) but were **denied by the tool authorizer** — `domain.Policy.AllowedCommands` is an exact-match whitelist with no knowledge of dynamic namespaces, so every MCP tool call failed fail-closed with "Action blocked by the system sandbox security policy". This PR adds a narrow, documented **`mcp_` prefix allowance** to the security whitelist so MCP tools are authorizable, while keeping the shell command gate strictly exact-match.

## Changes

| File | Change |
|---|---|
| `internal/domain/security/policy.go` | New `Policy.AllowedCommandPrefixes []string` (default `["mcp_"]`) and `Policy.IsToolAllowed(name)` = exact allowlist match **OR** prefix match; `IsCommandAllowed` remains exact-match (unchanged) |
| `internal/domain/security/policy_test.go` | `TestPolicy_IsToolAllowed` (10 cases: exact, `mcp_` allowed, case-sensitivity, fail-closed); `TestDefaultPolicy` prefix pin; `mcp_prefix_not_exact` regression row on `IsCommandAllowed` |
| `internal/domain/security/interfaces.go` | `PolicyEvaluator` gains `IsToolAllowed(name string) bool` |
| `internal/infrastructure/security/manager.go` | `SecurityManager.IsToolAllowed` delegating to the domain policy |
| `internal/agent/executor/authorizer.go` | `Authorize` checks `sm.IsToolAllowed(call.Name)` instead of `IsCommandAllowed`; error message unchanged |
| `internal/agent/executor/authorizer_test.go` + `mocks_test.go` | `TestAuthorize_AllowsMCPTool` / `TestAuthorize_DeniesUnknownNonMCPTool`; `mockSecurityManager` honors `AllowAll` → exact → prefix (mirrors `IsCommandAllowed` fidelity) |
| `internal/infrastructure/security/manager_test.go` | `TestSecurityManager_IsToolAllowed` + exact-gate pin (`IsCommandAllowed("mcp_…")` is still false) |
| Test-double additions (`agenttest`, `analysistest`, `toolstest`, `engine_test`, `container_test`, `common_test` ×2, `fault_injection_test`) | `IsToolAllowed` on every `Manager`/`PolicyEvaluator` implementor (compile-driven, mirroring each mock's existing behavior) |
| `docs/adr/2026-08-mcp-client-architecture.md` | ADR-067 **§11 amendment (2026-10)** — `mcp_` prefix allowance: decision, implementation (live symbols), consent unchanged (per-tool `RequiresConsent`; readonly servers dispatch without prompting — recorded posture consequence), security rationale, accepted trade-off |

## Design decisions

- **Two distinct gates:** `IsCommandAllowed` (exact, used by shell command validation via `SafetyService.IsCommandSafe` → `command_validator.go`) stays byte-identical; `IsToolAllowed` (exact-or-prefix) is used only by the tool authorizer. A naive prefix on the shared gate would have silently weakened the shell gate from deny to prompt for any `mcp_*` binary — avoided.
- **Consent untouched:** `AutoApprovableCommands` unchanged; consent remains per-tool via `RequiresConsent` (ADR-067 §8). `mcp_github_*` readonly tools dispatch without prompting (documented in the ADR); non-readonly servers still prompt.
- **Security rationale (ADR-067 §11.4):** the `mcp_` prefix is a reserved namespace produced only by `FormatToolName`; built-in tool names never start with `mcp_`; matching is case-sensitive; every other name remains fail-closed.

## Verification

| Check | Status |
|---|---|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, verify-transitive-gate, verify-nonfix-catalog, verify-ports-registry, verify-* convention gates, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, **test-race**) | **PASS** |
| `go test ./internal/agent/executor/ ./internal/infrastructure/security/... ./internal/domain/security/...` | PASS |
| `make verify-adr-index` | PASS |
| `go vet` + race on touched packages | PASS |

## Technical debt (recorded for a future PR — not this one)

1. **`verify-architecture` includes test-file imports:** `internal/tools/analysis/index.go` loads packages with `Tests: true`; the synthesized `[pkg.test]` variant's `PkgPath` equals the base package, so `collectTrackedImports` overwrites the base entry and `_test.go` imports leak into the tracked graph. This blocked an app-layer composition test (`internal/agent/executor` → `internal/infrastructure/security`) that was therefore dropped (its links are covered individually: real manager↔real policy in `TestSecurityManager_IsToolAllowed`; authorizer wiring in the mock-based authorizer tests). A future gate-hardening PR should exclude test-file imports explicitly, mirroring the `_test.go` exemptions in `verify-tools-toolchain-import` / `verify-tools-infrastructure-import`.
2. **`tests/integration/agent/executor` harness uses the permissive `toolstest.MockSecurityManager`** — its "Action blocked" rows do not exercise the real security chain. Any future end-to-end security proof must construct `security.NewSecurityManager` in a package whose imports cannot trip the arch gate.
