### PR TITLE
fix(persistence): make SQLite DSN pragmas real and retry SQLITE_BUSY during first-time init (#1383)

### DIFF
--- a/internal/infrastructure/persistence/sqlite_db.go
+++ b/internal/infrastructure/persistence/sqlite_db.go
@@ -75,8 +75,9 @@ func initSQLiteDB(ctx context.Context, dbPath string) (*sql.DB, error) {
 		return nil, fmt.Errorf("failed to open sqlite db: %w", err)
 	}
 
-	// Run schema migrations
-	if err := createTables(ctx, db); err != nil {
+	// Run schema migrations (single retry layer for SQLITE_BUSY; createTables
+	// itself stays pure so attempt counts are unambiguous at this call site).
+	if err := withBusyRetry(ctx, func() error { return createTables(ctx, db) }, createTablesAttempts); err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to create tables: %w", err)
 	}

--- a/internal/infrastructure/persistence/sqlite_db.go
+++ b/internal/infrastructure/persistence/sqlite_db.go
@@ -23,7 +23,7 @@ var sqlOpenFn = sql.Open
 
 // initSQLiteDB opens the SQLite database and runs migrations.
 func initSQLiteDB(ctx context.Context, dbPath string) (*sql.DB, error) {
-	db, err := sqlOpenFn("sqlite", dbPath+"?_journal_mode=WAL&_busy_timeout=5000")
+	db, err := sqlOpenFn("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")
 	if err != nil {
 		return nil, fmt.Errorf("failed to open sqlite db: %w", err)
 	}

--- a/internal/infrastructure/persistence/sqlite_db.go
+++ b/internal/infrastructure/persistence/sqlite_db.go
@@ -31,6 +31,43 @@ func isBusyErr(err error) bool {
 	return errors.As(err, &se) && se.Code() == sqliteBusyCode
 }
 
+// createTablesAttempts bounds SQLITE_BUSY retries for schema creation
+// (CREATE TABLE IF NOT EXISTS transactions are sub-ms).
+const createTablesAttempts = 2
+
+// migrateAttempts bounds SQLITE_BUSY retries for legacy migration; the
+// migrate write lock scales with the legacy file (a 100k+ row tasks.json
+// holds the lock well over 10 s), so the third attempt converts the
+// 10-15 s-hold contention window from failure to success.
+const migrateAttempts = 3
+
+// withBusyRetry runs fn, retrying only when fn returns SQLITE_BUSY, with
+// exponential backoff (50/100/200 ms base schedule), honoring ctx
+// cancellation during backoff. Non-busy errors fail immediately with the
+// error chain unchanged. Exhaustion returns the last real (busy) error.
+func withBusyRetry(ctx context.Context, fn func() error, attempts int) error {
+	var lastErr error
+	for i := 0; i < attempts; i++ {
+		if err := fn(); err != nil {
+			if !isBusyErr(err) {
+				return err // fail-fast: non-busy, no backoff
+			}
+			lastErr = err
+			if i < attempts-1 {
+				delay := time.Duration(50<<i) * time.Millisecond // 50, 100, 200...
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(delay):
+				}
+			}
+			continue
+		}
+		return nil
+	}
+	return lastErr // exhaustion: last real error
+}
+
 // initSQLiteDB opens the SQLite database and runs migrations.
 func initSQLiteDB(ctx context.Context, dbPath string) (*sql.DB, error) {
 	db, err := sqlOpenFn("sqlite", dbPath+"?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)")

--- a/internal/infrastructure/persistence/sqlite_db.go
+++ b/internal/infrastructure/persistence/sqlite_db.go
@@ -14,12 +14,22 @@ import (
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
-	_ "modernc.org/sqlite"
+	sqlite "modernc.org/sqlite"
 )
 
 // sqlOpenFn is a package-level variable for sql.Open, allowing tests to inject
 // failures into the database-open path without modifying the global driver registry.
 var sqlOpenFn = sql.Open
+
+// sqliteBusyCode is the SQLITE_BUSY result code (database is locked).
+const sqliteBusyCode = 5
+
+// isBusyErr reports whether err is a SQLITE_BUSY error, using typed
+// detection (errors.As + result code) rather than string matching.
+func isBusyErr(err error) bool {
+	var se *sqlite.Error
+	return errors.As(err, &se) && se.Code() == sqliteBusyCode
+}
 
 // initSQLiteDB opens the SQLite database and runs migrations.
 func initSQLiteDB(ctx context.Context, dbPath string) (*sql.DB, error) {

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -240,6 +240,26 @@ func TestInitSQLiteDB_PragmaFailure(t *testing.T) {
 	}
 }
 
+// TestInitSQLiteDB_Pragmas is the regression test for the DSN pragma fix
+// (issue #1383): the _pragma= DSN parameters must be applied to every
+// connection. This test fails against the old inert DSN
+// (?_journal_mode=WAL&_busy_timeout=5000), which modernc.org/sqlite strips.
+func TestInitSQLiteDB_Pragmas(t *testing.T) {
+	t.Parallel()
+
+	db, err := initSQLiteDB(context.Background(), filepath.Join(t.TempDir(), "pragmas.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var journalMode string
+	require.NoError(t, db.QueryRowContext(context.Background(), "PRAGMA journal_mode").Scan(&journalMode))
+	assert.Equal(t, "wal", journalMode)
+
+	var busyTimeout int
+	require.NoError(t, db.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busyTimeout))
+	assert.GreaterOrEqual(t, busyTimeout, 5000)
+}
+
 func TestCreateTables_SecondQueryFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -1150,4 +1151,245 @@ func TestCreateTables_PersistentBusyBounded(t *testing.T) {
 	require.True(t, errors.As(err, &se), "exhaustion must return the real busy error, got: %v", err)
 	assert.Equal(t, sqliteBusyCode, se.Code())
 	assert.Contains(t, err.Error(), "executing schema query")
+}
+
+// =============================================================================
+// Task 6 (issue #1383): deterministic migrateFromJSON SQLITE_BUSY retry +
+// convergence tests. Real-busy via the T5 holdBusyLock harness (RESERVED lock
+// from BEGIN IMMEDIATE), release→ack handshake inside the retried fn —
+// zero time.Sleep, zero timing assertions (ADR-036). queryLoggingConnector
+// pins the exact query sequence for the winner-commits convergence proof.
+// =============================================================================
+
+// writeNTasks writes a valid N-task JSON file (IDs 1..N, distinct content,
+// RFC3339 created_at) via fs — the shared seeder for the migrate busy tests.
+func writeNTasks(t *testing.T, ctx context.Context, fs persistence.FileSystem, tasksPath string, n int) {
+	t.Helper()
+
+	tasksJSON := "["
+	for i := 1; i <= n; i++ {
+		if i > 1 {
+			tasksJSON += ","
+		}
+		tasksJSON += fmt.Sprintf(`{"id": %d, "content": "Migrated Task %d", "status": "pending", "created_at": "2025-01-01T00:00:00Z"}`, i, i)
+	}
+	tasksJSON += "]"
+
+	if err := fs.WriteFile(ctx, tasksPath, []byte(tasksJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// queryLoggingConnector wraps a raw sqlite connection and appends every
+// ExecContext/QueryContext SQL string to a mutex-guarded log, so tests can
+// pin the exact query sequence (ADR-036 race-safety: database/sql pool
+// goroutines append concurrently).
+type queryLoggingConnector struct {
+	dbPath string
+	log    *[]string
+	logMu  *sync.Mutex
+}
+
+func (c *queryLoggingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	realConn, err := sqliteDriver.Open(c.dbPath)
+	if err != nil {
+		return nil, err
+	}
+	return &queryLoggingConn{conn: realConn, log: c.log, logMu: c.logMu}, nil
+}
+
+func (c *queryLoggingConnector) Driver() driver.Driver { return sqliteDriver }
+
+type queryLoggingConn struct {
+	conn  driver.Conn
+	log   *[]string
+	logMu *sync.Mutex
+}
+
+func (c *queryLoggingConn) logQuery(query string) {
+	c.logMu.Lock()
+	defer c.logMu.Unlock()
+	*c.log = append(*c.log, query)
+}
+
+func (c *queryLoggingConn) Prepare(query string) (driver.Stmt, error) { return c.conn.Prepare(query) }
+func (c *queryLoggingConn) Close() error                              { return c.conn.Close() }
+func (c *queryLoggingConn) Begin() (driver.Tx, error) {
+	return c.BeginTx(context.Background(), driver.TxOptions{})
+}
+
+func (c *queryLoggingConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	if bc, ok := c.conn.(driver.ConnBeginTx); ok {
+		return bc.BeginTx(ctx, opts)
+	}
+	return c.conn.Begin() //nolint:staticcheck // SA1019: fallback for older drivers
+}
+
+func (c *queryLoggingConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.logQuery(query)
+	if qc, ok := c.conn.(driver.QueryerContext); ok {
+		return qc.QueryContext(ctx, query, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+func (c *queryLoggingConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.logQuery(query)
+	if ec, ok := c.conn.(driver.ExecerContext); ok {
+		return ec.ExecContext(ctx, query, args)
+	}
+	return nil, driver.ErrSkip
+}
+
+// TestMigrateFromJSON_RetriesOnRealBusy proves migrateFromJSON retries on a
+// genuine SQLITE_BUSY at the batch INSERT (the COUNT read passes the RESERVED
+// lock; only the write contends). Attempt 1 releases the lock inside the
+// retried fn (T5 release→ack pattern); attempt 2 migrates fully; final
+// COUNT == N proves single-transaction atomicity + INSERT OR REPLACE
+// idempotency made the retry safe.
+func TestMigrateFromJSON_RetriesOnRealBusy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	tasksPath := filepath.Join(dir, "tasks.json")
+	dbPath := filepath.Join(dir, "test.db")
+	fs := NewOSFileSystem()
+	writeNTasks(t, ctx, fs, tasksPath, 5)
+
+	// SUT connection: bare path → busy_timeout 0 → immediate genuine busy.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	// Create the tasks table BEFORE taking the lock: a held RESERVED lock
+	// busy-fails the CREATE TABLE (write), which would break the premise
+	// that only the batch INSERT contends.
+	require.NoError(t, createTables(ctx, db))
+
+	release := holdBusyLock(t, dbPath)
+
+	var attempts atomic.Int32
+	err = withBusyRetry(ctx, func() error {
+		n := attempts.Add(1)
+		err := migrateFromJSON(ctx, db, fs, tasksPath, slog.Default())
+		if n == 1 && isBusyErr(err) {
+			release() // release→ack inside the retried fn (T5 pattern)
+		}
+		return err
+	}, migrateAttempts)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), attempts.Load(), "transient busy must succeed on attempt 2")
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM tasks").Scan(&count))
+	assert.Equal(t, 5, count)
+}
+
+// TestMigrateFromJSON_PersistentBusyBounded proves the retry budget is
+// honored with a persistent (never-released) lock: exactly migrateAttempts
+// (3) invocations, and the exhaustion error is the last real busy error
+// (code 5 via errors.As) wrapped through both migrateFromJSON layers.
+func TestMigrateFromJSON_PersistentBusyBounded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	tasksPath := filepath.Join(dir, "tasks.json")
+	dbPath := filepath.Join(dir, "test.db")
+	fs := NewOSFileSystem()
+	writeNTasks(t, ctx, fs, tasksPath, 5)
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	require.NoError(t, createTables(ctx, db))
+
+	_ = holdBusyLock(t, dbPath) // never released
+
+	var attempts atomic.Int32
+	err = withBusyRetry(ctx, func() error {
+		attempts.Add(1)
+		return migrateFromJSON(ctx, db, fs, tasksPath, slog.Default())
+	}, migrateAttempts)
+
+	require.Error(t, err)
+	assert.Equal(t, int32(3), attempts.Load(), "persistent busy must exhaust exactly migrateAttempts (3)")
+
+	var se *sqlite.Error
+	require.True(t, errors.As(err, &se), "exhaustion must return the real busy error, got: %v", err)
+	assert.Equal(t, sqliteBusyCode, se.Code())
+	assert.Contains(t, err.Error(), "migrating legacy tasks from")
+	assert.Contains(t, err.Error(), "bulk inserting legacy tasks")
+}
+
+// TestMigrateFromJSON_WinnerCommitsBetweenAttempts pins the convergence
+// behavior: B's attempt 1 hits genuine busy at the INSERT; the lock is
+// released and a third bare-path connection C migrates + commits all N rows
+// while B is between attempts (migrateFromJSON returns only after COMMIT, so
+// attempt 2 deterministically sees COUNT == N). Attempt 2 takes the
+// fast-path skip (count > 0 → nil), so the query log is exactly
+// [COUNT, INSERT(busy)] → [COUNT] with zero ExecContexts on attempt 2.
+func TestMigrateFromJSON_WinnerCommitsBetweenAttempts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	tasksPath := filepath.Join(dir, "tasks.json")
+	dbPath := filepath.Join(dir, "test.db")
+	fs := NewOSFileSystem()
+	writeNTasks(t, ctx, fs, tasksPath, 5)
+
+	var log []string
+	var logMu sync.Mutex
+	db := sql.OpenDB(&queryLoggingConnector{dbPath: dbPath, log: &log, logMu: &logMu})
+	t.Cleanup(func() { _ = db.Close() })
+
+	// Create the tasks table on the SUT connection BEFORE taking the lock
+	// (a held RESERVED lock would busy-fail the CREATE TABLE). The two
+	// CREATE TABLE ExecContexts land in the query log, so reset the log
+	// before the migrate attempts — the pin below must see exactly
+	// [COUNT, INSERT(busy)] → [COUNT].
+	require.NoError(t, createTables(ctx, db))
+	logMu.Lock()
+	log = log[:0]
+	logMu.Unlock()
+
+	release := holdBusyLock(t, dbPath)
+
+	var attempts atomic.Int32
+	err := withBusyRetry(ctx, func() error {
+		n := attempts.Add(1)
+		err := migrateFromJSON(ctx, db, fs, tasksPath, slog.Default())
+		if n == 1 && isBusyErr(err) {
+			release()
+			// Winner: a third bare-path connection migrates and commits N rows
+			// while B is between attempts; migrateFromJSON returns only after
+			// COMMIT completes, so attempt 2 deterministically sees COUNT == N.
+			dbC, cerr := sql.Open("sqlite", dbPath)
+			require.NoError(t, cerr)
+			cerr = migrateFromJSON(ctx, dbC, fs, tasksPath, slog.Default())
+			require.NoError(t, cerr)
+			require.NoError(t, dbC.Close())
+		}
+		return err
+	}, migrateAttempts)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), attempts.Load())
+
+	// Query-log pin: [COUNT, INSERT(busy)] -> [COUNT]; zero INSERTs on attempt 2.
+	// NOTE: explicit Unlock (not defer) — the convergence COUNT below
+	// re-enters the logging connector and would self-deadlock on a held logMu.
+	logMu.Lock()
+	require.Len(t, log, 3, "log = %v", log)
+	assert.Equal(t, "SELECT COUNT(*) FROM tasks", log[0])
+	assert.Contains(t, log[1], "INSERT OR REPLACE INTO tasks")
+	assert.Equal(t, "SELECT COUNT(*) FROM tasks", log[2])
+	logMu.Unlock()
+
+	// Convergence: exactly N rows, committed by the winner, observed by B's skip.
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM tasks").Scan(&count))
+	assert.Equal(t, 5, count)
 }

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"modernc.org/sqlite"
 )
 
 func TestSQLiteMigrations(t *testing.T) {
@@ -258,6 +259,73 @@ func TestInitSQLiteDB_Pragmas(t *testing.T) {
 	var busyTimeout int
 	require.NoError(t, db.QueryRowContext(context.Background(), "PRAGMA busy_timeout").Scan(&busyTimeout))
 	assert.GreaterOrEqual(t, busyTimeout, 5000)
+}
+
+// TestIsBusyErr_RealBusy verifies the true branch of isBusyErr with a genuine
+// driver SQLITE_BUSY error — no mocks, no string fixtures. A raw driver
+// connection holds the RESERVED lock (BEGIN IMMEDIATE) while a database/sql
+// handle with busy_timeout 0 (bare-path DSN) attempts a write; the driver
+// returns a real *sqlite.Error with result code 5.
+func TestIsBusyErr_RealBusy(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "busy.db")
+
+	// Lock holder: raw driver connection (bare path, busy_timeout 0).
+	lockConn, err := sqliteDriver.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lockConn.Close() })
+
+	// BEGIN IMMEDIATE acquires the RESERVED lock immediately. (A driver.Tx
+	// from Begin() is deferred and takes no lock — ExecContext is required.)
+	_, err = lockConn.(driver.ExecerContext).ExecContext(context.Background(), "BEGIN IMMEDIATE", nil)
+	require.NoError(t, err)
+
+	// SUT connection: bare path → busy_timeout 0 → immediate SQLITE_BUSY.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER)")
+	require.Error(t, err)
+	assert.True(t, isBusyErr(err), "expected SQLITE_BUSY, got: %v", err)
+}
+
+// TestIsBusyErr_NonBusy verifies the false branch of isBusyErr with two
+// genuine non-busy driver errors: a READONLY (code 8) error and a plain
+// closed-DB error.
+func TestIsBusyErr_NonBusy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("readonly code 8", func(t *testing.T) {
+		t.Parallel()
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "ro.db"))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		_, err = db.Exec("PRAGMA query_only = 1")
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER)")
+		require.Error(t, err)
+		assert.False(t, isBusyErr(err))
+		// Sanity: it really is a READONLY (code 8) error, not something else.
+		var se *sqlite.Error
+		if errors.As(err, &se) {
+			assert.Equal(t, 8, se.Code())
+		}
+	})
+
+	t.Run("closed db", func(t *testing.T) {
+		t.Parallel()
+		db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "closed.db"))
+		require.NoError(t, err)
+		_ = db.Close() // closed before any query → non-busy driver error
+
+		_, err = db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER)")
+		require.Error(t, err)
+		assert.False(t, isBusyErr(err))
+	})
 }
 
 func TestCreateTables_SecondQueryFailure(t *testing.T) {

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/persistence"
@@ -975,4 +976,76 @@ func TestMigrateTasks_RollbackWarning(t *testing.T) {
 			}
 		})
 	}
+}
+
+// =============================================================================
+// Task 3 (issue #1383): withBusyRetry — bounded, ctx-honoring, fail-fast
+// backoff for SQLITE_BUSY. Both tests are fully deterministic per ADR-036:
+// no time.Sleep, no timing assertions. Cancellation and fail-fast are proven
+// structurally (by ctx state and invocation count), never by waiting.
+// =============================================================================
+
+// TestWithBusyRetry_NonBusyFailsFast verifies that a non-busy error (READONLY,
+// code 8) fails immediately: fn is invoked exactly once and the error chain is
+// returned unchanged (code 8 detectable via errors.As).
+func TestWithBusyRetry_NonBusyFailsFast(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "ff.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec("PRAGMA query_only = 1")
+	require.NoError(t, err)
+
+	var calls atomic.Int32
+	err = withBusyRetry(context.Background(), func() error {
+		calls.Add(1)
+		_, e := db.ExecContext(context.Background(), "CREATE TABLE t (id INTEGER)")
+		return e
+	}, 3)
+
+	require.Error(t, err)
+	assert.Equal(t, int32(1), calls.Load(), "non-busy error must fail fast: fn invoked exactly once")
+	var se *sqlite.Error
+	if errors.As(err, &se) {
+		assert.Equal(t, 8, se.Code(), "error chain must be unchanged (READONLY)")
+	}
+}
+
+// TestCreateTables_BusyCancellation verifies that cancellation during backoff
+// surfaces as ctx.Err() and fn is never retried. Deterministic by ctx state:
+// the fn itself cancels the ctx on the first (busy) invocation, so
+// withBusyRetry's backoff select sees an already-closed ctx.Done().
+func TestCreateTables_BusyCancellation(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "cancel.db")
+
+	// Lock holder (bare path → busy_timeout 0 → immediate genuine busy).
+	lockConn, err := sqliteDriver.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lockConn.Close() })
+	_, err = lockConn.(driver.ExecerContext).ExecContext(context.Background(), "BEGIN IMMEDIATE", nil)
+	require.NoError(t, err)
+
+	// SUT connection: bare path, no busy_timeout.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var calls atomic.Int32
+	err = withBusyRetry(ctx, func() error {
+		if calls.Add(1) == 1 {
+			cancel() // cancel during backoff: deterministic by ctx state
+		}
+		return createTables(ctx, db)
+	}, 3)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled), "cancellation must surface as ctx.Err(), got: %v", err)
+	assert.Equal(t, int32(1), calls.Load(), "fn must not be retried after cancellation")
 }

--- a/internal/infrastructure/persistence/sqlite_db_test.go
+++ b/internal/infrastructure/persistence/sqlite_db_test.go
@@ -1049,3 +1049,105 @@ func TestCreateTables_BusyCancellation(t *testing.T) {
 	assert.True(t, errors.Is(err, context.Canceled), "cancellation must surface as ctx.Err(), got: %v", err)
 	assert.Equal(t, int32(1), calls.Load(), "fn must not be retried after cancellation")
 }
+
+// =============================================================================
+// Task 5 (issue #1383): deterministic createTables SQLITE_BUSY retry tests
+// with a real-busy lock harness. The release→ack handshake (ROLLBACK's
+// ExecContext return is the ack) sequences the release before the next
+// attempt with no timing window — zero time.Sleep, zero timing assertions,
+// zero require.Eventually (ADR-036 determinism).
+// =============================================================================
+
+// holdBusyLock acquires a real SQLITE_BUSY lock on dbPath via a raw driver
+// connection (bare path → busy_timeout 0 → contended statements fail
+// immediately with a genuine *sqlite.Error{code:5}). The returned release
+// func executes ROLLBACK synchronously: the lock is guaranteed released when
+// release returns (ExecContext's return is the ack), so a caller can sequence
+// the release before withBusyRetry's next attempt with no timing window.
+func holdBusyLock(t *testing.T, dbPath string) (release func()) {
+	t.Helper()
+
+	conn, err := sqliteDriver.Open(dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ec, ok := conn.(driver.ExecerContext)
+	require.True(t, ok, "raw sqlite conn must implement driver.ExecerContext")
+	if _, err := ec.ExecContext(context.Background(), "BEGIN IMMEDIATE", nil); err != nil {
+		t.Fatalf("BEGIN IMMEDIATE failed: %v", err)
+	}
+
+	return func() {
+		if _, err := ec.ExecContext(context.Background(), "ROLLBACK", nil); err != nil {
+			t.Fatalf("release (ROLLBACK) failed: %v", err)
+		}
+	}
+}
+
+// TestCreateTables_RetriesOnRealBusy proves the retry behavior end-to-end at
+// the withBusyRetry + createTables level: attempt 1 hits a genuine SQLITE_BUSY
+// (real RESERVED lock held by holdBusyLock), the release→ack handshake fires
+// INSIDE the retried fn, and attempt 2 succeeds. Attempt counter == 2 proves
+// the retry fired exactly once.
+func TestCreateTables_RetriesOnRealBusy(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "retry.db")
+	release := holdBusyLock(t, dbPath)
+
+	// SUT connection: bare path → busy_timeout 0 → immediate genuine busy.
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var attempts atomic.Int32
+	err = withBusyRetry(context.Background(), func() error {
+		n := attempts.Add(1)
+		err := createTables(context.Background(), db)
+		// Release→ack handshake INSIDE the retried fn: the lock is released
+		// (and the release acked by ExecContext's return) before the busy
+		// error is handed to withBusyRetry, so the 50 ms backoff can never
+		// race the release.
+		if n == 1 && isBusyErr(err) {
+			release()
+		}
+		return err
+	}, createTablesAttempts)
+
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), attempts.Load(), "transient busy must succeed on attempt 2")
+
+	// Tables exist.
+	var n int
+	require.NoError(t, db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM tasks").Scan(&n))
+	require.NoError(t, db.QueryRowContext(context.Background(), "SELECT COUNT(*) FROM settings").Scan(&n))
+}
+
+// TestCreateTables_PersistentBusyBounded proves the retry budget is honored
+// with a persistent (never-released) lock: exactly createTablesAttempts (2)
+// invocations, and the returned error is the last real busy error (code 5 via
+// errors.As, wrap string intact).
+func TestCreateTables_PersistentBusyBounded(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "persist.db")
+	_ = holdBusyLock(t, dbPath) // never released
+
+	db, err := sql.Open("sqlite", dbPath)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	var attempts atomic.Int32
+	err = withBusyRetry(context.Background(), func() error {
+		attempts.Add(1)
+		return createTables(context.Background(), db)
+	}, createTablesAttempts)
+
+	require.Error(t, err)
+	assert.Equal(t, int32(2), attempts.Load(), "persistent busy must exhaust exactly createTablesAttempts (2)")
+
+	var se *sqlite.Error
+	require.True(t, errors.As(err, &se), "exhaustion must return the real busy error, got: %v", err)
+	assert.Equal(t, sqliteBusyCode, se.Code())
+	assert.Contains(t, err.Error(), "executing schema query")
+}

--- a/internal/infrastructure/persistence/sqlite_store_test.go
+++ b/internal/infrastructure/persistence/sqlite_store_test.go
@@ -19,12 +19,14 @@ import (
 
 func setupSQLite(t *testing.T) *sql.DB {
 	t.Helper()
-	// Mirror the production initSQLiteDB DSN parameters (WAL journal mode
-	// and busy_timeout) so that tests exercise the same connection behavior.
-	// While in-memory databases are single-connection and don't benefit from
-	// WAL, this keeps the pattern consistent and prevents accidental
-	// regressions if future tests switch to file-backed databases.
-	db, err := sql.Open("sqlite", ":memory:?_journal_mode=WAL&_busy_timeout=5000")
+	// Mirror the production initSQLiteDB DSN parameters so that tests
+	// exercise the same connection behavior. Only busy_timeout is mirrored:
+	// journal_mode(WAL) is a silent no-op on in-memory databases — the
+	// journal mode is fixed at "memory"; the pragma succeeds and returns
+	// "memory". Therefore only the _pragma=busy_timeout(5000) parameter is
+	// included. If a future test moves to a file-backed database, the
+	// _pragma=journal_mode(WAL) parameter must be added back.
+	db, err := sql.Open("sqlite", ":memory:?_pragma=busy_timeout(5000)")
 	if err != nil {
 		t.Fatalf("Failed to open test database: %v", err)
 	}

--- a/internal/infrastructure/persistence/state.go
+++ b/internal/infrastructure/persistence/state.go
@@ -234,8 +234,10 @@ func initRepositories(ctx context.Context, configDir, storageType string) (ports
 		return nil, nil, nil, nil, err
 	}
 
-	// Perform migration if needed
-	err = migrateFromJSON(ctx, db, fs, tasksPath, slog.Default())
+	// Perform migration if needed (single retry layer for SQLITE_BUSY;
+	// migrateFromJSON stays pure. migrateAttempts=3 because the migrate
+	// write lock scales with the legacy file size).
+	err = withBusyRetry(ctx, func() error { return migrateFromJSON(ctx, db, fs, tasksPath, slog.Default()) }, migrateAttempts)
 	if err != nil {
 		_ = db.Close()
 		return nil, nil, nil, nil, err

--- a/internal/infrastructure/persistence/state_test.go
+++ b/internal/infrastructure/persistence/state_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -540,4 +541,63 @@ func TestSessionState_Close_WALCheckpointError(t *testing.T) {
 	// the WAL checkpoint failure being logged.
 
 	assert.Contains(t, buf.String(), "WAL checkpoint on close failed")
+}
+
+// TestNewSessionState_ConcurrentFirstTimeInit is a race smoke for the
+// acceptance-criterion-2 scenario (issue #1383): 8 goroutines concurrently
+// first-time-initialize session state in one fresh directory. The interleaving
+// is nondeterministic; the outcome is not — every init must succeed, the
+// tables must exist, and the migrated row count must be exactly N. This is a
+// smoke test, not a mechanism pin: it documents the convergent behavior that
+// the deterministic busy-retry tests (TestCreateTables_*, TestMigrateFromJSON_*)
+// pin at the unit level.
+func TestNewSessionState_ConcurrentFirstTimeInit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	fs := NewOSFileSystem()
+	const n = 3
+	writeNTasks(t, ctx, fs, filepath.Join(dir, "tasks.json"), n)
+
+	const goroutines = 8
+	var (
+		wg     sync.WaitGroup
+		errsMu sync.Mutex
+		errs   []error
+	)
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			state, err := newSessionState(ctx, dir)
+			if err != nil {
+				errsMu.Lock()
+				errs = append(errs, err)
+				errsMu.Unlock()
+				return
+			}
+			// Close exercises the (now real) WAL checkpoint path too.
+			if cerr := state.Close(); cerr != nil {
+				errsMu.Lock()
+				errs = append(errs, cerr)
+				errsMu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	require.Emptyf(t, errs, "all 8 concurrent inits must succeed, got %d errors: %v", len(errs), errs)
+
+	// Postcondition: tables exist and migration converged to exactly N rows.
+	db, err := sql.Open("sqlite", filepath.Join(dir, "tellmego.db"))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	for _, table := range []string{"tasks", "settings"} {
+		var count int
+		require.NoErrorf(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+table).Scan(&count),
+			"table %s must exist and be queryable", table)
+	}
+	var taskCount int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM tasks").Scan(&taskCount))
+	assert.Equal(t, n, taskCount, "migration must converge to exactly N rows")
 }


### PR DESCRIPTION
Closes #1383 (supersedes #1382, which was closed after a 10-question grill round).

## Summary

Makes the SQLite connection configuration **real** for the first time and adds a bounded, ctx-honoring, fail-fast retry for `SQLITE_BUSY` during first-time `--new` schema creation and legacy migration (issue #1375 Problem 1).

**The core discovery:** the DSN `?_journal_mode=WAL&_busy_timeout=5000` (landed in `1edde01f`, 2026-06-20) **never applied either pragma** — `modernc.org/sqlite` v1.53.0 strips the query off non-`file:` DSNs and honors only `_pragma=` parameters. The schema path has run with no WAL and no busy timeout since then; #1375's criterion 1 was never satisfied, and contended first-init failed in ~0 s (immediate `SQLITE_BUSY`).

### Production changes (2 files, +56/−6)

- **`internal/infrastructure/persistence/sqlite_db.go`**
  - DSN fixed to `?_pragma=journal_mode(WAL)&_pragma=busy_timeout(5000)` — both pragmas now real (file-backed).
  - `sqliteBusyCode = 5`, `isBusyErr` — typed detection (`errors.As` → `*sqlite.Error`, `Code() == 5`); **no string matching** (the removed `retryOnBusy` used string matching — fragile across drivers).
  - `createTablesAttempts = 2` / `migrateAttempts = 3` (differentiated budgets: createTables transactions are sub-ms; the migrate write lock scales with the legacy file).
  - `withBusyRetry(ctx, fn, attempts)` — retries **only** on `SQLITE_BUSY`; non-busy errors fail fast on the first invocation with the chain untouched; exponential backoff (50/100/200 ms); honors `ctx` cancellation (`ctx.Err()`); exhaustion returns the last real error.
  - `initSQLiteDB` wraps `createTables` at the **call site** (2 attempts) — single retry layer, inner functions stay pure.
- **`internal/infrastructure/persistence/state.go`**
  - `initRepositories` wraps `migrateFromJSON` at the call site (3 attempts) — same single-retry-layer pattern; every wrap string preserved verbatim.
  - `NewSessionStateFromEnv` catalog pin (INTENTIONAL_NON_FIXES.md, `state.go:208-214`) re-verified unshifted per the Drift Policy; no catalog change (coordination rule not triggered).

### Test changes (3 files, +579)

Full deterministic matrix (ADR-036-clean — zero `time.Sleep`, zero timing windows, release→ack handshakes, real-busy lock orchestration):

- `TestInitSQLiteDB_Pragmas` — **regression test for the DSN fix** (fails against the old inert DSN; RED proven).
- `TestIsBusyErr_RealBusy` / `TestIsBusyErr_NonBusy` — classifier both polarities against genuine driver errors (code 5 / code 8 / closed-DB).
- `TestWithBusyRetry_NonBusyFailsFast` — fail-fast gate: single invocation, chain unchanged.
- `TestCreateTables_BusyCancellation` — `ctx.Err()` on cancellation, deterministic by ctx state.
- `holdBusyLock` harness + `TestCreateTables_RetriesOnRealBusy` / `TestCreateTables_PersistentBusyBounded` — 2/2 attempt pins, code-5 exhaustion.
- `queryLoggingConnector` + `TestMigrateFromJSON_RetriesOnRealBusy` / `TestMigrateFromJSON_PersistentBusyBounded` / `TestMigrateFromJSON_WinnerCommitsBetweenAttempts` — 2/3/2 attempt pins, `[COUNT, INSERT(busy)] → [COUNT]` query-log pin (zero INSERTs on attempt 2), `COUNT == N` convergence.
- `TestNewSessionState_ConcurrentFirstTimeInit` — 8 goroutines on one fresh dir, 100% success (acceptance-criterion-2 scenario).
- `setupSQLite` (`:memory:`) mirrors only `_pragma=busy_timeout(5000)` with a corrected comment — `journal_mode(WAL)` is a silent no-op on in-memory databases.

## Acceptance-criteria mapping

| # | Criterion | Covered by |
|---|---|---|
| 1 | DSN fixed; `:memory:` mirrors only busy_timeout + corrected comment; `TestInitSQLiteDB_Pragmas` on file-backed DB | ✅ `sqlite_db.go:26`, `sqlite_store_test.go` (`setupSQLite`), `TestInitSQLiteDB_Pragmas` |
| 2 | `withBusyRetry`: retries busy, `ctx.Err()` on cancel, fail-fast non-busy (single invocation, chain unchanged) | ✅ `TestWithBusyRetry_NonBusyFailsFast`, `TestCreateTables_BusyCancellation` |
| 3 | Retry at call sites (2/3 attempts); inner fns pure | ✅ `sqlite_db.go:80`, `state.go:240`; attempt-count pins in T5/T6 |
| 4 | Deterministic tests: real-busy orchestration + query-log pins | ✅ `TestCreateTables_*`, `TestMigrateFromJSON_*` (incl. `[COUNT, INSERT(busy)] → [COUNT]`) |
| 5 | Existing error-path tests pass unchanged (no swallowed non-busy errors) | ✅ T4 preservation proof: `TestInitSQLiteDB_ErrorPaths`, `TestMigrateFromJSON_*`, `TestMigrateTasks_*`, `state_test.go` suite — all green unchanged |
| 6 | Concurrent first-time init (8 goroutines, fresh dir) succeeds 100% | ✅ `TestNewSessionState_ConcurrentFirstTimeInit` (20/20 stability, race-clean) |
| 7 | `make test` green incl. package-by-package `test-race` | ✅ `make check-full` PASS (below) |
| 8 | PR description: operative cadence numbers + corrected #1375/#1382 premise | ✅ This section |

## Verification

| Check | Status |
|---|---|
| `make check-full` (fmt, tidy, build, lint, verify-*, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, **test-race**) | ✅ PASS — "All checks passed (including race detection)" |
| Determinism/stability | ✅ 40/40 + 40/40 + 20/20 runs, zero flakes |
| `go vet ./internal/infrastructure/persistence/` | ✅ clean |

## Operative latency numbers (per issue checkbox 8)

With `busy_timeout(5000)` finally real, the in-driver busy handler waits up to **~5 s per attempt** before `SQLITE_BUSY` surfaces; the 50/100/200 ms backoff is **test-regime-operative, cosmetic in production**. Worst case (holder never releases): createTables 2 attempts ≈ **10.05 s**, migrate 3 attempts ≈ **15.15 s**, ≈ **25.2 s combined** — success-converting patience (a holder releasing at ~12 s makes the loser succeed at ~12 s on attempt 3), interruptible at any point via ctx cancellation. Typical concurrent-init (sub-ms transactions) completes in **milliseconds**, absorbed by the busy handler alone.

**Corrected premise:** #1375's acceptance criterion 1 ("busy_timeout ≥ 5000 + WAL already satisfied") was **false** — both pragmas were silent no-ops since `1edde01f` and are only now made real by this PR. The schema-creation path ran with no mitigation at all; the retry is the >5 s-hold backstop.

## References

- Issue #1383 (this PR's issue), #1382 (superseded; grill-round comment with corrections table)
- #1375 (parent — Problem 2, subprocess timeouts, out of scope)
- Grill transcript (public gist): https://gist.github.com/gosharplite/25193c136e933c0eac4c32283dd71f9a
- Driver source verified: `modernc.org/sqlite` v1.53.0 (`conn.go` `newConn`, `sqlite.go` `applyQueryParams`, `error.go` `*sqlite.Error`)
