### PR TITLE
fix(config): redact secret-bearing values from debug diagnostics (#1393)

### DIFF
--- a/docs/adr/2026-08-mcp-client-architecture.md
+++ b/docs/adr/2026-08-mcp-client-architecture.md
@@ -88,15 +88,54 @@ cannot be resolved, rather than failing startup for the whole agent.
    is an unconditional pass-through. The warn-and-skip path
    (`mcp_token_resolution_skipped`) remains reachable only from `gh`/`auto`
    resolution failures.
-3. **Config-loader debug-dump exception (tracked follow-up #1390).** The
-   config loader's debug dumps (config.go raw-content dump and viper
-   parsed-key dump with `slog.Any`) serialize all config values — including
-   live environment secrets — when debug logging is enabled. This is
-   pre-existing, debug-gated, and MCP-unaware; it is recorded here as a
-   known exception to the `mcp-token-not-logged` scope and is **not** fixed
-   in this change. The invariant's scope is the MCP credential plumbing
-   (config validation, DI factory, client transport), which never logs or
-   serializes credentials or derived headers.
+3. **Config-loader debug dumps — RESOLVED (issue #1393).** The two
+   debug-gated dumps in `internal/infrastructure/config/config.go` — the
+   raw-content dump and the viper parsed-key dump with `slog.Any` —
+   previously serialized config values when debug logging was enabled, and
+   were recorded here (as of #1389) as a known exception to the
+   `mcp-token-not-logged` scope with a tracked follow-up (#1390). Issue
+   #1393 supersedes that framing and closes the gap. **Corrected framing:**
+   the dumps were an **exception to the scope** of `mcp-token-not-logged`
+   (whose subject is the MCP credential plumbing: config validation, DI
+   factory, client transport — verified clean), **not a violation**;
+   post-fix the loader honors the invariant's *intent* on the `MCPServer`
+   credential surface as a side effect of general diagnostics hardening
+   while remaining outside its literal plumbing scope. The invariant
+   statement and the domain model are unchanged. **Wording:** the **two
+   secret-bearing debug dumps now redact secret-bearing values**.
+
+   **Verified exposure class (issue #1393):** the dumps serialize YAML-file
+   config values — plaintext secret-bearing values when present in the file —
+   plus `${ENV_VAR}` reference literals (the reference name, never the
+   resolved value). The original #1390 claim that `AutomaticEnv`-overridden
+   live secrets reach the parsed-key dump was incorrect for the current
+   wiring: the dump runs inside `readConfigFile`, which `configureViper`
+   calls **before** `SetEnvPrefix`/`SetEnvKeyReplacer`/`AutomaticEnv`, and
+   viper's env lookup is gated on `automaticEnvApplied` (viper v1.21
+   `find()`); the explicit `BindEnv` map is also populated only after the
+   dump. The deny-list redaction is future-proof: if a future refactor moves
+   the dump after env wiring, env-overridden secrets are redacted by the
+   same path (the liveness test's `env-super-secret` guard becomes live
+   under that wiring).
+
+   **Redaction contract (issue #1393):** the parsed-key dump routes each key
+   through a deny-list (`isSecretKey` — suffix-anchored on the leaf,
+   case-insensitive; `api_key`/`auth_token`/`authorization`/`token`/
+   `password`/`secret`/`credential`/`username`/`key` families incl. plurals;
+   `max_tokens`/`max_history_tokens` deliberately excluded) and logs
+   `value=[REDACTED]` for a deny-listed leaf while keeping the key visible;
+   the raw-content dump routes through a line-oriented parser
+   (`redactRawContent`) that redacts deny-listed key values (preserving the
+   key), suppresses continuation lines, handles colonless lines, flow maps
+   and brace-less subkey chains (value-mode scanning gated on unquoted
+   scalars so quoted prose/URLs pass byte-identically). Residual class
+   (accepted, pinned by boundary tests): (i) innocuous-name scalars (e.g.
+   `PAYLOAD: sk-1234`); (ii) key-shaped malformed-block content inside a
+   block scalar (fail-closed over-redaction); (iii) barred `tokens:` flow
+   sub-keys (kept off the deny-list to protect `max_tokens`). Unquoted
+   plain-scalar URLs containing `token:` are over-redacted — an accepted,
+   documented cosmetic trade (fail-closed), compensated in valid YAML by the
+   parsed dump (`url` leaf not deny-listed).
 4. **Hot-reload boundary unchanged.** `MCP_SERVERS` remains excluded from
    hot-reload (§10): changing Basic credentials (or any server
    configuration) requires starting a new session.

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -144,7 +144,7 @@ func readConfigFile(v *viper.Viper, path string) error {
 	}
 
 	if isDebug() {
-		slog.Debug("raw content", slog.String("content", string(data[:min(len(data), 1000)])))
+		slog.Debug("raw content", slog.String("content", redactRawContent(string(data[:min(len(data), 1000)]))))
 	}
 
 	v.SetConfigType("yaml")
@@ -155,7 +155,11 @@ func readConfigFile(v *viper.Viper, path string) error {
 	if isDebug() {
 		slog.Debug("viper parsed keys")
 		for _, key := range v.AllKeys() {
-			slog.Debug("parsed entry", slog.String("key", key), slog.Any("value", v.Get(key)))
+			if isSecretKey(key) {
+				slog.Debug("parsed entry", slog.String("key", key), slog.String("value", redactedValue))
+			} else {
+				slog.Debug("parsed entry", slog.String("key", key), slog.Any("value", v.Get(key)))
+			}
 		}
 	}
 	return nil

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"log/slog"
@@ -951,5 +952,114 @@ PROVIDERS:
 
 	if got := cfg.WrapWidth; got != 150 {
 		t.Errorf("expected env-only WRAP_WIDTH=150, got %d", got)
+	}
+}
+
+// captureDebugLogs promotes the default slog logger to Debug writing into a
+// buffer (restored via t.Cleanup) so tests can assert on emitted diagnostics.
+func captureDebugLogs(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	original := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(original) })
+	return &buf
+}
+
+// TestLoad_ParsedDump_EnvOverriddenValues is the liveness probe (issue #1393
+// acceptance criterion 1). The parsed-key debug dump runs inside
+// readConfigFile, which configureViper calls BEFORE wiring env overrides
+// (SetEnvPrefix + AutomaticEnv), so TODAY the dump serializes YAML-file
+// values, not TELL_ME_* overrides; the liveness probe therefore asserts the
+// YAML URL value appears. DEVATION (Architect adjudication, T1): the
+// env-overridden URL (env-url) cannot appear while the dump stays inside
+// readConfigFile; if a future refactor moves the dump after env wiring, the
+// env-super-secret assertion below becomes the critical leak guard — both
+// wiring orders are covered by this test. The env vars remain set so the
+// scenario the issue describes stays exercised.
+func TestLoad_ParsedDump_EnvOverriddenValues(t *testing.T) {
+	t.Setenv("TELL_ME_MODE", "")              // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+	t.Setenv("TELL_ME_MCP_SERVERS_ATLASSIAN_TOKEN", "env-super-secret")
+	t.Setenv("TELL_ME_MCP_SERVERS_ATLASSIAN_URL", "env-url")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_redaction.yaml")
+	yamlContent := `
+SELECTED_PROVIDER: "test-provider"
+PROVIDERS:
+  test-provider:
+    TYPE: "openai"
+    MODEL: "gpt-4o"
+    URL: "https://api.openai.com/v1"
+    API_KEY: "yaml-api-key"
+    MAX_TOKENS: 16384
+MCP_SERVERS:
+  atlassian:
+    URL: "https://example.com/mcp"
+    AUTH: "bearer"
+    TOKEN: "yaml-token"
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	buf := captureDebugLogs(t)
+	cfg, err := load(configPath)
+	if err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "env-super-secret") {
+		t.Error("debug output leaked the env-overridden TOKEN value (env-super-secret)")
+	}
+	if !strings.Contains(output, "https://example.com/mcp") {
+		t.Error("debug output missing the parsed URL value; liveness probe failed (dump not emitted or value redacted)")
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Error("debug output missing the [REDACTED] placeholder")
+	}
+	if strings.Contains(output, "yaml-token") {
+		t.Error("debug output leaked the raw YAML TOKEN value (yaml-token)")
+	}
+	if strings.Contains(output, "yaml-api-key") {
+		t.Error("debug output leaked the raw YAML API_KEY value (yaml-api-key)")
+	}
+	if !strings.Contains(output, "16384") {
+		t.Error("debug output missing the non-secret MAX_TOKENS value (16384)")
+	}
+}
+
+// TestRawContentDump_InvalidYAML_ColonlessSecretRedacted exercises issue
+// #1393 acceptance criterion 2's invalid-YAML class: a colonless secret line
+// (which viper rejects) must still be redacted in the raw-content debug dump
+// before the parse error surfaces.
+func TestRawContentDump_InvalidYAML_ColonlessSecretRedacted(t *testing.T) {
+	t.Setenv("TELL_ME_MODE", "")              // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_invalid_colonless.yaml")
+	yamlContent := "MODE: \"test\"\nTOKEN sk-123\n"
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	buf := captureDebugLogs(t)
+	_, err := load(configPath)
+	if err == nil {
+		t.Fatal("expected load() to reject the colonless YAML line")
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "sk-123") {
+		t.Error("debug output leaked the colonless secret value (sk-123)")
+	}
+	if !strings.Contains(output, "TOKEN [REDACTED]") {
+		t.Error("debug output missing the colonless redaction (TOKEN [REDACTED])")
 	}
 }

--- a/internal/infrastructure/config/redact.go
+++ b/internal/infrastructure/config/redact.go
@@ -1,0 +1,246 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"regexp"
+	"strings"
+)
+
+// redactedValue is the placeholder logged in place of a secret-bearing value.
+const redactedValue = "[REDACTED]"
+
+// secretKeyPattern is the deny-list: suffix-anchored on the leaf,
+// case-insensitive. `tokens?` is deliberately absent so max_tokens /
+// max_history_tokens (non-secret integer limits) never match; token$ singular
+// stays. NOTE: the trailing keys? alternative also matches any leaf ending in
+// "key"/"keys" (e.g. "monkey") — accepted fail-closed over-redaction.
+var secretKeyPattern = regexp.MustCompile(`(?i)(api[_-]?keys?|auth[_-]?tokens?|authorization|token|passwords?|secrets?|credentials?|usernames?|keys?)$`)
+
+// isSecretKey reports whether a config key is secret-bearing.
+// The regex is suffix-anchored and case-insensitive, so full viper paths
+// (e.g. "mcp_servers::atlassian::token", "providers::google::apikey")
+// match on their leaf without pre-splitting.
+func isSecretKey(key string) bool {
+	return secretKeyPattern.MatchString(strings.TrimSpace(key))
+}
+
+// normalizeKeyToken normalizes a raw key token for deny-list comparison:
+// trim, strip a "- " sequence prefix, take the part before the first ':' ,
+// trim again, and strip surrounding single/double quote characters. Used by
+// the raw-content parser for key extraction.
+func normalizeKeyToken(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "- ")
+	if i := strings.Index(s, ":"); i >= 0 {
+		s = s[:i]
+	}
+	s = strings.TrimSpace(s)
+	return strings.Trim(s, `"'`)
+}
+
+// redactFlowEntry scans an unquoted value for a deny-listed name followed by
+// ':' (a sub-key pattern, e.g. "Authorization:" inside HEADERS) and returns
+// the redacted extent plus the preserved suffix. redactFlowEntry redacts from
+// the matched sub-entry through its depth-0 extent (to the next depth-0
+// comma/brace/EOL), preserving siblings.
+func redactFlowEntry(rest string) string {
+	start := firstSecretTokenIndex(rest)
+	if start < 0 {
+		return rest
+	}
+	if strings.Contains(rest[:start], "{") {
+		end := flowExtentEnd(rest, start)
+		return rest[:start] + redactedValue + rest[end:]
+	}
+	// Brace-less chain (or a plain scalar containing a deny-listed name):
+	// redact the whole value, preserving only leading whitespace.
+	return rest[:leadingWhitespaceLen(rest)] + redactedValue
+}
+
+// firstSecretTokenIndex returns the start index of the first deny-listed
+// name token in rest, or -1 when no token is deny-listed.
+func firstSecretTokenIndex(rest string) int {
+	for i := 0; i < len(rest); {
+		for i < len(rest) && !isTokenChar(rest[i]) {
+			i++
+		}
+		start := i
+		for i < len(rest) && isTokenChar(rest[i]) {
+			i++
+		}
+		if start < i && isSecretKey(rest[start:i]) {
+			return start
+		}
+	}
+	return -1
+}
+
+// isTokenChar reports whether c can appear inside a config name token.
+// Underscore is a token char so api_key stays one token; punctuation
+// (':', '=', '?', '/', '-', braces, commas) splits tokens.
+func isTokenChar(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_'
+}
+
+// flowExtentEnd returns the index just past the depth-0 extent that begins
+// at start: the next depth-0 comma, the closing brace of the enclosing flow,
+// or the end of the string.
+func flowExtentEnd(rest string, start int) int {
+	depth := 0
+	for i := start; i < len(rest); i++ {
+		if rest[i] == '{' {
+			depth++
+		} else if rest[i] == '}' {
+			if depth == 0 {
+				return i
+			}
+			depth--
+		} else if rest[i] == ',' && depth == 0 {
+			return i
+		}
+	}
+	return len(rest)
+}
+
+// leadingWhitespaceLen returns the number of leading space/tab characters.
+func leadingWhitespaceLen(s string) int {
+	i := 0
+	for i < len(s) && (s[i] == ' ' || s[i] == '\t') {
+		i++
+	}
+	return i
+}
+
+// redactRawContent redacts secret-bearing values from a raw config dump.
+// Line-oriented parser contract (each rule pinned by redact_test.go):
+//
+//  1. Split on '\n'; process each element; rejoin with '\n'. Blank or
+//     whitespace-only elements (incl. the final element from a trailing
+//     newline) pass through byte-identically — NEVER index
+//     strings.Fields(body)[0] without a len(fields) == 0 guard.
+//  2. Key extraction per line: trim; strip a leading "- " sequence prefix
+//     (preserve the prefix in output); take the part before the first ':';
+//     normalizeKeyToken. If no ':' exists, fall to rule 5 (colonless scan).
+//  3. Key-mode redaction: if the extracted key is deny-listed (isSecretKey),
+//     emit "<preserved-indent><preserved-prefix><normalized-key>: [REDACTED]"
+//     and enter suppression: subsequent lines that are MORE indented than
+//     this line's key column are dropped; subsequent lines at EQUAL indent
+//     that are NOT key-shaped (no ':') are dropped (invalid-YAML
+//     de-indented block scalars); a key-shaped equal-indent line terminates
+//     suppression and is processed normally. A less-indented line also
+//     terminates suppression.
+//  4. Value-mode scan (key NOT deny-listed): let rest = text after the first
+//     ':'. If strings.TrimSpace(rest) starts with a double or single quote
+//     (quoted-scalar gate) OR is empty, the line passes through
+//     byte-identically. Otherwise scan rest for a deny-listed name+':' sub-key
+//     (redactFlowEntry); if one is found, replace from the sub-entry through
+//     its depth-0 extent with redactedValue, preserving any prefix (e.g. '{')
+//     and siblings after the extent. Brace-less chains
+//     ("MCP_SERVERS: atlassian: TOKEN: file-token") redact to end of line.
+//  5. Colonless scan (invalid-YAML class): fields := strings.Fields(line);
+//     if len(fields) == 0 pass through; else if isSecretKey(fields[0]) emit
+//     "<fields[0]> [REDACTED]"; else pass through byte-identically.
+//
+// Accepted residual class (documented, pinned by boundary tests):
+//
+//	(i)   innocuous-name scalars (PAYLOAD: sk-1234) pass through;
+//	(ii)  key-shaped malformed-block content inside a block scalar is treated
+//	      as a key line (fail-closed over-redaction of prose);
+//	(iii) barred "tokens:" flow sub-keys are NOT redacted (kept off the
+//	      deny-list to protect max_tokens);
+//	plus unquoted plain-scalar URLs containing "token:" are over-redacted
+//	(fail-closed; compensated in valid YAML by the parsed dump, whose "url"
+//	leaf is not deny-listed).
+func redactRawContent(content string) string {
+	lines := strings.Split(content, "\n")
+	out := make([]string, 0, len(lines))
+	suppressing := false
+	keyColumn := 0
+	for _, line := range lines {
+		if isBlankLine(line) {
+			out = append(out, line)
+			continue
+		}
+		indent := leadingWhitespaceLen(line)
+		rest := line[indent:]
+		prefix, rest := stripSequencePrefix(rest)
+		if suppressing && shouldSuppressDrop(indent, keyColumn, rest) {
+			continue
+		}
+		suppressing = false
+		colonIdx := strings.Index(rest, ":")
+		if colonIdx < 0 {
+			if redacted, ok := redactColonless(line); ok {
+				out = append(out, redacted)
+			} else {
+				out = append(out, line)
+			}
+			continue
+		}
+		key := normalizeKeyToken(rest[:colonIdx])
+		if isSecretKey(key) {
+			out = append(out, line[:indent]+prefix+key+": "+redactedValue)
+			suppressing = true
+			keyColumn = indent
+			continue
+		}
+		value := rest[colonIdx+1:]
+		if isQuotedOrEmptyValue(value) {
+			out = append(out, line)
+			continue
+		}
+		if redacted := redactFlowEntry(value); redacted != value {
+			out = append(out, line[:indent]+prefix+rest[:colonIdx+1]+redacted)
+			continue
+		}
+		out = append(out, line)
+	}
+	return strings.Join(out, "\n")
+}
+
+// isBlankLine reports whether a line is empty or whitespace-only; such
+// elements always pass through byte-identically (rule 1).
+func isBlankLine(line string) bool {
+	return strings.TrimSpace(line) == ""
+}
+
+// stripSequencePrefix removes a leading "- " sequence prefix, returning it
+// separately so callers can preserve it in the redacted output.
+func stripSequencePrefix(s string) (string, string) {
+	if strings.HasPrefix(s, "- ") {
+		return "- ", s[2:]
+	}
+	return "", s
+}
+
+// shouldSuppressDrop reports whether a line is dropped while suppression is
+// active: strictly more indented than the secret key's column, or at equal
+// indent but not key-shaped (no ':').
+func shouldSuppressDrop(indent, keyColumn int, rest string) bool {
+	if indent > keyColumn {
+		return true
+	}
+	return indent == keyColumn && !strings.Contains(rest, ":")
+}
+
+// redactColonless applies rule 5 to a colonless line, returning the redacted
+// form and true when the first field is deny-listed.
+func redactColonless(line string) (string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) == 0 || !isSecretKey(fields[0]) {
+		return "", false
+	}
+	return fields[0] + " " + redactedValue, true
+}
+
+// isQuotedOrEmptyValue reports whether the value text after a key's colon is
+// empty or a quoted scalar; both pass through byte-identically (rule 4).
+func isQuotedOrEmptyValue(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return true
+	}
+	return trimmed[0] == '"' || trimmed[0] == '\''
+}

--- a/internal/infrastructure/config/redact_test.go
+++ b/internal/infrastructure/config/redact_test.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package config
+
+import "testing"
+
+func TestIsSecretKey(t *testing.T) {
+	positives := []string{
+		"token",
+		"api_key",
+		"api_keys",
+		"api-key",
+		"apikey",
+		"auth_token",
+		"auth_tokens",
+		"authorization",
+		"password",
+		"passwords",
+		"secret",
+		"secrets",
+		"credential",
+		"credentials",
+		"username",
+		"usernames",
+		"key",
+		"keys",
+		"API_KEY",
+		"Api-Key",
+		"mcp_servers::atlassian::token",
+		"providers::google::apikey",
+		"TELL_ME_MCP_SERVERS_ATLASSIAN_TOKEN",
+		"github_token",
+		"mcp_token",
+	}
+	negatives := []string{
+		"max_tokens",
+		"max_history_tokens",
+		"token_count",
+		"auth",
+		"user_id",
+		"model",
+		"url",
+		"context_window",
+		"timeout",
+		"wrap_width",
+	}
+
+	for _, key := range positives {
+		if !isSecretKey(key) {
+			t.Errorf("isSecretKey(%q) = false; want true", key)
+		}
+	}
+	for _, key := range negatives {
+		if isSecretKey(key) {
+			t.Errorf("isSecretKey(%q) = true; want false", key)
+		}
+	}
+}
+
+func TestRedactRawContent(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"api key scalar", "API_KEY: sk-123", "API_KEY: [REDACTED]"},
+		{"quoted key", `"API_KEY": "sk-123"`, "API_KEY: [REDACTED]"},
+		{"space before colon", `API_KEY : "sk-123"`, "API_KEY: [REDACTED]"},
+		{"sequence item", "- API_KEY: sk-123", "- API_KEY: [REDACTED]"},
+		{"indented key", "  TOKEN: file-token", "  TOKEN: [REDACTED]"},
+		{"suppress more-indented continuation", "API_KEY: sk-123\n  continuation line\nMODEL: gpt", "API_KEY: [REDACTED]\nMODEL: gpt"},
+		{"suppress equal-indent non-key line", "API_KEY: sk-123\nnot a key line\nMODEL: gpt", "API_KEY: [REDACTED]\nMODEL: gpt"},
+		{"colonless secret", "TOKEN sk-123", "TOKEN [REDACTED]"},
+		{"colonless secret trailing newline", "TOKEN sk-123\n", "TOKEN [REDACTED]\n"},
+		{"empty input", "", ""},
+		{"whitespace-only lines", "   \n", "   \n"},
+		{"flow sub-key redacted preserving siblings", "HEADERS: {Authorization: Bearer sk-123, X-Other: y}", "HEADERS: {[REDACTED], X-Other: y}"},
+		{"brace-less chain redacts to end of line", "MCP_SERVERS: atlassian: TOKEN: file-token", "MCP_SERVERS: [REDACTED]"},
+		{"brace-less chain with deny-listed head", "HEADERS: Authorization: Bearer sk-123", "HEADERS: [REDACTED]"},
+		{"quoted prose with token passes through", `PERSON: "a token: decline"`, `PERSON: "a token: decline"`},
+		{"quoted URL passes through", `URL: "https://example.com/path?token=abc"`, `URL: "https://example.com/path?token=abc"`},
+		{"unquoted URL over-redacted", "URL: https://example.com/path?token=abc", "URL: [REDACTED]"},
+		{"innocuous-name scalar passes through", "PAYLOAD: sk-1234", "PAYLOAD: sk-1234"},
+		{"block scalar key-shaped content fail-closed", "PERSON: |\n  API_KEY: sk-123", "PERSON: |\n  API_KEY: [REDACTED]"},
+		{"barred plural tokens passes through", "HEADERS: {tokens: sk-123}", "HEADERS: {tokens: sk-123}"},
+		{"multi-line mixed content", "MODE: test\nMODEL: gpt-4\nAPI_KEY: sk-123\n", "MODE: test\nMODEL: gpt-4\nAPI_KEY: [REDACTED]\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redactRawContent(tt.input); got != tt.want {
+				t.Errorf("redactRawContent(%q) = %q; want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #1393.

## Summary

Redact secret-bearing values from the two debug-gated dumps in `internal/infrastructure/config/config.go` (raw-content dump and viper parsed-key dump), so tokens, API keys, passwords, usernames, and secret-bearing YAML-file values never serialize in debug output — while non-secret values (e.g. `max_tokens`) and quoted prose/URLs pass through byte-identically.

Delivered via the Architect–Coder loop (grill transcript: https://gist.github.com/gosharplite/b1f818c0f7e46c8ea66acc5caa302e93).

### Changes

- **`internal/infrastructure/config/redact.go`** (new) — unexported redaction engine: `isSecretKey` (suffix-anchored, case-insensitive deny-list; `tokens?` deliberately excluded so `max_tokens`/`max_history_tokens` stay visible), `redactRawContent` (line-oriented parser: key-mode redaction + continuation suppression, colonless scan guarded by `len(fields)==0`, flow-map/brace-less-subkey value scanning gated on unquoted scalars), `normalizeKeyToken`, `redactFlowEntry`. Residual class documented and pinned by boundary tests.
- **`internal/infrastructure/config/config.go`** — exactly two wiring changes: raw dump → `redactRawContent(...)`; parsed-key dump → `value=[REDACTED]` for deny-listed leaves (key stays visible).
- **`internal/infrastructure/config/redact_test.go`** (new) — `TestIsSecretKey` (25 positives / 10 negatives), `TestRedactRawContent` (21 byte-exact rows incl. the three residual boundary pins).
- **`internal/infrastructure/config/config_test.go`** — `captureDebugLogs` helper + `TestLoad_ParsedDump_EnvOverriddenValues` (liveness probe) + `TestRawContentDump_InvalidYAML_ColonlessSecretRedacted`.
- **`docs/adr/2026-08-mcp-client-architecture.md`** — ADR-067 §4 item 3 flipped from "known exception (tracked follow-up #1390)" to **RESOLVED (#1393)** with the corrected exception-to-scope framing.

## Acceptance criteria

- [x] Parsed-entry debug dump redacts secret-bearing values while preserving non-secret values — pinned by `TestLoad_ParsedDump_EnvOverriddenValues` (URL-leaf liveness probe, `[REDACTED]` present, `16384` preserved).
- [x] Raw-content debug dump no longer exposes secret-bearing lines across all edge classes (quoted keys, pre-colon whitespace, sequence items, flow maps, brace-less chains, colonless lines, block-scalar continuations) — pinned by `TestRedactRawContent` (21 byte-exact rows) + `TestRawContentDump_InvalidYAML_ColonlessSecretRedacted`; quoted prose/URLs pass byte-identically.
- [x] ADR-067 §4 item 3 updated to RESOLVED referencing #1393 with corrected framing and narrowed wording.
- [x] `make check-full` passes (incl. race detection).

## Important finding (verified, recorded in ADR-067)

The issue's premise that `AutomaticEnv`-overridden live secrets reach the parsed-key dump was **factually incorrect for the current wiring**: the dump runs inside `readConfigFile`, which `configureViper` calls **before** `SetEnvPrefix`/`SetEnvKeyReplacer`/`AutomaticEnv`, and viper's env lookup is gated on `automaticEnvApplied` (verified against viper v1.21 `find()`). The real exposure class is plaintext secret-bearing **YAML-file** values in both dumps (plus `${ENV_VAR}` reference literals — the name, never the resolved value). The deny-list redaction is future-proof: if a future refactor moves the dump after env wiring, env-overridden secrets are redacted by the same path (the liveness test's `env-super-secret` guard becomes live under that wiring). The `mcp-token-not-logged` invariant statement and the domain model are unchanged (exception to scope, not a violation).

## Verification

| Check | Status |
|-------|--------|
| `go test ./internal/infrastructure/config/...` | PASS |
| `go test ./...` | PASS |
| `go vet` / `golangci-lint` | PASS (0 issues) |
| `go run ./cmd/deadcode` | "No dead code found." |
| CC of new functions | `redactRawContent`=10, all helpers ≤8 |
| `make verify-adr-index` | PASS |
| `make verify-no-test-sleep` / `verify-no-testing-import` | PASS |
| `make check-full` (incl. test-race) | **PASS** |
| modelith / catalog churn | none |

## Commits

- `3c4dbe71` — `fix(config): redact secret-bearing values from debug diagnostics (#1393)`
- `1358370f` — `docs(adr): mark ADR-067 §4 item 3 config-loader debug dumps RESOLVED (#1393)`
