### PR TITLE
feat(mcp): stdio / local-process MCP servers (COMMAND + ARGS) (#1396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A high-performance CLI assistant unifying the world's most powerful reasoning en
     *   **System & Dev**: Shell execution (`execute_command`, `pipe_commands`), testing, linting, and vulnerability scanning (`govulncheck`).
     *   **State & History**: Task tracking, `summarize_history`, `manage_history` (pinning/unpinning turns to protect them from pruning), and **Interactive History Browser** (`tell-me-go browse`) with full-text search and O(1) archive navigation.
     *   **Media**: Imagen 3 image generation and Vision analysis.
-    *   **Model Context Protocol (MCP)**: Native consumption of remote MCP servers (GitHub Copilot, custom endpoints) over streamable HTTP with automatic credential resolution.
+    *   **Model Context Protocol (MCP)**: Native consumption of MCP servers — remote endpoints over streamable HTTP with automatic credential resolution, and local stdio servers (COMMAND).
 *   **Safety Guardrails**: 
     *   **Context Control**: Automatic "self-healing" summarization and turn pinning to prevent overflow without losing intent.
     *   **Runaway Protection**: Hallucination loop detection (SHA-256 response hashing), tool repetition guards, and recursion limits.
@@ -346,6 +346,37 @@ MCP_SERVERS:
     # TOKEN: "${GITHUB_TOKEN}"  # Optional: auto-resolved via gh auth token if omitted
     # TIMEOUT: 300              # Seconds (default: 300)
     # REQUIRES_CONSENT: false   # Optional override (default: false for /readonly)
+```
+
+Local stdio servers spawn a child process and talk to it over stdin/stdout:
+
+```yaml
+# COMMAND is resolved via tell-me-go's PATH (parent process); use an absolute path or ${VAR} for venv/toolchain locations.
+MCP_SERVERS:
+  fs:
+    COMMAND: "npx"
+    ARGS: ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/dir"]
+  git:
+    COMMAND: "uvx"
+    ARGS: ["mcp-server-git"]
+```
+
+A bare `COMMAND` (no path separator) is resolved via `exec.LookPath` in
+tell-me-go's own process PATH — not `ENV.PATH`, not `DIR`; a separator-bearing
+`COMMAND` (`/abs`, `./rel`) is used as-is, with relative paths resolved
+against `DIR`. `ENV.PATH` governs the child only after exec (it does reach
+the server's own subprocess resolution, e.g. uvx finding `mcp-server-git`).
+`${VAR}` is expanded at config load in `COMMAND`, `ARGS`, `DIR`, and `ENV`
+values.
+
+For executables inside a venv or toolchain directory, use an absolute or
+`${VAR}`-expanded `COMMAND`:
+
+```yaml
+# Absolute path or ${VAR}-expanded COMMAND for venv/toolchain locations:
+venv-tools:
+  COMMAND: "${UVX_PATH}/uvx"
+  ARGS: ["mcp-server-git"]
 ```
 
 ## ⌨️ Shell Integration (Recommended)

--- a/docs/adr/2026-08-mcp-client-architecture.md
+++ b/docs/adr/2026-08-mcp-client-architecture.md
@@ -273,6 +273,150 @@ subset of configuration the per-turn config watcher manages.
    in-process code and the alternative (provenance tracking) adds registry
    coupling disproportionate to the threat model.
 
+### Amendment (2026-08, issue #1396 — stdio transport for local MCP servers)
+
+1. **Second transport implementation.** tell-me-go now supports local stdio
+   MCP servers via a separate `StdioClient` type
+   (`internal/infrastructure/mcp/stdio_client.go`) in the same package — not
+   a mode on the HTTP `Client`. Eager construction: `NewStdioClient(cfg,
+   logger)` spawns `COMMAND` with `ARGS`/`DIR`/`ENV` via
+   `exec.CommandContext`, connects over
+   `sdkmcp.IOTransport{Reader: stdoutPipe, Writer: stdinPipe}` inside the
+   constructor, bounded by the server's `TIMEOUT` (default 300s). One child
+   process per server; no reliance on `os.Stdin`/`os.Stdout` (the SDK's
+   `StdioTransport` is hard-wired to those, one per process, hence rejected).
+   Reuses the HTTP client's unexported conversion helpers; SDK confinement
+   (§2) unchanged.
+
+2. **Lifecycle & process-tree guarantees (two-tier).** Direct-child reaping
+   is **deterministic**: a reaper goroutine started immediately after
+   `cmd.Start()` sends `cmd.Wait()`'s result to a buffered channel, so the
+   child is reaped the moment it dies — zombie prevention is not contingent
+   on `Close()`. Tree termination is **best-effort** via shared-pipe stdin
+   EOF: launchers (`npx`, `uvx`) pass stdio through rather than proxying it,
+   so a grandchild sees EOF directly and SDK-built servers
+   (`server.Run(ctx, &StdioTransport{})` read loop exits on `io.EOF`)
+   self-terminate; the Unix SIGPIPE write-backstop covers a grandchild that
+   writes after our read end closes. **Zombie vs orphan**: no zombies,
+   guaranteed; orphans possible for transport-contract-violating servers (an
+   EOF-ignoring **and silent** grandchild on Unix; any EOF-ignoring
+   grandchild on Windows — no signal backstop) — accepted residuals. **No
+   process-group kill this PR** (Unix-only platform split for a
+   misbehaving-server edge; pgid-kill is wrong for a reparenting child;
+   Windows needs Job Objects) — tracked future option.
+
+3. **Fast-death and failure surfaces.** A non-blocking pre-check at the top
+   of `ListTools`/`CallTool` (under the client mutex) returns a sticky
+   `mcp: stdio child %q exited: %w` error once the child has died — every
+   subsequent call fails fast deterministically (the SDK alone does not
+   guarantee this). In-flight EOF (`io.EOF`/`ErrConnectionClosed`)
+   coinciding with a confirmed child exit is annotated with the exit status;
+   a wedge surfaces as the plain `context.DeadlineExceeded` wrap — dead vs
+   wedged are distinguishable by error text and latency.
+   Spawn/connect/handshake failures and handshake timeout surface at DI
+   `Build` as the existing warn+skip (server skipped for the session;
+   `MCP_SERVERS` read once, §10 unchanged); per-call timeouts are
+   recoverable (call fails, session remains); **no kill on
+   operation-timeout** — a slow legitimate call (e.g. a 200s filesystem op
+   under TIMEOUT 300) is indistinguishable from a wedge and does not poison
+   the session; documented known limitation, child stderr is the operator's
+   visibility window.
+
+4. **Close semantics.** `Close()` is idempotent and mutex-guarded, in this
+   order: (1) `session.Close()` first — closes both pipes, sending stdin EOF
+   so a well-behaved child (and its tree) exits gracefully; (2) `cancel()` as
+   the kill backstop for uncooperative children (called explicitly and
+   deferred so it fires even on an error unwinding `session.Close`);
+   (3) join the reaper (expected `signal: killed`/`context.Canceled` logged
+   at debug, not surfaced). `factory.Close()` iterates tracked clients, so
+   session teardown kills every child.
+
+5. **Consent/serial defaults — trusted local spawns (MAINTAINER DECISION).**
+   Stdio servers are trusted by virtue of config trust: `consent=false`
+   default (no user prompt), `serial=true` default (mutating local
+   processes), with `REQUIRES_CONSENT: true` opting back in. **This deviates
+   from the #1394 grill round's recommendation (`consent=true` default)** —
+   flag the deviation explicitly and record the maintainer's rationale: a
+   `COMMAND`/`ARGS` config entry is an explicit, operator-authored grant of
+   local execution — no different in trust class from the config's own
+   `SELECTED_PROVIDER` — and prompting on every call would make "many local
+   MCP services" tedious. `EffectiveRequiresConsent()` gains an explicit
+   stdio branch (override wins, then `IsStdio()` → false, else
+   `!isReadOnly()`); `EffectiveSerial()` remains `!isReadOnly()` — stdio has
+   no URL, so it already yields `true`. **Known consequence (accepted):** a
+   read-only local server (e.g. `fetch`) is forced serial forever — there is
+   no serial override for any transport today (`EffectiveSerial()` is
+   global; consent is the only overridable axis), so stdio is not made
+   *more* configurable than HTTP. A per-server serial override is a tracked
+   future option: if ever added, it must apply to both transports or carry a
+   justification for asymmetry.
+
+6. **Mode-conflict validation rule.** `validate()` rejects
+   `AUTH: bearer`/`basic` together with `COMMAND` ("stdio (COMMAND) servers
+   transmit no credentials"), checked before the positive credential rules
+   so the mode-conflict message wins. This is a mode-conflict rule, same
+   family as COMMAND/URL mutual exclusivity — it does not disturb §4's
+   positive-rule-only credential philosophy; `auto`/`gh`/`none`/empty under
+   stdio are accepted (inert under the stdio short-circuit, which also means
+   `gh`/`auto` under stdio never resolve and never invoke the resolver), and
+   stray `TOKEN`/`USERNAME` under stdio remain tolerated (§4 stray-field
+   tolerance). COMMAND and URL are mutually exclusive — exactly one must be
+   set.
+
+7. **Concurrent construction.** The DI factory
+   (`internal/infrastructure/di/mcp_factory.go`) builds clients in two
+   phases: a sequential token pre-pass (stdio short-circuits first;
+   `gh`/`auto` under stdio never resolve; HTTP servers resolve via the
+   single-flight `gh`-memoized resolver, credentials stamped into per-server
+   copies), then concurrent construction per server (`sync.WaitGroup`,
+   per-server spawn+handshake bounded by `TIMEOUT`), failures warn+skip per
+   server, no overall `Build` bound. First-`GetRegistry` latency caps at
+   `max(Tᵢ)` + plugin discovery rather than ΣTᵢ. **Nuance:** the plugin's
+   own 30s per-server discovery bound (`defaultDiscoveryTimeout`) is separate
+   from and additional to `TIMEOUT` — a server whose handshake took the full
+   `TIMEOUT` still gets its own 30s `ListTools` window.
+
+8. **Stderr scope.** Child stderr is always logged at Info with
+   `mcp_server=<name>`, line-buffered, and never parsed as JSON-RPC. This is
+   **outside** the `mcp-token-not-logged` invariant (the invariant governs
+   tell-me-go's own credential plumbing — config validation, DI factory,
+   client transport — not arbitrary child output); a misbehaving child that
+   echoes secrets to stderr is an accepted residual of the wedge/death
+   visibility window. The domain model invariant statement is unchanged.
+
+9. **Command resolution semantics.** Bare `COMMAND` (no path separator)
+   resolves via `exec.LookPath` in **tell-me-go's own process PATH** — not
+   `ENV.PATH`, not `DIR`; separator-bearing `COMMAND` (`/abs`, `./rel`) is
+   used as-is, relative resolved against `DIR`; `ENV.PATH` governs the child
+   only post-exec (it reaches the server's own subprocess resolution — e.g.
+   uvx finding `mcp-server-git` — which is why it is set and why failures
+   are confusing). `${VAR}` expands at config load via `expandEnvHook` in
+   `COMMAND`, `ARGS`, `DIR`, and `ENV` values. Windows bare-name lookup
+   honors `PATHEXT` via the same stdlib path. On `exec.ErrNotFound`, the
+   error is annotated with the resolution contract (fail-point only; no
+   heuristic warning when `ENV` contains a PATH override).
+
+10. **Tracked future options** (explicitly NOT this PR): (a) per-server
+    serial override, applying to both transports or with a justified
+    asymmetry; (b) process-group kill (Unix pgid) / Job Objects (Windows)
+    for transport-contract-violating grandchildren; (c) extraction refactor
+    of `(*MCPServerConfig).validate` (CC=20, cataloged as structural guards
+    in `INTENTIONAL_NON_FIXES.md`).
+
+### Consequences
+
+Stdio support broadens the MCP surface from remote-only to local processes
+while preserving the SDK-confined, port-based architecture: a separate
+`StdioClient` type keeps the HTTP `Client` untouched, and the two-tier
+lifecycle (deterministic direct-child reaping + best-effort tree termination
+via shared-pipe EOF) prevents zombies with accepted orphan residuals for
+contract-violating servers. The trusted-spawn consent default is a deliberate
+deviation from the #1394 grill recommendation, justified by the
+operator-authored trust class of `COMMAND`/`ARGS`; the forced-serial
+consequence for read-only local servers and the no-kill-on-operation-timeout
+policy are documented known limitations with tracked future options rather
+than silent trade-offs.
+
 ## Consequences
 
 **Positive:** the SDK is fully isolated behind `tools.MCPClient`, so the

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -894,6 +894,12 @@ catalog a new gap no one reviewed. Policy:
 - **Rationale**: Sequential launcher test (spawn → stderr poll for pid → ListTools → Close → deadline-bounded liveness poll with `syscall.Kill`). CC is the poll/assertion sequence, not branching business logic. Splitting would duplicate the child-process/launcher setup. Same acceptance class as `TestHistoryNavigation_CompleteWorkflow` (CC=15) — sequential workflow where steps depend on prior state.
 - **See**: `internal/infrastructure/mcp/stdio_client_integration_test.go:216`
 
+### internal/infrastructure/mcp/stdio_client_integration_test.go — TestStdio_ChildDeathMidSession (CC=11)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Sequential death-mid-session integration test over a real child process (die call → race-tolerant death-indication assertion → deadline-bounded poll loop that deterministically closes the async-reap window by waiting for the sticky child-exit error → post-sticky pointer-equality assertions). CC comes from the poll/branch structure (the poll's if/break, the deadline guard, and the two sticky assertions), not branching business logic — and the poll is the test's synchronization mechanism, not refactorable: splitting it would both duplicate the expensive child-process setup and destroy the deterministic reaper synchronization it provides. Same acceptance class as `TestStdio_RoundTrip` (CC=11) and `TestStdio_LauncherTreePassThrough` (CC=13) in the same file.
+- **See**: `internal/infrastructure/mcp/stdio_client_integration_test.go:278`
+
 ---
 
 ## Complexity Alerts (ACCEPTED)

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -870,6 +870,30 @@ catalog a new gap no one reviewed. Policy:
 - **Rationale**: Table-driven transport test pinning the Basic auth header contract across three subtest closures (header set with exact base64, no-header when username empty, no-header when token empty), each building its own roundTripFunc assertion closure. CC comes from subtest enumeration and assertion boilerplate, not branching business logic. Same acceptance class as `TestMediaBlocks` (CC=11) — assertion boilerplate across a coverage matrix.
 - **See**: `internal/infrastructure/mcp/client_test.go:645`
 
+### internal/infrastructure/di/mcp_factory_test.go — TestMCPFactory_ConcurrentBuild (CC=11)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Channel-gated concurrency proof for the factory's phase-2 construction: per-server fake calls block on release channels while a started-channel deadline select proves all N constructions entered before any completed. CC comes from harness/assertion boilerplate (deadline select, started-counter check, per-server dep assertions), not branching business logic. Splitting would duplicate the channel-gated harness. Same acceptance class as `TestGetModelTurn` (CC=16) and `TestFakeToolchainRunner_PresetValues` (CC=28).
+- **See**: `internal/infrastructure/di/mcp_factory_test.go:683`
+
+### internal/infrastructure/di/mcp_factory_test.go — TestMCPFactory_ConcurrentBuild_FailingServerSkips (CC=15)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Same channel-gated harness as `TestMCPFactory_ConcurrentBuild` plus sequential setup and per-server assertions over N servers (failing server absent, others present, exactly one `mcp_client_init_failed` log). CC is harness/assertion boilerplate, not branching business logic. Splitting would duplicate the expensive harness. Same acceptance class as `TestFakeToolchainRunner_PresetValues` (CC=28).
+- **See**: `internal/infrastructure/di/mcp_factory_test.go:743`
+
+### internal/infrastructure/mcp/stdio_client_integration_test.go — TestStdio_RoundTrip (CC=11)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Sequential integration test over a real child process (list tools → echo round-trip → stderr-capture poll → stderr tool call). CC is multi-step assertion boilerplate and the deadline-bounded stderr poll, not branching business logic. Splitting would duplicate the expensive child-process setup per subtest. Same acceptance class as `TestGetModelTurn` (CC=16) and `TestHistoryNavigation_CompleteWorkflow` (CC=15).
+- **See**: `internal/infrastructure/mcp/stdio_client_integration_test.go:112`
+
+### internal/infrastructure/mcp/stdio_client_integration_test.go — TestStdio_LauncherTreePassThrough (CC=13)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Sequential launcher test (spawn → stderr poll for pid → ListTools → Close → deadline-bounded liveness poll with `syscall.Kill`). CC is the poll/assertion sequence, not branching business logic. Splitting would duplicate the child-process/launcher setup. Same acceptance class as `TestHistoryNavigation_CompleteWorkflow` (CC=15) — sequential workflow where steps depend on prior state.
+- **See**: `internal/infrastructure/mcp/stdio_client_integration_test.go:216`
+
 ---
 
 ## Complexity Alerts (ACCEPTED)
@@ -1035,6 +1059,12 @@ to reason about.
   `WrapWidth > 0` guard added to the markdown-renderer selection branch —
   the same structural-guard acceptance class as the rest of this function.
 - **See**: `internal/ui/history.go:26`
+
+### internal/domain/config/mcp_config.go — (*MCPServerConfig).validate (CC=20)
+
+- **Status**: ACCEPTED (2026-08, #1396)
+- **Rationale**: Sequential validation with structural guards only: the issue-mandated most-specific-error-wins check order (COMMAND/URL mutual exclusion, ARGS/DIR/ENV-require-COMMAND, bearer/basic mode conflict, TIMEOUT, the 6-case auth-mode switch, and the positive credential rules) — every branch is a one-line error return whose message is pinned by the T1 table tests. CC is driven by guard count + the auth switch, not branching business logic. Extracting helpers would fragment a coherent, message-pinned validation sequence for cosmetic CC reduction — same acceptance class as `renderHistory` (CC=12) and `(*HistoryEditor).Edit` (CC=10) in this section. A future extraction refactor is possible but is tracked, not this PR.
+- **See**: `internal/domain/config/mcp_config.go:103`
 
 ### ui/tui/browser.go — (*rootBrowserModel).handleActionKeys (CC=15) → RESOLVED
 
@@ -1296,14 +1326,14 @@ to reason about.
 ### di/mcp_factory.go — resolveServerToken default case
 
 - **Status**: ACCEPTED (2026-09)
-- **Rationale**: the inline comment documents it: unknown auth modes are rejected by config validation before Build runs, so the default treats them defensively as "none". Defensive guard on internal pipeline state — same acceptance class as the 2026-07 Batch Triage defensive nil/empty guards. Re-anchored 2026-08 (#1389): lines drifted 148-151 → 157-160 as the basic-auth DI resolution added the username parameter to the newClient closure.
-- **See**: `internal/infrastructure/di/mcp_factory.go:157-160`
+- **Rationale**: the inline comment documents it: unknown auth modes are rejected by config validation before Build runs, so the default treats them defensively as "none". Defensive guard on internal pipeline state — same acceptance class as the 2026-07 Batch Triage defensive nil/empty guards. Re-anchored 2026-08 (#1389): lines drifted 148-151 → 157-160 as the basic-auth DI resolution added the username parameter to the newClient closure. Re-anchored 2026-08 (#1396): lines drifted 157-160 → 223-227 as the stdio factory refactor replaced the newClient seam with newClientFor and split Build into a two-phase pre-pass + concurrent construction.
+- **See**: `internal/infrastructure/di/mcp_factory.go:223-227`
 
 ### di/mcp_factory.go — gh auth token resolver
 
 - **Status**: ACCEPTED (2026-09)
-- **Rationale**: the tokenResolver closure shells out to `gh auth token` via exec.Command at the composition root; triggering the error requires `gh` to be missing or failing mid-resolution — environment fault injection disproportionate to the value. Same acceptance class as the 2026-07 fault-injection gaps.
-- **See**: `internal/infrastructure/di/mcp_factory.go:60-65`
+- **Rationale**: the tokenResolver closure shells out to `gh auth token` via exec.Command at the composition root; triggering the error requires `gh` to be missing or failing mid-resolution — environment fault injection disproportionate to the value. Same acceptance class as the 2026-07 fault-injection gaps. Re-anchored 2026-08 (#1396): lines drifted 60-65 → 67-70 as the stdio factory refactor replaced the newClient seam with newClientFor.
+- **See**: `internal/infrastructure/di/mcp_factory.go:67-70`
 
 ### di/toolchain_factory.go — registerSkillsShTools error
 

--- a/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
+++ b/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
@@ -108,6 +108,9 @@ allowed: llm, persistence, services, tools
 ## consumer: internal/infrastructure/logging
 allowed: events, llm, persistence, services, telemetry, tools
 # P1+P2+P3: via events/llm deps
+## consumer: internal/infrastructure/mcp
+allowed: config, events, llm, pricing, telemetry, tools
+# P3+P1+P2 (#1396): stdio transport constructor takes domain config (NewStdioClient); closure via config — same approved set as internal/infrastructure/config
 ## consumer: internal/infrastructure/telemetry
 allowed: config, events, llm, pricing, security, telemetry, tools
 # P2+P3: config via events/telemetry deps

--- a/docs/domain-model/tell-me-go.modelith.md
+++ b/docs/domain-model/tell-me-go.modelith.md
@@ -121,7 +121,7 @@ The persisted record of a `Session`'s `Turn`s, stored as an append-only JSON Lin
 
 ### `MCPServer`
 
-An external Model Context Protocol (MCP) server providing dynamic tool capabilities to the agent over Streamable HTTP.
+An external Model Context Protocol (MCP) server providing dynamic tool capabilities to the agent, reached over Streamable HTTP (URL) or spawned as a local stdio child process (COMMAND).
 
 **Relationships**
 
@@ -132,7 +132,11 @@ An external Model Context Protocol (MCP) server providing dynamic tool capabilit
 | Name | Type | Description |
 | --- | --- | --- |
 | `name` | string | The unique server identifier (map key in Config.MCPServers). |
-| `url` | string | Base URL of the remote MCP server endpoint. |
+| `url` | string | Base URL of the remote MCP server endpoint (Streamable HTTP); mutually exclusive with command. |
+| `command` | string | Executable for a local stdio MCP server child process (COMMAND); mutually exclusive with url. |
+| `args` | []string | Optional arguments passed to command (ARGS). |
+| `dir` | string | Optional working directory for the child process (DIR). |
+| `env` | object | Optional extra environment variables for the child process (ENV). |
 | `auth` | string | Authentication mode: auto, gh, bearer, basic, or none. |
 | `username` | string | Username for Basic authentication (AUTH: basic); sent as the Basic user with TOKEN as the password. |
 | `requiresConsent` | boolean | Whether tools from this server require user approval before execution. |
@@ -144,6 +148,7 @@ An external Model Context Protocol (MCP) server providing dynamic tool capabilit
 - **mcp-server-key-format** — MCP server keys must be 1 to 24 characters matching `^[a-z0-9-]+$`.
 - **mcp-token-not-logged** — Credentials and derived Authorization headers for `MCPServer`s must never be logged or serialized by the MCP credential plumbing (config validation, DI factory, client transport).
 - **mcp-readonly-defaults** — An `MCPServer` targeting a read-only endpoint defaults to `requiresConsent: false` and concurrent execution (`serial: false`).
+- **mcp-stdio-trusted-defaults** — A stdio `MCPServer` (command set) defaults to `requiresConsent: false` (trusted local spawn) and `serial: true`; an explicit `REQUIRES_CONSENT: true` opts back in.
 
 ### `Pricing`
 
@@ -705,13 +710,14 @@ The agent initializes external tools from configured MCP servers over Streamable
 3. Tools are normalized, namespaced, and registered as `Tool` entities with appropriate consent and serial flags.
 4. Unsupported schema combinators gracefully degrade to freeform arguments.
 5. LLM requests an MCP tool execution via `ToolCall`.
-6. `ToolCall` delegates execution to the remote `MCPServer` over Streamable HTTP.
+6. `ToolCall` delegates execution to the `MCPServer` — over Streamable HTTP for URL-based servers, or to the local stdio child process for COMMAND-based servers.
 7. Non-terminal MCP tool errors (isError: true) return error text with nil Go error for in-turn LLM recovery.
 
 **Invariants touched**
 
 - **mcp-server-key-format** — MCP server keys must be 1 to 24 characters matching `^[a-z0-9-]+$`.
 - **mcp-readonly-defaults** — An `MCPServer` targeting a read-only endpoint defaults to `requiresConsent: false` and concurrent execution (`serial: false`).
+- **mcp-stdio-trusted-defaults** — A stdio `MCPServer` (command set) defaults to `requiresConsent: false` (trusted local spawn) and `serial: true`; an explicit `REQUIRES_CONSENT: true` opts back in.
 - **tool-timeout** — Execution duration must not exceed `Config.toolTimeout` seconds.
 - **tool-unique-name** — Each `Tool` has a unique name.
 

--- a/docs/domain-model/tell-me-go.modelith.yaml
+++ b/docs/domain-model/tell-me-go.modelith.yaml
@@ -479,7 +479,8 @@ entities:
   MCPServer:
     definition: >
       An external Model Context Protocol (MCP) server providing dynamic tool
-      capabilities to the agent over Streamable HTTP.
+      capabilities to the agent, reached over Streamable HTTP (URL) or spawned
+      as a local stdio child process (COMMAND).
     relationships:
       - entity: Tool
         cardinality: "1:n"
@@ -491,7 +492,19 @@ entities:
         description: The unique server identifier (map key in Config.MCPServers).
       - name: url
         type: string
-        description: Base URL of the remote MCP server endpoint.
+        description: Base URL of the remote MCP server endpoint (Streamable HTTP); mutually exclusive with command.
+      - name: command
+        type: string
+        description: Executable for a local stdio MCP server child process (COMMAND); mutually exclusive with url.
+      - name: args
+        type: "[]string"
+        description: Optional arguments passed to command (ARGS).
+      - name: dir
+        type: string
+        description: Optional working directory for the child process (DIR).
+      - name: env
+        type: object
+        description: Optional extra environment variables for the child process (ENV).
       - name: auth
         type: string
         description: "Authentication mode: auto, gh, bearer, basic, or none."
@@ -514,6 +527,8 @@ entities:
         statement: "Credentials and derived Authorization headers for `MCPServer`s must never be logged or serialized by the MCP credential plumbing (config validation, DI factory, client transport)."
       - id: mcp-readonly-defaults
         statement: "An `MCPServer` targeting a read-only endpoint defaults to `requiresConsent: false` and concurrent execution (`serial: false`)."
+      - id: mcp-stdio-trusted-defaults
+        statement: "A stdio `MCPServer` (command set) defaults to `requiresConsent: false` (trusted local spawn) and `serial: true`; an explicit `REQUIRES_CONSENT: true` opts back in."
 
   Skill:
     definition: >
@@ -915,9 +930,9 @@ scenarios:
       - "Tools are normalized, namespaced, and registered as `Tool` entities with appropriate consent and serial flags."
       - "Unsupported schema combinators gracefully degrade to freeform arguments."
       - "LLM requests an MCP tool execution via `ToolCall`."
-      - "`ToolCall` delegates execution to the remote `MCPServer` over Streamable HTTP."
+      - "`ToolCall` delegates execution to the `MCPServer` — over Streamable HTTP for URL-based servers, or to the local stdio child process for COMMAND-based servers."
       - "Non-terminal MCP tool errors (isError: true) return error text with nil Go error for in-turn LLM recovery."
-    invariants_touched: [mcp-server-key-format, mcp-readonly-defaults, tool-timeout, tool-unique-name]
+    invariants_touched: [mcp-server-key-format, mcp-readonly-defaults, mcp-stdio-trusted-defaults, tool-timeout, tool-unique-name]
 
 invariants:
   - id: deterministic-cost-audit

--- a/internal/domain/config/mcp_config.go
+++ b/internal/domain/config/mcp_config.go
@@ -33,12 +33,16 @@ const (
 
 // MCPServerConfig defines configuration for an external Model Context Protocol server.
 type MCPServerConfig struct {
-	URL             string `yaml:"URL"`
-	Token           string `yaml:"TOKEN"`
-	Username        string `yaml:"USERNAME"`
-	Auth            string `yaml:"AUTH"` // "auto", "gh", "bearer", "basic", "none" (default: "auto")
-	RequiresConsent *bool  `yaml:"REQUIRES_CONSENT"`
-	Timeout         int    `yaml:"TIMEOUT"` // Seconds (0 = default 300s)
+	URL             string            `yaml:"URL"`
+	Token           string            `yaml:"TOKEN"`
+	Username        string            `yaml:"USERNAME"`
+	Auth            string            `yaml:"AUTH"` // "auto", "gh", "bearer", "basic", "none" (default: "auto")
+	RequiresConsent *bool             `yaml:"REQUIRES_CONSENT"`
+	Timeout         int               `yaml:"TIMEOUT"` // Seconds (0 = default 300s)
+	Command         string            `yaml:"COMMAND"` // executable for a stdio (local-process) MCP server; mutually exclusive with URL
+	Args            []string          `yaml:"ARGS"`    // optional arguments for COMMAND
+	Dir             string            `yaml:"DIR"`     // optional working directory for the child process
+	Env             map[string]string `yaml:"ENV"`     // optional extra environment variables for the child
 }
 
 // isReadOnly reports whether the server URL targets a read-only endpoint.
@@ -47,20 +51,31 @@ func (c *MCPServerConfig) isReadOnly() bool {
 	return strings.HasSuffix(strings.TrimRight(c.URL, "/"), "/readonly")
 }
 
+// IsStdio reports whether this server is configured as a local stdio child
+// process (COMMAND set) rather than a remote Streamable HTTP endpoint.
+func (c *MCPServerConfig) IsStdio() bool {
+	return strings.TrimSpace(c.Command) != ""
+}
+
 // EffectiveRequiresConsent resolves whether tool calls against this server
 // require user consent. An explicit REQUIRES_CONSENT wins; otherwise
 // "/readonly" endpoints default to false and mutating endpoints default to
-// true.
+// true. Stdio servers default to false: a local spawn is a trusted process
+// (maintainer decision, #1396).
 func (c *MCPServerConfig) EffectiveRequiresConsent() bool {
 	if c.RequiresConsent != nil {
 		return *c.RequiresConsent
+	}
+	if c.IsStdio() {
+		return false // trusted local spawn (maintainer decision, #1396)
 	}
 	return !c.isReadOnly()
 }
 
 // EffectiveSerial reports whether tool calls against this server must execute
 // serially. "/readonly" endpoints may execute concurrently (false); mutating
-// endpoints execute serially (true).
+// endpoints execute serially (true). Stdio servers have no URL, so
+// isReadOnly() is false and serial is true by construction.
 func (c *MCPServerConfig) EffectiveSerial() bool {
 	return !c.isReadOnly()
 }
@@ -86,14 +101,35 @@ func (c *MCPServerConfig) EffectiveTimeout() time.Duration {
 
 // validate reports hard configuration errors for a single MCP server.
 func (c *MCPServerConfig) validate(name string) error {
-	if strings.TrimSpace(c.URL) == "" {
-		return fmt.Errorf("MCP_SERVERS.%s.URL must not be empty", name)
+	// A server is either a local stdio child process (COMMAND) or a remote
+	// Streamable HTTP endpoint (URL) — never both, never neither.
+	if c.IsStdio() && strings.TrimSpace(c.URL) != "" {
+		return fmt.Errorf("MCP_SERVERS.%s.COMMAND and URL are mutually exclusive", name)
 	}
+	if !c.IsStdio() && strings.TrimSpace(c.URL) == "" {
+		return fmt.Errorf("MCP_SERVERS.%s.URL must not be empty (or set COMMAND for a stdio server)", name)
+	}
+
+	// ARGS/DIR/ENV are stdio-only knobs: without COMMAND they are inert
+	// configuration noise, so reject them.
+	if !c.IsStdio() && (len(c.Args) > 0 || strings.TrimSpace(c.Dir) != "" || len(c.Env) > 0) {
+		return fmt.Errorf("MCP_SERVERS.%s.ARGS/DIR/ENV require COMMAND", name)
+	}
+
+	auth := c.EffectiveAuth()
+
+	// Mode conflict: stdio servers transmit no credentials, so bearer/basic
+	// (which resolve credentials over HTTP) are invalid under COMMAND. This
+	// check precedes the positive credential rules so the mode conflict — the
+	// more specific diagnosis — wins over missing-TOKEN errors.
+	if c.IsStdio() && (auth == MCPAuthBearer || auth == MCPAuthBasic) {
+		return fmt.Errorf("MCP_SERVERS.%s.AUTH bearer/basic requires an HTTP endpoint; stdio (COMMAND) servers transmit no credentials", name)
+	}
+
 	if c.Timeout < 0 {
 		return fmt.Errorf("MCP_SERVERS.%s.TIMEOUT must be >= 0, got %d", name, c.Timeout)
 	}
 
-	auth := c.EffectiveAuth()
 	switch auth {
 	case MCPAuthAuto, MCPAuthGH, MCPAuthBearer, MCPAuthBasic, MCPAuthNone:
 		// valid

--- a/internal/domain/config/mcp_config_test.go
+++ b/internal/domain/config/mcp_config_test.go
@@ -409,3 +409,238 @@ MCP_SERVERS:
 	assert.Equal(t, "user@example.com", rovo.Username)
 	assert.Equal(t, "tok", rovo.Token)
 }
+
+// TestMCPServerConfig_IsStdio pins the stdio predicate: a server is stdio
+// iff COMMAND is set — whitespace-only COMMAND does not count.
+func TestMCPServerConfig_IsStdio(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		command string
+		want    bool
+	}{
+		{"empty command is not stdio", "", false},
+		{"whitespace-only command is not stdio", "   ", false},
+		{"command set is stdio", "npx", true},
+		{"command with surrounding whitespace is stdio", "  npx  ", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			c := MCPServerConfig{Command: tt.command}
+			assert.Equal(t, tt.want, c.IsStdio())
+		})
+	}
+}
+
+// TestMCPServerConfig_Validate_StdioModeConflict pins the stdio/HTTP mode
+// contract: COMMAND and URL are mutually exclusive, neither may be absent,
+// and ARGS/DIR/ENV require COMMAND. The most specific error wins (each
+// check returns immediately).
+func TestMCPServerConfig_Validate_StdioModeConflict(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         MCPServerConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "COMMAND and URL are mutually exclusive",
+			cfg:         MCPServerConfig{Command: "npx", URL: "https://example.com/mcp"},
+			wantErr:     true,
+			errContains: "mutually exclusive",
+		},
+		{
+			name:        "neither COMMAND nor URL",
+			cfg:         MCPServerConfig{},
+			wantErr:     true,
+			errContains: "URL must not be empty",
+		},
+		{
+			name:        "ARGS without COMMAND",
+			cfg:         MCPServerConfig{URL: "https://example.com/mcp", Args: []string{"--foo"}},
+			wantErr:     true,
+			errContains: "ARGS/DIR/ENV require COMMAND",
+		},
+		{
+			name:        "DIR without COMMAND",
+			cfg:         MCPServerConfig{URL: "https://example.com/mcp", Dir: "/tmp"},
+			wantErr:     true,
+			errContains: "ARGS/DIR/ENV require COMMAND",
+		},
+		{
+			name:        "ENV without COMMAND",
+			cfg:         MCPServerConfig{URL: "https://example.com/mcp", Env: map[string]string{"FOO": "bar"}},
+			wantErr:     true,
+			errContains: "ARGS/DIR/ENV require COMMAND",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.validate("server")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestMCPServerConfig_Validate_StdioAuth pins the stdio auth contract:
+// bearer/basic are hard-rejected under COMMAND (stdio servers transmit no
+// credentials) — the mode conflict is diagnosed before the positive
+// credential rules — while auto/gh/none/empty remain valid and stray
+// TOKEN/USERNAME are tolerated.
+func TestMCPServerConfig_Validate_StdioAuth(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         MCPServerConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "COMMAND with bearer rejected",
+			cfg:         MCPServerConfig{Command: "npx", Auth: "bearer", Token: "tok"},
+			wantErr:     true,
+			errContains: "requires an HTTP endpoint",
+		},
+		{
+			name:        "COMMAND with basic rejected even with valid credentials",
+			cfg:         MCPServerConfig{Command: "npx", Auth: "basic", Username: "user", Token: "tok"},
+			wantErr:     true,
+			errContains: "requires an HTTP endpoint",
+		},
+		{
+			name:        "COMMAND with bearer and empty token: mode conflict wins",
+			cfg:         MCPServerConfig{Command: "npx", Auth: "bearer"},
+			wantErr:     true,
+			errContains: "requires an HTTP endpoint",
+		},
+		{
+			name:    "COMMAND with auto valid",
+			cfg:     MCPServerConfig{Command: "npx", Auth: "auto"},
+			wantErr: false,
+		},
+		{
+			name:    "COMMAND with gh valid",
+			cfg:     MCPServerConfig{Command: "npx", Auth: "gh"},
+			wantErr: false,
+		},
+		{
+			name:    "COMMAND with none valid",
+			cfg:     MCPServerConfig{Command: "npx", Auth: "none"},
+			wantErr: false,
+		},
+		{
+			name:    "COMMAND with empty auth valid",
+			cfg:     MCPServerConfig{Command: "npx"},
+			wantErr: false,
+		},
+		{
+			name:    "COMMAND with gh and stray token valid",
+			cfg:     MCPServerConfig{Command: "npx", Auth: "gh", Token: "stray"},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := tt.cfg.validate("server")
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				// The mode-conflict diagnosis must win over the positive
+				// credential rules (bearer/basic missing-credential errors).
+				assert.NotContains(t, err.Error(), "must not be empty when AUTH")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestMCPServerConfig_ConsentAndSerial_Stdio pins the stdio defaults for
+// consent and serialization: a stdio server defaults to no consent (trusted
+// local spawn) and serial execution (no URL → not read-only). The explicit
+// REQUIRES_CONSENT override still wins; HTTP URL-class defaults are
+// regression-pinned.
+func TestMCPServerConfig_ConsentAndSerial_Stdio(t *testing.T) {
+	t.Parallel()
+
+	trueVal := true
+	falseVal := false
+
+	tests := []struct {
+		name        string
+		cfg         MCPServerConfig
+		wantConsent bool
+		wantSerial  bool
+	}{
+		{
+			name:        "stdio default: no consent, serial",
+			cfg:         MCPServerConfig{Command: "npx"},
+			wantConsent: false,
+			wantSerial:  true,
+		},
+		{
+			name:        "stdio with explicit consent true",
+			cfg:         MCPServerConfig{Command: "npx", RequiresConsent: &trueVal},
+			wantConsent: true,
+			wantSerial:  true,
+		},
+		{
+			name:        "stdio with explicit consent false",
+			cfg:         MCPServerConfig{Command: "npx", RequiresConsent: &falseVal},
+			wantConsent: false,
+			wantSerial:  true,
+		},
+		{
+			name:        "HTTP readonly regression",
+			cfg:         MCPServerConfig{URL: "https://api.githubcopilot.com/mcp/readonly"},
+			wantConsent: false,
+			wantSerial:  false,
+		},
+		{
+			name:        "HTTP mutating regression",
+			cfg:         MCPServerConfig{URL: "https://api.githubcopilot.com/mcp/"},
+			wantConsent: true,
+			wantSerial:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.wantConsent, tt.cfg.EffectiveRequiresConsent())
+			assert.Equal(t, tt.wantSerial, tt.cfg.EffectiveSerial())
+		})
+	}
+}
+
+// TestConfig_ValidateMCPServers_Stdio pins that a valid stdio server
+// config survives ValidateMCPServers: the key-regex check runs first and
+// the per-server validate() accepts a COMMAND-only stdio configuration.
+func TestConfig_ValidateMCPServers_Stdio(t *testing.T) {
+	t.Parallel()
+
+	cfg := &Config{MCPServers: map[string]MCPServerConfig{
+		"local-fs": {
+			Command: "npx",
+			Args:    []string{"-y", "@modelcontextprotocol/server-filesystem"},
+			Dir:     "/tmp",
+			Env:     map[string]string{"FOO": "bar"},
+		},
+	}}
+	require.NoError(t, cfg.ValidateMCPServers())
+}

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -155,7 +155,9 @@ func readConfigFile(v *viper.Viper, path string) error {
 	if isDebug() {
 		slog.Debug("viper parsed keys")
 		for _, key := range v.AllKeys() {
-			if isSecretKey(key) {
+			// ENV/ARGS subtrees are dropped wholesale so innocuous-named
+			// sub-keys (e.g. env::FOO) cannot leak values.
+			if isSecretKey(key) || hasSecretAncestor(key) {
 				slog.Debug("parsed entry", slog.String("key", key), slog.String("value", redactedValue))
 			} else {
 				slog.Debug("parsed entry", slog.String("key", key), slog.Any("value", v.Get(key)))

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -1063,3 +1063,102 @@ func TestRawContentDump_InvalidYAML_ColonlessSecretRedacted(t *testing.T) {
 		t.Error("debug output missing the colonless redaction (TOKEN [REDACTED])")
 	}
 }
+
+// TestLoad_ParsedDump_MCPStdioRedaction pins the #1396 parsed-dump redaction
+// contract for MCP stdio servers: neither the raw-content dump nor the
+// parsed-key dump may log an ARGS element or an ENV value. The parsed dump
+// must additionally drop innocuous-named ENV sub-keys (env::FOO) via
+// hasSecretAncestor, since their leaf alone is not deny-listed.
+func TestLoad_ParsedDump_MCPStdioRedaction(t *testing.T) {
+	t.Setenv("TELL_ME_MODE", "")              // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_stdio_redaction.yaml")
+	yamlContent := `
+MCP_SERVERS:
+  fs:
+    COMMAND: "uvx"
+    ARGS: ["--token", "sk-1234"]
+    ENV:
+      FOO: "sk-5678"
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	buf := captureDebugLogs(t)
+	cfg, err := load(configPath)
+	if err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config")
+	}
+
+	output := buf.String()
+	if strings.Contains(output, "sk-1234") {
+		t.Error("debug output leaked an ARGS element value (sk-1234)")
+	}
+	if strings.Contains(output, "sk-5678") {
+		t.Error("debug output leaked an ENV value (sk-5678)")
+	}
+	if !strings.Contains(output, "[REDACTED]") {
+		t.Error("debug output missing the [REDACTED] placeholder")
+	}
+	if !strings.Contains(output, "mcp_servers::fs::env") {
+		t.Error("debug output missing the parsed env key; parsed dump not emitted")
+	}
+}
+
+// TestLoad_MCPStdio_EnvExpansion pins the issue §1 claim: ${VAR} expansion
+// must apply to the new stdio fields — the COMMAND string, each ARGS slice
+// element, and each ENV map value. expandEnvHook fires per string element /
+// value through mapstructure's decode hook pipeline; if it ever stops firing
+// for []string elements or map[string]string values, this test fails and the
+// hook needs a change (the values are compared against the expanded forms).
+func TestLoad_MCPStdio_EnvExpansion(t *testing.T) {
+	t.Setenv("TELL_ME_MODE", "")              // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+	t.Setenv("UVX_PATH", "/venv/bin")
+	t.Setenv("ARG_VAL", "expanded-arg")
+	t.Setenv("CUSTOM_PATH", "/custom/bin")
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "test_stdio_expansion.yaml")
+	yamlContent := `
+MCP_SERVERS:
+  fs:
+    COMMAND: "${UVX_PATH}/uvx"
+    ARGS: ["--flag=${ARG_VAL}"]
+    ENV:
+      PATH: "${CUSTOM_PATH}"
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatalf("failed to write test config: %v", err)
+	}
+
+	cfg, err := load(configPath)
+	if err != nil {
+		t.Fatalf("load() failed: %v", err)
+	}
+
+	fs := cfg.MCPServers["fs"]
+	if fs.Command != "/venv/bin/uvx" {
+		t.Errorf("COMMAND not expanded: got %q, want %q", fs.Command, "/venv/bin/uvx")
+	}
+	if len(fs.Args) != 1 || fs.Args[0] != "--flag=expanded-arg" {
+		t.Errorf("ARGS element not expanded: got %v, want [--flag=expanded-arg]", fs.Args)
+	}
+	// Viper lowercases nested map keys, so assert on the value rather than
+	// the key casing to pin the expansion itself.
+	expanded := false
+	for _, v := range fs.Env {
+		if v == "/custom/bin" {
+			expanded = true
+		}
+	}
+	if !expanded {
+		t.Errorf("ENV value not expanded: got %v, want a value of /custom/bin", fs.Env)
+	}
+}

--- a/internal/infrastructure/config/redact.go
+++ b/internal/infrastructure/config/redact.go
@@ -15,8 +15,11 @@ const redactedValue = "[REDACTED]"
 // case-insensitive. `tokens?` is deliberately absent so max_tokens /
 // max_history_tokens (non-secret integer limits) never match; token$ singular
 // stays. NOTE: the trailing keys? alternative also matches any leaf ending in
-// "key"/"keys" (e.g. "monkey") — accepted fail-closed over-redaction.
-var secretKeyPattern = regexp.MustCompile(`(?i)(api[_-]?keys?|auth[_-]?tokens?|authorization|token|passwords?|secrets?|credentials?|usernames?|keys?)$`)
+// "key"/"keys" (e.g. "monkey") — accepted fail-closed over-redaction. The
+// args?/env alternatives cover MCP stdio ARGS/ENV config, over-redacting any
+// leaf ending in arg/args/env (e.g. an ARGS list that holds no secrets) —
+// same accepted fail-closed trade as keys?.
+var secretKeyPattern = regexp.MustCompile(`(?i)(api[_-]?keys?|auth[_-]?tokens?|authorization|token|passwords?|secrets?|credentials?|usernames?|keys?|args?|env)$`)
 
 // isSecretKey reports whether a config key is secret-bearing.
 // The regex is suffix-anchored and case-insensitive, so full viper paths
@@ -24,6 +27,20 @@ var secretKeyPattern = regexp.MustCompile(`(?i)(api[_-]?keys?|auth[_-]?tokens?|a
 // match on their leaf without pre-splitting.
 func isSecretKey(key string) bool {
 	return secretKeyPattern.MatchString(strings.TrimSpace(key))
+}
+
+// hasSecretAncestor reports whether any proper ancestor of key (split on the
+// viper "::" key delimiter) is deny-listed. Example: the parsed dump must drop
+// mcp_servers::fs::env::FOO because its ancestor mcp_servers::fs::env has the
+// deny-listed leaf "env" — a leaf-suffix match on FOO alone cannot see it.
+func hasSecretAncestor(key string) bool {
+	parts := strings.Split(key, "::")
+	for i := 1; i < len(parts); i++ {
+		if isSecretKey(strings.Join(parts[:i], "::")) {
+			return true
+		}
+	}
+	return false
 }
 
 // normalizeKeyToken normalizes a raw key token for deny-list comparison:

--- a/internal/infrastructure/config/redact_test.go
+++ b/internal/infrastructure/config/redact_test.go
@@ -32,6 +32,9 @@ func TestIsSecretKey(t *testing.T) {
 		"TELL_ME_MCP_SERVERS_ATLASSIAN_TOKEN",
 		"github_token",
 		"mcp_token",
+		"mcp_servers.fs.args",
+		"mcp_servers.fs.arg",
+		"mcp_servers.fs.env",
 	}
 	negatives := []string{
 		"max_tokens",
@@ -44,6 +47,8 @@ func TestIsSecretKey(t *testing.T) {
 		"context_window",
 		"timeout",
 		"wrap_width",
+		"mcp_servers.fs.command",
+		"mcp_servers.fs.timeout",
 	}
 
 	for _, key := range positives {
@@ -84,6 +89,10 @@ func TestRedactRawContent(t *testing.T) {
 		{"innocuous-name scalar passes through", "PAYLOAD: sk-1234", "PAYLOAD: sk-1234"},
 		{"block scalar key-shaped content fail-closed", "PERSON: |\n  API_KEY: sk-123", "PERSON: |\n  API_KEY: [REDACTED]"},
 		{"barred plural tokens passes through", "HEADERS: {tokens: sk-123}", "HEADERS: {tokens: sk-123}"},
+		{"stdio ARGS list collapses on key", `ARGS: ["-p", "sk-1234"]`, "ARGS: [REDACTED]"},
+		{"stdio ARGS non-secret list fail-closed", `ARGS: ["-y", "@modelcontextprotocol/server-filesystem"]`, "ARGS: [REDACTED]"},
+		{"stdio ENV block collapses and drops sub-lines", "ENV:\n  FOO: sk-5678\n  BAR: other\n", "ENV: [REDACTED]\n"},
+		{"max_tokens passes through byte-identically", "max_tokens: 4096", "max_tokens: 4096"},
 		{"multi-line mixed content", "MODE: test\nMODEL: gpt-4\nAPI_KEY: sk-123\n", "MODE: test\nMODEL: gpt-4\nAPI_KEY: [REDACTED]\n"},
 	}
 
@@ -91,6 +100,32 @@ func TestRedactRawContent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := redactRawContent(tt.input); got != tt.want {
 				t.Errorf("redactRawContent(%q) = %q; want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestHasSecretAncestor pins the ancestor-skip helper used by the parsed-key
+// debug dump: a key whose proper ancestor is deny-listed (e.g. the env subtree
+// of an MCP stdio server) must be dropped even when its own leaf is
+// innocuous. A deny-listed leaf is never its own ancestor.
+func TestHasSecretAncestor(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+		want bool
+	}{
+		{"env sub-key has secret ancestor", "mcp_servers::fs::env::FOO", true},
+		{"env leaf itself is not its own ancestor", "mcp_servers::fs::env", false},
+		{"url leaf has no secret ancestor", "mcp_servers::fs::url", false},
+		{"apikey subtree ancestor", "providers::google::apikey::sub", true},
+		{"top-level key has no ancestor", "token", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasSecretAncestor(tt.key); got != tt.want {
+				t.Errorf("hasSecretAncestor(%q) = %v; want %v", tt.key, got, tt.want)
 			}
 		})
 	}

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -15,7 +15,6 @@ import (
 	"runtime"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
@@ -1944,7 +1943,7 @@ func TestBuildSessionDependencies_CleanupClosesMCPClients(t *testing.T) {
 	// without contacting a live MCP endpoint.
 	tf := b.toolchainFactory.(*defaultToolchainFactory)
 	var constructed []*closeCountingMCPClient
-	tf.mcpFactory.newClient = func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
+	tf.mcpFactory.newClientFor = func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
 		c := &closeCountingMCPClient{}
 		constructed = append(constructed, c)
 		return c, nil

--- a/internal/infrastructure/di/mcp_factory.go
+++ b/internal/infrastructure/di/mcp_factory.go
@@ -9,9 +9,9 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
@@ -32,11 +32,16 @@ type mcpFactory struct {
 	// token).
 	tokenResolver func() (string, error)
 
-	// newClient constructs the tools.MCPClient adapter for an endpoint.
-	newClient func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error)
+	// newClientFor constructs the tools.MCPClient adapter for a single server,
+	// dispatching on transport: stdio (COMMAND) vs remote Streamable HTTP (URL).
+	// It is injectable so the factory is unit-testable without spawning a
+	// process or contacting a live endpoint.
+	newClientFor func(serverCfg config.MCPServerConfig) (tools.MCPClient, error)
 
 	// cachedToken memoizes a successfully resolved token so that multiple
 	// servers sharing the same fallback do not spawn `gh` repeatedly.
+	// Written and read only during Build's phase-1 pre-pass
+	// (single-threaded); phase-2 goroutines never call resolveToken.
 	cachedToken string
 
 	// mu protects clients. Build may be invoked concurrently with Close
@@ -49,8 +54,9 @@ type mcpFactory struct {
 }
 
 // newMCPFactory constructs the default MCP dependency factory. The default
-// token resolver executes `gh auth token`; the default client constructor is
-// the streamable-HTTP MCP adapter.
+// token resolver executes `gh auth token`; the default client constructor
+// dispatches on transport — local stdio child processes via StdioClient, and
+// remote Streamable HTTP endpoints via the HTTP MCP adapter.
 func newMCPFactory(logger *slog.Logger) *mcpFactory {
 	if logger == nil {
 		logger = slog.Default()
@@ -64,44 +70,104 @@ func newMCPFactory(logger *slog.Logger) *mcpFactory {
 			}
 			return strings.TrimSpace(string(out)), nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			if username != "" {
-				return infra_mcp.NewClient(endpoint, token, timeout, infra_mcp.WithBasicAuth(username))
+		newClientFor: func(serverCfg config.MCPServerConfig) (tools.MCPClient, error) {
+			if serverCfg.IsStdio() {
+				return infra_mcp.NewStdioClient(serverCfg, logger)
 			}
-			return infra_mcp.NewClient(endpoint, token, timeout)
+			if serverCfg.Username != "" {
+				return infra_mcp.NewClient(serverCfg.URL, serverCfg.Token, serverCfg.EffectiveTimeout(), infra_mcp.WithBasicAuth(serverCfg.Username))
+			}
+			return infra_mcp.NewClient(serverCfg.URL, serverCfg.Token, serverCfg.EffectiveTimeout())
 		},
 	}
 }
 
 // Build constructs the MCP client dependencies for every configured server.
-// A server whose credentials cannot be resolved, or whose client cannot be
-// constructed, is skipped with a warning rather than failing startup.
+// Construction is two-phase: a sequential token pre-pass resolves and stamps
+// credentials into per-server copies (single-flight gh memoization), then
+// per-server construction runs concurrently. A server whose credentials
+// cannot be resolved, or whose client cannot be constructed, is skipped with
+// a warning rather than failing startup.
 func (f *mcpFactory) Build(servers map[string]config.MCPServerConfig) map[string]plugin.MCPServerDependency {
 	deps := make(map[string]plugin.MCPServerDependency, len(servers))
-
-	for name, serverCfg := range servers {
-		username, token, ok := f.resolveServerToken(name, serverCfg)
-		if !ok {
-			continue
-		}
-
-		client, err := f.newClient(serverCfg.URL, username, token, serverCfg.EffectiveTimeout())
-		if err != nil {
-			f.logger.Warn("mcp_client_init_failed", "server", name, "error", err)
-			continue
-		}
-
-		f.mu.Lock()
-		f.clients = append(f.clients, client)
-		f.mu.Unlock()
-
-		deps[name] = plugin.MCPServerDependency{
-			Client:          client,
-			RequiresConsent: serverCfg.EffectiveRequiresConsent(),
-			Serial:          serverCfg.EffectiveSerial(),
-		}
+	if len(servers) == 0 {
+		return deps
 	}
 
+	// Deterministic iteration order (map iteration is not).
+	names := make([]string, 0, len(servers))
+	for name := range servers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	// Phase 1 — SEQUENTIAL token pre-pass. Stdio servers short-circuit first:
+	// gh/auto under COMMAND never resolve, never warn, never invoke the
+	// resolver. HTTP servers resolve via resolveServerToken (single-flight gh
+	// memoization via f.cachedToken — written and read only in this phase,
+	// which is single-threaded). Resolved credentials are stamped into a
+	// per-server copy so phase 2 goroutines never touch shared mutable state.
+	type entry struct {
+		name string
+		cfg  config.MCPServerConfig // HTTP: Token/Username stamped; stdio: unchanged
+		ok   bool
+	}
+	entries := make([]entry, 0, len(names))
+	for _, name := range names {
+		serverCfg := servers[name]
+		if serverCfg.IsStdio() {
+			entries = append(entries, entry{name: name, cfg: serverCfg, ok: true})
+			continue
+		}
+		username, token, ok := f.resolveServerToken(name, serverCfg)
+		if !ok {
+			continue // resolver already warned (mcp_token_resolution_skipped)
+		}
+		resolved := serverCfg
+		resolved.Username = username
+		resolved.Token = token
+		entries = append(entries, entry{name: name, cfg: resolved, ok: true})
+	}
+
+	// Phase 2 — CONCURRENT construction, mirroring the plugin's own pattern
+	// (internal/tools/integrations/mcp/plugin.go:61-89). Per-server
+	// spawn+handshake is bounded by EffectiveTimeout inside the constructor.
+	// Goroutines write only to their own result slot — no shared writes, no
+	// locks in the hot path. Failures warn+skip per server; no overall bound.
+	type result struct {
+		name   string
+		cfg    config.MCPServerConfig
+		client tools.MCPClient
+		err    error
+	}
+	results := make([]result, len(entries))
+	var wg sync.WaitGroup
+	for i, e := range entries {
+		wg.Add(1)
+		go func(i int, e entry) {
+			defer wg.Done()
+			client, err := f.newClientFor(e.cfg)
+			results[i] = result{name: e.name, cfg: e.cfg, client: client, err: err}
+		}(i, e)
+	}
+	wg.Wait()
+
+	// Merge deterministically (sorted by name) so warn order and registration
+	// order are stable regardless of goroutine completion order.
+	for _, res := range results {
+		if res.err != nil {
+			f.logger.Warn("mcp_client_init_failed", "server", res.name, "error", res.err)
+			continue
+		}
+		f.mu.Lock()
+		f.clients = append(f.clients, res.client)
+		f.mu.Unlock()
+		deps[res.name] = plugin.MCPServerDependency{
+			Client:          res.client,
+			RequiresConsent: res.cfg.EffectiveRequiresConsent(),
+			Serial:          res.cfg.EffectiveSerial(),
+		}
+	}
 	return deps
 }
 

--- a/internal/infrastructure/di/mcp_factory_test.go
+++ b/internal/infrastructure/di/mcp_factory_test.go
@@ -7,12 +7,17 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/tools/integrations/plugin"
 )
 
 // fakeMCPClient is a minimal tools.MCPClient double used to assert that a
@@ -85,8 +90,8 @@ func TestMCPFactory_ExplicitToken(t *testing.T) {
 			resolverCalls++
 			return "", errors.New("should not be called")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			capturedToken = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			capturedToken = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -112,7 +117,8 @@ func TestMCPFactory_ExplicitToken(t *testing.T) {
 
 func TestMCPFactory_GhFallbackAndCaching(t *testing.T) {
 	resolverCalls := 0
-	var tokens []string
+	var mu sync.Mutex
+	tokens := map[string]string{}
 
 	f := &mcpFactory{
 		logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
@@ -120,8 +126,10 @@ func TestMCPFactory_GhFallbackAndCaching(t *testing.T) {
 			resolverCalls++
 			return "gh-token", nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			tokens = append(tokens, token)
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			mu.Lock()
+			tokens[cfg.URL] = cfg.Token
+			mu.Unlock()
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -138,11 +146,11 @@ func TestMCPFactory_GhFallbackAndCaching(t *testing.T) {
 		t.Fatalf("deps count = %d, want 2", len(deps))
 	}
 	if len(tokens) != 2 {
-		t.Fatalf("client constructor called %d times, want 2", len(tokens))
+		t.Fatalf("client constructor called for %d servers, want 2", len(tokens))
 	}
-	for i, tok := range tokens {
-		if tok != "gh-token" {
-			t.Errorf("token[%d] = %q, want %q", i, tok, "gh-token")
+	for _, rawURL := range []string{"https://github.com/org/repo/mcp", "https://api.githubcopilot.com/mcp/"} {
+		if tokens[rawURL] != "gh-token" {
+			t.Errorf("client token for %q = %q, want %q", rawURL, tokens[rawURL], "gh-token")
 		}
 	}
 }
@@ -156,8 +164,8 @@ func TestMCPFactory_EnvFallback(t *testing.T) {
 		tokenResolver: func() (string, error) {
 			return "", errors.New("gh unavailable")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			capturedToken = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			capturedToken = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -183,7 +191,7 @@ func TestMCPFactory_TokenResolutionFailureSkips(t *testing.T) {
 		tokenResolver: func() (string, error) {
 			return "", errors.New("gh unavailable")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -204,7 +212,7 @@ func TestMCPFactory_ClientInitFailureSkips(t *testing.T) {
 	var buf bytes.Buffer
 	f := &mcpFactory{
 		logger: slog.New(slog.NewTextHandler(&buf, nil)),
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
 			return nil, errors.New("boom")
 		},
 	}
@@ -224,7 +232,7 @@ func TestMCPFactory_ClientInitFailureSkips(t *testing.T) {
 func TestMCPFactory_ConsentAndSerialPropagation(t *testing.T) {
 	f := &mcpFactory{
 		logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -273,8 +281,8 @@ func TestMCPFactory_AuthNone(t *testing.T) {
 			resolverCalls++
 			return "", errors.New("should not be called")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			captured[cfg.URL] = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -308,8 +316,8 @@ func TestMCPFactory_AuthBearer(t *testing.T) {
 			resolverCalls++
 			return "", errors.New("should not be called")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			captured[cfg.URL] = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -344,9 +352,9 @@ func TestMCPFactory_AuthBearer(t *testing.T) {
 				resolverCalls++
 				return "", errors.New("should not be called")
 			},
-			newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-				capturedUsername = username
-				capturedToken = token
+			newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+				capturedUsername = cfg.Username
+				capturedToken = cfg.Token
 				return &fakeMCPClient{}, nil
 			},
 		}
@@ -380,9 +388,9 @@ func TestMCPFactory_AuthBasic(t *testing.T) {
 			resolverCalls++
 			return "", errors.New("should not be called")
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			capturedUsername = username
-			capturedToken = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			capturedUsername = cfg.Username
+			capturedToken = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -419,8 +427,8 @@ func TestMCPFactory_AuthGH(t *testing.T) {
 			resolverCalls++
 			return "gh-token", nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			captured[cfg.URL] = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -455,8 +463,8 @@ func TestMCPFactory_AuthGH_ExplicitTokenWins(t *testing.T) {
 			resolverCalls++
 			return "gh-token", nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			captured[cfg.URL] = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -478,6 +486,7 @@ func TestMCPFactory_AuthGH_ExplicitTokenWins(t *testing.T) {
 
 func TestMCPFactory_AuthAuto(t *testing.T) {
 	resolverCalls := 0
+	var mu sync.Mutex
 	captured := map[string]string{}
 
 	f := &mcpFactory{
@@ -486,8 +495,10 @@ func TestMCPFactory_AuthAuto(t *testing.T) {
 			resolverCalls++
 			return "gh-token", nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			mu.Lock()
+			captured[cfg.URL] = cfg.Token
+			mu.Unlock()
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -521,8 +532,8 @@ func TestMCPFactory_AuthAuto_ExplicitTokenWins(t *testing.T) {
 			resolverCalls++
 			return "gh-token", nil
 		},
-		newClient: func(endpoint, username, token string, timeout time.Duration) (tools.MCPClient, error) {
-			captured[endpoint] = token
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			captured[cfg.URL] = cfg.Token
 			return &fakeMCPClient{}, nil
 		},
 	}
@@ -539,6 +550,310 @@ func TestMCPFactory_AuthAuto_ExplicitTokenWins(t *testing.T) {
 	}
 	if got := captured["https://github.com/org/repo/mcp"]; got != "explicit-token" {
 		t.Errorf("client token = %q, want %q", got, "explicit-token")
+	}
+}
+
+// TestMCPFactory_StdioDispatch pins the transport dispatch: a stdio (COMMAND)
+// server and a URL server are both built, and each dep carries the correct
+// consent/serial policy for its transport class.
+func TestMCPFactory_StdioDispatch(t *testing.T) {
+	var mu sync.Mutex
+	stdioSeen := 0
+	urlSeen := 0
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if cfg.IsStdio() {
+				stdioSeen++
+			} else {
+				urlSeen++
+			}
+			return &fakeMCPClient{}, nil
+		},
+	}
+
+	deps := f.Build(map[string]config.MCPServerConfig{
+		"fs":     {Command: "npx", Args: []string{"-y", "server"}},
+		"remote": {URL: "https://example.com/mcp"},
+	})
+
+	fs, ok := deps["fs"]
+	if !ok {
+		t.Fatal("expected 'fs' dependency")
+	}
+	if fs.RequiresConsent {
+		t.Error("stdio dep RequiresConsent = true, want false (trusted local spawn)")
+	}
+	if !fs.Serial {
+		t.Error("stdio dep Serial = false, want true (no URL → serial by construction)")
+	}
+
+	remote, ok := deps["remote"]
+	if !ok {
+		t.Fatal("expected 'remote' dependency")
+	}
+	if !remote.RequiresConsent {
+		t.Error("remote dep RequiresConsent = false, want true (mutating URL class)")
+	}
+	if !remote.Serial {
+		t.Error("remote dep Serial = false, want true (mutating URL class)")
+	}
+
+	if stdioSeen != 1 || urlSeen != 1 {
+		t.Errorf("fake saw stdio=%d url=%d, want exactly one of each", stdioSeen, urlSeen)
+	}
+}
+
+// TestMCPFactory_StdioSkipsTokenResolution pins that a stdio server under gh
+// auth short-circuits before token resolution: the resolver is never invoked
+// and no mcp_token_resolution_skipped warning is emitted.
+func TestMCPFactory_StdioSkipsTokenResolution(t *testing.T) {
+	var buf bytes.Buffer
+	resolverCalls := 0
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&buf, nil)),
+		tokenResolver: func() (string, error) {
+			resolverCalls++
+			return "", errors.New("should not be called")
+		},
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			return &fakeMCPClient{}, nil
+		},
+	}
+
+	deps := f.Build(map[string]config.MCPServerConfig{
+		"fs": {Command: "npx", Auth: config.MCPAuthGH},
+	})
+
+	if resolverCalls != 0 {
+		t.Errorf("token resolver called %d times, want 0 (stdio short-circuits before resolution)", resolverCalls)
+	}
+	if _, ok := deps["fs"]; !ok {
+		t.Fatal("expected 'fs' dependency")
+	}
+	if bytes.Contains(buf.Bytes(), []byte("mcp_token_resolution_skipped")) {
+		t.Error("stdio server must not emit mcp_token_resolution_skipped")
+	}
+}
+
+// TestMCPFactory_ConstructorError_NoArgsEnvLeak pins that constructor-failure
+// warning text carries the COMMAND at most — never ARGS elements or ENV
+// values — and that the failing servers are skipped.
+func TestMCPFactory_ConstructorError_NoArgsEnvLeak(t *testing.T) {
+	var buf bytes.Buffer
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&buf, nil)),
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			return nil, fmt.Errorf("init failed for %s", cfg.Command)
+		},
+	}
+
+	deps := f.Build(map[string]config.MCPServerConfig{
+		"fs":     {Command: "npx", Args: []string{"sk-args-leak"}, Env: map[string]string{"K": "sk-env-leak"}},
+		"remote": {URL: "https://example.com/mcp"},
+	})
+
+	if len(deps) != 0 {
+		t.Fatalf("deps count = %d, want 0 (both servers must be skipped)", len(deps))
+	}
+	out := buf.String()
+	if !strings.Contains(out, "npx") {
+		t.Error("log missing the COMMAND (npx); error text must carry the command name")
+	}
+	if strings.Contains(out, "sk-args-leak") {
+		t.Error("log leaked an ARGS value (sk-args-leak)")
+	}
+	if strings.Contains(out, "sk-env-leak") {
+		t.Error("log leaked an ENV value (sk-env-leak)")
+	}
+	if !bytes.Contains(buf.Bytes(), []byte("mcp_client_init_failed")) {
+		t.Error("expected mcp_client_init_failed warning")
+	}
+}
+
+// TestMCPFactory_ConcurrentBuild proves phase-2 construction is concurrent:
+// each fake call blocks on its own release channel, so all N constructions
+// must have entered the fake before any completes. A deadline select bounds
+// the wait — no time.Sleep (ADR-036).
+func TestMCPFactory_ConcurrentBuild(t *testing.T) {
+	const n = 4
+
+	releases := make([]chan struct{}, n)
+	for i := range releases {
+		releases[i] = make(chan struct{})
+	}
+	entered := make(chan struct{}, n)
+	var started atomic.Int32
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			idx := int(started.Add(1)) - 1
+			entered <- struct{}{}
+			<-releases[idx]
+			return &fakeMCPClient{}, nil
+		},
+	}
+
+	servers := make(map[string]config.MCPServerConfig, n)
+	for i := 0; i < n; i++ {
+		servers[fmt.Sprintf("server-%d", i)] = config.MCPServerConfig{URL: fmt.Sprintf("https://example.com/mcp/%d", i)}
+	}
+
+	done := make(chan map[string]plugin.MCPServerDependency)
+	go func() {
+		done <- f.Build(servers)
+	}()
+
+	for i := 0; i < n; i++ {
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of %d constructions started; Build is not concurrent", i, n)
+		}
+	}
+	if got := started.Load(); got != n {
+		t.Fatalf("started counter = %d, want %d", got, n)
+	}
+
+	for _, ch := range releases {
+		close(ch)
+	}
+	deps := <-done
+
+	if len(deps) != n {
+		t.Fatalf("deps count = %d, want %d", len(deps), n)
+	}
+	for name := range servers {
+		if _, ok := deps[name]; !ok {
+			t.Errorf("missing dependency %q", name)
+		}
+	}
+}
+
+// TestMCPFactory_ConcurrentBuild_FailingServerSkips pins the per-server
+// failure path under concurrent construction: the failing server's dep is
+// absent, the others are present, and mcp_client_init_failed is logged
+// exactly once.
+func TestMCPFactory_ConcurrentBuild_FailingServerSkips(t *testing.T) {
+	const n = 4
+
+	releases := make([]chan struct{}, n)
+	for i := range releases {
+		releases[i] = make(chan struct{})
+	}
+	entered := make(chan struct{}, n)
+	var started atomic.Int32
+	var buf bytes.Buffer
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&buf, nil)),
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			idx := int(started.Add(1)) - 1
+			entered <- struct{}{}
+			<-releases[idx]
+			if strings.HasSuffix(cfg.URL, "/fail") {
+				return nil, errors.New("boom")
+			}
+			return &fakeMCPClient{}, nil
+		},
+	}
+
+	servers := make(map[string]config.MCPServerConfig, n)
+	for i := 0; i < n; i++ {
+		url := fmt.Sprintf("https://example.com/mcp/%d", i)
+		if i == 2 {
+			url = "https://example.com/mcp/fail"
+		}
+		servers[fmt.Sprintf("server-%d", i)] = config.MCPServerConfig{URL: url}
+	}
+
+	done := make(chan map[string]plugin.MCPServerDependency)
+	go func() {
+		done <- f.Build(servers)
+	}()
+
+	for i := 0; i < n; i++ {
+		select {
+		case <-entered:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("only %d of %d constructions started", i, n)
+		}
+	}
+	for _, ch := range releases {
+		close(ch)
+	}
+	deps := <-done
+
+	if len(deps) != n-1 {
+		t.Fatalf("deps count = %d, want %d (failing server skipped)", len(deps), n-1)
+	}
+	if _, ok := deps["server-2"]; ok {
+		t.Error("failing server 'server-2' must be absent from deps")
+	}
+	for i := 0; i < n; i++ {
+		if i == 2 {
+			continue
+		}
+		name := fmt.Sprintf("server-%d", i)
+		if _, ok := deps[name]; !ok {
+			t.Errorf("missing dependency %q", name)
+		}
+	}
+	if got := bytes.Count(buf.Bytes(), []byte("mcp_client_init_failed")); got != 1 {
+		t.Errorf("mcp_client_init_failed logged %d times, want exactly 1", got)
+	}
+}
+
+// TestMCPFactory_StdioAndHTTPMixed pins the mixed-transport pre-pass: one
+// stdio server (gh mode, resolved untouched) plus two gh HTTP servers
+// (single-flight token resolution). The stdio config reaches the constructor
+// with its token still empty even though gh mode is set.
+func TestMCPFactory_StdioAndHTTPMixed(t *testing.T) {
+	resolverCalls := 0
+	var mu sync.Mutex
+	stdioToken := "unset"
+	stdioSeen := false
+
+	f := &mcpFactory{
+		logger: slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+		tokenResolver: func() (string, error) {
+			resolverCalls++
+			return "gh-token", nil
+		},
+		newClientFor: func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			if cfg.IsStdio() {
+				stdioSeen = true
+				stdioToken = cfg.Token
+			}
+			return &fakeMCPClient{}, nil
+		},
+	}
+
+	deps := f.Build(map[string]config.MCPServerConfig{
+		"fs":       {Command: "npx", Auth: config.MCPAuthGH},
+		"github-1": {URL: "https://github.com/org/repo/mcp", Auth: config.MCPAuthGH},
+		"github-2": {URL: "https://github.com/org/other/mcp", Auth: config.MCPAuthGH},
+	})
+
+	if resolverCalls != 1 {
+		t.Errorf("token resolver called %d times, want exactly 1 (single-flight pre-pass)", resolverCalls)
+	}
+	if len(deps) != 3 {
+		t.Fatalf("deps count = %d, want 3", len(deps))
+	}
+	if !stdioSeen {
+		t.Error("fake never saw a stdio config")
+	}
+	if stdioToken != "" {
+		t.Errorf("stdio cfg token = %q, want empty (stdio is resolved untouched; gh mode is inert under COMMAND)", stdioToken)
 	}
 }
 

--- a/internal/infrastructure/mcp/client.go
+++ b/internal/infrastructure/mcp/client.go
@@ -2,10 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 // Package mcp implements the infrastructure adapter for the tools.MCPClient
-// domain port using the Model Context Protocol (MCP) Go SDK. It targets the
-// Streamable HTTP transport (the transport used by GitHub's hosted remote MCP
-// server) and keeps the SDK isolated behind the domain port so it remains
-// swappable (ADR-055/060 injection pattern).
+// domain port using the Model Context Protocol (MCP) Go SDK. It exposes two
+// transports: Streamable HTTP for remote servers (Client — the transport used
+// by GitHub's hosted remote MCP server) and local stdio child processes
+// (StdioClient — COMMAND + ARGS spawned as a subprocess). The SDK is isolated
+// behind the domain port so it remains swappable (ADR-055/060 injection
+// pattern).
 package mcp
 
 import (

--- a/internal/infrastructure/mcp/main_test.go
+++ b/internal/infrastructure/mcp/main_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// stdioServerPath is the absolute path to the built stdioserver fixture
+// binary, populated by TestMain. Every integration test spawns it as a real
+// child process via StdioClient.
+var stdioServerPath string
+
+func TestMain(m *testing.M) {
+	tmpDir, err := os.MkdirTemp("", "tmgo-mcp-stdio-test-*")
+	if err != nil {
+		log.Fatalf("failed to create temp dir: %v", err)
+	}
+
+	// Build the fixture binary. Relative to the mcp package directory (go
+	// test runs with the package dir as the working directory).
+	target := filepath.Join(tmpDir, "stdioserver")
+	if runtime.GOOS == "windows" {
+		target += ".exe"
+	}
+
+	cmd := exec.Command("go", "build", "-o", target, "./testdata/stdioserver")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		log.Fatalf("failed to build stdio test server: %v\n%s", err, string(out))
+	}
+
+	absPath, err := filepath.Abs(target)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		log.Fatalf("failed to get absolute path for stdio test server: %v", err)
+	}
+
+	stdioServerPath = absPath
+
+	code := m.Run()
+	_ = os.RemoveAll(tmpDir)
+	os.Exit(code)
+}

--- a/internal/infrastructure/mcp/stdio_client.go
+++ b/internal/infrastructure/mcp/stdio_client.go
@@ -276,7 +276,11 @@ func (c *StdioClient) childExitErrLocked() error {
 	}
 	select {
 	case err := <-c.waitDone:
-		c.exitErr = fmt.Errorf("mcp: stdio child %q exited: %w", c.command, err)
+		if err == nil {
+			c.exitErr = fmt.Errorf("mcp: stdio child %q exited", c.command)
+		} else {
+			c.exitErr = fmt.Errorf("mcp: stdio child %q exited: %w", c.command, err)
+		}
 		return c.exitErr
 	default:
 		return nil
@@ -285,9 +289,13 @@ func (c *StdioClient) childExitErrLocked() error {
 
 // annotateIfDead annotates an in-flight operation error when it coincides with
 // the child having exited (io.EOF / sdkmcp.ErrConnectionClosed + reaper
-// confirms exit). A wedge surfaces as the plain context.DeadlineExceeded wrap
-// — the two failure modes stay distinguishable by error text and latency.
-// Takes c.mu internally; do NOT call while holding c.mu.
+// confirms exit). Once death is confirmed, the returned error IS the sticky
+// child-exit error (c.exitErr) — the same value the fast-death pre-check
+// returns — so the death representation is consistent across the race
+// boundary: an error containing "exited" is always c.exitErr itself. A wedge
+// surfaces as the plain context.DeadlineExceeded wrap — the two failure modes
+// stay distinguishable by error text and latency. Takes c.mu internally; do
+// NOT call while holding c.mu.
 func (c *StdioClient) annotateIfDead(err error) error {
 	if err == nil {
 		return nil
@@ -299,7 +307,7 @@ func (c *StdioClient) annotateIfDead(err error) error {
 		return err
 	}
 	if errors.Is(err, io.EOF) || errors.Is(err, sdkmcp.ErrConnectionClosed) {
-		return fmt.Errorf("%w: %v", childErr, err)
+		return childErr
 	}
 	return err
 }

--- a/internal/infrastructure/mcp/stdio_client.go
+++ b/internal/infrastructure/mcp/stdio_client.go
@@ -1,0 +1,393 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// StdioClient implements tools.MCPClient for a local MCP server spawned as a
+// stdio child process (COMMAND + ARGS). The child is spawned eagerly in
+// NewStdioClient; the MCP handshake runs inside the constructor bounded by the
+// server's EffectiveTimeout. Lifecycle: a reaper goroutine reaps the direct
+// child the moment it dies (no zombies); Close sends stdin EOF first, then
+// cancels as the kill backstop, then joins the reaper.
+type StdioClient struct {
+	name    string // cfg.Command (adapter error text carries this at most — never ARGS/ENV values)
+	command string // resolved executable path
+	args    []string
+	dir     string
+	env     []string // os.Environ() + cfg.Env as K=V, sorted keys appended last (last-wins)
+	timeout time.Duration
+	logger  *slog.Logger
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	mu       sync.Mutex
+	sdk      *sdkmcp.Client
+	session  *sdkmcp.ClientSession
+	waitDone chan error // buffered 1; reaper sends cmd.Wait()'s result exactly once
+	exitErr  error      // sticky wrapped child-exit error set by the fast-death pre-check
+	closed   bool
+}
+
+// Compile-time assertion that StdioClient satisfies the domain port.
+var _ tools.MCPClient = (*StdioClient)(nil)
+
+// NewStdioClient spawns COMMAND as a stdio child process and completes the MCP
+// handshake against it, bounded by the server's EffectiveTimeout. On any
+// failure after Start, the child is cancelled and reaped before returning —
+// a failed handshake never leaks a child process.
+func NewStdioClient(cfg config.MCPServerConfig, logger *slog.Logger) (*StdioClient, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	timeout := cfg.EffectiveTimeout()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	resolved, err := resolveCommand(cfg.Command)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, resolved, cfg.Args...)
+	cmd.Dir = cfg.Dir
+	// Appended pairs override os.Environ() duplicates for the child (last-wins
+	// in the exec environment); keys are sorted so the child env is
+	// deterministic regardless of map iteration order.
+	cmd.Env = append(os.Environ(), sortedEnvPairs(cfg.Env)...)
+
+	// Both pipes must be obtained before Start; any error here leaves nothing
+	// to clean up (no child exists yet).
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	cmd.Stderr = newSlogWriter(logger, cfg.Command)
+
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return nil, err
+	}
+
+	// Reaper started immediately after Start: zombie prevention is not
+	// contingent on Close ever being called.
+	waitDone := make(chan error, 1)
+	go func() {
+		waitDone <- cmd.Wait()
+	}()
+
+	sdk := sdkmcp.NewClient(&sdkmcp.Implementation{
+		Name:    "tell-me-go",
+		Version: "dev",
+	}, nil)
+
+	connectCtx, cancelConnect := context.WithTimeout(ctx, timeout)
+	session, err := sdk.Connect(connectCtx, &sdkmcp.IOTransport{Reader: stdout, Writer: stdin}, nil)
+	cancelConnect()
+	if err != nil {
+		// Self-clean, never leak the child: cancel kills the direct child via
+		// CommandContext, then join the reaper before returning.
+		cancel()
+		<-waitDone
+		return nil, fmt.Errorf("mcp stdio connect: %w", err)
+	}
+
+	c := &StdioClient{
+		name:     cfg.Command,
+		command:  resolved,
+		args:     cfg.Args,
+		dir:      cfg.Dir,
+		env:      append(os.Environ(), sortedEnvPairs(cfg.Env)...),
+		timeout:  timeout,
+		logger:   logger,
+		ctx:      ctx,
+		cancel:   cancel,
+		sdk:      sdk,
+		session:  session,
+		waitDone: waitDone,
+	}
+	return c, nil
+}
+
+// ListTools queries the MCP server for available tools.
+func (c *StdioClient) ListTools(ctx context.Context) ([]tools.MCPToolDefinition, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, errors.New("mcp: client is closed")
+	}
+	if err := c.childExitErrLocked(); err != nil {
+		c.mu.Unlock()
+		return nil, err
+	}
+	c.mu.Unlock()
+
+	ctx, cancel := c.operationContext(ctx)
+	defer cancel()
+
+	res, err := c.session.ListTools(ctx, &sdkmcp.ListToolsParams{})
+	if err != nil {
+		return nil, c.annotateIfDead(fmt.Errorf("mcp list tools: %w", err))
+	}
+
+	defs := make([]tools.MCPToolDefinition, 0, len(res.Tools))
+	for _, t := range res.Tools {
+		raw, err := marshalInputSchema(t.InputSchema)
+		if err != nil {
+			return nil, fmt.Errorf("mcp list tools %q: %w", t.Name, err)
+		}
+		defs = append(defs, tools.MCPToolDefinition{
+			Name:        t.Name,
+			Description: t.Description,
+			InputSchema: raw,
+		})
+	}
+	return defs, nil
+}
+
+// CallTool executes a tool on the MCP server with the provided arguments.
+func (c *StdioClient) CallTool(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return tools.ToolResult{}, errors.New("mcp: client is closed")
+	}
+	if err := c.childExitErrLocked(); err != nil {
+		c.mu.Unlock()
+		return tools.ToolResult{}, err
+	}
+	c.mu.Unlock()
+
+	ctx, cancel := c.operationContext(ctx)
+	defer cancel()
+
+	res, err := c.session.CallTool(ctx, &sdkmcp.CallToolParams{
+		Name:      name,
+		Arguments: args,
+	})
+	if err != nil {
+		return tools.ToolResult{}, c.annotateIfDead(fmt.Errorf("mcp call %s: %w", name, err))
+	}
+
+	text, binaries, metadata := convertCallToolResult(res)
+
+	// Three-way split (ADR-022 / issue #1373): an MCP-level tool error is a
+	// non-terminal domain outcome surfaced through ToolResult.Error with a nil
+	// Go error, so the LLM can recover in-turn. Transport/JSON-RPC errors are
+	// terminal Go errors (returned above).
+	if res.IsError {
+		return tools.ToolResult{
+			Text:     text,
+			Error:    fmt.Errorf("%s", toolErrorSummary(name, text)),
+			Metadata: metadata,
+		}, nil
+	}
+
+	return tools.ToolResult{
+		Text:       text,
+		BinaryData: binaries,
+		Metadata:   metadata,
+	}, nil
+}
+
+// Close terminates the child process and releases all resources. It is
+// idempotent and concurrency safe: stdin EOF first (a well-behaved child
+// exits gracefully), then cancel as the kill backstop, then join the reaper.
+func (c *StdioClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil
+	}
+	c.closed = true
+
+	// (1) stdin EOF first: closing the transport closes both pipes, so a
+	// well-behaved child (and its tree, via the shared pipe) exits
+	// gracefully. (2) cancel() is the kill backstop for children that ignore
+	// EOF — called explicitly before the join AND deferred so it fires even
+	// if session.Close unwinds with an error (cancel is idempotent).
+	defer c.cancel()
+
+	var closeErr error
+	if c.session != nil {
+		if err := c.session.Close(); err != nil {
+			closeErr = err
+		}
+	}
+	c.cancel()
+
+	// (3) join the reaper — post-cancel, cmd.Wait returns promptly (SIGKILL
+	// delivered by CommandContext). If the fast-death pre-check already
+	// reaped the child, exitErr holds the result.
+	waitErr := c.exitErr
+	if waitErr == nil {
+		waitErr = <-c.waitDone
+	}
+	if waitErr != nil && !isExpectedKill(waitErr) {
+		c.logger.Debug("mcp_stdio_child_wait", "server", c.name, "error", waitErr)
+	}
+	return closeErr
+}
+
+// operationContext applies the configured per-operation timeout to ctx.
+// Non-positive timeout passes the original context through unchanged.
+func (c *StdioClient) operationContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	if c.timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, c.timeout)
+}
+
+// childExitErrLocked returns the sticky child-exit error, or nil while the
+// child is alive. Non-blocking select on waitDone; on the first detection the
+// wrapped error is stashed in c.exitErr so every subsequent call fails fast
+// with the same error (the SDK alone does not guarantee this — its read loop
+// terminates on EOF and teardown can race). Caller must hold c.mu.
+func (c *StdioClient) childExitErrLocked() error {
+	if c.exitErr != nil {
+		return c.exitErr
+	}
+	select {
+	case err := <-c.waitDone:
+		c.exitErr = fmt.Errorf("mcp: stdio child %q exited: %w", c.command, err)
+		return c.exitErr
+	default:
+		return nil
+	}
+}
+
+// annotateIfDead annotates an in-flight operation error when it coincides with
+// the child having exited (io.EOF / sdkmcp.ErrConnectionClosed + reaper
+// confirms exit). A wedge surfaces as the plain context.DeadlineExceeded wrap
+// — the two failure modes stay distinguishable by error text and latency.
+// Takes c.mu internally; do NOT call while holding c.mu.
+func (c *StdioClient) annotateIfDead(err error) error {
+	if err == nil {
+		return nil
+	}
+	c.mu.Lock()
+	childErr := c.childExitErrLocked()
+	c.mu.Unlock()
+	if childErr == nil {
+		return err
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, sdkmcp.ErrConnectionClosed) {
+		return fmt.Errorf("%w: %v", childErr, err)
+	}
+	return err
+}
+
+// isExpectedKill reports whether a cmd.Wait error is the expected outcome of
+// Close's cancel backstop: nil, context.Canceled, or an exec.ExitError whose
+// message contains "signal: killed" (Unix SIGKILL). Other errors are logged
+// at debug, never surfaced from Close.
+func isExpectedKill(err error) bool {
+	if err == nil {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ProcessState != nil {
+		return strings.Contains(exitErr.ProcessState.String(), "signal: killed")
+	}
+	return strings.Contains(err.Error(), "signal: killed")
+}
+
+// resolveCommand applies the documented resolution contract: a COMMAND
+// containing a path separator is used as-is (relative paths resolve against
+// DIR, per exec); a bare COMMAND is resolved via exec.LookPath in tell-me-go's
+// own process PATH — not ENV.PATH, not DIR. ENV.PATH governs the child only
+// post-exec. Windows bare-name lookup honors PATHEXT via the same stdlib path.
+func resolveCommand(command string) (string, error) {
+	if strings.ContainsAny(command, `/\`) {
+		return command, nil
+	}
+	resolved, err := exec.LookPath(command)
+	if err != nil {
+		if errors.Is(err, exec.ErrNotFound) {
+			return "", fmt.Errorf("mcp stdio: command %q not found in tell-me-go's PATH (COMMAND resolves before ENV is applied; use an absolute path, a DIR-relative path, or ${VAR}-expanded COMMAND): %w", command, err)
+		}
+		return "", fmt.Errorf("mcp stdio: resolve command %q: %w", command, err)
+	}
+	return resolved, nil
+}
+
+// sortedEnvPairs converts cfg.Env into deterministic "K=V" pairs with keys
+// sorted. An empty map yields nil.
+func sortedEnvPairs(env map[string]string) []string {
+	if len(env) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	pairs := make([]string, 0, len(keys))
+	for _, k := range keys {
+		pairs = append(pairs, k+"="+env[k])
+	}
+	return pairs
+}
+
+// slogWriter routes child stderr to slog at Info with mcp_server=<name>,
+// line-buffered. It is the operator's visibility window for wedged/dead
+// children and is never parsed as JSON-RPC. Documented in the ADR as outside
+// mcp-token-not-logged: the invariant governs tell-me-go's own credential
+// plumbing, not arbitrary child output.
+type slogWriter struct {
+	logger *slog.Logger
+	name   string
+	buf    []byte
+}
+
+// newSlogWriter constructs the stderr writer for a child whose COMMAND is
+// name (used in the mcp_server log attribute).
+func newSlogWriter(logger *slog.Logger, name string) *slogWriter {
+	return &slogWriter{logger: logger, name: name}
+}
+
+func (w *slogWriter) Write(p []byte) (int, error) {
+	w.buf = append(w.buf, p...)
+	for {
+		i := bytes.IndexByte(w.buf, '\n')
+		if i < 0 {
+			break
+		}
+		line := string(w.buf[:i])
+		w.buf = w.buf[i+1:]
+		w.logger.Info("mcp_stdio_stderr", "mcp_server", w.name, "line", line)
+	}
+	// A trailing partial line at process exit is not flushed: cmd.Stderr
+	// writers receive no Close, so there is no hook to flush on.
+	return len(p), nil
+}

--- a/internal/infrastructure/mcp/stdio_client_integration_test.go
+++ b/internal/infrastructure/mcp/stdio_client_integration_test.go
@@ -167,7 +167,7 @@ func TestStdio_HandshakeTimeoutKillsChild(t *testing.T) {
 		Timeout: 1,
 	}, slog.Default())
 	if err == nil {
-		c.Close() // cleanup; constructor should not have succeeded
+		_ = c.Close() // cleanup; constructor should not have succeeded
 		t.Fatal("NewStdioClient(never-init) error = nil, want connect error")
 	}
 	if !strings.Contains(err.Error(), "connect") {

--- a/internal/infrastructure/mcp/stdio_client_integration_test.go
+++ b/internal/infrastructure/mcp/stdio_client_integration_test.go
@@ -278,9 +278,9 @@ func TestStdio_LauncherTreePassThrough(t *testing.T) {
 func TestStdio_ChildDeathMidSession(t *testing.T) {
 	c := newTestClient(t, []string{"serve"}, 0, slog.Default())
 
-	// The die tool exits the child process; the first call errors with
-	// EOF/connection-closed, possibly annotated with the child-exit wrap
-	// (accept either — the annotation races the reaper).
+	// The die tool exits the child process (os.Exit(0), no response); the
+	// first call errors with EOF/connection-closed, possibly annotated with
+	// the child-exit wrap (accept either — the annotation races the reaper).
 	_, err1 := c.CallTool(context.Background(), "die", nil)
 	if err1 == nil {
 		t.Fatal("CallTool(die) error = nil, want error")
@@ -290,21 +290,35 @@ func TestStdio_ChildDeathMidSession(t *testing.T) {
 		t.Errorf("first call error = %q, want a child-death indication (exited/EOF/closed)", err1.Error())
 	}
 
-	// The second call fails fast via the sticky pre-check: its error must
-	// carry the child-exit wrap.
-	_, err2 := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
-	if err2 == nil {
-		t.Fatal("CallTool after child death error = nil, want error")
-	}
-	if !strings.Contains(err2.Error(), "exited") {
-		t.Errorf("second call error = %q, want child-exit wrap", err2.Error())
+	// The reaper is asynchronous: calls racing ahead of it surface the raw
+	// SDK connection-closed error. With annotateIfDead returning the sticky
+	// error, the ONLY error carrying "exited" is c.exitErr itself — so poll
+	// until it appears: that deterministically closes the async-reap window
+	// and yields the sticky error value. Deadline-bounded, ADR-036 (no
+	// time.Sleep).
+	var sticky error
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		_, err := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
+		if err != nil && strings.Contains(err.Error(), "exited") {
+			sticky = err
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sticky child-exit error not established within 5s (last err: %v)", err)
+		}
+		runtime.Gosched()
 	}
 
-	// The third call returns the identical sticky error value (pointer
-	// equality — the pre-check short-circuits on c.exitErr).
-	_, err3 := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
-	if err3 != err2 {
-		t.Error("third call error != second call error; expected the identical sticky error value")
+	// Once the sticky pre-check is established, every subsequent call fails
+	// at it (the SDK is never touched) and returns the identical error value.
+	_, errA := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
+	_, errB := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
+	if errA != sticky {
+		t.Errorf("post-sticky call error = %v, want the sticky child-exit error %v", errA, sticky)
+	}
+	if errB != errA {
+		t.Error("consecutive post-sticky calls returned different error values; want the identical sticky pointer")
 	}
 }
 

--- a/internal/infrastructure/mcp/stdio_client_integration_test.go
+++ b/internal/infrastructure/mcp/stdio_client_integration_test.go
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+)
+
+// captureHandler is a minimal slog.Handler that records mcp_stdio_stderr
+// records (mcp_server + line) for assertions on child stderr output.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []stderrRecord
+}
+
+type stderrRecord struct {
+	server string
+	line   string
+}
+
+func (h *captureHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	var rec stderrRecord
+	r.Attrs(func(a slog.Attr) bool {
+		switch a.Key {
+		case "mcp_server":
+			rec.server = a.Value.String()
+		case "line":
+			rec.line = a.Value.String()
+		}
+		return true
+	})
+	h.mu.Lock()
+	h.records = append(h.records, rec)
+	h.mu.Unlock()
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+// hasLine reports whether a stderr record for the given server and line was
+// captured.
+func (h *captureHandler) hasLine(server, line string) bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, r := range h.records {
+		if r.server == server && r.line == line {
+			return true
+		}
+	}
+	return false
+}
+
+// newCaptureLogger builds a slog.Logger backed by a captureHandler.
+func newCaptureLogger() (*captureHandler, *slog.Logger) {
+	h := &captureHandler{}
+	return h, slog.New(h)
+}
+
+// newTestClient spawns the fixture binary with the given args and a
+// per-operation timeout of timeoutSeconds (0 → the 300s default). The client
+// is registered for cleanup so every test closes its child.
+func newTestClient(t *testing.T, args []string, timeoutSeconds int, logger *slog.Logger) *StdioClient {
+	t.Helper()
+	cfg := config.MCPServerConfig{
+		Command: stdioServerPath,
+		Args:    args,
+		Timeout: timeoutSeconds,
+	}
+	c, err := NewStdioClient(cfg, logger)
+	if err != nil {
+		t.Fatalf("NewStdioClient() error = %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	return c
+}
+
+// waitForStderr polls (deadline-bounded, ADR-036 — no time.Sleep) until the
+// child stderr record server/line is captured or the deadline elapses. Child
+// stderr is copied asynchronously by os/exec, so assertions must wait.
+func waitForStderr(t *testing.T, h *captureHandler, server, line string, within time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(within)
+	for {
+		if h.hasLine(server, line) {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("stderr record %q (server %q) not captured within %v", line, server, within)
+		}
+		runtime.Gosched()
+	}
+}
+
+// TestStdio_RoundTrip pins the happy path over a real child process: tool
+// listing, an echo round-trip, child stderr surfaced through slog (including
+// the startup fixture_ready line), and stderr never parsed as JSON-RPC.
+func TestStdio_RoundTrip(t *testing.T) {
+	h, logger := newCaptureLogger()
+	c := newTestClient(t, []string{"serve"}, 0, logger)
+
+	defs, err := c.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(defs) < 5 {
+		t.Fatalf("ListTools() returned %d tools, want >= 5", len(defs))
+	}
+	names := make(map[string]bool, len(defs))
+	for _, d := range defs {
+		names[d.Name] = true
+	}
+	for _, want := range []string{"echo", "slow", "die", "stderr", "block"} {
+		if !names[want] {
+			t.Errorf("ListTools() missing tool %q", want)
+		}
+	}
+
+	res, err := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "hello"})
+	if err != nil {
+		t.Fatalf("CallTool(echo) error = %v", err)
+	}
+	if res.Text != "hello" {
+		t.Errorf("echo Text = %q, want %q", res.Text, "hello")
+	}
+	if res.Error != nil {
+		t.Errorf("echo Error = %v, want nil", res.Error)
+	}
+
+	// The fixture writes fixture_ready to stderr before serving; it must be
+	// surfaced via slog with mcp_server=<stdioServerPath>.
+	waitForStderr(t, h, stdioServerPath, "fixture_ready", 5*time.Second)
+
+	// stderr output must not break the JSON-RPC protocol: a tool that writes
+	// to stderr still returns its result.
+	res, err = c.CallTool(context.Background(), "stderr", nil)
+	if err != nil {
+		t.Fatalf("CallTool(stderr) error = %v", err)
+	}
+	if res.Text != "stderr done" {
+		t.Errorf("stderr tool Text = %q, want %q", res.Text, "stderr done")
+	}
+	waitForStderr(t, h, stdioServerPath, "stderr-fixture-line", 5*time.Second)
+}
+
+// TestStdio_HandshakeTimeoutKillsChild pins the constructor's bounded
+// handshake: a child that never speaks on stdout fails the connect within the
+// configured timeout, and the child is killed (no leak).
+func TestStdio_HandshakeTimeoutKillsChild(t *testing.T) {
+	c, err := NewStdioClient(config.MCPServerConfig{
+		Command: stdioServerPath,
+		Args:    []string{"never-init"},
+		Timeout: 1,
+	}, slog.Default())
+	if err == nil {
+		c.Close() // cleanup; constructor should not have succeeded
+		t.Fatal("NewStdioClient(never-init) error = nil, want connect error")
+	}
+	if !strings.Contains(err.Error(), "connect") {
+		t.Errorf("error = %q, want it to contain %q", err.Error(), "connect")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(strings.ToLower(err.Error()), "deadline") {
+		t.Errorf("error = %q, want DeadlineExceeded or a deadline mention", err.Error())
+	}
+}
+
+// TestStdio_GracefulEOFClose pins the graceful shutdown path: a well-behaved
+// child exits on stdin EOF, Close returns nil, and a second Close is a no-op.
+func TestStdio_GracefulEOFClose(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 0, slog.Default())
+
+	if _, err := c.ListTools(context.Background()); err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() (second) error = %v", err)
+	}
+}
+
+// TestStdio_EOFIgnoringBackstop pins the kill backstop against an
+// EOF-ignoring child: Close must return even though stdin EOF alone cannot
+// reap the child. If this test hangs, that is a real production defect in
+// StdioClient.Close (its session.Close blocking on a non-responding peer).
+func TestStdio_EOFIgnoringBackstop(t *testing.T) {
+	c := newTestClient(t, []string{"ignore-eof"}, 0, slog.Default())
+
+	if _, err := c.ListTools(context.Background()); err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	// The assertion is that this returns at all.
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+// TestStdio_LauncherTreePassThrough pins the npx/uvx pass-through shape: the
+// launcher (direct child) inherits stdio to its own child, and Close reaps
+// the launcher AND the grandchild via shared-pipe stdin EOF.
+func TestStdio_LauncherTreePassThrough(t *testing.T) {
+	h, logger := newCaptureLogger()
+	c := newTestClient(t, []string{"launcher", stdioServerPath}, 0, logger)
+
+	// The launcher prints launcher_child_pid=<pid> to stderr before waiting.
+	waitForStderrLine := func() string {
+		h.mu.Lock()
+		defer h.mu.Unlock()
+		for _, r := range h.records {
+			if strings.HasPrefix(r.line, "launcher_child_pid=") {
+				return r.line
+			}
+		}
+		return ""
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	var pidLine string
+	for pidLine == "" {
+		pidLine = waitForStderrLine()
+		if pidLine != "" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("launcher_child_pid never observed on stderr")
+		}
+		runtime.Gosched()
+	}
+	pid, err := strconv.Atoi(strings.TrimPrefix(pidLine, "launcher_child_pid="))
+	if err != nil {
+		t.Fatalf("malformed pid line %q: %v", pidLine, err)
+	}
+
+	// The handshake and tool listing prove the stdio streams pass through the
+	// launcher to the grandchild server.
+	if _, err := c.ListTools(context.Background()); err != nil {
+		t.Fatalf("ListTools() through launcher error = %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if runtime.GOOS == "windows" {
+		t.Skip("process liveness poll is Unix-only")
+	}
+	// deadline-bounded liveness poll, ADR-036: the grandchild (serve) must be
+	// gone within 5s, reaped via shared-pipe stdin EOF (the launcher exits on
+	// EOF and takes its child with it).
+	killDeadline := time.Now().Add(5 * time.Second)
+	for {
+		if err := syscall.Kill(pid, 0); err != nil {
+			return // ESRCH: grandchild is gone
+		}
+		if time.Now().After(killDeadline) {
+			t.Fatalf("grandchild pid %d still alive 5s after Close", pid)
+		}
+		runtime.Gosched()
+	}
+}
+
+// TestStdio_ChildDeathMidSession pins the fast-death pre-check stickiness: a
+// child that dies mid-session surfaces as a terminal error on the first call
+// and as the identical sticky exit error on every subsequent call.
+func TestStdio_ChildDeathMidSession(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 0, slog.Default())
+
+	// The die tool exits the child process; the first call errors with
+	// EOF/connection-closed, possibly annotated with the child-exit wrap
+	// (accept either — the annotation races the reaper).
+	_, err1 := c.CallTool(context.Background(), "die", nil)
+	if err1 == nil {
+		t.Fatal("CallTool(die) error = nil, want error")
+	}
+	lower := strings.ToLower(err1.Error())
+	if !strings.Contains(err1.Error(), "exited") && !strings.Contains(lower, "eof") && !strings.Contains(lower, "closed") {
+		t.Errorf("first call error = %q, want a child-death indication (exited/EOF/closed)", err1.Error())
+	}
+
+	// The second call fails fast via the sticky pre-check: its error must
+	// carry the child-exit wrap.
+	_, err2 := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
+	if err2 == nil {
+		t.Fatal("CallTool after child death error = nil, want error")
+	}
+	if !strings.Contains(err2.Error(), "exited") {
+		t.Errorf("second call error = %q, want child-exit wrap", err2.Error())
+	}
+
+	// The third call returns the identical sticky error value (pointer
+	// equality — the pre-check short-circuits on c.exitErr).
+	_, err3 := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "x"})
+	if err3 != err2 {
+		t.Error("third call error != second call error; expected the identical sticky error value")
+	}
+}
+
+// TestStdio_WedgeTimesOut pins the wedge failure mode: a server that never
+// responds surfaces as context.DeadlineExceeded (distinguishable from a child
+// death by error text).
+func TestStdio_WedgeTimesOut(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 1, slog.Default())
+
+	_, err := c.CallTool(context.Background(), "block", nil)
+	if err == nil {
+		t.Fatal("CallTool(block) error = nil, want DeadlineExceeded")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("CallTool(block) error = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+// TestStdio_SlowButAlive_NoKill pins the no-kill-on-operation-timeout policy:
+// an operation that exceeds the per-call timeout must NOT kill the child — a
+// subsequent call on the same client succeeds.
+func TestStdio_SlowButAlive_NoKill(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 1, slog.Default())
+
+	_, err := c.CallTool(context.Background(), "slow", map[string]interface{}{"ms": 1500})
+	if err == nil {
+		t.Fatal("CallTool(slow 1500ms) with 1s timeout error = nil, want DeadlineExceeded")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("CallTool(slow) error = %v, want context.DeadlineExceeded", err)
+	}
+
+	// The child survived the timeout: a fresh call succeeds.
+	res, err := c.CallTool(context.Background(), "echo", map[string]interface{}{"text": "ok"})
+	if err != nil {
+		t.Fatalf("CallTool(echo) after timeout error = %v (child was killed?)", err)
+	}
+	if res.Text != "ok" {
+		t.Errorf("echo Text = %q, want %q", res.Text, "ok")
+	}
+}
+
+// TestStdio_TwoClientsIndependent pins that two StdioClients on separate
+// child processes do not share stdio state: both list tools, both serve
+// calls, both close cleanly.
+func TestStdio_TwoClientsIndependent(t *testing.T) {
+	c1 := newTestClient(t, []string{"serve"}, 0, slog.Default())
+	c2 := newTestClient(t, []string{"serve"}, 0, slog.Default())
+
+	if _, err := c1.ListTools(context.Background()); err != nil {
+		t.Fatalf("client1 ListTools() error = %v", err)
+	}
+	if _, err := c2.ListTools(context.Background()); err != nil {
+		t.Fatalf("client2 ListTools() error = %v", err)
+	}
+
+	res1, err := c1.CallTool(context.Background(), "echo", map[string]interface{}{"text": "one"})
+	if err != nil {
+		t.Fatalf("client1 CallTool(echo) error = %v", err)
+	}
+	res2, err := c2.CallTool(context.Background(), "echo", map[string]interface{}{"text": "two"})
+	if err != nil {
+		t.Fatalf("client2 CallTool(echo) error = %v", err)
+	}
+	if res1.Text != "one" || res2.Text != "two" {
+		t.Errorf("echo results = %q / %q, want one / two", res1.Text, res2.Text)
+	}
+
+	if err := c1.Close(); err != nil {
+		t.Fatalf("client1 Close() error = %v", err)
+	}
+	if err := c2.Close(); err != nil {
+		t.Fatalf("client2 Close() error = %v", err)
+	}
+}

--- a/internal/infrastructure/mcp/stdio_client_test.go
+++ b/internal/infrastructure/mcp/stdio_client_test.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestResolveCommand pins the resolution contract: a separator-bearing COMMAND
+// is used as-is; a bare COMMAND resolves via exec.LookPath against
+// tell-me-go's own process PATH; a missing bare command yields the prescribed
+// annotation.
+func TestResolveCommand(t *testing.T) {
+	t.Run("bare name found on PATH resolves to absolute path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		t.Setenv("PATH", tmpDir)
+		toolPath := filepath.Join(tmpDir, "tool.cmd")
+		if err := os.WriteFile(toolPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("failed to create executable: %v", err)
+		}
+
+		got, err := resolveCommand("tool.cmd")
+		if err != nil {
+			t.Fatalf("resolveCommand() error = %v", err)
+		}
+		if got != toolPath {
+			t.Errorf("resolveCommand() = %q, want %q", got, toolPath)
+		}
+	})
+
+	t.Run("separator-bearing command used as-is", func(t *testing.T) {
+		for _, cmd := range []string{"/abs/path", "./rel"} {
+			got, err := resolveCommand(cmd)
+			if err != nil {
+				t.Fatalf("resolveCommand(%q) error = %v", cmd, err)
+			}
+			if got != cmd {
+				t.Errorf("resolveCommand(%q) = %q, want as-is %q", cmd, got, cmd)
+			}
+		}
+	})
+
+	t.Run("bare name not found yields prescribed annotation", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir()) // empty PATH dir guarantees not-found
+		_, err := resolveCommand("definitely-missing-1396")
+		if err == nil {
+			t.Fatal("resolveCommand() error = nil, want error")
+		}
+		if !strings.HasPrefix(err.Error(), "mcp stdio: command ") {
+			t.Errorf("error = %q, want prefix %q", err.Error(), "mcp stdio: command ")
+		}
+		if !strings.Contains(err.Error(), "not found in tell-me-go's PATH") {
+			t.Errorf("error = %q, want fragment %q", err.Error(), "not found in tell-me-go's PATH")
+		}
+	})
+}
+
+// TestIsExpectedKill pins the Close-backstop classification: nil,
+// context.Canceled, and signal-kill errors are expected; other exits are not.
+// The "signal: killed" message check is pinned via a plain error — an
+// *exec.ExitError carrying a signal-death ProcessState cannot be constructed
+// without a real signal death (ProcessState internals are unexported), so the
+// ExitError branch is pinned by its negative: an ExitError without the marker
+// is not an expected kill.
+func TestIsExpectedKill(t *testing.T) {
+	expected := []error{
+		nil,
+		context.Canceled,
+		errors.New("signal: killed"),
+	}
+	for _, err := range expected {
+		if !isExpectedKill(err) {
+			t.Errorf("isExpectedKill(%v) = false, want true", err)
+		}
+	}
+
+	notExpected := []error{
+		errors.New("exit status 1"),
+		errors.New("boom"),
+		&exec.ExitError{ProcessState: &os.ProcessState{}}, // "exit status 0", no kill marker
+	}
+	for _, err := range notExpected {
+		if isExpectedKill(err) {
+			t.Errorf("isExpectedKill(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestStdioClient_Close pins Close idempotency and the closed-state guard: a
+// client already marked closed returns nil on every call.
+func TestStdioClient_Close(t *testing.T) {
+	c := &StdioClient{closed: true, cancel: func() {}, logger: slog.Default()}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() (already closed) error = %v", err)
+	}
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close() (idempotent) error = %v", err)
+	}
+}
+
+// TestStdioClient_ClosedState pins that operations on a closed client fail
+// with the closed error before touching the child or the SDK.
+func TestStdioClient_ClosedState(t *testing.T) {
+	c := &StdioClient{closed: true, cancel: func() {}, logger: slog.Default()}
+
+	if _, err := c.ListTools(context.Background()); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Errorf("ListTools() on closed client error = %v, want closed error", err)
+	}
+	if _, err := c.CallTool(context.Background(), "tool", nil); err == nil || !strings.Contains(err.Error(), "closed") {
+		t.Errorf("CallTool() on closed client error = %v, want closed error", err)
+	}
+}
+
+// TestChildExitErrLocked_Sticky pins the fast-death pre-check stickiness: the
+// first call consumes waitDone and stashes the wrapped error; subsequent calls
+// return the identical error without touching the channel.
+func TestChildExitErrLocked_Sticky(t *testing.T) {
+	c := &StdioClient{
+		command:  "/bin/true",
+		waitDone: make(chan error, 1),
+	}
+	c.waitDone <- errors.New("exit status 1")
+
+	c.mu.Lock()
+	first := c.childExitErrLocked()
+	c.mu.Unlock()
+	if first == nil {
+		t.Fatal("childExitErrLocked() = nil, want error")
+	}
+	if !strings.Contains(first.Error(), "exited") {
+		t.Errorf("childExitErrLocked() = %q, want child-exit wrap", first.Error())
+	}
+
+	c.mu.Lock()
+	second := c.childExitErrLocked()
+	c.mu.Unlock()
+	if second == nil {
+		t.Fatal("childExitErrLocked() (second) = nil, want error")
+	}
+	if second != first {
+		t.Error("childExitErrLocked() (second) != first; expected identical sticky error")
+	}
+}
+
+// newExitErrClient builds a minimal StdioClient whose waitDone channel is
+// pre-filled with a child-exit error, then consumes it once via
+// childExitErrLocked so exitErr is set — no subprocess involved.
+func newExitErrClient(t *testing.T) *StdioClient {
+	t.Helper()
+	c := &StdioClient{
+		command:  "/bin/true",
+		logger:   slog.Default(),
+		waitDone: make(chan error, 1),
+	}
+	c.waitDone <- errors.New("exit status 1")
+	c.mu.Lock()
+	c.childExitErrLocked()
+	c.mu.Unlock()
+	return c
+}
+
+// TestAnnotateIfDead pins the in-flight error annotation: an io.EOF error
+// coinciding with a confirmed child exit gets the child-exit annotation;
+// context.DeadlineExceeded (a wedge) stays unannotated; nil stays nil.
+func TestAnnotateIfDead(t *testing.T) {
+	t.Run("io.EOF annotated when child exited", func(t *testing.T) {
+		c := newExitErrClient(t)
+		err := c.annotateIfDead(io.EOF)
+		if err == nil {
+			t.Fatal("annotateIfDead(io.EOF) = nil, want annotated error")
+		}
+		if !strings.Contains(err.Error(), "exited") {
+			t.Errorf("annotateIfDead(io.EOF) = %q, want child-exit annotation", err.Error())
+		}
+	})
+
+	t.Run("DeadlineExceeded not annotated", func(t *testing.T) {
+		c := newExitErrClient(t)
+		err := c.annotateIfDead(context.DeadlineExceeded)
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("annotateIfDead(DeadlineExceeded) = %v, want DeadlineExceeded preserved", err)
+		}
+		if strings.Contains(err.Error(), "exited") {
+			t.Errorf("annotateIfDead(DeadlineExceeded) = %q, must not carry the child-exit annotation", err.Error())
+		}
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		c := newExitErrClient(t)
+		if err := c.annotateIfDead(nil); err != nil {
+			t.Errorf("annotateIfDead(nil) = %v, want nil", err)
+		}
+	})
+}
+
+// TestSortedEnvPairs pins the deterministic K=V ordering and the nil result
+// for an empty map.
+func TestSortedEnvPairs(t *testing.T) {
+	got := sortedEnvPairs(map[string]string{"B": "2", "A": "1"})
+	want := []string{"A=1", "B=2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("sortedEnvPairs() = %v, want %v", got, want)
+	}
+
+	if got := sortedEnvPairs(nil); got != nil {
+		t.Errorf("sortedEnvPairs(nil) = %v, want nil", got)
+	}
+	if got := sortedEnvPairs(map[string]string{}); got != nil {
+		t.Errorf("sortedEnvPairs(empty) = %v, want nil", got)
+	}
+}

--- a/internal/infrastructure/mcp/stdio_client_test.go
+++ b/internal/infrastructure/mcp/stdio_client_test.go
@@ -164,7 +164,7 @@ func newExitErrClient(t *testing.T) *StdioClient {
 	}
 	c.waitDone <- errors.New("exit status 1")
 	c.mu.Lock()
-	c.childExitErrLocked()
+	_ = c.childExitErrLocked()
 	c.mu.Unlock()
 	return c
 }

--- a/internal/infrastructure/mcp/testdata/stdioserver/main.go
+++ b/internal/infrastructure/mcp/testdata/stdioserver/main.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Command stdioserver is the SDK fixture server for the StdioClient
+// integration suite. It is built by TestMain and spawned as a real child
+// process; subcommands are selected via os.Args[1]:
+//
+//	serve        canonical fixture: MCP server over stdin/stdout
+//	launcher     execs <path> serve with inherited stdio (pass-through pin)
+//	never-init   writes nothing to stdout, blocks forever (handshake timeout)
+//	ignore-eof   serves normally but ignores stdin EOF (kill-backstop pin)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"syscall"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintln(os.Stderr, "usage: stdioserver <serve|launcher|never-init|ignore-eof>")
+		os.Exit(2)
+	}
+	switch os.Args[1] {
+	case "serve":
+		serve()
+	case "launcher":
+		launcher()
+	case "never-init":
+		neverInit()
+	case "ignore-eof":
+		ignoreEOF()
+	default:
+		fmt.Fprintf(os.Stderr, "unknown subcommand %q\n", os.Args[1])
+		os.Exit(2)
+	}
+}
+
+// newFixtureServer builds the canonical SDK MCP server with the five fixture
+// tools: echo, slow, die, stderr, block.
+func newFixtureServer() *sdkmcp.Server {
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "stdioserver-fixture", Version: "1.0.0"}, nil)
+
+	textOnly := map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"text": map[string]any{"type": "string"}},
+	}
+
+	server.AddTool(&sdkmcp.Tool{Name: "echo", Description: "echoes the text argument back", InputSchema: textOnly},
+		func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			var args map[string]any
+			if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+				return toolError("echo: bad arguments"), nil
+			}
+			text, ok := args["text"].(string)
+			if !ok {
+				return toolError("echo: missing text"), nil
+			}
+			return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}}}, nil
+		})
+
+	server.AddTool(&sdkmcp.Tool{Name: "slow", Description: "sleeps ms milliseconds then returns", InputSchema: map[string]any{
+		"type":       "object",
+		"properties": map[string]any{"ms": map[string]any{"type": "number"}},
+	}}, func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+		var args struct {
+			Ms float64 `json:"ms"`
+		}
+		if err := json.Unmarshal(req.Params.Arguments, &args); err != nil {
+			return toolError("slow: bad arguments"), nil
+		}
+		time.Sleep(time.Duration(args.Ms) * time.Millisecond)
+		return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "slow done"}}}, nil
+	})
+
+	server.AddTool(&sdkmcp.Tool{Name: "die", Description: "exits the process immediately", InputSchema: map[string]any{"type": "object"}},
+		func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			os.Exit(0)
+			return nil, nil // unreachable
+		})
+
+	server.AddTool(&sdkmcp.Tool{Name: "stderr", Description: "writes a fixed line to stderr and returns", InputSchema: map[string]any{"type": "object"}},
+		func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			fmt.Fprintln(os.Stderr, "stderr-fixture-line")
+			return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: "stderr done"}}}, nil
+		})
+
+	server.AddTool(&sdkmcp.Tool{Name: "block", Description: "blocks forever (wedge test)", InputSchema: map[string]any{"type": "object"}},
+		func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			select {}
+			return nil, nil // unreachable
+		})
+
+	return server
+}
+
+func toolError(text string) *sdkmcp.CallToolResult {
+	return &sdkmcp.CallToolResult{IsError: true, Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}}}
+}
+
+// serve runs the canonical fixture server over stdin/stdout until the client
+// closes the connection (stdin EOF), at which point server.Run returns and the
+// process exits cleanly. A SIGTERM/SIGINT also cancels the run.
+func serve() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := newFixtureServer()
+	fmt.Fprintln(os.Stderr, "fixture_ready")
+	if err := server.Run(ctx, &sdkmcp.StdioTransport{}); err != nil && ctx.Err() == nil {
+		fmt.Fprintf(os.Stderr, "serve: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// launcher execs <servePath> serve with all three stdio streams inherited —
+// no new pipes — pinning the npx/uvx pass-through shape. The child pid is
+// printed to stderr so the integration test can poll its liveness.
+func launcher() {
+	if len(os.Args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: stdioserver launcher <servePath>")
+		os.Exit(2)
+	}
+	servePath := os.Args[2]
+
+	cmd := exec.Command(servePath, "serve")
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintf(os.Stderr, "launcher start: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintf(os.Stderr, "launcher_child_pid=%d\n", cmd.Process.Pid)
+
+	err := cmd.Wait()
+	if err == nil {
+		return
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		os.Exit(exitErr.ExitCode())
+	}
+	fmt.Fprintf(os.Stderr, "launcher wait: %v\n", err)
+	os.Exit(1)
+}
+
+// neverInit writes nothing to stdout and blocks forever: the MCP handshake
+// never completes, pinning the constructor's handshake-timeout kill path.
+func neverInit() {
+	select {}
+}
+
+// ignoreEOF is a functioning MCP server that completes the handshake and
+// serves tools but, unlike serve, does NOT exit when stdin reaches EOF: on
+// session close it blocks forever instead of returning. This pins the
+// client's Close kill backstop (stdin EOF alone cannot reap this child).
+func ignoreEOF() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	server := newFixtureServer()
+	ss, err := server.Connect(ctx, &sdkmcp.StdioTransport{}, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ignore-eof connect: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Fprintln(os.Stderr, "fixture_ready")
+
+	ssClosed := make(chan error, 1)
+	go func() {
+		ssClosed <- ss.Wait()
+	}()
+
+	select {
+	case <-ctx.Done():
+		ss.Close()
+		<-ssClosed
+	case <-ssClosed:
+		// stdin EOF — a normal server returns here; this fixture ignores EOF
+		// and blocks forever.
+		select {}
+	}
+}

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -98,6 +98,11 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestToOpenAISchema_EmptyTypeOmitsKey":                      {Line: 21, Complexity: 11, FilePath: "internal/infrastructure/llm/openai/tools_test.go"},
 		"TestToOpenAITools_EmptyTypeNested_OmitsEmptyTypeKey":       {Line: 124, Complexity: 16, FilePath: "internal/infrastructure/llm/openai/tools_test.go"},
 		"TestConvertSchema_NestedUnrepresentable_BecomesUntypedAny": {Line: 241, Complexity: 12, FilePath: "internal/tools/integrations/mcp/schema_test.go"},
+		"(*MCPServerConfig).validate":                               {Line: 103, Complexity: 20, FilePath: "internal/domain/config/mcp_config.go"},
+		"TestMCPFactory_ConcurrentBuild":                            {Line: 683, Complexity: 11, FilePath: "internal/infrastructure/di/mcp_factory_test.go"},
+		"TestMCPFactory_ConcurrentBuild_FailingServerSkips":         {Line: 743, Complexity: 15, FilePath: "internal/infrastructure/di/mcp_factory_test.go"},
+		"TestStdio_RoundTrip":                                       {Line: 112, Complexity: 11, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
+		"TestStdio_LauncherTreePassThrough":                         {Line: 216, Complexity: 13, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)
@@ -133,8 +138,8 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 571, 573},
 		{"failover.go ExtractDocument body", "internal/infrastructure/llm/failover.go", 131, 133},
 		{"resilient_client.go ExtractDocument body", "internal/infrastructure/llm/resilient_client.go", 106, 108},
-		{"mcp_factory.go resolveServerToken default case", "internal/infrastructure/di/mcp_factory.go", 157, 160},
-		{"mcp_factory.go gh auth token resolver", "internal/infrastructure/di/mcp_factory.go", 60, 65},
+		{"mcp_factory.go resolveServerToken default case", "internal/infrastructure/di/mcp_factory.go", 223, 227},
+		{"mcp_factory.go gh auth token resolver", "internal/infrastructure/di/mcp_factory.go", 67, 70},
 		{"toolchain_factory.go registerSkillsShTools error", "internal/infrastructure/di/toolchain_factory.go", 124, 126},
 		{"provider_health.go buildRequest error branch", "internal/infrastructure/llm/provider_health.go", 126, 128},
 		{"provider_health.go getPingEndpoint panic", "internal/infrastructure/llm/provider_health.go", 238, 238},

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -103,6 +103,7 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestMCPFactory_ConcurrentBuild_FailingServerSkips":         {Line: 743, Complexity: 15, FilePath: "internal/infrastructure/di/mcp_factory_test.go"},
 		"TestStdio_RoundTrip":                                       {Line: 112, Complexity: 11, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
 		"TestStdio_LauncherTreePassThrough":                         {Line: 216, Complexity: 13, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
+		"TestStdio_ChildDeathMidSession":                            {Line: 278, Complexity: 11, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)


### PR DESCRIPTION
Closes #1396.

## Summary

Adds first-class **stdio / local-process MCP server support** to tell-me-go, alongside the existing Streamable HTTP transport (ADR-067). A new `MCP_SERVERS.<name>.COMMAND` (+ `ARGS`/`DIR`/`ENV`) config spawns the MCP server as a local child process, wired through the SDK's `IOTransport` (not the process-pinned `StdioTransport`). Per the maintainer decision in #1396, stdio servers default to **trusted local spawns**: `consent=false` (no prompt), `serial=true`, with `REQUIRES_CONSENT: true` opt-in — a documented deviation from the #1394 grill round's recommendation.

**Architect–Coder loop:** issue #1396 was implemented task-by-task by an Architect (design/review, read-only) and Coder (implementation, only writer) with per-increment review, the repo's full gate pipeline, and a catalog/whitelist adjudication. 10 commits.

## What changed

- **Config** — `MCPServerConfig` gains `COMMAND`/`ARGS`/`DIR`/`ENV`; validation: COMMAND/URL mutually exclusive (exactly one), ARGS/DIR/ENV require COMMAND, `AUTH` bearer/basic under COMMAND rejected (mode-conflict rule, before the positive credential rules); `EffectiveRequiresConsent()` stdio branch (trusted default).
- **Transport** — new `StdioClient` in `internal/infrastructure/mcp/` (separate type, not a mode on `Client`): eager construction with in-constructor handshake bounded by `TIMEOUT`, reaper goroutine (deterministic direct-child reaping), fast-death pre-check (sticky child-exit error), idempotent `Close` (stdin EOF → cancel backstop → reaper join), no kill on operation-timeout, stderr routed to slog (never parsed as JSON-RPC), `exec.ErrNotFound` annotated with the resolution contract.
- **DI** — `newClientFor(serverCfg)` dispatch seam; two-phase `Build` (sequential token pre-pass with stdio short-circuit + single-flight `gh` memoization, then concurrent construction via `sync.WaitGroup`); first-`GetRegistry` latency capped at `max(Tᵢ)` instead of ΣTᵢ.
- **Secrecy** — `args?|env` added to `secretKeyPattern` (covers both config debug dumps incl. ENV sub-keys via ancestor-skip); adapter errors never include ARGS/ENV values.
- **Tests** — 9 integration tests against a real SDK fixture server (round-trip, handshake-timeout kill, graceful EOF close, EOF-ignoring backstop, launcher-tree pass-through, child death mid-session, wedge timeout, slow-but-alive no-kill, two independent clients), plus factory concurrency/redaction/validation suites.
- **Docs** — ADR-067 amendment (10 items incl. the trusted-spawn decision, two-tier lifecycle guarantees, resolution semantics); domain model (`MCPServer` attributes + `mcp-stdio-trusted-defaults` invariant + scenario, re-rendered); README stdio example + resolution-contract paragraph; catalog re-anchors + 5 new pins (Complexity/Test-Complexity); ADR-056 whitelist extension for the mcp consumer closure.

## Acceptance criteria mapping

- [x] `MCP_SERVERS.<name>.COMMAND` (+ `ARGS`/`DIR`/`ENV`) spawns a local stdio MCP server; tools appear as `mcp_<name>_*` alongside remote MCP tools — `StdioClient` (611665bf), integration suite (efea6946), pre-existing plugin namespacing.
- [x] Multiple stdio servers run as independent child processes in one session — one child each, no shared `os.Stdin`/`os.Stdout`; concurrent discovery/lifecycle; tool *execution* serialized per existing `ToolOptions.Serial` semantics — integration test 9, factory concurrency test, `EffectiveSerial` rows, pre-existing `TestDispatcher_SerialBatching`.
- [x] Spawn/connect/handshake failures and handshake timeout are clear, recoverable errors (warn+skip); per-call timeouts recoverable; **no zombie processes** (deterministic direct-child reap, tree best-effort via stdin EOF); `Close` idempotent; dead vs wedged distinguishable (fast child-exit error vs TIMEOUT) — integration tests 2-7.
- [x] Config validation rejects ambiguous entries (COMMAND+URL, neither, ARGS/DIR/ENV without COMMAND, bearer/basic with COMMAND) — config validation suite (afa77c1d).
- [x] `ARGS`/`ENV` values redacted in config debug dumps; adapter errors never include them — redaction suite (51366da7) + factory sentinel test.
- [x] Stdio servers default to **trusted** (`consent=false`, no prompt) with `REQUIRES_CONSENT: true` opt-in; `serial=true`; no serial knob — config + factory tests + ADR-067 amendment.
- [x] README + ADR-067 amendment + domain model updated (modelith re-render committed; `modelith-check` green); `mcp_factory.go` catalog pins re-anchored same-PR as the partition test; `make check-full` green.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, verify-transitive-gate, verify-nonfix-catalog, verify-ports-registry, verify-mcp-sdk-confinement, verify-no-test-sleep, verify-adr-index, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, test-race) | **PASS** — "All checks passed (including race detection)" |
| `go test -race` on the new packages | PASS |
| `make modelith-lint` / `modelith-check` | PASS (0 errors/warnings) |
| `make verify-nonfix-catalog` | PASS (all seven gate lines) |
| `make verify-transitive-gate` | PASS (80 approved constants, 0 decision-required) |

## Notes

- The two `mcp_factory.go` catalog pins were re-anchored and the 5 new over-threshold functions (the `validate` rework + 4 stdio/factory tests) were cataloged in the same commit as the partition test (coordination rule).
- The `internal/infrastructure/mcp` ADR-056 whitelist entry was added because the `StdioClient` constructor legitimately consumes the domain `config` type — its closure matches the already-approved `internal/infrastructure/config` adapter exactly.
- Tracked ADR future options (not this PR): per-server serial override (both transports or justified asymmetry); process-group kill / Job Objects for transport-contract-violating grandchildren; `validate` extraction refactor (CC=20, cataloged).