### PR TITLE
fix(mcp): normalize nil args before CallToolParams — emit "arguments":{} not null (#1399)

### DIFF
--- a/internal/domain/tools/mcp_client.go
+++ b/internal/domain/tools/mcp_client.go
@@ -21,6 +21,8 @@ type MCPClient interface {
 	ListTools(ctx context.Context) ([]MCPToolDefinition, error)
 
 	// CallTool executes a tool on the remote MCP server with the provided arguments.
+	// A nil args map is normalized to an empty object by implementations — the MCP
+	// wire must never carry "arguments": null (strict servers reject it).
 	CallTool(ctx context.Context, name string, args map[string]interface{}) (ToolResult, error)
 
 	// Close terminates the client connection and releases any underlying resources.

--- a/internal/infrastructure/mcp/client.go
+++ b/internal/infrastructure/mcp/client.go
@@ -129,6 +129,18 @@ func (c *Client) ListTools(ctx context.Context) ([]tools.MCPToolDefinition, erro
 	return defs, nil
 }
 
+// normalizeArguments ensures the SDK never receives a nil map in the
+// Arguments any-field. A nil map inside an interface defeats the SDK's
+// own nil guard (interface-nil vs typed-nil, go-sdk mcp/client.go:1281-1284,
+// "Avoid sending nil over the wire"), so the adapter — the only layer
+// confined to the SDK (ADR-067 §2) — must normalize before construction.
+func normalizeArguments(args map[string]interface{}) map[string]interface{} {
+	if args == nil {
+		return map[string]interface{}{}
+	}
+	return args
+}
+
 // CallTool executes a tool on the remote MCP server with the provided arguments.
 func (c *Client) CallTool(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
 	ctx, cancel := c.operationContext(ctx)
@@ -141,7 +153,7 @@ func (c *Client) CallTool(ctx context.Context, name string, args map[string]inte
 
 	res, err := session.CallTool(ctx, &sdkmcp.CallToolParams{
 		Name:      name,
-		Arguments: args,
+		Arguments: normalizeArguments(args),
 	})
 	if err != nil {
 		return tools.ToolResult{}, fmt.Errorf("mcp call %s: %w", name, err)

--- a/internal/infrastructure/mcp/stdio_client.go
+++ b/internal/infrastructure/mcp/stdio_client.go
@@ -190,7 +190,7 @@ func (c *StdioClient) CallTool(ctx context.Context, name string, args map[string
 
 	res, err := c.session.CallTool(ctx, &sdkmcp.CallToolParams{
 		Name:      name,
-		Arguments: args,
+		Arguments: normalizeArguments(args),
 	})
 	if err != nil {
 		return tools.ToolResult{}, c.annotateIfDead(fmt.Errorf("mcp call %s: %w", name, err))

--- a/internal/infrastructure/mcp/testdata/stdioserver/main.go
+++ b/internal/infrastructure/mcp/testdata/stdioserver/main.go
@@ -44,8 +44,8 @@ func main() {
 	}
 }
 
-// newFixtureServer builds the canonical SDK MCP server with the five fixture
-// tools: echo, slow, die, stderr, block.
+// newFixtureServer builds the canonical SDK MCP server with the six fixture
+// tools: echo, slow, die, stderr, block, args-capture.
 func newFixtureServer() *sdkmcp.Server {
 	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "stdioserver-fixture", Version: "1.0.0"}, nil)
 
@@ -97,6 +97,15 @@ func newFixtureServer() *sdkmcp.Server {
 		func(_ context.Context, _ *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
 			select {}
 			return nil, nil // unreachable
+		})
+
+	server.AddTool(&sdkmcp.Tool{Name: "args-capture", Description: "returns the raw arguments bytes as text", InputSchema: map[string]any{"type": "object"}},
+		func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			text := string(req.Params.Arguments) // json.RawMessage; pre-fix this is "null"
+			if text == "" {
+				text = "{}" // defensive default for a genuinely-absent field
+			}
+			return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: text}}}, nil
 		})
 
 	return server

--- a/internal/infrastructure/mcp/wire_arguments_test.go
+++ b/internal/infrastructure/mcp/wire_arguments_test.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package mcp
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestCallTool_WireArguments_NilBecomesEmptyObject pins the #1399 wire
+// regression over the HTTP transport: a nil arguments value must reach the
+// server as "{}", not "null". A typed-nil map[string]interface{} stored in
+// the SDK's CallToolParams.Arguments `any` field defeats both omitempty and
+// the SDK's interface-nil guard, so pre-fix the wire carries
+// `"arguments": null` and the server echoes "null". RED pre-fix: fails with
+// Text = "null", want "{}".
+func TestCallTool_WireArguments_NilBecomesEmptyObject(t *testing.T) {
+	toolsList := []*sdkmcp.Tool{
+		{Name: "args-capture", Description: "returns the raw arguments bytes as text", InputSchema: objectSchema(nil)},
+	}
+	handlers := map[string]sdkmcp.ToolHandler{
+		"args-capture": func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: string(req.Params.Arguments)}}}, nil
+		},
+	}
+
+	ts := newSDKTestServer(t, toolsList, handlers)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, "", 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.CallTool(context.Background(), "args-capture", nil)
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if res.Error != nil {
+		t.Errorf("Error = %v, want nil", res.Error)
+	}
+	if res.Text != "{}" {
+		t.Errorf("Text = %q, want %q", res.Text, "{}")
+	}
+}
+
+// TestCallTool_WireArguments_NonEmptyPassthrough pins that non-nil arguments
+// pass through verbatim over HTTP (green both pre- and post-fix).
+func TestCallTool_WireArguments_NonEmptyPassthrough(t *testing.T) {
+	toolsList := []*sdkmcp.Tool{
+		{Name: "args-capture", Description: "returns the raw arguments bytes as text", InputSchema: objectSchema(nil)},
+	}
+	handlers := map[string]sdkmcp.ToolHandler{
+		"args-capture": func(_ context.Context, req *sdkmcp.CallToolRequest) (*sdkmcp.CallToolResult, error) {
+			return &sdkmcp.CallToolResult{Content: []sdkmcp.Content{&sdkmcp.TextContent{Text: string(req.Params.Arguments)}}}, nil
+		},
+	}
+
+	ts := newSDKTestServer(t, toolsList, handlers)
+	defer ts.Close()
+
+	c, err := NewClient(ts.URL, "", 5*time.Second)
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	defer func() { _ = c.Close() }()
+
+	res, err := c.CallTool(context.Background(), "args-capture", map[string]interface{}{"text": "x"})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if res.Error != nil {
+		t.Errorf("Error = %v, want nil", res.Error)
+	}
+	if !strings.Contains(res.Text, "text") {
+		t.Errorf("Text = %q, want it to contain %q", res.Text, "text")
+	}
+}
+
+// TestStdio_WireArguments_NilBecomesEmptyObject pins the same #1399 wire
+// regression over the stdio transport against the real fixture binary's
+// args-capture tool. RED pre-fix: fails with Text = "null", want "{}".
+func TestStdio_WireArguments_NilBecomesEmptyObject(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 0, slog.Default())
+
+	res, err := c.CallTool(context.Background(), "args-capture", nil)
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if res.Error != nil {
+		t.Errorf("Error = %v, want nil", res.Error)
+	}
+	if res.Text != "{}" {
+		t.Errorf("Text = %q, want %q", res.Text, "{}")
+	}
+}
+
+// TestStdio_WireArguments_NonEmptyPassthrough pins that non-nil arguments
+// pass through verbatim over stdio (green both pre- and post-fix).
+func TestStdio_WireArguments_NonEmptyPassthrough(t *testing.T) {
+	c := newTestClient(t, []string{"serve"}, 0, slog.Default())
+
+	res, err := c.CallTool(context.Background(), "args-capture", map[string]interface{}{"text": "x"})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if res.Error != nil {
+		t.Errorf("Error = %v, want nil", res.Error)
+	}
+	if !strings.Contains(res.Text, "text") {
+		t.Errorf("Text = %q, want it to contain %q", res.Text, "text")
+	}
+}

--- a/internal/infrastructure/mcp/wire_arguments_test.go
+++ b/internal/infrastructure/mcp/wire_arguments_test.go
@@ -6,6 +6,7 @@ package mcp
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -116,5 +117,36 @@ func TestStdio_WireArguments_NonEmptyPassthrough(t *testing.T) {
 	}
 	if !strings.Contains(res.Text, "text") {
 		t.Errorf("Text = %q, want it to contain %q", res.Text, "text")
+	}
+}
+
+// TestNormalizeArguments pins the normalizeArguments contract (issue #1399):
+// a nil map becomes a non-nil empty map — the SDK must never receive a
+// typed-nil map in the CallToolParams.Arguments any-field, which would emit
+// "arguments": null on the wire — while a non-nil map is returned unchanged.
+func TestNormalizeArguments(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    map[string]interface{}
+		wantLen int
+	}{
+		{"nil becomes empty", nil, 0},
+		{"non-nil empty unchanged", map[string]interface{}{}, 0},
+		{"non-empty unchanged", map[string]interface{}{"text": "x"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeArguments(tt.args)
+			if got == nil {
+				t.Fatalf("normalizeArguments(%v) = nil, want non-nil", tt.args)
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("len(normalizeArguments(%v)) = %d, want %d", tt.args, len(got), tt.wantLen)
+			}
+			if tt.args != nil && !reflect.DeepEqual(got, tt.args) {
+				t.Errorf("normalizeArguments(%v) = %v, want the input unchanged", tt.args, got)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes **#1399** (supersedes #1398). Zero-argument MCP tools emitted `"arguments": null` on the JSON-RPC `tools/call` wire: a nil `map[string]interface{}` passed into the go-sdk's `CallToolParams.Arguments` (`any` field, `json:"arguments,omitempty"`) defeats both `omitempty` (a nil map inside an interface is not "empty") and the SDK's own nil guard (`if params.Arguments == nil` tests the **interface**, which is non-nil for a typed-nil map). Strict servers (the official `@modelcontextprotocol/server-*` suite, zod-validated) reject the call with `invalid_type: expected record, received null` — reproduced against `@modelcontextprotocol/server-filesystem` (`mcp_fs_list_allowed_directories`).

**The fix is protocol compliance** (MCP spec: `arguments` must be an object or absent, never `null`; go-sdk intent "Avoid sending nil over the wire"): normalize the nil map **before** it enters the `any` field, at the adapter layer — the only layer confined to the SDK (ADR-067 §2).

## Changes

| Commit | Change |
| --- | --- |
| `d5395fa1` | `test(mcp)`: `args-capture` fixture tool + `wire_arguments_test.go` — wire-level regression tests, **red pre-fix** (`Text = "null", want "{}"` on both HTTP and stdio nil-arg rows) |
| `4d352a51` | `fix(mcp)`: `normalizeArguments` helper called at **both** `CallToolParams` construction sites (`client.go`, `stdio_client.go`) — the only two repo-wide — emitting `"arguments":{}` for zero-arg calls |
| `57d7b355` | `docs(mcp)`: comment-only note on `MCPClient.CallTool` — nil args are normalized by implementations; the wire must never carry `arguments: null` |

5 files changed, +179/−4: `internal/infrastructure/mcp/client.go`, `internal/infrastructure/mcp/stdio_client.go`, `internal/infrastructure/mcp/wire_arguments_test.go` (new), `internal/infrastructure/mcp/testdata/stdioserver/main.go`, `internal/domain/tools/mcp_client.go` (comment only).

## Acceptance criteria — issue #1399

- [x] `normalizeArguments` helper in `internal/infrastructure/mcp/`, called at both `CallTool` construction sites (`client.go`, `stdio_client.go`) — repo-wide grep confirms exactly two `CallToolParams` sites, both normalized
- [x] Zero-arg wire payload is `"arguments":{}`, never `"arguments":null` — proven red pre-fix on **both** transports (HTTP + stdio), green post-fix
- [x] `wire_arguments_test.go` added; **no catalog-pinned file/line touched** (`client_test.go:645`, `stdio_client_integration_test.go:112/216/278` untouched — `verify-nonfix-catalog` interaction vacuous by construction)
- [x] `args-capture` fixture tool added to unpinned `testdata/stdioserver/main.go`
- [x] No SDK-guard white-box pin; no plugin-layer pin
- [x] `go test ./internal/infrastructure/mcp/... ./internal/tools/integrations/mcp/...` passes
- [x] `make check-full` green
- [x] PR framing: protocol compliance; strict/lenient server behavior cited as issue-sourced exposure evidence (#1398/#1399)

## Verification

| Gate | Result |
| --- | --- |
| `go test ./internal/infrastructure/mcp/...` | ✅ ok (4.270s, uncached) |
| `go test ./internal/tools/integrations/mcp/...` | ✅ ok |
| `go vet ./internal/infrastructure/mcp/...` | ✅ clean |
| `gofmt` | ✅ clean |
| `make check-full` (lint, verify-architecture, verify-transitive-gate, verify-nonfix-catalog, verify-ports-registry, all verify-* guards, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, **test-race**) | ✅ **All checks passed (including race detection)** |
| CC of new functions | ≤ 6 (below the `complexity-threshold-policy` boundary) |

## Deliberate side effects (reviewer notes)

1. **Silent wire-shape change in existing lenient-server tests**: existing nil-args tests (`client_test.go` `TestCallTool_MixedContent` etc., and the stdio suite) assert **response** semantics on lenient fixture servers; their wire shape changes `null` → `{}`. They stay green and remain valid — this is exactly what a wire-correctness fix does.
2. **T1 doc-comment correction**: the `newFixtureServer` doc comment was corrected `five` → `six fixture tools` to match the function modified (comment accuracy only, zero behavioral impact).
3. `TestNormalizeArguments` uses a per-row `wantLen` column (0/0/1) so the `len == 0` contract applies only to nil/empty rows (a self-caught test-authoring bug fixed within T2, no scope change).

## References

- Issue: https://github.com/gosharplite/tell-me-go/issues/1399 (supersedes #1398)
- Grill-round transcript (diagnosis + plan review): https://gist.github.com/gosharplite/0a464e6c9807bb3962991431cd2dd43f
- ADR-067 — `docs/adr/2026-08-mcp-client-architecture.md`
- go-sdk v1.7.0 — `CallToolParams.Arguments` (`mcp/protocol.go:219-231`), `ClientSession.CallTool` nil guard (`mcp/client.go:1278-1291`)

## Not in scope

- #1377/#1378 (empty `"type": ""` in LLM-facing tool schemas) — provider-facing schema path, disjoint code.
