### PR TITLE
feat(memory): automatic PLUR memory integration — context injection + turn-hook learning (#1404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Significant architectural decisions are documented in our [Architecture Decision
 *   **[ADR-061](docs/adr/2026-08-per-turn-turn-lifecycle.md)** — per-turn Turn lifecycle (constructor-is-the-reset).
 *   **[ADR-066](docs/adr/2026-08-infrastructure-application-dependency-inversion.md)** — infrastructure→application dependency inversion: six-type port relocation, `internal/app` construction seam, factory slim, and the ADR-carved `di → ui` exception (issue #1364).
 *   **[ADR-067](docs/adr/2026-08-mcp-client-architecture.md)** — MCP client architecture: remote MCP server consumption via streamable HTTP and `tools.MCPClient` domain port (issue #1373).
+*   **[ADR-068](docs/adr/2026-09-automatic-plur-memory-integration.md)** — automatic PLUR memory integration: `plurInjector` context transformer (priority 15, marker-keyed replace-in-place) and `plurHook` TurnHook (four-tier `LEARN`) over the `tools.MCPClient` domain port (issue #1404).
 
 For the evolution of the shell-based environment management tooling — from simple bash aliases through Toby, Dobby, Porter, Sprawl, Winky, Flopsy, and Niffler — see [Evolution of Environment Management](docs/architect/environments/environment-management-evolution.md).
 

--- a/docs/adr/2026-09-automatic-plur-memory-integration.md
+++ b/docs/adr/2026-09-automatic-plur-memory-integration.md
@@ -1,0 +1,354 @@
+# ADR-068: Automatic PLUR Memory Integration
+
+- **Status**: Accepted
+- **Date**: 2026-09
+- **Deciders**: Architect, Coder
+- **Consulted**: Issue #1404 (supersedes #1403, which superseded #1402)
+
+## Context
+
+tell-me-go is a generic MCP client: it exposes MCP tools (e.g. `plur_learn`,
+`plur_recall`, `plur_inject_hybrid`, `plur_status`) to the agent, but there is
+**no hooks mechanism** for an MCP server to inject content into the prompt and
+no automatic learning extraction. In any multi-persona deployment where
+personas share one `TELL_ME_HOME`:
+
+- A correction made to one persona session is invisible to the others unless
+  the agent explicitly calls `plur_learn` and every other agent explicitly
+  calls `plur_recall`/`plur_inject_hybrid`.
+- Memory quality depends on agent self-discipline, not guaranteed plumbing.
+- Competitor integrations (Claude Code hooks, OpenClaw plugin, Hermes plugin,
+  DeepSeek Harness plugin) all do this automatically; tell-me-go cannot
+  without a feature.
+
+Goal: **"install once, memory works"** — the same value PLUR provides to Claude
+Code, delivered through tell-me-go's own extension seams. This issue is the
+final implementation spec; it supersedes #1403 (which superseded #1402). The
+two-seam design was adversarially reviewed in **two grill rounds** — Round 1 on
+#1402 (9 questions, verdict: proceed with changes) and Round 2 on #1403
+(5 questions, verdict: proceed with changes) — and **all design decisions,
+including the Round 2 refinements, are settled. There are no open questions.**
+
+## Decision
+
+### 1. Seam A — Injection: `plurInjector` as a `ContextTransformer`
+
+1. **Construction & registration.** `plurInjector` is a
+   `sessctx.ContextTransformer` constructed by the DI composition root with
+   the `tools.MCPClient` for `MEMORY.SERVER`, and registered in
+   `sessctx.Factory.Extras` at `initComponents`. **Priority 15** — after
+   skills (10), before gatekeeper (80). The injector is token-counted and can
+   trigger summarization of unpinned history. Distinct priorities are
+   mandatory: pipeline ordering uses the non-stable `sort.Slice` (ADR-036), so
+   priority 15 must not collide with skills' 10 or gatekeeper's 80.
+2. **Marker-keyed replace-in-place, never append.** The `## PLUR MEMORY` /
+   `[/PLUR-MEMORY]` sentinels delimit one self-delimited Part. On each turn
+   the Part's `Text` is **replaced**; it is appended only on first injection.
+   At most one memory block exists at any time (`memory-single-block`). The
+   injector **never sets `req.PersistHistory`**: when a sibling canonical
+   transformer does, the *latest* block persists and is marker-identified and
+   replaced on the next turn.
+3. **Fully stateless transformer (Round 2 refinement — no `lastEnabled`
+   tracking).** Strip-on-disable is **content-driven**: when
+   `ENABLED == false`, scan for the sentinel; if present, remove the Part
+   (and drop the system Content if left with zero Parts) and set
+   `req.PersistHistory = true`; if absent, no-op. The transformer is
+   idempotent and self-healing under multi-pass `Prepare` (a failed strip
+   persists → next pass retries; after a persisted strip the sentinel is gone
+   until re-enable re-introduces it).
+4. **Fetch-per-turn.** Each turn issues `plur_inject_hybrid` with
+   `{task: <current user prompt>, budget: INJECT_BUDGET, scope?}`. **No
+   `session_id`** — it is unobtainable at Transform time, and cross-persona
+   recall argues against session-scoping. **No v1 cache** — the eager stdio
+   spawn makes every call a warm roundtrip. The `MEMORY.CACHE_TTL` = 60s
+   task-fingerprint-keyed cache is a **measured fallback ONLY** (trigger: E2E
+   p95 > ~100–150ms) and is **not implemented in v1**. Contract: *recall is
+   the live per-turn relevance-gated query result; staleness is bounded only
+   by the query, never indefinite.*
+5. **Fail-open with strip semantics.** On any MCP error/timeout: log, strip
+   the marker block **in memory only** (never `PersistHistory`), and return
+   unchanged. Invariant: *inject current recall, or nothing — never stale
+   recall.*
+6. **Defensive trim.** The returned block is trimmed to `INJECT_BUDGET`
+   because pinned engrams make server-side size non-deterministic.
+
+### 2. Seam B — Learning: `plurHook` as a `TurnHook`
+
+1. **Registered once at `initComponents`**, never per-Chat: `WithEngineHook`
+   appends, so per-Chat registration would double-fire. Belt-and-suspenders
+   turn-scoped dedupe on the last `SessionID` + `Index`.
+2. **Detached bounded context for all hook MCP calls.** Every call uses
+   `context.WithTimeout(context.Background(), 3*time.Second)` (bounded by
+   `min(3s, server EffectiveTimeout)`), because `AfterTurn` is synchronous on
+   `ExecuteTurn`'s return path and the turn's own ctx is dead on
+   cancellation/timeout. User aborts (`err == context.Canceled` /
+   `DeadlineExceeded`) are still captured as error episodes via the detached
+   ctx.
+3. **Episode sourcing — three-way classification keyed on the hook's `err`
+   argument** (never `Turn.State.LastError`, which is stale on the
+   empty-response retry path):
+   - (i) `Response != nil` (any `err`) → episode = this turn's response text
+     + `Mode` + `SessionID` + timestamp; annotate `LastError` if set.
+   - (ii) `Response == nil && err != nil` → episode =
+     `{error, prompt: <last user message from PreparedHistory, else omitted>,
+     mode, session, timestamp}`. **Never `GetLastModelTurn`** (it would
+     return the previous turn's response). No learning from this branch.
+     **Round 2 refinement:** skip the episode when `IsTransient(err)` is true
+     (retry-exhaustion on a transient error — `errors.Is` unwraps the "max
+     retries reached" wrap) and record the skip at debug level.
+   - (iii) `Response == nil && err == nil` → `GetLastModelTurn` (**the only
+     valid case** — provably this turn's: the phase loop has exited and no
+     history writes occur between `AddContent` and `notifyAfterTurn`); skip
+     if the retrieved response has no text parts (this also suppresses
+     intermediate tool-iteration turns, which fire `AfterTurn` per
+     `Engine.Run` iteration).
+
+### 3. `LEARN` tiers — `off | capture | batch | full`
+
+The tiers are **mutually exclusive** (`memory-learn-tier-exclusive`); the
+default is `batch`:
+
+- `off` — nothing.
+- `capture` — per-turn `plur_capture` episodes (`{agent: Mode, session_id}`).
+- `batch` — episodes + **session-end `plur_learn_batch`** of a bounded
+  per-session ring buffer (~20 turns, per-entry text/token cap — bounded in
+  count and bytes), flushed via `defer plurHook.FlushSession()` in `Chat`
+  (success and error). Local extraction, zero LLM cost. `FlushSession` drains
+  under lock, deletes the map entry, then issues the MCP call **outside** the
+  lock.
+- `full` — episodes + **gated per-turn direct `plur_learn`**: signal = the
+  **user message only**; matcher = correction *frames* (`please remember` /
+  `note`, `from now on`, `stop <verb>`, `don't|do not|never|always
+  <imperative>` — documented heuristic list); flood bounds =
+  `MAX_LEARNS_PER_SESSION` = **3** (hot-reloadable) + per-session exact-match
+  hash dedupe. Statement = the user's own words, trimmed, tagged mode/scope.
+
+`plur_ingest` (LLM extraction) is **never auto-fired** — explicit ingestion
+remains agent-mediated. Fail-open: memory errors are logged and ignored
+(ADR-029 §5 posture).
+
+### 4. Write-path concurrency (multi-persona)
+
+Documented acceptance: **last-write-wins** for genuinely concurrent writers —
+PLUR's single `~/.plur/` YAML store is atomic+fsync but **unlocked**, so the
+lost-update window is real and shared across all personas that share `$HOME`
+(episodes/tensions/config are lock-protected). Mitigations:
+
+1. **Sequential-orchestration rule** codified here: orchestrated multi-agent
+   flows (e.g. the Issue-to-PR loop) relay one send/retrieve at a time and
+   never run agents in parallel, so tell-me-go writers are naturally
+   sequential in practice.
+2. **Best-effort advisory `flock`** on `~/.plur/.tmg-write.lock`, held
+   **only across the write MCP calls** — non-blocking `LOCK_EX|LOCK_NB`,
+   polled on a bounded budget (max ~200–500ms via an injected clock),
+   fail-open (log + proceed unlocked). Uncreatable lock file → proceed
+   unlocked. Unix-only (build tags, no-op on Windows). Serializes
+   tell-me-go writers only.
+
+### 5. Config surface
+
+```yaml
+MEMORY:
+  ENABLED: false            # master switch; default false (opt-in); hot-reloadable
+  SERVER: "plur"            # key of the MCP_SERVERS entry backing the memory; session-fixed
+  INJECT_BUDGET: 2000       # tokens for plur_inject_hybrid per turn; hot-reloadable
+  LEARN: "batch"            # off | capture | batch | full; default batch; hot-reloadable
+  SCOPE: ""                 # optional; precedence: override-if-set → .plur.yaml → one surfaced warning
+  MAX_LEARNS_PER_SESSION: 3 # flood bound for `full`; hot-reloadable
+  # CACHE_TTL: 60           # fallback ONLY (measured trigger p95 > 100–150ms); task-keyed, write-invalidated
+```
+
+- **Default disabled → zero behavior change** for existing users.
+- **Enabled-but-absent-server → warn and disable (two stages):**
+  (1) *static* — `MemoryConfig.validate()` (mirroring `MCPServerConfig.validate`)
+  at config load and every hot-reload re-parse; (2) *dynamic* — if
+  `mcpFactory.Build` skips the server (client construction/token failure),
+  `GetMCPClient` returns `(nil, false)` and `initComponents` logs
+  `memory_server_unavailable` and constructs the memory components with
+  effective `ENABLED = false` (inert, stable DI shape). Plus a **nil-client
+  runtime guard** in `Transform`/`AfterTurn` (hot-reload `ENABLED=true` with a
+  DI-fixed nil client → log + fail-open no-op).
+- **Hot-reload:** `ENABLED` / `LEARN` / `INJECT_BUDGET` /
+  `MAX_LEARNS_PER_SESSION` ride the existing watcher →
+  `configRefreshHook.OnPhaseTransition` → `applyConfig` path; `SERVER` is
+  restart-level.
+
+### 6. DI wiring (Round 2 — settled)
+
+- `defaultToolchainFactory.BuildRegistry` **stashes the built `mcpClients`
+  map** on the factory (not retained today).
+- `ports.ChatterComposer` gains **`GetMCPClient(name string)
+  (tools.MCPClient, bool)`**, implemented on `sessionDeps` by unwrapping
+  `plugin.MCPServerDependency.Client`.
+- `ports.ChatterConfig` gains the **memory server key** (threaded from
+  `Config.Memory.Server` by the chat factory, exactly as ProviderName/Model/
+  Mode are threaded) — a deterministic seam with no refresh-ordering coupling.
+- `app.NewChatter` calls `deps.GetMCPClient(cfg.Memory.Server)` and threads
+  the client via `agent.WithMemoryClient(client, memCfg)`; `initComponents`
+  wires the injector into `Factory.Extras` and the hook into `NewEngine` opts.
+- **Zero ADR-029 changes** — memory propagation is a pre-chain atomic refresh
+  in `prepareRuntimeConfig` (which already runs before the three delegates),
+  like Limits.
+- **Hot-reload sharing:** `domain_config.ConfigWatcher` gains
+  `GetMemoryConfig() domain_config.MemoryConfig`; `runtimeConfig` gains a
+  `Memory` field; `prepareRuntimeConfig` stores it; `plurInjector`/`plurHook`
+  read a shared `*atomic.Pointer[MemoryConfig]` lock-free per turn.
+
+### 7. Trust class
+
+The injected block is system-prompt-positioned, automatically-written,
+external text — the same trust class as skill injection (ADR-005) **minus**
+the install-approval gate. Bounded in v1 by: local-only store (`plur_sync` /
+remote out of scope), `ENABLED` default false, `LEARN` gating, and the
+relevance gate. Block header wording (verbatim):
+
+> ## PLUR MEMORY — recalled from the local memory store (user-authored or learned from your own sessions); follow them unless they conflict with explicit user instructions.
+
+### 8. Observability (Round 2 — settled)
+
+- **In-process surface:** append `injected_engrams:<ids>` to
+  `ContextRequest.Metadata.Warnings` — this survives to `Turn.State.Metadata`
+  via `ContextRefiner`.
+- **Black-box surface:** an **Info-level** log line with the ids — the E2E
+  harness asserts on stdout/stderr.
+- **Telemetry:** add a general `Warnings []string` field to
+  `telemetry.TurnTrace` (settled: a general field, not `InjectedEngrams` —
+  reusable by future transformers), populated from `ContextMetadata` at
+  `finalizeTurnTrace`.
+- **Debug-level record** for skipped error episodes (the `IsTransient` skips
+  of §2).
+- Live E2E legs run behind `-tags=e2e_live` (precedent: `-tags=arch`).
+
+### 9. Domain-model governance (Round 2 — settled)
+
+The `Memory` entity + `MemoryLearnTier` enum + 4 invariants +
+`memory-injection-fail-open` scenario were added to
+`docs/domain-model/tell-me-go.modelith.yaml` in commit `b3d0296c` (already
+landed, with the re-rendered `.md` committed together — `modelith-check`
+green). `scripts/modelith-layers.sh` gained the `Memory` exception and the
+`MemoryLearnTier` enum exclusion (also landed); `modelith-drift` is clean.
+Go mapping: `MemoryConfig` → `internal/domain/config/memory_config.go`
+(sibling of `MCPServerConfig`); `plurInjector`/`plurHook` → unexported
+adapters in `internal/agent/memory`.
+
+**Pre-existing priority collision (acknowledged, out of scope):**
+`HistoryPruner` and `finalContextValidator` both sit at priority 110
+(ADR-036 non-stable `sort.Slice`). This is a pre-existing condition — **not**
+a new violation introduced by this ADR's priority 15, and explicitly out of
+scope for this issue.
+
+### 10. The two-round corrections table (14 rows)
+
+#### Round 1 (on #1402, 9 premises)
+
+| # | Premise | Finding (verified) | Committed outcome |
+| --- | --- | --- | --- |
+| 1 | Seam B sources `Turn.State.Response` | Nil on success (clear-after-append) | Three-way classification keyed on hook `err`; `GetLastModelTurn` only when `err == nil` |
+| 2 | Seam A appends to system `Parts` | Pinned system message never summarised → unbounded accumulation | Marker-keyed replace-in-place @ priority 15; `memory-single-block` |
+| 3 | Fail-open = return unchanged | Leaves stale recall in a pinned message | Strip-on-failure AND strip-on-disable; `ENABLED` hot-reloadable |
+| 4 | Hook registered per-Chat | `WithEngineHook` appends → double-fire | Registered once at `initComponents` |
+| 5 | "One memory-enabled persona per HOME" | Contradicts E2E; guts multi-persona value | Withdrawn → multi-persona + last-write-wins + advisory `flock` + sequential backstop |
+| 6 | Per-session cache/TTL | Eager spawn amortizes cold start; cache serves task-mismatched recall | No v1 cache, fetch-per-turn; `CACHE_TTL` 60s as measured fallback only |
+| 7 | Single-sentence E2E | Nondeterministic (relevance gate + no pin tool) | Two-legged E2E (below) |
+| 8 | `session_id` on injection call | Unobtainable at Transform time | Dropped; additive `ContextRequest.SessionID` as v1.1 follow-up |
+| 9 | `LEARN: full` gating unspecified | Mechanics/flood control undefined | Four-point gate + four-tier ladder, default `batch` |
+
+#### Round 2 (on #1403, 5 refinements — all settled)
+
+| # | Area | Finding (verified) | Committed outcome |
+| --- | --- | --- | --- |
+| 10 | Seam A state machine | Multi-pass `Prepare` breaks stateful transition tracking | Fully stateless, content-driven strip-on-disable (sentinel presence), self-healing; replace-or-append single sentinel-delimited Part |
+| 11 | Seam B lifecycle | `AfterTurn` has no ctx, is synchronous on the turn's return path, fires per `Engine.Run` iteration; `errors.Is` unwraps retry wraps | Detached bounded ~3s ctx per MCP call; text-parts filter suppresses tool iterations; branch (ii) gains `!IsTransient(err)` + debug-level skip record |
+| 12 | DI wiring | `ChatterComposer` has no MCP accessor; clients not retained after registration; `ChatterConfig` lacks server key | `GetMCPClient(name)` on `ChatterComposer` (factory stashes map); server key on `ChatterConfig`; nil-client runtime guard; two-stage fallback |
+| 13 | Governance | `MemoryLearnTier` also caught by layers regex; ADR-068 filename/numbering | `Memory` exception + `MemoryLearnTier` enum exclusion; `docs/adr/2026-09-automatic-plur-memory-integration.md` indexed + linked in main README; pre-existing 110/110 collision acknowledged in ADR-068 |
+| 14 | Observability | `TurnTrace` carries no warnings today | `ContextMetadata.Warnings` (in-process) + additive general `TurnTrace.Warnings []string` + Info-level log line for CLI legs; live E2E behind `-tags=e2e_live` |
+
+### 11. Failure/disable matrix
+
+| Condition | Behavior |
+| --- | --- |
+| Server available | **Inject latest** recall (fetch-per-turn `plur_inject_hybrid`, trimmed to `INJECT_BUDGET`) |
+| Error/timeout | **Strip, no persist** — log, remove the marker block in memory only (never `PersistHistory`), return unchanged (*inject current recall, or nothing — never stale recall*) |
+| Disabled (`ENABLED == false`) | **One-shot persisted strip** — remove the sentinel-delimited Part if present (drop the system Content if left with zero Parts), set `req.PersistHistory = true`; if absent, no-op |
+
+### 12. v1.1 follow-ups (recorded, not deferred silently)
+
+- Additive `ContextRequest.SessionID` — **only if** PLUR's relevance scoring
+  measurably benefits from session context.
+- Per-persona scope separation via `plur_rescope` / store entries — the
+  concurrency remedy; note `plur_inject_hybrid` takes a single `scope`, so
+  cross-scope injection needs one call per scope.
+- If PLUR gains a pin capability: optional `pinned: true` flag on learn — a
+  config nicety, not a blocker.
+
+### 13. Out of scope (this issue)
+
+- **Deployment-specific work** (e.g. Niffler templates/provisioning/
+  per-deployment defaults) — this issue is tell-me-go core.
+- PLUR sync/team-store integration (`plur_sync`, shared remotes) —
+  configuration-level, not core.
+- Cursor-style lean tool profiles or `plur_admin` tool curating.
+- **Changing PLUR itself** — the MCP surface is consumed as-is; there is no
+  pin tool in v1, so pinning is out-of-band (PLUR CLI / store edit),
+  documented as an E2E setup step.
+- Memory for the TUI/history-browser surfaces.
+
+## Consequences
+
+**Positive:** memory flows automatically — relevant engrams are injected into
+the context before each turn and learnings/episodes are captured after each
+turn, so multi-persona deployments sharing one `TELL_ME_HOME` get
+"install once, memory works" without relying on agent self-discipline. The two
+seams (`plurInjector` context transformer at priority 15, `plurHook` TurnHook)
+are deterministic extension points on existing architecture. `ENABLED` defaults
+to false, so existing users see **zero behavior change**. Fail-open guarantees
+hold everywhere: injection failure strips and never persists stale recall, and
+memory errors are logged and ignored (ADR-029 §5 posture).
+
+**Negative:** the write path accepts **last-write-wins** for genuinely
+concurrent writers; the advisory `flock` is best-effort and serializes
+tell-me-go writers only. Per-turn fetch adds latency on the turn's critical
+path (no v1 cache — `CACHE_TTL` is a measured fallback only). The injected
+block is system-prompt-positioned, automatically-written external text — a
+trust surface, bounded in v1 by local-only storage, opt-in `ENABLED`, `LEARN`
+gating, and the relevance gate (minus the skill-injection install-approval
+gate).
+
+**Neutral:** the MCP client is retained after tool registration (factory stash
++ `GetMCPClient` accessor); `telemetry.TurnTrace` gains a general `Warnings
+[]string` field reusable by future transformers; the pre-existing 110/110
+priority collision (`HistoryPruner` / `finalContextValidator`) is acknowledged
+but untouched; the v1.1 follow-ups (additive `ContextRequest.SessionID`,
+per-persona scope separation, optional pin flag) are recorded, not deferred
+silently.
+
+## References
+
+- ADR-067 — MCP client architecture (`docs/adr/2026-08-mcp-client-architecture.md`)
+- ADR-005 — skill injection (`docs/adr/2026-01-skill-injection-architecture.md`)
+- ADR-029 — fallible `Reconfigure` delegate chain / `configRefreshHook`
+  (`docs/adr/2026-05-fallible-reconfigure-delegate-chain.md`)
+- ADR-036 — test determinism standards, non-stable `sort.Slice`
+  (`docs/adr/2026-05-test-determinism-standards.md`)
+- ADR-021 — test doubles in `*test` sub-packages
+  (`docs/adr/2026-04-test-doubles-in-pkgtest-subpackages.md`)
+- ADR-040 — complete session subpackage extraction (the skills extraction;
+  the earlier draft's "ADR-030" citation was wrong — ADR-030 is Release
+  Branch Synchronization Policy)
+  (`docs/adr/2026-05-session-extraction-completion.md`)
+- Domain model: `Context`, `Config`, `Turn` entities; invariants
+  `context-within-budget`, `context-pinned-preserved`,
+  `history-persisted-after-turn` (`docs/domain-model/tell-me-go.modelith.yaml`)
+- Code seams: `internal/agent/session/context/`,
+  `internal/agent/skills/injector.go`,
+  `internal/agent/orchestrator/{engine,engine_types,engine_phases}.go`,
+  `internal/agent/agent.go` (`initComponents`, `prepareRuntimeConfig`,
+  `applyConfig`), `internal/domain/ports/session.go` (`ChatterComposer`),
+  `internal/domain/config/{watcher,mcp_config}.go`,
+  `internal/domain/telemetry/trace.go`,
+  `internal/domain/tools/mcp_client.go`,
+  `internal/infrastructure/di/{container,toolchain_factory,mcp_factory}.go`,
+  `internal/pkg/clock/clock.go`, `tests/e2e/`, `scripts/modelith-layers.sh`
+- Grill rounds: [Round 1 transcript](https://gist.github.com/gosharplite/6af5e8d44cd3d7cfd765ff4be1a2537e) ·
+  [Round 2 transcript](https://gist.github.com/gosharplite/213ada4b83cca349afeadef12ff729f0)
+- Superseded issues: #1402, #1403

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -73,6 +73,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-065** | Infra-Only Multi-Package Seam Realigns to Concept-Side Contract Leaf | 2026-08 | Accepted | [2026-08-infra-seam-contract-leaf-rule.md](2026-08-infra-seam-contract-leaf-rule.md) |
 | **ADR-066** | Infrastructure→Application Dependency Inversion — Port Relocation and internal/app Construction Seam (TD-1, M-scope) | 2026-08 | Accepted | [2026-08-infrastructure-application-dependency-inversion.md](2026-08-infrastructure-application-dependency-inversion.md) |
 | **ADR-067** | MCP Client Architecture — Remote MCP Server Consumption via Streamable HTTP | 2026-08 | Accepted | [2026-08-mcp-client-architecture.md](2026-08-mcp-client-architecture.md) |
+| **ADR-068** | Automatic PLUR Memory Integration | 2026-09 | Accepted | [2026-09-automatic-plur-memory-integration.md](2026-09-automatic-plur-memory-integration.md) |
 
 ## How to Create a New ADR
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -301,7 +301,7 @@ catalog a new gap no one reviewed. Policy:
   error-return branch flagged by coverage tools does not exist in the current
   single-file architecture. Structurally unreachable — same acceptance class
   as `json.Marshal` on all-string structs in `global_prompt_tracker.go`.
-- **See**: `internal/domain/config/config.go:224-229` (definition), `:250-252` (call-site error branch, covered by this entry)
+- **See**: `internal/domain/config/config.go:224-229` (definition), `:251-253` (call-site error branch, covered by this entry)
 
 ### domain/events/events.go — NoOpEventBus no-op stubs at 0%
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -905,6 +905,60 @@ catalog a new gap no one reviewed. Policy:
 - **Rationale**: Table-driven resolution-contract test pinning the COMMAND resolution rules (separator-bearing passthrough, bare-name LookPath, empty-command failure, nonexistent-bare-command annotation). CC comes from case enumeration and assertion boilerplate, not branching business logic. CC rose 10→13 (2026-09) when two not-found subtests were added — still the same acceptance class as `TestGetModelTurn` (CC=16) and `TestMediaBlocks` (CC=11): assertion boilerplate across a coverage matrix.
 - **See**: `internal/infrastructure/mcp/stdio_client_test.go:25`
 
+### internal/agent/memory/hook_test.go — TestHookBatch (CC=14)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Sequential state-mutation test over the batch tier:
+  AfterTurn appends to the shared ring buffer (no MCP call); FlushSession
+  drains under lock, deletes the map entry, and calls plur_learn_batch
+  outside the lock; a second flush is a no-op. Steps mutate shared hook
+  state and depend on prior steps — splitting would duplicate setup. Same
+  acceptance class as `TestGetModelTurn` (CC=16) — test-complexity, not
+  branching business logic.
+- **See**: `internal/agent/memory/hook_test.go:209`
+
+### internal/agent/memory/hook_test.go — TestHookFull (CC=15)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Sequential full-tier test: frame-match learns, sha256
+  dedupe, flood bound, and non-frame suppression — each subtest mutates the
+  hook's per-session learn state built up by prior steps. CC is assertion
+  boilerplate across dependent steps. Same acceptance class as
+  `TestGetModelTurn` (CC=16).
+- **See**: `internal/agent/memory/hook_test.go:273`
+
+### internal/agent/memory/injector_test.go — TestInjectorEnabledInsert (CC=22)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Table-driven injector test across the enabled-path insertion
+  behaviors — prepend when no system Content, append to an existing system
+  Content, replace an existing marker Part, at most one memory block — plus
+  trim and warning surfaces. CC comes from case enumeration and assertion
+  boilerplate, not branching business logic. Same acceptance class as
+  `TestHydrateMediaAssets` (CC=13) — assertion boilerplate across a coverage
+  matrix.
+- **See**: `internal/agent/memory/injector_test.go:108`
+
+### internal/app/chatter_test.go — TestNewChatter_MemoryClientLookup (CC=12)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Subtest enumeration over the memory-lookup seam
+  (configured → client returned, skipped → nil-degrade, empty → not
+  called) with per-subtest setup — assertion boilerplate across a coverage
+  matrix. CC is subtest enumeration, not branching business logic. Same
+  acceptance class as `TestGetModelTurn` (CC=16).
+- **See**: `internal/app/chatter_test.go:226`
+
+### tests/e2e/testdata/fakeplur/main.go — newServer (CC=13)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Testdata helper constructor for the fake plur MCP server:
+  config branching for store/seed loading and the tool dispatch table
+  setup — structural setup branching in a testdata helper binary, not
+  business logic. Same acceptance class as `createPrecisionWorkspace`
+  (CC=12, test-fixture builder).
+- **See**: `tests/e2e/testdata/fakeplur/main.go:104`
+
 ---
 
 ## Complexity Alerts (ACCEPTED)
@@ -1141,6 +1195,41 @@ to reason about.
   `handleDomainEvent` (CC=12) and `(*model).Update` (CC=14) — structural
   dispatch where CC is switch/branch count, not branching business logic.
 - **See**: `internal/agent/orchestrator/engine_phases.go:129`
+
+### internal/agent/memory/hook.go — (*plurHook).AfterTurn (CC=21)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Sequential guarded classification: three-way switch on the
+  hook err (nil / correction-frame / other) plus LEARN-tier dispatch
+  (off/batch/full), with nil-client and nil-config guards. Every branch is a
+  single-line episode build or tier dispatch — CC is structural
+  guard/branch count, not branching business logic. Extracting would
+  fragment a coherent sequential function for cosmetic CC reduction (same
+  class as `handleDomainEvent` CC=12, `(*RecoveryStep).Process` CC=12). The
+  fail-open guard structure (return on every path; memory errors logged and
+  ignored) is mandated by ADR-068 §2.
+- **See**: `internal/agent/memory/hook.go:80`
+
+### internal/agent/memory/injector.go — (*plurInjector).Transform (CC=16)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: Sequential fail-open pipeline mandated by ADR-068 §1:
+  disabled-strip, nil-client guard, error-strip, defensive trim, marker
+  insert, observability — each step a single-line guard or delegation, and
+  the function returns nil on every path so the turn is never broken. CC is
+  structural guards, not business logic. Same acceptance class as
+  `renderHistory` (CC=12).
+- **See**: `internal/agent/memory/injector.go:64`
+
+### internal/agent/memory/injector.go — metadataIDs (CC=11)
+
+- **Status**: ACCEPTED (2026-09, issue #1404)
+- **Rationale**: 4-case type-switch + guards normalizing the
+  `Metadata["ids"]` value into a string slice — dispatch-structural, same
+  class as `handleDomainEvent` (CC=12). Each case is a single-line
+  conversion or return; the CC is inherent to the type-switch dispatch
+  pattern, not branching business logic.
+- **See**: `internal/agent/memory/injector.go:226`
 
 ---
 

--- a/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
+++ b/docs/architect/TRANSITIVE_IMPORT_WHITELIST.md
@@ -60,6 +60,9 @@ allowed: config, events, llm, persistence, pricing, security, skills, telemetry,
 ## consumer: internal/agent/skills
 allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
 # P1+P2+P5: skill-injection deps
+## consumer: internal/agent/memory
+allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
+# P1+P2+P5: memory adapters (plurInjector/plurHook) via orchestrator + sessctx deps
 ## consumer: internal/cli
 allowed: config, events, llm, persistence, pricing, security, services, skills, telemetry, tools
 # P1+P2+P5: CLI command deps

--- a/docs/domain-model/tell-me-go.modelith.md
+++ b/docs/domain-model/tell-me-go.modelith.md
@@ -38,6 +38,17 @@ Categories of `Provider` error that affect retry and failover behaviour. Disting
 | `server_error` | A transient 5xx from the `Provider`; may succeed on retry or failover. |
 | `timeout` | The `Provider` did not respond within `Config.httpTimeout`. |
 
+### `MemoryLearnTier`
+
+The automatic-learning tier of `Memory`. Mutually exclusive — exactly one tier is active. `batch` is the default.
+
+| Value | Definition |
+| --- | --- |
+| `off` | No automatic learning; `Memory` is read-only (injection may still be enabled). |
+| `capture` | Per-turn `plur_capture` episodes are recorded; no batch flush, no LLM extraction. |
+| `batch` | Episodes are captured and flushed as a `plur_learn_batch` at session end; zero LLM cost. Default tier. |
+| `full` | Episodes plus gated per-turn direct `plur_learn` on correction frames, bounded by `maxLearnsPerSession`. |
+
 ## Entities
 
 ### `Config`
@@ -48,6 +59,7 @@ The YAML configuration loaded at startup. Defines the active `Provider`, the ful
 
 - `Pricing` — 1:n — owned — Per-model cost rates from the built-in pricing table, overridable per model via the MODELS section. Realized in code as `Config.Models` (`map[string]ModelConfig`, each entry embedding `pricing.ModelPricing`).
 - `MCPServer` — 1:n — owned — Configured external MCP servers (YAML key MCP_SERVERS). Realized in code as Config.MCPServers (map[string]MCPServerConfig).
+- `Memory` — 1:1 — owned — The MEMORY configuration section; realized in code as Config.Memory (MemoryConfig).
 
 **Attributes**
 
@@ -149,6 +161,33 @@ An external Model Context Protocol (MCP) server providing dynamic tool capabilit
 - **mcp-token-not-logged** — Credentials and derived Authorization headers for `MCPServer`s must never be logged or serialized by the MCP credential plumbing (config validation, DI factory, client transport).
 - **mcp-readonly-defaults** — An `MCPServer` targeting a read-only endpoint defaults to `requiresConsent: false` and concurrent execution (`serial: false`).
 - **mcp-stdio-trusted-defaults** — A stdio `MCPServer` (command set) defaults to `requiresConsent: false` (trusted local spawn) and `serial: true`; an explicit `REQUIRES_CONSENT: true` opts back in.
+
+### `Memory`
+
+Local-first shared memory for AI agents, exposed as an MCP server (PLUR). Relevant engrams are injected automatically into the assembled `Context` before each `Turn`, and learnings/episodes are captured automatically after each `Turn` — instead of relying on the agent to call plur tools explicitly. Governed by the `Config` MEMORY section.
+
+**Relationships**
+
+- `MCPServer` — 1:1 — referenced — The MCP server backing recall and learning; `server` is a key into MCP_SERVERS (session-fixed).
+- `Context` — 1:n — referenced — Recall blocks injected into the `Context` system message each `Turn` (marker-delimited, replace-in-place).
+
+**Attributes**
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `enabled` | boolean | Master switch; default false (opt-in); hot-reloadable. |
+| `server` | string | Key of the MCP_SERVERS entry backing the memory; session-fixed (restart-level). |
+| `injectBudget` | integer | Token budget for `plur_inject_hybrid` per `Turn`; hot-reloadable. |
+| `learnTier` | MemoryLearnTier | Learning tier: off, capture, batch, or full; default batch; hot-reloadable. |
+| `scope` | string | Optional scope override passed to injection/learning calls; precedence: override-if-set → .plur.yaml → one surfaced warning. |
+| `maxLearnsPerSession` | integer | Flood bound for the `full` tier's per-turn direct learns; hot-reloadable. |
+
+**Invariants**
+
+- **memory-injection-fail-open** — `Memory` never breaks a `Turn`: on any injection error, timeout, or disable, the injected block is stripped and the `Turn` proceeds unchanged.
+- **memory-injection-budgeted** — Injected `Memory` recall is counted against the `Context` token budget before the gatekeeper runs; the injected block never exceeds `injectBudget`.
+- **memory-single-block** — At most one `Memory` block is present in the assembled `Context` system message; fresh recall replaces, never appends.
+- **memory-learn-tier-exclusive** — Exactly one MemoryLearnTier is active; `batch` and `full` are never combined.
 
 ### `Pricing`
 
@@ -352,6 +391,7 @@ erDiagram
     Context {}
     History {}
     MCPServer {}
+    Memory {}
     Pricing {}
     Provider {}
     SafePath {}
@@ -363,7 +403,10 @@ erDiagram
     Turn {}
     Config ||--o{ Pricing : ""
     Config ||--o{ MCPServer : ""
+    Config ||--|| Memory : ""
     MCPServer ||--o{ Tool : ""
+    Memory ||..|| MCPServer : ""
+    Memory ||..o{ Context : ""
     Session ||--o{ Turn : ""
     Session }o..|| Config : ""
     Session }o..|| Provider : ""
@@ -720,4 +763,29 @@ The agent initializes external tools from configured MCP servers over Streamable
 - **mcp-stdio-trusted-defaults** — A stdio `MCPServer` (command set) defaults to `requiresConsent: false` (trusted local spawn) and `serial: true`; an explicit `REQUIRES_CONSENT: true` opts back in.
 - **tool-timeout** — Execution duration must not exceed `Config.toolTimeout` seconds.
 - **tool-unique-name** — Each `Tool` has a unique name.
+
+### Automatic memory injection and learning
+
+A correction taught in one persona's `Session` is automatically recalled into another persona's `Context`: `Memory` injects relevant engrams before each `Turn` (marker-delimited, replace-in-place) and captures episodes after each `Turn`; on any injection error the block is stripped and the `Turn` proceeds unchanged.
+
+**Actors:** Memory, Config, MCPServer, Context, Session, Turn
+
+**Steps**
+
+1. A user corrects persona A: "please remember: always use X".
+2. Persona A's `Memory` captures the correction as an episode (`plur_learn` under the `full` tier).
+3. Persona B starts a fresh `Session`; `Memory` calls `plur_inject_hybrid` with the user prompt as task.
+4. The recalled engram is injected as a single marker-delimited block in the `Context` system message.
+5. `Context` is counted against the token budget; the block never exceeds `injectBudget`.
+6. On the next `Turn`, fresh recall replaces the previous block — never appends.
+7. If the injection call fails, the block is stripped and the `Turn` proceeds unchanged.
+
+**Invariants touched**
+
+- **memory-injection-fail-open** — `Memory` never breaks a `Turn`: on any injection error, timeout, or disable, the injected block is stripped and the `Turn` proceeds unchanged.
+- **memory-injection-budgeted** — Injected `Memory` recall is counted against the `Context` token budget before the gatekeeper runs; the injected block never exceeds `injectBudget`.
+- **memory-single-block** — At most one `Memory` block is present in the assembled `Context` system message; fresh recall replaces, never appends.
+- **memory-learn-tier-exclusive** — Exactly one MemoryLearnTier is active; `batch` and `full` are never combined.
+- **context-within-budget** — `tokenCount` must not exceed the model's `Pricing.contextWindow`.
+- **history-persisted-after-turn** — Every completed `Turn` is persisted before the next `Turn` begins.
 

--- a/docs/domain-model/tell-me-go.modelith.yaml
+++ b/docs/domain-model/tell-me-go.modelith.yaml
@@ -79,6 +79,20 @@ enums:
       - name: timeout
         definition: The `Provider` did not respond within `Config.httpTimeout`.
 
+  MemoryLearnTier:
+    description: >
+      The automatic-learning tier of `Memory`. Mutually exclusive — exactly
+      one tier is active. `batch` is the default.
+    values:
+      - name: "off"
+        definition: No automatic learning; `Memory` is read-only (injection may still be enabled).
+      - name: capture
+        definition: Per-turn `plur_capture` episodes are recorded; no batch flush, no LLM extraction.
+      - name: batch
+        definition: Episodes are captured and flushed as a `plur_learn_batch` at session end; zero LLM cost. Default tier.
+      - name: full
+        definition: Episodes plus gated per-turn direct `plur_learn` on correction frames, bounded by `maxLearnsPerSession`.
+
 entities:
   Session:
     definition: >
@@ -356,6 +370,10 @@ entities:
         note: >
           Configured external MCP servers (YAML key MCP_SERVERS). Realized in
           code as Config.MCPServers (map[string]MCPServerConfig).
+      - entity: Memory
+        cardinality: "1:1"
+        ownership: owned
+        note: The MEMORY configuration section; realized in code as Config.Memory (MemoryConfig).
     attributes:
       - name: selectedProvider
         type: string
@@ -650,6 +668,54 @@ entities:
       - id: history-persisted-after-turn
         statement: "Every completed `Turn` is persisted before the next `Turn` begins."
 
+  Memory:
+    definition: >
+      Local-first shared memory for AI agents, exposed as an MCP server
+      (PLUR). Relevant engrams are injected automatically into the
+      assembled `Context` before each `Turn`, and learnings/episodes are
+      captured automatically after each `Turn` — instead of relying on
+      the agent to call plur tools explicitly. Governed by the `Config`
+      MEMORY section.
+    relationships:
+      - entity: MCPServer
+        cardinality: "1:1"
+        ownership: referenced
+        note: The MCP server backing recall and learning; `server` is a key into MCP_SERVERS (session-fixed).
+      - entity: Context
+        cardinality: "1:n"
+        ownership: referenced
+        note: Recall blocks injected into the `Context` system message each `Turn` (marker-delimited, replace-in-place).
+    attributes:
+      - name: enabled
+        type: boolean
+        description: Master switch; default false (opt-in); hot-reloadable.
+      - name: server
+        type: string
+        description: Key of the MCP_SERVERS entry backing the memory; session-fixed (restart-level).
+      - name: injectBudget
+        type: integer
+        description: Token budget for `plur_inject_hybrid` per `Turn`; hot-reloadable.
+      - name: learnTier
+        type: MemoryLearnTier
+        description: "Learning tier: off, capture, batch, or full; default batch; hot-reloadable."
+      - name: scope
+        type: string
+        description: >
+          Optional scope override passed to injection/learning calls;
+          precedence: override-if-set → .plur.yaml → one surfaced warning.
+      - name: maxLearnsPerSession
+        type: integer
+        description: Flood bound for the `full` tier's per-turn direct learns; hot-reloadable.
+    invariants:
+      - id: memory-injection-fail-open
+        statement: "`Memory` never breaks a `Turn`: on any injection error, timeout, or disable, the injected block is stripped and the `Turn` proceeds unchanged."
+      - id: memory-injection-budgeted
+        statement: "Injected `Memory` recall is counted against the `Context` token budget before the gatekeeper runs; the injected block never exceeds `injectBudget`."
+      - id: memory-single-block
+        statement: "At most one `Memory` block is present in the assembled `Context` system message; fresh recall replaces, never appends."
+      - id: memory-learn-tier-exclusive
+        statement: "Exactly one MemoryLearnTier is active; `batch` and `full` are never combined."
+
 scenarios:
   - name: Basic question-answer turn
     description: >
@@ -933,6 +999,25 @@ scenarios:
       - "`ToolCall` delegates execution to the `MCPServer` — over Streamable HTTP for URL-based servers, or to the local stdio child process for COMMAND-based servers."
       - "Non-terminal MCP tool errors (isError: true) return error text with nil Go error for in-turn LLM recovery."
     invariants_touched: [mcp-server-key-format, mcp-readonly-defaults, mcp-stdio-trusted-defaults, tool-timeout, tool-unique-name]
+
+  - name: Automatic memory injection and learning
+    description: >
+      A correction taught in one persona's `Session` is automatically
+      recalled into another persona's `Context`: `Memory` injects relevant
+      engrams before each `Turn` (marker-delimited, replace-in-place) and
+      captures episodes after each `Turn`; on any injection error the block
+      is stripped and the `Turn` proceeds unchanged.
+    actors: [Memory, Config, MCPServer, Context, Session, Turn]
+    steps:
+      - "A user corrects persona A: \"please remember: always use X\"."
+      - "Persona A's `Memory` captures the correction as an episode (`plur_learn` under the `full` tier)."
+      - "Persona B starts a fresh `Session`; `Memory` calls `plur_inject_hybrid` with the user prompt as task."
+      - "The recalled engram is injected as a single marker-delimited block in the `Context` system message."
+      - "`Context` is counted against the token budget; the block never exceeds `injectBudget`."
+      - "On the next `Turn`, fresh recall replaces the previous block — never appends."
+      - "If the injection call fails, the block is stripped and the `Turn` proceeds unchanged."
+    invariants_touched:
+      [memory-injection-fail-open, memory-injection-budgeted, memory-single-block, memory-learn-tier-exclusive, context-within-budget, history-persisted-after-turn]
 
 invariants:
   - id: deterministic-cost-audit

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 
 	"github.com/gosharplite/tell-me-go/internal/agent/executor"
+	agentsmemory "github.com/gosharplite/tell-me-go/internal/agent/memory"
 	"github.com/gosharplite/tell-me-go/internal/agent/orchestrator"
 	"github.com/gosharplite/tell-me-go/internal/agent/session"
 	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
@@ -34,6 +35,7 @@ type runtimeConfig struct {
 	Model            string
 	Mode             string
 	PricingOverrides map[string]domain_pricing.ModelPricing
+	Memory           domain_config.MemoryConfig
 }
 
 // agent represents the chat orchestration logic (Stateless Service).
@@ -72,6 +74,15 @@ type agent struct {
 	// an inert memory integration.
 	memoryClient tools.MCPClient
 	memorySeed   domain_config.MemoryConfig
+
+	// memoryCfg is the shared hot-reload snapshot for the memory components
+	// (plurInjector/plurHook). prepareRuntimeConfig refreshes it lock-free per
+	// turn from the ConfigWatcher (ADR-068 §6) — the pointer itself is stored
+	// at initComponents and read by the components on every Transform/AfterTurn.
+	memoryCfg atomic.Pointer[domain_config.MemoryConfig]
+	// memoryHook is the plurHook TurnHook, registered once at initComponents
+	// via NewEngine opts — never per-Chat (WithEngineHook appends → double-fire).
+	memoryHook orchestrator.TurnHook
 
 	config atomic.Pointer[runtimeConfig]
 }
@@ -152,6 +163,21 @@ func (a *agent) initComponents() error {
 		Extras:     []sessctx.ContextTransformer{agentskills.NewSkillInjector(a.skillSelector, a.logger, injectorOpts...)},
 	}
 
+	// Memory integration (ADR-068 §6): construct once, at initComponents —
+	// never per-Chat (WithEngineHook appends → double-fire). Enabled-but-
+	// absent-server → warn and disable (two-stage fallback): a nil client
+	// yields an inert, stable DI shape; the runtime nil-client guards fail
+	// open.
+	if a.memoryClient != nil || a.memorySeed.Server != "" {
+		if a.memoryClient == nil {
+			a.getLogger().Warn("memory_server_unavailable", "server", a.memorySeed.Server)
+			a.memorySeed.Enabled = false // effective disable — inert DI shape
+		}
+		a.memoryCfg.Store(&a.memorySeed)
+		factory.Extras = append(factory.Extras, agentsmemory.NewPlurInjector(a.memoryClient, &a.memoryCfg, a.logger))
+		a.memoryHook = agentsmemory.NewPlurHook(a.memoryClient, &a.memoryCfg, a.logger, a.clock, a.hManager)
+	}
+
 	a.ctxManager = sessctx.NewManager(strategy, a.hManager, a.events, factory,
 		sessctx.WithLogger(a.logger),
 		sessctx.WithSessionProvider(a.sessionProvider),
@@ -159,13 +185,17 @@ func (a *agent) initComponents() error {
 
 	// Initialize engine
 	initialCfg := a.config.Load()
-	a.engine = orchestrator.NewEngine(a.gateway, exec, a.ctxManager, a.registry, a.events, strategy,
+	engineOpts := []orchestrator.EngineOption{
 		orchestrator.WithEngineConfig(a.sm, initialCfg.ProviderName, initialCfg.Model, initialCfg.Mode, initialCfg.PricingOverrides),
 		orchestrator.WithEngineCostTracker(a.tracker),
 		orchestrator.WithEngineLogger(a.logger),
 		orchestrator.WithEngineTurnsLogger(a.turnsLogger),
 		orchestrator.WithEngineClock(a.clock),
-	)
+	}
+	if a.memoryHook != nil {
+		engineOpts = append(engineOpts, orchestrator.WithEngineHook(a.memoryHook))
+	}
+	a.engine = orchestrator.NewEngine(a.gateway, exec, a.ctxManager, a.registry, a.events, strategy, engineOpts...)
 
 	return nil
 }
@@ -237,6 +267,7 @@ func (a *agent) prepareRuntimeConfig() runtimeConfig {
 	newCfg.Limits.MaxHistoryTokens = tokens
 	newCfg.Limits.MaxToolTurns = toolTurns
 	newCfg.Limits.MaxHistoryTurns = histTurns
+	newCfg.Memory = a.configWatcher.GetMemoryConfig()
 
 	if a.strategy != nil {
 		a.strategy.SetLimits(tokens, toolTurns, histTurns)
@@ -244,6 +275,10 @@ func (a *agent) prepareRuntimeConfig() runtimeConfig {
 	}
 
 	a.config.Store(&newCfg)
+	// Memory propagation is pre-chain (before the ADR-029 delegates), like
+	// Limits: the shared atomic pointer gives plurInjector/plurHook a lock-free
+	// per-turn read of the hot-reloaded MEMORY config. Zero ADR-029 changes.
+	a.memoryCfg.Store(&newCfg.Memory)
 	return newCfg
 }
 
@@ -327,6 +362,17 @@ func (a *agent) Chat(ctx context.Context, s *ports.Session, prompt string) error
 		Parts: []*domain_llm.Part{{Text: prompt}},
 	}); err != nil {
 		return fmt.Errorf("failed to initialize session history: %w", err)
+	}
+
+	// Memory: flush the per-session learning ring buffer at session end —
+	// success and error (ADR-068 §2.3, batch/full tiers). The type assertion
+	// is the optional-behavior seam: TurnHook does not declare FlushSession;
+	// only the plurHook concrete type implements it. A nil/absent hook
+	// yields ok=false and no defer is registered.
+	if a.memoryHook != nil {
+		if flusher, ok := a.memoryHook.(interface{ FlushSession(string) }); ok {
+			defer flusher.FlushSession(s.ID)
+		}
 	}
 
 	if err := a.applyConfig(ctx); err != nil {
@@ -459,6 +505,7 @@ type InternalAccessor interface {
 		Mode             string
 		PricingOverrides map[string]domain_pricing.ModelPricing
 		Limits           events.Limits
+		Memory           domain_config.MemoryConfig
 	}
 	SetEventsForInternalUse(bus events.EventBus)
 	SetConfigWatcherForInternalUse(cw domain_config.ConfigWatcher)

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -65,6 +65,14 @@ type agent struct {
 	initCtx          context.Context
 	ecosystemIntro   string
 
+	// memoryClient and memorySeed are the memory integration seam (ADR-068):
+	// the MCP client for MEMORY.SERVER plus the seed MemoryConfig. They are
+	// stored here by WithMemoryClient for the later injector/hook wiring
+	// task; no behavior consumes them yet. A nil client is legal and yields
+	// an inert memory integration.
+	memoryClient tools.MCPClient
+	memorySeed   domain_config.MemoryConfig
+
 	config atomic.Pointer[runtimeConfig]
 }
 

--- a/internal/agent/agentinternal/accessor.go
+++ b/internal/agent/agentinternal/accessor.go
@@ -107,6 +107,7 @@ type RuntimeSnapshot struct {
 	Mode             string
 	PricingOverrides map[string]domain_pricing.ModelPricing
 	Limits           events.Limits
+	Memory           domain_config.MemoryConfig
 }
 
 // GetRuntimeConfig returns a snapshot of the agent's current runtime

--- a/internal/agent/agentinternal/accessor_test.go
+++ b/internal/agent/agentinternal/accessor_test.go
@@ -62,6 +62,7 @@ func (m *mockInternalAccessor) GetRuntimeSnapshotForInternalUse() struct {
 	Mode             string
 	PricingOverrides map[string]domain_pricing.ModelPricing
 	Limits           events.Limits
+	Memory           domain_config.MemoryConfig
 } {
 	return m.Called().Get(0).(struct {
 		ProviderName     string
@@ -69,6 +70,7 @@ func (m *mockInternalAccessor) GetRuntimeSnapshotForInternalUse() struct {
 		Mode             string
 		PricingOverrides map[string]domain_pricing.ModelPricing
 		Limits           events.Limits
+		Memory           domain_config.MemoryConfig
 	})
 }
 
@@ -243,6 +245,7 @@ func TestAgentInternal_Getters(t *testing.T) {
 					Mode             string
 					PricingOverrides map[string]domain_pricing.ModelPricing
 					Limits           events.Limits
+					Memory           domain_config.MemoryConfig
 				}{
 					ProviderName: "test-provider",
 					Model:        "test-model",

--- a/internal/agent/agenttest/helpers.go
+++ b/internal/agent/agenttest/helpers.go
@@ -292,6 +292,7 @@ type StubChatterComposer struct {
 	Summarizer        ports.Summarizer
 	ConfigWatcher     domain_config.ConfigWatcher
 	RegisterTraceFunc func(path string)
+	MCPClients        map[string]tools.MCPClient
 }
 
 var _ ports.ChatterComposer = (*StubChatterComposer)(nil)
@@ -314,6 +315,10 @@ func (s *StubChatterComposer) GetSkillRepository() domain_skills.SkillRepository
 }
 func (s *StubChatterComposer) GetSummarizer() ports.Summarizer               { return s.Summarizer }
 func (s *StubChatterComposer) GetConfigWatcher() domain_config.ConfigWatcher { return s.ConfigWatcher }
+func (s *StubChatterComposer) GetMCPClient(name string) (tools.MCPClient, bool) {
+	c, ok := s.MCPClients[name]
+	return c, ok
+}
 func (s *StubChatterComposer) RegisterTrace(path string) {
 	if s.RegisterTraceFunc != nil {
 		s.RegisterTraceFunc(path)

--- a/internal/agent/agenttest/helpers_test.go
+++ b/internal/agent/agenttest/helpers_test.go
@@ -337,6 +337,48 @@ func TestStubChatterComposer_Getters_ConfigWatcher(t *testing.T) {
 	}
 }
 
+// stubMCPClientDouble is a minimal non-nil tools.MCPClient for asserting the
+// GetMCPClient identity path without contacting a live MCP endpoint.
+type stubMCPClientDouble struct{ tools.MCPClient }
+
+func TestStubChatterComposer_Getters_MCPClients(t *testing.T) {
+	t.Parallel()
+
+	client := &stubMCPClientDouble{}
+	c := &StubChatterComposer{
+		MCPClients: map[string]tools.MCPClient{"plur": client},
+	}
+
+	got, ok := c.GetMCPClient("plur")
+	if !ok {
+		t.Error("GetMCPClient should report ok=true for a configured key")
+	}
+	if got != client {
+		t.Errorf("GetMCPClient mismatch: got %v, want %v", got, client)
+	}
+
+	missing, ok := c.GetMCPClient("missing")
+	if missing != nil {
+		t.Errorf("GetMCPClient(missing) client = %v, want nil", missing)
+	}
+	if ok {
+		t.Error("GetMCPClient(missing) should report ok=false")
+	}
+}
+
+func TestStubChatterComposer_NilFields_MCPClients(t *testing.T) {
+	t.Parallel()
+
+	c := &StubChatterComposer{}
+	got, ok := c.GetMCPClient("plur")
+	if got != nil {
+		t.Errorf("nil MCPClients should return nil client, got %v", got)
+	}
+	if ok {
+		t.Error("nil MCPClients should return ok=false")
+	}
+}
+
 func TestStubChatterComposer_RegisterTrace(t *testing.T) {
 	t.Parallel()
 

--- a/internal/agent/applyconfig_failpath_test.go
+++ b/internal/agent/applyconfig_failpath_test.go
@@ -35,6 +35,9 @@ func (s *stubConfigWatcher) SetLimits(_, _, _ int)       {}
 func (s *stubConfigWatcher) GetLimits() (int, int, int)  { return s.tokens, s.toolTurns, s.historyTurns }
 func (s *stubConfigWatcher) ApplyLimits(_ events.Limits) {}
 func (s *stubConfigWatcher) GetContextWindow() int       { return 1000000 }
+func (s *stubConfigWatcher) GetMemoryConfig() domain_config.MemoryConfig {
+	return domain_config.DefaultMemoryConfig()
+}
 
 // ---------------------------------------------------------------------------
 // TestApplyConfig_FailFastChain

--- a/internal/agent/internal_bridge.go
+++ b/internal/agent/internal_bridge.go
@@ -68,6 +68,7 @@ func (a *agent) GetRuntimeSnapshotForInternalUse() (snap struct {
 	Mode             string
 	PricingOverrides map[string]domain_pricing.ModelPricing
 	Limits           events.Limits
+	Memory           domain_config.MemoryConfig
 }) {
 	cfg := a.config.Load()
 	if cfg == nil {
@@ -78,6 +79,7 @@ func (a *agent) GetRuntimeSnapshotForInternalUse() (snap struct {
 	snap.Mode = cfg.Mode
 	snap.PricingOverrides = cfg.PricingOverrides
 	snap.Limits = cfg.Limits
+	snap.Memory = cfg.Memory
 	return
 }
 

--- a/internal/agent/memory/buffer.go
+++ b/internal/agent/memory/buffer.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"time"
+	"unicode/utf8"
+)
+
+const (
+	// maxBufferEpisodes bounds the per-session ring buffer in count
+	// (ADR-068 §3, ~20 turns).
+	maxBufferEpisodes = 20
+	// maxEpisodeBytes caps each episode's text in bytes.
+	maxEpisodeBytes = 2000
+)
+
+// episode is one learnable unit captured by plurHook. The JSON tags define
+// the plur_learn_batch wire contract (T7's fake plur server mirrors them).
+type episode struct {
+	Text      string    `json:"text,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	Prompt    string    `json:"prompt,omitempty"`
+	Mode      string    `json:"agent,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// sessionBuffer is a bounded per-session ring buffer of episodes for the
+// batch and full LEARN tiers. All access is serialized by the hook's mutex.
+type sessionBuffer struct {
+	episodes []episode
+	bytes    int
+}
+
+// append adds an episode to the buffer, truncating ep.Text to maxEpisodeBytes
+// (rune-safe) and evicting the oldest entry when the count exceeds
+// maxBufferEpisodes. bytes tracks the sum of text bytes in the buffer.
+// Callers must hold the hook's mutex.
+func (b *sessionBuffer) append(ep episode) {
+	ep.Text = truncateToBytes(ep.Text, maxEpisodeBytes)
+	b.episodes = append(b.episodes, ep)
+	b.bytes += len(ep.Text)
+
+	for len(b.episodes) > maxBufferEpisodes {
+		oldest := b.episodes[0]
+		b.episodes = b.episodes[1:]
+		b.bytes -= len(oldest.Text)
+	}
+}
+
+// truncateToBytes cuts s to at most max bytes without splitting a UTF-8
+// rune. max is clamped to len(s); a non-positive max yields "".
+func truncateToBytes(s string, max int) string {
+	if max <= 0 {
+		return ""
+	}
+	if len(s) <= max {
+		return s
+	}
+	cut := max
+	for cut > 0 && !utf8.RuneStart(s[cut]) {
+		cut--
+	}
+	return s[:cut]
+}

--- a/internal/agent/memory/flock_other.go
+++ b/internal/agent/memory/flock_other.go
@@ -1,0 +1,16 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+//go:build !unix
+
+package memory
+
+import (
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+)
+
+// acquireWriteLock is a no-op on non-Unix platforms: the advisory flock is
+// Unix-only, so callers always proceed unlocked (fail-open).
+func acquireWriteLock(clk clock.Clock) (release func(), acquired bool) {
+	return nil, false
+}

--- a/internal/agent/memory/flock_unix.go
+++ b/internal/agent/memory/flock_unix.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+//go:build unix
+
+package memory
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+)
+
+const (
+	// flockPollInterval is the sleep between non-blocking lock attempts.
+	flockPollInterval = 100 * time.Millisecond
+	// flockMaxAttempts bounds the poll budget (~500ms via the injected clock).
+	flockMaxAttempts = 5
+)
+
+// acquireWriteLock takes a non-blocking LOCK_EX|LOCK_NB on
+// ~/.plur/.tmg-write.lock, polling up to the bounded budget via clk.Sleep.
+// Returns (release, true) on success; (nil, false) on any failure
+// (uncreatable, EWOULDBLOCK budget exhausted, other error) — callers log
+// and proceed unlocked. Unix-only; no-op (nil, false) on !unix.
+func acquireWriteLock(clk clock.Clock) (release func(), acquired bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, false
+	}
+	f, err := os.OpenFile(filepath.Join(home, ".plur", ".tmg-write.lock"), os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		return nil, false
+	}
+	for i := 0; i < flockMaxAttempts; i++ {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				_ = f.Close()
+			}, true
+		}
+		if err == syscall.EWOULDBLOCK || err == syscall.EAGAIN {
+			if clk != nil {
+				clk.Sleep(flockPollInterval)
+			}
+			continue
+		}
+		_ = f.Close()
+		return nil, false
+	}
+	_ = f.Close()
+	return nil, false
+}

--- a/internal/agent/memory/hook.go
+++ b/internal/agent/memory/hook.go
@@ -1,0 +1,317 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/orchestrator"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+)
+
+// detachedTimeout bounds every MCP call made from the hook. AfterTurn is
+// synchronous on ExecuteTurn's return path and the turn's own ctx is dead on
+// cancellation/timeout, so calls use a detached bounded context
+// (ADR-068 §2.2).
+const detachedTimeout = 3 * time.Second
+
+// learnFramePattern matches documented correction frames in the user message
+// (full tier only): please remember / please note, from now on, stop <verb>,
+// and don't|do not|never|always <imperative>.
+var learnFramePattern = regexp.MustCompile(`(?i)\b(please\s+remember\b|please\s+note\b|from\s+now\s+on\b|stop\s+\w+|(?:don't|do\s+not|never|always)\s+\w+)`)
+
+// NewPlurHook creates the Seam B TurnHook. history is the HistoryManager
+// port (the same store the context manager uses) — injected at construction
+// so branch (iii) GetLastModelTurn is testable without a full sessctx.Manager
+// and consistent with accept-interfaces. clk is the injected clock (flock
+// poll budget + episode timestamps).
+func NewPlurHook(client tools.MCPClient, cfg *atomic.Pointer[config.MemoryConfig], logger ports.Logger, clk clock.Clock, history ports.HistoryManager) orchestrator.TurnHook {
+	return &plurHook{
+		client:      client,
+		cfg:         cfg,
+		logger:      logger,
+		clock:       clk,
+		history:     history,
+		buffers:     make(map[string]*sessionBuffer),
+		learnCounts: make(map[string]int),
+		learnHashes: make(map[string]map[string]struct{}),
+	}
+}
+
+// plurHook captures learnings/episodes after each turn (ADR-068 §2). The
+// LEARN tier is mutually exclusive; fail-open everywhere.
+type plurHook struct {
+	client  tools.MCPClient
+	cfg     *atomic.Pointer[config.MemoryConfig]
+	logger  ports.Logger
+	clock   clock.Clock
+	history ports.HistoryManager
+	mu      sync.Mutex // guards buffers, lastSessionID/lastIndex, learnCounts, learnHashes
+	buffers map[string]*sessionBuffer
+	// lastSessionID/lastIndex implement belt-and-suspenders turn-scoped
+	// dedupe against double-fire (withEngineHook appends, so registration
+	// must be once; this is the runtime backstop).
+	lastSessionID string
+	lastIndex     int
+	learnCounts   map[string]int
+	learnHashes   map[string]map[string]struct{}
+}
+
+// BeforeTurn is a no-op (interface satisfaction).
+func (h *plurHook) BeforeTurn(turn *orchestrator.Turn) {}
+
+// OnPhaseTransition is a no-op (interface satisfaction).
+func (h *plurHook) OnPhaseTransition(from, to orchestrator.TurnPhase, state *orchestrator.TurnState) {
+}
+
+// AfterTurn classifies the turn outcome and dispatches to the active LEARN
+// tier. It returns on every path — memory errors are logged and ignored.
+func (h *plurHook) AfterTurn(turn *orchestrator.Turn, err error) {
+	cfg := h.cfg.Load()
+	if cfg == nil {
+		return
+	}
+	tier := cfg.EffectiveLearnTier()
+	if tier == config.MemoryLearnOff {
+		return
+	}
+
+	// Turn-scoped dedupe (belt-and-suspenders against double-fire).
+	h.mu.Lock()
+	if turn.SessionID == h.lastSessionID && turn.Index == h.lastIndex {
+		h.mu.Unlock()
+		return
+	}
+	h.lastSessionID = turn.SessionID
+	h.lastIndex = turn.Index
+	h.mu.Unlock()
+
+	// Nil-client runtime guard (hot-reload LEARN != off with a DI-fixed nil
+	// client → fail-open no-op).
+	if h.client == nil {
+		if h.logger != nil {
+			h.logger.Warn("memory_client_unavailable", "reason", "nil MCP client", "phase", "learn")
+		}
+		return
+	}
+
+	// Three-way classification keyed on the hook's err argument — never
+	// Turn.State.LastError, which is stale on the empty-response retry path.
+	var ep episode
+	switch {
+	case turn.State.Response != nil:
+		// (i) Response present (any err): learn from this turn's response.
+		text := joinTextParts(turn.State.Response)
+		if text == "" {
+			return
+		}
+		ep = episode{Text: text, Mode: turn.Mode, SessionID: turn.SessionID, Timestamp: h.clock.Now()}
+		if err != nil {
+			ep.Error = err.Error()
+		}
+	case err != nil:
+		// (ii) No response + error: error episode sourced from PreparedHistory
+		// (never GetLastModelTurn — it would return the previous turn's
+		// response). Transient errors (retry exhaustion) are skipped.
+		if orchestrator.IsTransient(err) {
+			if h.logger != nil {
+				h.logger.Debug("memory_skip_transient_episode", "error", err, "turn", turn.Index)
+			}
+			return
+		}
+		ep = episode{
+			Error:     err.Error(),
+			Prompt:    lastUserText(turn.State.PreparedHistory),
+			Mode:      turn.Mode,
+			SessionID: turn.SessionID,
+			Timestamp: h.clock.Now(),
+		}
+	default:
+		// (iii) No response, no error: the phase loop exited cleanly, so
+		// GetLastModelTurn is provably this turn's response. The text-parts
+		// filter suppresses intermediate tool-iteration turns.
+		detachedCtx, cancel := context.WithTimeout(context.Background(), detachedTimeout)
+		_, content, gerr := h.history.GetLastModelTurn(detachedCtx)
+		cancel()
+		if gerr != nil || content == nil {
+			if h.logger != nil {
+				h.logger.Warn("memory_get_last_model_turn_failed", "error", gerr, "turn", turn.Index)
+			}
+			return
+		}
+		text := joinTextParts(content)
+		if text == "" {
+			return
+		}
+		ep = episode{Text: text, Mode: turn.Mode, SessionID: turn.SessionID, Timestamp: h.clock.Now()}
+	}
+
+	// Tier dispatch (mutually exclusive; default batch).
+	switch tier {
+	case config.MemoryLearnCapture:
+		h.capture(turn, ep)
+	case config.MemoryLearnBatch:
+		h.bufferAppend(turn.SessionID, ep)
+	case config.MemoryLearnFull:
+		h.bufferAppend(turn.SessionID, ep)
+		h.maybeLearn(turn, cfg)
+	}
+}
+
+// capture writes a single episode via plur_capture (capture tier). Fail-open:
+// errors are logged and ignored.
+func (h *plurHook) capture(turn *orchestrator.Turn, ep episode) {
+	args := map[string]interface{}{
+		"agent":      turn.Mode,
+		"session_id": turn.SessionID,
+	}
+	if ep.Text != "" {
+		args["text"] = ep.Text
+	}
+	if ep.Error != "" {
+		args["error"] = ep.Error
+	}
+	if ep.Prompt != "" {
+		args["prompt"] = ep.Prompt
+	}
+
+	detachedCtx, cancel := context.WithTimeout(context.Background(), detachedTimeout)
+	defer cancel()
+
+	release, ok := acquireWriteLock(h.clock)
+	if ok {
+		defer release()
+	}
+	if _, err := h.client.CallTool(detachedCtx, "plur_capture", args); err != nil {
+		if h.logger != nil {
+			h.logger.Warn("memory_capture_failed", "error", err, "turn", turn.Index)
+		}
+	}
+}
+
+// bufferAppend appends an episode to the per-session ring buffer (batch and
+// full tiers). No MCP call.
+func (h *plurHook) bufferAppend(sessionID string, ep episode) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	buf, ok := h.buffers[sessionID]
+	if !ok {
+		buf = &sessionBuffer{}
+		h.buffers[sessionID] = buf
+	}
+	buf.append(ep)
+}
+
+// maybeLearn runs the gated direct learn (full tier only): signal is the
+// user message only; the matcher is the correction-frame regex; flood bounds
+// are MAX_LEARNS_PER_SESSION plus per-session sha256 exact-match dedupe.
+// plur_ingest is never auto-fired.
+func (h *plurHook) maybeLearn(turn *orchestrator.Turn, cfg *config.MemoryConfig) {
+	signal := lastUserText(turn.State.PreparedHistory)
+	if !learnFramePattern.MatchString(signal) {
+		return
+	}
+	statement := strings.TrimSpace(signal)
+	hash := sha256.Sum256([]byte(strings.ToLower(statement)))
+	hashKey := fmt.Sprintf("%x", hash[:])
+
+	h.mu.Lock()
+	if h.learnHashes[turn.SessionID] == nil {
+		h.learnHashes[turn.SessionID] = make(map[string]struct{})
+	}
+	if _, dup := h.learnHashes[turn.SessionID][hashKey]; dup {
+		h.mu.Unlock()
+		return
+	}
+	if h.learnCounts[turn.SessionID] >= cfg.MaxLearnsPerSession {
+		if h.logger != nil {
+			h.logger.Debug("memory_learn_flood_bound", "session", turn.SessionID, "limit", cfg.MaxLearnsPerSession)
+		}
+		h.mu.Unlock()
+		return
+	}
+	h.learnHashes[turn.SessionID][hashKey] = struct{}{}
+	h.learnCounts[turn.SessionID]++
+	h.mu.Unlock()
+
+	args := map[string]interface{}{
+		"statement": statement,
+		"agent":     turn.Mode,
+	}
+	if strings.TrimSpace(cfg.Scope) != "" {
+		args["scope"] = cfg.Scope
+	}
+
+	detachedCtx, cancel := context.WithTimeout(context.Background(), detachedTimeout)
+	defer cancel()
+
+	release, ok := acquireWriteLock(h.clock)
+	if ok {
+		defer release()
+	}
+	if _, err := h.client.CallTool(detachedCtx, "plur_learn", args); err != nil {
+		if h.logger != nil {
+			h.logger.Warn("memory_learn_failed", "error", err, "turn", turn.Index)
+		}
+	}
+}
+
+// FlushSession drains the per-session ring buffer and writes it via
+// plur_learn_batch (batch and full tiers; called via defer in Chat — success
+// and error). Drain happens under lock; the MCP call goes outside the lock —
+// never hold the lock across I/O.
+func (h *plurHook) FlushSession(sessionID string) {
+	h.mu.Lock()
+	buf, ok := h.buffers[sessionID]
+	if !ok {
+		h.mu.Unlock()
+		return
+	}
+	delete(h.buffers, sessionID)
+	episodes := append([]episode(nil), buf.episodes...)
+	h.mu.Unlock()
+
+	if len(episodes) == 0 {
+		return
+	}
+
+	// Nil-client guard: drain happened above (fail-open); skip the call.
+	if h.client == nil {
+		if h.logger != nil {
+			h.logger.Warn("memory_client_unavailable", "reason", "nil MCP client", "phase", "learn_batch")
+		}
+		return
+	}
+
+	payload := map[string]interface{}{
+		"episodes":   episodes,
+		"session_id": sessionID,
+	}
+
+	detachedCtx, cancel := context.WithTimeout(context.Background(), detachedTimeout)
+	defer cancel()
+
+	release, ok := acquireWriteLock(h.clock)
+	if ok {
+		defer release()
+	}
+	if _, err := h.client.CallTool(detachedCtx, "plur_learn_batch", payload); err != nil {
+		if h.logger != nil {
+			h.logger.Warn("memory_learn_batch_failed", "error", err, "session", sessionID)
+		}
+	}
+}
+
+// compile-time interface assertion.
+var _ orchestrator.TurnHook = (*plurHook)(nil)

--- a/internal/agent/memory/hook_test.go
+++ b/internal/agent/memory/hook_test.go
@@ -1,0 +1,440 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/orchestrator"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// turn builds a minimal Turn for hook tests.
+func turn(index int, sessionID string, state *orchestrator.TurnState) *orchestrator.Turn {
+	return &orchestrator.Turn{
+		Index:     index,
+		SessionID: sessionID,
+		Mode:      "coder",
+		State:     state,
+	}
+}
+
+func responseTurn(index int, sessionID, text string) *orchestrator.Turn {
+	return turn(index, sessionID, &orchestrator.TurnState{
+		Response: &llm.Content{Role: "model", Parts: []*llm.Part{{Text: text}}},
+	})
+}
+
+// TestHookTierOff verifies the off tier: no MCP calls, buffer untouched.
+func TestHookTierOff(t *testing.T) {
+	mock := &MockMCPClient{}
+	h, _ := newTestHook(t, mock, config.MemoryLearnOff, &stubHistoryManager{})
+	h.AfterTurn(responseTurn(0, "s1", "hello"), nil)
+
+	if calls := mock.recordedNames(); len(calls) != 0 {
+		t.Errorf("off tier must not call MCP, got %v", calls)
+	}
+	h.mu.Lock()
+	bufCount := len(h.buffers)
+	h.mu.Unlock()
+	if bufCount != 0 {
+		t.Errorf("off tier must not buffer, got %d session buffers", bufCount)
+	}
+}
+
+// TestHookCaptureBranchI covers branch (i): Response present — with and
+// without an error annotation.
+func TestHookCaptureBranchI(t *testing.T) {
+	t.Run("response nil err", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		var gotName string
+		var gotArgs map[string]interface{}
+		mock.CallToolFunc = func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotName = name
+			gotArgs = args
+			return tools.ToolResult{}, nil
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, &stubHistoryManager{})
+		h.AfterTurn(responseTurn(0, "s1", "hello"), nil)
+
+		if gotName != "plur_capture" {
+			t.Errorf("tool = %q, want plur_capture", gotName)
+		}
+		if gotArgs["agent"] != "coder" || gotArgs["session_id"] != "s1" || gotArgs["text"] != "hello" {
+			t.Errorf("args = %v, want agent/session_id/text", gotArgs)
+		}
+		if _, ok := gotArgs["error"]; ok {
+			t.Errorf("error key must be omitted when err is nil, got %v", gotArgs)
+		}
+		if _, ok := gotArgs["prompt"]; ok {
+			t.Errorf("prompt key must be omitted on branch (i), got %v", gotArgs)
+		}
+	})
+
+	t.Run("response with err annotated", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		var gotArgs map[string]interface{}
+		mock.CallToolFunc = func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotArgs = args
+			return tools.ToolResult{}, nil
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, &stubHistoryManager{})
+		h.AfterTurn(responseTurn(0, "s1", "hello"), errors.New("boom"))
+
+		if gotArgs["text"] != "hello" {
+			t.Errorf("text = %v, want hello", gotArgs["text"])
+		}
+		if gotArgs["error"] != "boom" {
+			t.Errorf("error = %v, want boom", gotArgs["error"])
+		}
+	})
+}
+
+// TestHookCaptureBranchII covers branch (ii): Response nil + error.
+func TestHookCaptureBranchII(t *testing.T) {
+	t.Run("non-transient error captures error + prompt", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		var gotArgs map[string]interface{}
+		mock.CallToolFunc = func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotArgs = args
+			return tools.ToolResult{}, nil
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, &stubHistoryManager{})
+		tun := turn(1, "s1", &orchestrator.TurnState{
+			PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "fix the bug"}}}},
+		})
+		h.AfterTurn(tun, errors.New("inference failed"))
+
+		if gotArgs["error"] != "inference failed" {
+			t.Errorf("error = %v, want inference failed", gotArgs["error"])
+		}
+		if gotArgs["prompt"] != "fix the bug" {
+			t.Errorf("prompt = %v, want fix the bug", gotArgs["prompt"])
+		}
+		if _, ok := gotArgs["text"]; ok {
+			t.Errorf("text key must be omitted on branch (ii), got %v", gotArgs)
+		}
+	})
+
+	t.Run("transient error skipped with debug record", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, &stubHistoryManager{})
+		tun := turn(1, "s1", &orchestrator.TurnState{
+			PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "fix"}}}},
+		})
+		// "max retries reached" wrap must unwrap via errors.Is.
+		h.AfterTurn(tun, fmt.Errorf("max retries reached: %w", llm.ErrTransient))
+
+		if calls := mock.recordedNames(); len(calls) != 0 {
+			t.Errorf("transient error must produce no episode, got %v", calls)
+		}
+		h.mu.Lock()
+		bufCount := len(h.buffers)
+		h.mu.Unlock()
+		if bufCount != 0 {
+			t.Errorf("transient error must not buffer, got %d session buffers", bufCount)
+		}
+	})
+}
+
+// TestHookCaptureBranchIII covers branch (iii): Response nil + nil err —
+// the episode is sourced from GetLastModelTurn; content without text parts
+// produces no episode.
+func TestHookCaptureBranchIII(t *testing.T) {
+	t.Run("model turn with text", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		var gotArgs map[string]interface{}
+		mock.CallToolFunc = func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotArgs = args
+			return tools.ToolResult{}, nil
+		}
+		stub := &stubHistoryManager{
+			GetLastModelTurnFunc: func(ctx context.Context) (int, *llm.Content, error) {
+				return 3, &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "model text"}}}, nil
+			},
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, stub)
+		h.AfterTurn(turn(0, "s1", &orchestrator.TurnState{}), nil)
+
+		if gotArgs["text"] != "model text" {
+			t.Errorf("text = %v, want model text", gotArgs["text"])
+		}
+	})
+
+	t.Run("model turn without text parts filtered", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		stub := &stubHistoryManager{
+			GetLastModelTurnFunc: func(ctx context.Context) (int, *llm.Content, error) {
+				return 3, &llm.Content{Role: "model", Parts: []*llm.Part{
+					{Text: "", IsThought: true},
+					{Text: ""},
+				}}, nil
+			},
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, stub)
+		h.AfterTurn(turn(0, "s1", &orchestrator.TurnState{}), nil)
+
+		if calls := mock.recordedNames(); len(calls) != 0 {
+			t.Errorf("text-parts filter must suppress tool-iteration turns, got %v", calls)
+		}
+	})
+
+	t.Run("GetLastModelTurn failure logged and skipped", func(t *testing.T) {
+		mock := &MockMCPClient{}
+		stub := &stubHistoryManager{
+			GetLastModelTurnFunc: func(ctx context.Context) (int, *llm.Content, error) {
+				return 0, nil, errors.New("history missing")
+			},
+		}
+		h, _ := newTestHook(t, mock, config.MemoryLearnCapture, stub)
+		h.AfterTurn(turn(0, "s1", &orchestrator.TurnState{}), nil)
+
+		if calls := mock.recordedNames(); len(calls) != 0 {
+			t.Errorf("failed GetLastModelTurn must produce no episode, got %v", calls)
+		}
+	})
+}
+
+// TestHookBatch covers the batch tier: AfterTurn appends to the ring buffer
+// (no MCP call); FlushSession drains under lock, deletes the map entry, and
+// calls plur_learn_batch outside the lock; a second flush is a no-op.
+func TestHookBatch(t *testing.T) {
+	mock := &MockMCPClient{}
+	h, _ := newTestHook(t, mock, config.MemoryLearnBatch, &stubHistoryManager{})
+
+	h.AfterTurn(responseTurn(0, "s1", "first"), nil)
+	h.AfterTurn(responseTurn(1, "s1", "second"), nil)
+
+	if calls := mock.recordedNames(); len(calls) != 0 {
+		t.Fatalf("batch tier must not call MCP on AfterTurn, got %v", calls)
+	}
+	h.mu.Lock()
+	buf, ok := h.buffers["s1"]
+	h.mu.Unlock()
+	if !ok {
+		t.Fatal("buffer missing for session s1")
+	}
+	if len(buf.episodes) != 2 {
+		t.Fatalf("buffer episodes = %d, want 2", len(buf.episodes))
+	}
+
+	var gotName string
+	var gotArgs map[string]interface{}
+	mock.CallToolFunc = func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+		gotName = name
+		gotArgs = args
+		return tools.ToolResult{}, nil
+	}
+	h.FlushSession("s1")
+
+	if gotName != "plur_learn_batch" {
+		t.Errorf("tool = %q, want plur_learn_batch", gotName)
+	}
+	if gotArgs["session_id"] != "s1" {
+		t.Errorf("session_id = %v, want s1", gotArgs["session_id"])
+	}
+	eps, ok := gotArgs["episodes"].([]episode)
+	if !ok {
+		t.Fatalf("episodes payload = %T, want []episode", gotArgs["episodes"])
+	}
+	if len(eps) != 2 || eps[0].Text != "first" || eps[1].Text != "second" {
+		t.Errorf("episodes payload wrong: %+v", eps)
+	}
+	if eps[0].Mode != "coder" || eps[0].SessionID != "s1" {
+		t.Errorf("episode fields wrong: %+v", eps[0])
+	}
+
+	h.mu.Lock()
+	_, stillPresent := h.buffers["s1"]
+	h.mu.Unlock()
+	if stillPresent {
+		t.Error("buffer map entry must be deleted after flush")
+	}
+
+	// Second flush on the same session → no call (empty).
+	before := len(mock.recordedNames())
+	h.FlushSession("s1")
+	if got := len(mock.recordedNames()); got != before {
+		t.Errorf("second flush must not call MCP: %d -> %d calls", before, got)
+	}
+}
+
+// TestHookFull covers the full tier: gated direct learn on correction frames,
+// sha256 dedupe, flood bound, and non-frame suppression — with the ring
+// buffer appended on every turn.
+func TestHookFull(t *testing.T) {
+	t.Run("frame match learns", func(t *testing.T) {
+		var learnArgs []map[string]interface{}
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			if name == "plur_learn" {
+				learnArgs = append(learnArgs, args)
+			}
+			return tools.ToolResult{}, nil
+		}}
+		h, _ := newTestHook(t, mock, config.MemoryLearnFull, &stubHistoryManager{})
+		tun := turn(0, "s1", &orchestrator.TurnState{
+			Response:        &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}},
+			PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "please remember to always use X"}}}},
+		})
+		h.AfterTurn(tun, nil)
+
+		if len(learnArgs) != 1 {
+			t.Fatalf("learn calls = %d, want 1", len(learnArgs))
+		}
+		if learnArgs[0]["statement"] != "please remember to always use X" {
+			t.Errorf("statement = %v", learnArgs[0]["statement"])
+		}
+		if learnArgs[0]["agent"] != "coder" {
+			t.Errorf("agent = %v, want coder", learnArgs[0]["agent"])
+		}
+	})
+
+	t.Run("hash dedupe identical statement", func(t *testing.T) {
+		learnCount := 0
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			if name == "plur_learn" {
+				learnCount++
+			}
+			return tools.ToolResult{}, nil
+		}}
+		h, _ := newTestHook(t, mock, config.MemoryLearnFull, &stubHistoryManager{})
+		for i := 0; i < 2; i++ {
+			tun := turn(i, "s1", &orchestrator.TurnState{
+				Response:        &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}},
+				PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "please remember to use X"}}}},
+			})
+			h.AfterTurn(tun, nil)
+		}
+		if learnCount != 1 {
+			t.Errorf("learn calls = %d, want 1 (dedupe)", learnCount)
+		}
+	})
+
+	t.Run("flood bound", func(t *testing.T) {
+		learnCount := 0
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			if name == "plur_learn" {
+				learnCount++
+			}
+			return tools.ToolResult{}, nil
+		}}
+		h, _ := newTestHook(t, mock, config.MemoryLearnFull, &stubHistoryManager{})
+		statements := []string{
+			"please remember to use X1",
+			"please remember to use X2",
+			"please remember to use X3",
+			"please remember to use X4", // 4th distinct → flood bound
+		}
+		for i, s := range statements {
+			tun := turn(i, "s1", &orchestrator.TurnState{
+				Response:        &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}},
+				PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: s}}}},
+			})
+			h.AfterTurn(tun, nil)
+		}
+		if learnCount != 3 {
+			t.Errorf("learn calls = %d, want 3 (flood bound)", learnCount)
+		}
+	})
+
+	t.Run("non-frame no learn but buffer appended", func(t *testing.T) {
+		learnCount := 0
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			if name == "plur_learn" {
+				learnCount++
+			}
+			return tools.ToolResult{}, nil
+		}}
+		h, _ := newTestHook(t, mock, config.MemoryLearnFull, &stubHistoryManager{})
+		tun := turn(0, "s1", &orchestrator.TurnState{
+			Response:        &llm.Content{Role: "model", Parts: []*llm.Part{{Text: "ok"}}},
+			PreparedHistory: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "what time is it"}}}},
+		})
+		h.AfterTurn(tun, nil)
+
+		if learnCount != 0 {
+			t.Errorf("learn calls = %d, want 0 for non-frame", learnCount)
+		}
+		h.mu.Lock()
+		buf, ok := h.buffers["s1"]
+		h.mu.Unlock()
+		if !ok || len(buf.episodes) != 1 {
+			t.Errorf("full tier must still append to the ring buffer, got ok=%v", ok)
+		}
+	})
+}
+
+// TestHookTurnDedupe verifies the turn-scoped dedupe: the same
+// SessionID+Index twice → the second AfterTurn is a no-op.
+func TestHookTurnDedupe(t *testing.T) {
+	mock := &MockMCPClient{}
+	h, _ := newTestHook(t, mock, config.MemoryLearnCapture, &stubHistoryManager{})
+	tun := responseTurn(0, "s1", "hello")
+	h.AfterTurn(tun, nil)
+	h.AfterTurn(tun, nil)
+	if calls := mock.recordedNames(); len(calls) != 1 {
+		t.Errorf("expected exactly 1 capture after dedupe, got %v", calls)
+	}
+}
+
+// TestHookNilClient verifies the nil-client runtime guard: no panic, no MCP
+// call.
+func TestHookNilClient(t *testing.T) {
+	h, _ := newTestHook(t, nil, config.MemoryLearnCapture, &stubHistoryManager{})
+	h.AfterTurn(responseTurn(0, "s1", "hello"), nil) // must not panic
+}
+
+func TestHookNilClientFlush(t *testing.T) {
+	h, _ := newTestHook(t, nil, config.MemoryLearnBatch, &stubHistoryManager{})
+	h.AfterTurn(responseTurn(0, "s1", "hello"), nil)
+	h.FlushSession("s1") // must not panic
+}
+
+// TestHookNilCfg verifies the nil-config guard: AfterTurn returns immediately.
+func TestHookNilCfg(t *testing.T) {
+	mock := &MockMCPClient{}
+	cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+	cfgPtr.Store(nil)
+	h := &plurHook{client: mock, cfg: cfgPtr, logger: nil}
+	h.AfterTurn(responseTurn(0, "s1", "hello"), nil) // must not panic
+	if calls := mock.recordedNames(); len(calls) != 0 {
+		t.Errorf("nil cfg must be a no-op, got %v", calls)
+	}
+}
+
+// TestHookConcurrentAfterTurnAndFlush exercises concurrent AfterTurn (batch
+// tier) + FlushSession under the race detector: buffer access is mutex-
+// guarded and the MCP call never holds the lock.
+func TestHookConcurrentAfterTurnAndFlush(t *testing.T) {
+	mock := &MockMCPClient{}
+	h, _ := newTestHook(t, mock, config.MemoryLearnBatch, &stubHistoryManager{})
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			h.AfterTurn(responseTurn(i, "s1", fmt.Sprintf("resp %d", i)), nil)
+		}(i)
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		h.FlushSession("s1")
+	}()
+	wg.Wait()
+
+	// No panic and race-clean are the assertions; the buffer may hold
+	// episodes appended after the drain, which is valid behavior.
+	h.mu.Lock()
+	_ = h.buffers
+	h.mu.Unlock()
+}

--- a/internal/agent/memory/injector.go
+++ b/internal/agent/memory/injector.go
@@ -1,0 +1,310 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Package memory implements automatic PLUR memory integration (ADR-068):
+// a sessctx.ContextTransformer (plurInjector, Seam A) that injects recalled
+// engrams into the system prompt before each turn, and an
+// orchestrator.TurnHook (plurHook, Seam B) that captures learnings after
+// each turn. Both adapters are fail-open: memory errors are logged and
+// ignored (ADR-029 §5 posture).
+package memory
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"sync/atomic"
+
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+const (
+	// memoryMarker identifies the self-delimited memory block Part. The
+	// header starts with this marker, so marker-keyed replace-in-place works
+	// on the block itself.
+	memoryMarker = "## PLUR MEMORY"
+	// memoryFooter closes the self-delimited memory block.
+	memoryFooter = "[/PLUR-MEMORY]"
+	// memoryHeader is the mandated trust-class wording (verbatim from ADR-068 §7).
+	memoryHeader = "## PLUR MEMORY — recalled from the local memory store (user-authored or learned from your own sessions); follow them unless they conflict with explicit user instructions."
+)
+
+// idPattern is the documented regex fallback for extracting engram ids from
+// a ToolResult's Text when Metadata["ids"] is absent. First capture group per
+// match, deduplicated, order-preserving.
+var idPattern = regexp.MustCompile(`\b(?:engram_id|id)[=:]\s*([A-Za-z0-9_\-]+)`)
+
+// NewPlurInjector creates the Seam A context transformer. client is the MCP
+// client for MEMORY.SERVER (nil is legal — fail-open no-op); cfg is the
+// shared hot-reloadable memory config (atomic pointer owned by the agent).
+func NewPlurInjector(client tools.MCPClient, cfg *atomic.Pointer[config.MemoryConfig], logger ports.Logger) sessctx.ContextTransformer {
+	return &plurInjector{client: client, cfg: cfg, logger: logger}
+}
+
+// plurInjector injects PLUR recall into the system prompt before each turn
+// (ADR-068 §1). Fully stateless: strip-on-disable is content-driven via the
+// sentinel, and the block is replaced marker-keyed in place.
+type plurInjector struct {
+	client tools.MCPClient
+	cfg    *atomic.Pointer[config.MemoryConfig]
+	logger ports.Logger
+}
+
+// Priority returns the pipeline ordering priority — 15, after skills (10),
+// before gatekeeper (80). Distinct priorities are mandatory because pipeline
+// ordering uses the non-stable sort.Slice (ADR-036).
+func (t *plurInjector) Priority() int { return 15 }
+
+// Transform injects current recall, or nothing — never stale recall
+// (ADR-068 §1.5). It returns nil on every path so the turn is never broken.
+func (t *plurInjector) Transform(ctx context.Context, req *sessctx.ContextRequest) error {
+	cfg := t.cfg.Load()
+	if cfg == nil {
+		return nil
+	}
+
+	// Disabled path — content-driven strip (stateless, idempotent,
+	// self-healing): remove the sentinel-delimited Part if present and set
+	// PersistHistory so the strip survives; a failed persisted strip is
+	// retried on the next Prepare pass.
+	if !cfg.Enabled {
+		if stripMemoryBlock(req) {
+			req.PersistHistory = true
+		}
+		return nil
+	}
+
+	// Nil-client runtime guard: hot-reload ENABLED=true with a DI-fixed nil
+	// client → fail-open no-op.
+	if t.client == nil {
+		if t.logger != nil {
+			t.logger.Warn("memory_client_unavailable", "reason", "nil MCP client", "phase", "inject")
+		}
+		return nil
+	}
+
+	// Extract the task: last user message (may be empty — pass as-is).
+	task := lastUserText(req.History)
+
+	// Fetch-per-turn: live relevance-gated recall query, bounded by budget.
+	args := map[string]interface{}{
+		"task":   task,
+		"budget": cfg.InjectBudget,
+	}
+	if strings.TrimSpace(cfg.Scope) != "" {
+		args["scope"] = cfg.Scope
+	}
+	result, err := t.client.CallTool(ctx, "plur_inject_hybrid", args)
+	if err != nil {
+		// Fail-open with strip semantics: strip the marker block in memory
+		// only (never PersistHistory — no stale recall survives).
+		if t.logger != nil {
+			t.logger.Warn("memory_injection_failed", "error", err)
+		}
+		stripMemoryBlock(req)
+		return nil
+	}
+
+	block := memoryHeader + "\n\n" + strings.TrimSpace(result.Text) + "\n" + memoryFooter
+
+	// Defensive trim: pinned engrams make server-side size non-deterministic.
+	// Heuristic tokens = len(block)/4 (matches the model's tokenCount
+	// heuristic). Trim the body to a rune-safe byte boundary so the rebuilt
+	// block fits the budget.
+	if len(block)/4 > cfg.InjectBudget {
+		maxBody := cfg.InjectBudget*4 - len(memoryHeader) - len(memoryFooter) - 4
+		if maxBody < 0 {
+			if t.logger != nil {
+				t.logger.Debug("memory_block_overflow", "budget", cfg.InjectBudget, "block_bytes", len(block))
+			}
+			stripMemoryBlock(req)
+			return nil
+		}
+		body := strings.TrimSpace(result.Text)
+		if len(body) > maxBody {
+			body = truncateToBytes(body, maxBody)
+		}
+		block = memoryHeader + "\n\n" + body + "\n" + memoryFooter
+	}
+
+	// Insert marker-keyed replace-in-place — never append after first.
+	insertMemoryBlock(req, block)
+
+	// Observability: in-process Warnings + Info-level log line (ADR-068 §8).
+	ids := extractIDs(result)
+	if len(ids) > 0 {
+		req.Metadata.Warnings = append(req.Metadata.Warnings, "injected_engrams:"+strings.Join(ids, ","))
+		if t.logger != nil {
+			t.logger.Info("memory_injected", "engrams", strings.Join(ids, ","), "task", task)
+		}
+	} else if t.logger != nil {
+		t.logger.Debug("memory_injected_no_ids", "task", task)
+	}
+
+	return nil
+}
+
+// stripMemoryBlock removes the marker Part from the first system Content
+// (and the Content itself if it is left with zero Parts). Returns true if a
+// marker Part was removed. Callers decide whether to persist the strip.
+func stripMemoryBlock(req *sessctx.ContextRequest) bool {
+	for i := range req.History {
+		c := req.History[i]
+		if c == nil || c.Role != "system" {
+			continue
+		}
+		filtered := make([]*llm.Part, 0, len(c.Parts))
+		removed := false
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, memoryMarker) {
+				removed = true
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		if !removed {
+			return false
+		}
+		c.Parts = filtered
+		if len(c.Parts) == 0 {
+			req.History = append(req.History[:i], req.History[i+1:]...)
+		}
+		return true
+	}
+	return false
+}
+
+// insertMemoryBlock replaces an existing marker Part, appends a new one to
+// the first system Content, or prepends a fresh system Content when none
+// exists. At most one memory block exists at any time. It never sets Pinned
+// and never sets req.PersistHistory (a sibling canonical transformer's
+// persist carries the block; it is marker-identified for next-turn
+// replacement).
+func insertMemoryBlock(req *sessctx.ContextRequest, block string) {
+	for _, c := range req.History {
+		if c == nil || c.Role != "system" {
+			continue
+		}
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, memoryMarker) {
+				p.Text = block
+				return
+			}
+		}
+		c.Parts = append(c.Parts, &llm.Part{Text: block})
+		return
+	}
+	req.History = append([]*llm.Content{
+		{Role: "system", Parts: []*llm.Part{{Text: block}}},
+	}, req.History...)
+}
+
+// extractIDs prefers ToolResult.Metadata["ids"] (string, []string, or
+// []interface{} of strings), else a documented regex over result.Text:
+// \b(?:engram_id|id)[=:]\s*([A-Za-z0-9_\-]+) — first capture group per
+// match, deduplicated, order-preserving.
+func extractIDs(result tools.ToolResult) []string {
+	if ids, ok := metadataIDs(result.Metadata["ids"]); ok {
+		return dedupeStrings(ids)
+	}
+	var ids []string
+	for _, m := range idPattern.FindAllStringSubmatch(result.Text, -1) {
+		if len(m) > 1 {
+			ids = append(ids, m[1])
+		}
+	}
+	return dedupeStrings(ids)
+}
+
+// metadataIDs converts the Metadata["ids"] value into a string slice.
+// Returns ok=false when the value is absent, empty, or of an unsupported
+// type (fall back to the regex).
+func metadataIDs(v interface{}) ([]string, bool) {
+	switch t := v.(type) {
+	case string:
+		if strings.TrimSpace(t) == "" {
+			return nil, false
+		}
+		return []string{t}, true
+	case []string:
+		if len(t) == 0 {
+			return nil, false
+		}
+		return t, true
+	case []interface{}:
+		out := make([]string, 0, len(t))
+		for _, e := range t {
+			if s, ok := e.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+		if len(out) == 0 {
+			return nil, false
+		}
+		return out, true
+	default:
+		return nil, false
+	}
+}
+
+// dedupeStrings removes duplicates while preserving order. Returns nil for
+// empty input so callers can distinguish "no ids" from an empty result.
+func dedupeStrings(in []string) []string {
+	if len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, dup := seen[s]; dup {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// lastUserText returns the last user Content's non-empty text parts joined
+// with spaces, trimmed. Returns "" when no user message exists.
+func lastUserText(history []*llm.Content) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		c := history[i]
+		if c == nil || c.Role != "user" {
+			continue
+		}
+		parts := make([]string, 0, len(c.Parts))
+		for _, p := range c.Parts {
+			if p != nil && p.Text != "" {
+				parts = append(parts, p.Text)
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, " "))
+	}
+	return ""
+}
+
+// joinTextParts concatenates the non-thought, non-empty text parts of a
+// Content, joined by "\n".
+func joinTextParts(c *llm.Content) string {
+	if c == nil {
+		return ""
+	}
+	parts := make([]string, 0, len(c.Parts))
+	for _, p := range c.Parts {
+		if p == nil || p.IsThought || p.Text == "" {
+			continue
+		}
+		parts = append(parts, p.Text)
+	}
+	return strings.Join(parts, "\n")
+}
+
+// compile-time interface assertions.
+var (
+	_ sessctx.ContextTransformer = (*plurInjector)(nil)
+)

--- a/internal/agent/memory/injector_test.go
+++ b/internal/agent/memory/injector_test.go
@@ -1,0 +1,404 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	sessctx "github.com/gosharplite/tell-me-go/internal/agent/session/context"
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+)
+
+// TestInjectorDisabledStrip covers the content-driven strip-on-disable path:
+// no marker → no-op (PersistHistory unchanged, no MCP call); marker Part →
+// removed with PersistHistory set; zero-Parts system Content → dropped.
+func TestInjectorDisabledStrip(t *testing.T) {
+	markerBlock := memoryHeader + "\n\nrecall\n" + memoryFooter
+	tests := []struct {
+		name           string
+		history        []*llm.Content
+		wantPersist    bool
+		wantHistoryLen int
+		wantRoleFirst  string
+	}{
+		{
+			name: "no marker no-op",
+			history: []*llm.Content{
+				{Role: "system", Parts: []*llm.Part{{Text: "base"}}},
+				{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+			},
+			wantPersist:    false,
+			wantHistoryLen: 2,
+			wantRoleFirst:  "system",
+		},
+		{
+			name: "marker part removed other kept",
+			history: []*llm.Content{
+				{Role: "system", Parts: []*llm.Part{{Text: "base"}, {Text: markerBlock}}},
+				{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+			},
+			wantPersist:    true,
+			wantHistoryLen: 2,
+			wantRoleFirst:  "system",
+		},
+		{
+			name: "system content dropped when zero parts",
+			history: []*llm.Content{
+				{Role: "system", Parts: []*llm.Part{{Text: markerBlock}}},
+				{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+			},
+			wantPersist:    true,
+			wantHistoryLen: 1,
+			wantRoleFirst:  "user",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &MockMCPClient{}
+			inj, _ := newTestInjector(t, mock, false)
+			req := &sessctx.ContextRequest{History: tt.history}
+			if err := inj.Transform(context.Background(), req); err != nil {
+				t.Fatalf("Transform error: %v", err)
+			}
+			if req.PersistHistory != tt.wantPersist {
+				t.Errorf("PersistHistory = %v, want %v", req.PersistHistory, tt.wantPersist)
+			}
+			if len(req.History) != tt.wantHistoryLen {
+				t.Errorf("history len = %d, want %d", len(req.History), tt.wantHistoryLen)
+			}
+			if len(req.History) > 0 && req.History[0].Role != tt.wantRoleFirst {
+				t.Errorf("first content role = %q, want %q", req.History[0].Role, tt.wantRoleFirst)
+			}
+			if countMarkerParts(req.History) != 0 {
+				t.Error("marker still present after strip")
+			}
+			if calls := mock.recordedNames(); len(calls) != 0 {
+				t.Errorf("disabled path must not call MCP, got %v", calls)
+			}
+		})
+	}
+}
+
+// TestInjectorNilCfg verifies the nil-config guard: no-op, no panic.
+func TestInjectorNilCfg(t *testing.T) {
+	cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+	cfgPtr.Store(nil)
+	inj := &plurInjector{client: &MockMCPClient{}, cfg: cfgPtr, logger: &ports.NoOpLogger{}}
+	req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("nil cfg must no-op, got err %v", err)
+	}
+	if len(req.History) != 1 {
+		t.Errorf("history mutated with nil cfg: %d entries", len(req.History))
+	}
+}
+
+// TestInjectorEnabledInsert covers the enabled-path insertion behaviors:
+// prepend when no system Content, append to an existing system Content,
+// replace an existing marker Part — at most one memory block.
+func TestInjectorEnabledInsert(t *testing.T) {
+	t.Run("no system content prepends", func(t *testing.T) {
+		mock := &MockMCPClient{CallToolFunc: recall("recall text")}
+		inj, _ := newTestInjector(t, mock, true)
+		req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		if len(req.History) != 2 || req.History[0].Role != "system" {
+			t.Fatalf("expected prepended system Content, got %d entries", len(req.History))
+		}
+		sys := req.History[0]
+		if sys.Pinned {
+			t.Error("injected block must not be pinned")
+		}
+		if len(sys.Parts) != 1 {
+			t.Fatalf("expected exactly one part, got %d", len(sys.Parts))
+		}
+		text := sys.Parts[0].Text
+		if !strings.Contains(text, memoryHeader) || !strings.Contains(text, "recall text") || !strings.Contains(text, memoryFooter) {
+			t.Errorf("block missing components: %q", text)
+		}
+		if req.PersistHistory {
+			t.Error("PersistHistory must remain unchanged on the enabled path")
+		}
+		if calls := mock.recordedNames(); len(calls) != 1 || calls[0] != "CallTool:plur_inject_hybrid" {
+			t.Errorf("unexpected MCP calls: %v", calls)
+		}
+	})
+
+	t.Run("appends part to existing system", func(t *testing.T) {
+		mock := &MockMCPClient{CallToolFunc: recall("recall text")}
+		inj, _ := newTestInjector(t, mock, true)
+		req := &sessctx.ContextRequest{History: []*llm.Content{
+			{Role: "system", Parts: []*llm.Part{{Text: "base"}}},
+			{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+		}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		sys := req.History[0]
+		if len(sys.Parts) != 2 {
+			t.Fatalf("expected 2 parts (base + block), got %d", len(sys.Parts))
+		}
+		if sys.Parts[0].Text != "base" {
+			t.Errorf("first part = %q, want %q", sys.Parts[0].Text, "base")
+		}
+		if !strings.Contains(sys.Parts[1].Text, memoryHeader) {
+			t.Errorf("second part is not the memory block: %q", sys.Parts[1].Text)
+		}
+		if countMarkerParts(req.History) != 1 {
+			t.Errorf("expected exactly one marker part (memory-single-block)")
+		}
+	})
+
+	t.Run("replaces existing marker part", func(t *testing.T) {
+		mock := &MockMCPClient{CallToolFunc: recall("new recall")}
+		inj, _ := newTestInjector(t, mock, true)
+		req := &sessctx.ContextRequest{History: []*llm.Content{
+			{Role: "system", Parts: []*llm.Part{{Text: "base"}, {Text: memoryHeader + "\n\nstale recall\n" + memoryFooter}}},
+			{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+		}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		sys := req.History[0]
+		if len(sys.Parts) != 2 {
+			t.Fatalf("expected 2 parts, got %d", len(sys.Parts))
+		}
+		if !strings.Contains(sys.Parts[1].Text, "new recall") || strings.Contains(sys.Parts[1].Text, "stale recall") {
+			t.Errorf("marker part not replaced in place: %q", sys.Parts[1].Text)
+		}
+		if countMarkerParts(req.History) != 1 {
+			t.Errorf("expected exactly one marker part (memory-single-block)")
+		}
+	})
+}
+
+// TestInjectorFailOpenStrip verifies the fail-open contract: on an MCP error,
+// the marker block is stripped in memory only — PersistHistory is NOT set —
+// and Transform returns nil.
+func TestInjectorFailOpenStrip(t *testing.T) {
+	mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+		return tools.ToolResult{}, errors.New("inject failed")
+	}}
+	inj, _ := newTestInjector(t, mock, true)
+	req := &sessctx.ContextRequest{History: []*llm.Content{
+		{Role: "system", Parts: []*llm.Part{{Text: "base"}, {Text: memoryHeader + "\n\nstale\n" + memoryFooter}}},
+		{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+	}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("Transform must return nil on failure, got %v", err)
+	}
+	if req.PersistHistory {
+		t.Error("PersistHistory must NOT be set on the fail-open path")
+	}
+	sys := req.History[0]
+	if len(sys.Parts) != 1 || strings.Contains(sys.Parts[0].Text, memoryMarker) {
+		t.Errorf("marker not stripped in memory: %+v", sys.Parts)
+	}
+	if calls := mock.recordedNames(); len(calls) != 1 || calls[0] != "CallTool:plur_inject_hybrid" {
+		t.Errorf("unexpected MCP calls: %v", calls)
+	}
+}
+
+// TestInjectorNilClient verifies the nil-client runtime guard: no-op, nil
+// error, no panic, history untouched.
+func TestInjectorNilClient(t *testing.T) {
+	inj, _ := newTestInjector(t, nil, true)
+	req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("nil client must no-op, got err %v", err)
+	}
+	if len(req.History) != 1 {
+		t.Errorf("history mutated with nil client: %d entries", len(req.History))
+	}
+	if req.PersistHistory {
+		t.Error("PersistHistory must remain unchanged")
+	}
+}
+
+// TestInjectorTrim verifies the defensive trim: a very long recall results
+// in a block whose len/4 heuristic fits the inject budget.
+func TestInjectorTrim(t *testing.T) {
+	long := strings.Repeat("lorem ipsum dolor sit amet ", 20000)
+	mock := &MockMCPClient{CallToolFunc: recall(long)}
+	inj, cfgPtr := newTestInjector(t, mock, true)
+	req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("Transform error: %v", err)
+	}
+	cfg := cfgPtr.Load()
+	block := req.History[0].Parts[0].Text
+	if got := len(block) / 4; got > cfg.InjectBudget {
+		t.Errorf("block len/4 = %d exceeds budget %d", got, cfg.InjectBudget)
+	}
+	if !strings.HasPrefix(block, memoryHeader) || !strings.HasSuffix(block, memoryFooter) {
+		t.Errorf("trimmed block lost header/footer: %q", block)
+	}
+	if countMarkerParts(req.History) != 1 {
+		t.Errorf("expected exactly one marker part after trim")
+	}
+}
+
+// TestInjectorTrimOverflow verifies the maxBody < 0 overflow path: the block
+// is stripped in memory and Transform returns nil.
+func TestInjectorTrimOverflow(t *testing.T) {
+	mock := &MockMCPClient{CallToolFunc: recall("recall")}
+	inj, cfgPtr := newTestInjector(t, mock, true)
+	memCfg := cfgPtr.Load()
+	memCfg.InjectBudget = 0 // header+footer alone exceed the budget
+	cfgPtr.Store(memCfg)
+	req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("Transform must return nil on overflow, got %v", err)
+	}
+	if countMarkerParts(req.History) != 0 {
+		t.Error("marker must be stripped on overflow")
+	}
+	if req.PersistHistory {
+		t.Error("PersistHistory must not be set on overflow")
+	}
+}
+
+// TestInjectorWarnings verifies the observability surface: metadata ids and
+// the regex fallback both produce injected_engrams:<ids> warnings.
+func TestInjectorWarnings(t *testing.T) {
+	t.Run("metadata ids", func(t *testing.T) {
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			return tools.ToolResult{Text: "recall", Metadata: map[string]interface{}{"ids": []string{"e1", "e2"}}}, nil
+		}}
+		inj, _ := newTestInjector(t, mock, true)
+		req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		if !containsString(req.Metadata.Warnings, "injected_engrams:e1,e2") {
+			t.Errorf("warnings = %v, want injected_engrams:e1,e2", req.Metadata.Warnings)
+		}
+	})
+
+	t.Run("regex fallback deduplicated", func(t *testing.T) {
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			return tools.ToolResult{Text: "engram_id: e1\nid: e2\nid: e1\nid: e3"}, nil
+		}}
+		inj, _ := newTestInjector(t, mock, true)
+		req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		if !containsString(req.Metadata.Warnings, "injected_engrams:e1,e2,e3") {
+			t.Errorf("warnings = %v, want injected_engrams:e1,e2,e3", req.Metadata.Warnings)
+		}
+	})
+}
+
+// TestInjectorMultiPassIdempotent verifies that repeated Transform passes
+// keep exactly one marker Part (memory-single-block) and refresh its content.
+func TestInjectorMultiPassIdempotent(t *testing.T) {
+	mock := &MockMCPClient{CallToolFunc: recall("recall A")}
+	inj, _ := newTestInjector(t, mock, true)
+	req := &sessctx.ContextRequest{History: []*llm.Content{
+		{Role: "system", Parts: []*llm.Part{{Text: "base"}, {Text: memoryHeader + "\n\nold recall\n" + memoryFooter}}},
+		{Role: "user", Parts: []*llm.Part{{Text: "hi"}}},
+	}}
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("first pass error: %v", err)
+	}
+	if countMarkerParts(req.History) != 1 {
+		t.Fatalf("pass 1: expected exactly one marker part, got %d", countMarkerParts(req.History))
+	}
+	mock.CallToolFunc = recall("recall B")
+	if err := inj.Transform(context.Background(), req); err != nil {
+		t.Fatalf("second pass error: %v", err)
+	}
+	if countMarkerParts(req.History) != 1 {
+		t.Errorf("pass 2: expected exactly one marker part, got %d", countMarkerParts(req.History))
+	}
+	foundB := false
+	for _, p := range req.History[0].Parts {
+		if strings.Contains(p.Text, "recall B") {
+			foundB = true
+		}
+	}
+	if !foundB {
+		t.Error("second pass did not refresh the block content")
+	}
+}
+
+// TestInjectorPriority verifies the mandated pipeline priority.
+func TestInjectorPriority(t *testing.T) {
+	inj, _ := newTestInjector(t, nil, true)
+	if got := inj.Priority(); got != 15 {
+		t.Errorf("Priority() = %d, want 15", got)
+	}
+}
+
+// TestInjectorScope verifies the scope arg is forwarded when set and omitted
+// when empty, plus task/budget forwarding.
+func TestInjectorScope(t *testing.T) {
+	t.Run("scope set", func(t *testing.T) {
+		memCfg := config.DefaultMemoryConfig()
+		memCfg.Enabled = true
+		memCfg.Scope = "team-x"
+		cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+		cfgPtr.Store(&memCfg)
+		var gotArgs map[string]interface{}
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotArgs = args
+			return tools.ToolResult{Text: "recall"}, nil
+		}}
+		inj := NewPlurInjector(mock, cfgPtr, &ports.NoOpLogger{}).(*plurInjector)
+		req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		if gotArgs["scope"] != "team-x" {
+			t.Errorf("scope arg = %v, want team-x", gotArgs["scope"])
+		}
+		if gotArgs["task"] != "hi" {
+			t.Errorf("task arg = %v, want hi", gotArgs["task"])
+		}
+		if gotArgs["budget"] != 2000 {
+			t.Errorf("budget arg = %v, want 2000", gotArgs["budget"])
+		}
+	})
+
+	t.Run("scope empty omitted", func(t *testing.T) {
+		memCfg := config.DefaultMemoryConfig()
+		memCfg.Enabled = true
+		cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+		cfgPtr.Store(&memCfg)
+		var gotArgs map[string]interface{}
+		mock := &MockMCPClient{CallToolFunc: func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+			gotArgs = args
+			return tools.ToolResult{Text: "recall"}, nil
+		}}
+		inj := NewPlurInjector(mock, cfgPtr, &ports.NoOpLogger{}).(*plurInjector)
+		req := &sessctx.ContextRequest{History: []*llm.Content{{Role: "user", Parts: []*llm.Part{{Text: "hi"}}}}}
+		if err := inj.Transform(context.Background(), req); err != nil {
+			t.Fatalf("Transform error: %v", err)
+		}
+		if _, ok := gotArgs["scope"]; ok {
+			t.Errorf("scope key must be omitted when empty, got %v", gotArgs["scope"])
+		}
+	})
+}
+
+// containsString reports whether s appears in the slice.
+func containsString(haystack []string, s string) bool {
+	for _, v := range haystack {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/agent/memory/memory_test.go
+++ b/internal/agent/memory/memory_test.go
@@ -325,11 +325,11 @@ func TestAcquireWriteLockBudgetExhausted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open lock file: %v", err)
 	}
-	defer holder.Close()
+	defer func() { _ = holder.Close() }()
 	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
 		t.Fatalf("flock holder: %v", err)
 	}
-	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+	defer func() { _ = syscall.Flock(int(holder.Fd()), syscall.LOCK_UN) }()
 
 	clk := &clock.FakeClock{SleepChan: make(chan time.Duration, flockMaxAttempts)}
 	release, ok := acquireWriteLock(clk)
@@ -370,11 +370,11 @@ func TestAcquireWriteLockNilClock(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open lock file: %v", err)
 	}
-	defer holder.Close()
+	defer func() { _ = holder.Close() }()
 	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
 		t.Fatalf("flock holder: %v", err)
 	}
-	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+	defer func() { _ = syscall.Flock(int(holder.Fd()), syscall.LOCK_UN) }()
 
 	release, ok := acquireWriteLock(nil)
 	if ok || release != nil {

--- a/internal/agent/memory/memory_test.go
+++ b/internal/agent/memory/memory_test.go
@@ -1,0 +1,383 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
+	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
+)
+
+// MockMCPClient is a hand-rolled function-field test double for
+// tools.MCPClient (ADR-021/036 pattern): methods lock → append call record →
+// unlock, then invoke the user Func OUTSIDE the lock (non-reentrant deadlock
+// hazard). The zero value is usable — CallTool returns (zero, nil) and
+// records every call.
+type MockMCPClient struct {
+	mu            sync.Mutex
+	ListToolsFunc func(ctx context.Context) ([]tools.MCPToolDefinition, error)
+	CallToolFunc  func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error)
+	records       []string
+}
+
+// ListTools implements tools.MCPClient.
+func (m *MockMCPClient) ListTools(ctx context.Context) ([]tools.MCPToolDefinition, error) {
+	m.mu.Lock()
+	m.records = append(m.records, "ListTools")
+	m.mu.Unlock()
+	if m.ListToolsFunc != nil {
+		return m.ListToolsFunc(ctx)
+	}
+	return nil, nil
+}
+
+// CallTool implements tools.MCPClient. Record format: "CallTool:<name>".
+func (m *MockMCPClient) CallTool(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+	m.mu.Lock()
+	m.records = append(m.records, "CallTool:"+name)
+	m.mu.Unlock()
+	if m.CallToolFunc != nil {
+		return m.CallToolFunc(ctx, name, args)
+	}
+	return tools.ToolResult{}, nil
+}
+
+// Close implements tools.MCPClient.
+func (m *MockMCPClient) Close() error { return nil }
+
+// recordedNames returns a race-safe snapshot of the call records.
+func (m *MockMCPClient) recordedNames() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]string, len(m.records))
+	copy(out, m.records)
+	return out
+}
+
+// stubHistoryManager implements ports.HistoryManager (16 methods — hand-rolled
+// per the interface-satisfying-stub acceptance class). Only GetLastModelTurn
+// is meaningful; the rest return zero values. Deliberately NOT
+// agenttest.MockHistoryManager: agenttest imports agent, which will import
+// memory in the wiring task (a test-only import cycle).
+type stubHistoryManager struct {
+	GetLastModelTurnFunc func(ctx context.Context) (int, *llm.Content, error)
+}
+
+func (s *stubHistoryManager) GetWindow(ctx context.Context, startIdx, endIdx int) ([]*llm.Content, error) {
+	return nil, nil
+}
+
+func (s *stubHistoryManager) GetTotalEntries() int { return 0 }
+
+func (s *stubHistoryManager) GetLastUserMessage(ctx context.Context) (string, int, error) {
+	return "", 0, nil
+}
+
+func (s *stubHistoryManager) GetResolver() llm.AssetResolver { return nil }
+
+func (s *stubHistoryManager) SetContents(ctx context.Context, contents []*llm.Content) error {
+	return nil
+}
+
+func (s *stubHistoryManager) AddContent(ctx context.Context, content *llm.Content) error {
+	return nil
+}
+
+func (s *stubHistoryManager) AppendParts(ctx context.Context, index int, parts []*llm.Part) error {
+	return nil
+}
+
+func (s *stubHistoryManager) Save(ctx context.Context) error { return nil }
+
+func (s *stubHistoryManager) Sync(ctx context.Context) error { return nil }
+
+func (s *stubHistoryManager) Archive(ctx context.Context, contents []*llm.Content) error {
+	return nil
+}
+
+func (s *stubHistoryManager) SetPinned(ctx context.Context, turnID string, pinned bool) error {
+	return nil
+}
+
+func (s *stubHistoryManager) GetFilePath() string { return "" }
+
+func (s *stubHistoryManager) RollbackTurns(ctx context.Context, turns int) (int, int, int, error) {
+	return 0, 0, 0, nil
+}
+
+func (s *stubHistoryManager) GetLastModelTurn(ctx context.Context) (int, *llm.Content, error) {
+	if s.GetLastModelTurnFunc != nil {
+		return s.GetLastModelTurnFunc(ctx)
+	}
+	return 0, nil, nil
+}
+
+func (s *stubHistoryManager) GetModelTurn(ctx context.Context, index int) (*llm.Content, error) {
+	return nil, nil
+}
+
+func (s *stubHistoryManager) UpdateTurnContent(ctx context.Context, index int, newText string, newThought string) error {
+	return nil
+}
+
+// newTestInjector builds a plurInjector with a DefaultMemoryConfig (budget
+// 2000, batch tier, flood bound 3) and the given enabled state.
+func newTestInjector(t *testing.T, client tools.MCPClient, enabled bool) (*plurInjector, *atomic.Pointer[config.MemoryConfig]) {
+	t.Helper()
+	memCfg := config.DefaultMemoryConfig()
+	memCfg.Enabled = enabled
+	cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+	cfgPtr.Store(&memCfg)
+	return NewPlurInjector(client, cfgPtr, &ports.NoOpLogger{}).(*plurInjector), cfgPtr
+}
+
+// newTestHook builds a plurHook with a DefaultMemoryConfig and the given
+// tier. HOME is redirected to a temp dir so flock side effects never touch
+// the developer's real ~/.plur. clk is a FakeClock (deterministic Now()).
+func newTestHook(t *testing.T, client tools.MCPClient, tier config.MemoryLearnTier, hist ports.HistoryManager) (*plurHook, *atomic.Pointer[config.MemoryConfig]) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	memCfg := config.DefaultMemoryConfig()
+	memCfg.Enabled = true
+	memCfg.LearnTier = tier
+	cfgPtr := &atomic.Pointer[config.MemoryConfig]{}
+	cfgPtr.Store(&memCfg)
+	return NewPlurHook(client, cfgPtr, &ports.NoOpLogger{}, &clock.FakeClock{}, hist).(*plurHook), cfgPtr
+}
+
+// recall returns a CallToolFunc that always returns the given recall text.
+func recall(text string) func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+	return func(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+		return tools.ToolResult{Text: text}, nil
+	}
+}
+
+// countMarkerParts counts Parts whose Text contains the memory marker.
+func countMarkerParts(history []*llm.Content) int {
+	n := 0
+	for _, c := range history {
+		for _, p := range c.Parts {
+			if p != nil && strings.Contains(p.Text, memoryMarker) {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func TestSessionBufferAppendTruncatesLongText(t *testing.T) {
+	b := &sessionBuffer{}
+	ep := episode{Text: strings.Repeat("x", maxEpisodeBytes+1000), Timestamp: time.Unix(0, 0)}
+	b.append(ep)
+	if len(b.episodes) != 1 {
+		t.Fatalf("expected 1 episode, got %d", len(b.episodes))
+	}
+	if got := len(b.episodes[0].Text); got != maxEpisodeBytes {
+		t.Errorf("text length = %d, want %d", got, maxEpisodeBytes)
+	}
+	if b.bytes != maxEpisodeBytes {
+		t.Errorf("bytes = %d, want %d", b.bytes, maxEpisodeBytes)
+	}
+}
+
+func TestSessionBufferAppendTruncatesAtRuneBoundary(t *testing.T) {
+	b := &sessionBuffer{}
+	// 1000 two-byte runes = 2000 bytes exactly (fits); add 1 to exceed.
+	text := strings.Repeat("é", maxEpisodeBytes/2+1)
+	b.append(episode{Text: text, Timestamp: time.Unix(0, 0)})
+	if got := len(b.episodes[0].Text); got > maxEpisodeBytes {
+		t.Errorf("text bytes = %d, want <= %d", got, maxEpisodeBytes)
+	}
+	// The truncated text must not end mid-rune (all é are 2 bytes).
+	if got := len(b.episodes[0].Text); got%2 != 0 {
+		t.Errorf("text ends mid-rune: byte length %d not divisible by 2", got)
+	}
+}
+
+func TestSessionBufferAppendEvictsOldest(t *testing.T) {
+	b := &sessionBuffer{}
+	for i := 0; i < maxBufferEpisodes+5; i++ {
+		b.append(episode{Text: fmt.Sprintf("ep-%d", i), Timestamp: time.Unix(0, 0)})
+	}
+	if len(b.episodes) != maxBufferEpisodes {
+		t.Fatalf("episodes = %d, want %d", len(b.episodes), maxBufferEpisodes)
+	}
+	if got := b.episodes[0].Text; got != "ep-5" {
+		t.Errorf("first (oldest) episode = %q, want %q", got, "ep-5")
+	}
+	if got := b.episodes[len(b.episodes)-1].Text; got != fmt.Sprintf("ep-%d", maxBufferEpisodes+4) {
+		t.Errorf("last episode = %q, want %q", got, fmt.Sprintf("ep-%d", maxBufferEpisodes+4))
+	}
+}
+
+func TestExtractIDs(t *testing.T) {
+	tests := []struct {
+		name   string
+		result tools.ToolResult
+		want   []string
+	}{
+		{
+			name:   "metadata string",
+			result: tools.ToolResult{Metadata: map[string]interface{}{"ids": "e1"}},
+			want:   []string{"e1"},
+		},
+		{
+			name:   "metadata string slice",
+			result: tools.ToolResult{Metadata: map[string]interface{}{"ids": []string{"e1", "e2"}}},
+			want:   []string{"e1", "e2"},
+		},
+		{
+			name:   "metadata interface slice",
+			result: tools.ToolResult{Metadata: map[string]interface{}{"ids": []interface{}{"e1", "e2"}}},
+			want:   []string{"e1", "e2"},
+		},
+		{
+			name:   "metadata dedupe order-preserving",
+			result: tools.ToolResult{Metadata: map[string]interface{}{"ids": []string{"e1", "e1", "e2"}}},
+			want:   []string{"e1", "e2"},
+		},
+		{
+			name:   "regex fallback engram_id and id",
+			result: tools.ToolResult{Text: "engram_id: e1\nid: e2"},
+			want:   []string{"e1", "e2"},
+		},
+		{
+			name:   "regex equals form",
+			result: tools.ToolResult{Text: "id=e1"},
+			want:   []string{"e1"},
+		},
+		{
+			name:   "regex dedupe order-preserving",
+			result: tools.ToolResult{Text: "id: e1\nid: e1\nid: e2"},
+			want:   []string{"e1", "e2"},
+		},
+		{
+			name:   "regex ignores malformed ids",
+			result: tools.ToolResult{Text: "id: !!not-a-match!!"},
+			want:   nil,
+		},
+		{
+			name:   "no ids",
+			result: tools.ToolResult{Text: "plain recall text"},
+			want:   nil,
+		},
+		{
+			name:   "empty metadata ids falls back to regex",
+			result: tools.ToolResult{Text: "id: e1", Metadata: map[string]interface{}{"ids": []string{}}},
+			want:   []string{"e1"},
+		},
+		{
+			name:   "nil metadata",
+			result: tools.ToolResult{},
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractIDs(tt.result)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("extractIDs(%+v) = %v, want %v", tt.result, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAcquireWriteLockSuccess(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// OpenFile does not create parent directories; production ~/.plur exists
+	// (PLUR's store), so the test mirrors that shape.
+	if err := os.MkdirAll(filepath.Join(home, ".plur"), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	clk := &clock.FakeClock{}
+	release, ok := acquireWriteLock(clk)
+	if !ok || release == nil {
+		t.Fatal("expected lock acquisition to succeed")
+	}
+	release()
+}
+
+func TestAcquireWriteLockBudgetExhausted(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	lockPath := filepath.Join(home, ".plur", ".tmg-write.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	holder, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("flock holder: %v", err)
+	}
+	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+
+	clk := &clock.FakeClock{SleepChan: make(chan time.Duration, flockMaxAttempts)}
+	release, ok := acquireWriteLock(clk)
+	if ok || release != nil {
+		t.Fatal("expected lock acquisition to fail after budget exhaustion")
+	}
+	if got := len(clk.SleepChan); got != flockMaxAttempts {
+		t.Errorf("Sleep calls = %d, want %d", got, flockMaxAttempts)
+	}
+	select {
+	case d := <-clk.SleepChan:
+		if d != flockPollInterval {
+			t.Errorf("Sleep duration = %v, want %v", d, flockPollInterval)
+		}
+	default:
+		t.Error("SleepChan empty; expected flockPollInterval durations")
+	}
+}
+
+func TestAcquireWriteLockUncreatable(t *testing.T) {
+	// HOME points inside a non-existent directory → OpenFile fails → fail-open.
+	t.Setenv("HOME", filepath.Join(t.TempDir(), "missing", "home"))
+	release, ok := acquireWriteLock(&clock.FakeClock{})
+	if ok || release != nil {
+		t.Fatal("expected fail-open (nil, false) when the lock file cannot be created")
+	}
+}
+
+func TestAcquireWriteLockNilClock(t *testing.T) {
+	// Nil clock: EWOULDBLOCK still exhausts the budget without sleeping.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	lockPath := filepath.Join(home, ".plur", ".tmg-write.lock")
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	holder, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0600)
+	if err != nil {
+		t.Fatalf("open lock file: %v", err)
+	}
+	defer holder.Close()
+	if err := syscall.Flock(int(holder.Fd()), syscall.LOCK_EX); err != nil {
+		t.Fatalf("flock holder: %v", err)
+	}
+	defer syscall.Flock(int(holder.Fd()), syscall.LOCK_UN)
+
+	release, ok := acquireWriteLock(nil)
+	if ok || release != nil {
+		t.Fatal("expected fail-open (nil, false) with nil clock")
+	}
+}

--- a/internal/agent/memory_wiring_test.go
+++ b/internal/agent/memory_wiring_test.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package agent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gosharplite/tell-me-go/internal/agent/agenttest"
+	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
+	"github.com/gosharplite/tell-me-go/internal/domain/events"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
+	"github.com/gosharplite/tell-me-go/internal/pkg/testfixtures"
+)
+
+// newMemoryTestAgent constructs a fully-initialized agent with a SpyLogger
+// plus the given options, returning the Chatter interface, the white-box
+// *agent, and the logger for assertion.
+func newMemoryTestAgent(t *testing.T, opts ...AgentOption) (ports.Chatter, *agent, *testfixtures.SpyLogger) {
+	t.Helper()
+
+	ctx := context.Background()
+	gw := &agenttest.MockGateway{}
+	bus := events.NewSimpleEventBus(ctx, events.WithAsync(false))
+	reg := agenttest.NewMockToolRegistry()
+	sm := &mockSecurityManager{AllowAll: true}
+	spy := &testfixtures.SpyLogger{}
+
+	all := append([]AgentOption{
+		WithSecurityManager(sm),
+		WithProviderName("test-provider"),
+		WithPricing("test-model", "test-mode", nil),
+		WithLogger(spy),
+	}, opts...)
+
+	chatter, err := NewAgent(gw, bus, reg, all...)
+	if err != nil {
+		t.Fatalf("NewAgent failed: %v", err)
+	}
+	return chatter, chatter.(*agent), spy
+}
+
+// TestNewAgent_MemoryEnabledAbsentServer_WarnsAndDisables verifies the
+// two-stage fallback (ADR-068 §5): an enabled-but-absent server (nil MCP
+// client with a non-empty seed SERVER) yields a successful NewAgent, a
+// memory_server_unavailable warn, an effectively-disabled shared config
+// snapshot, and a constructed (inert, nil-client) hook. Structural wiring
+// proof (injector in the pipeline, hook firing) is deferred to the T7 E2E;
+// this test proves construction + fail-open posture.
+func TestNewAgent_MemoryEnabledAbsentServer_WarnsAndDisables(t *testing.T) {
+	seed := domain_config.MemoryConfig{
+		Enabled:             true,
+		Server:              "plur",
+		InjectBudget:        2000,
+		LearnTier:           domain_config.MemoryLearnBatch,
+		MaxLearnsPerSession: 3,
+	}
+
+	_, a, spy := newMemoryTestAgent(t, WithMemoryClient(nil, seed))
+
+	if !spy.CalledWith("Warn", "memory_server_unavailable") {
+		t.Error("expected memory_server_unavailable warn for enabled-but-absent server")
+	}
+	// Effective disable: the shared snapshot must be non-nil and disabled.
+	if cfg := a.memoryCfg.Load(); cfg == nil || cfg.Enabled {
+		t.Errorf("memoryCfg snapshot = %+v; want non-nil with Enabled=false", cfg)
+	}
+	// The hook was constructed (once, at initComponents) with the nil client.
+	if a.memoryHook == nil {
+		t.Error("expected memoryHook to be constructed for enabled-but-absent server")
+	}
+}
+
+// TestNewAgent_NoMemory_NoWarnNoComponents verifies the default posture:
+// without WithMemoryClient the agent constructs NO memory components, emits
+// no memory_server_unavailable warn, and leaves memoryHook nil — zero
+// behavior change for existing users (ADR-068 §5).
+func TestNewAgent_NoMemory_NoWarnNoComponents(t *testing.T) {
+	_, a, spy := newMemoryTestAgent(t) // default: no memory options
+
+	if spy.CalledWith("Warn", "memory_server_unavailable") {
+		t.Error("expected NO memory_server_unavailable warn when memory is not configured")
+	}
+	if a.memoryHook != nil {
+		t.Error("expected memoryHook nil when memory is not configured")
+	}
+}

--- a/internal/agent/options.go
+++ b/internal/agent/options.go
@@ -11,6 +11,7 @@ import (
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/security"
 	"github.com/gosharplite/tell-me-go/internal/domain/skills"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/clock"
 )
 
@@ -123,5 +124,17 @@ func WithProviderName(name string) AgentOption {
 func WithSkillEcosystemIntro(intro string) AgentOption {
 	return func(a *agent) {
 		a.ecosystemIntro = intro
+	}
+}
+
+// WithMemoryClient sets the MCP client for the MEMORY.SERVER and the seed
+// MemoryConfig. A nil client is legal — it yields an inert memory
+// integration (runtime nil-client guards fail open). The live config
+// comes from the ConfigWatcher at runtime (later wiring task); seed only
+// pre-populates the atomic before the first applyConfig.
+func WithMemoryClient(client tools.MCPClient, seed domain_config.MemoryConfig) AgentOption {
+	return func(a *agent) {
+		a.memoryClient = client
+		a.memorySeed = seed
 	}
 }

--- a/internal/agent/options_test.go
+++ b/internal/agent/options_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_pricing "github.com/gosharplite/tell-me-go/internal/domain/pricing"
 	"github.com/gosharplite/tell-me-go/internal/domain/skills"
+	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/stretchr/testify/require"
 )
 
 type localMockSummarizer struct{ ports.Summarizer }
 type localMockTracker struct{ domain_pricing.CostTracker }
 type localMockSkillSelector struct{ skills.SkillSelector }
+type localMockMCPClient struct{ tools.MCPClient }
 
 func TestAgentOptions(t *testing.T) {
 	t.Parallel()
@@ -83,6 +85,26 @@ func TestAgentOptions(t *testing.T) {
 			option: WithSkillSelector(mockSkillSelector),
 			validate: func(t *testing.T, a *agent) {
 				require.Equal(t, mockSkillSelector, a.skillSelector)
+			},
+		},
+		{
+			name: "WithMemoryClient",
+			option: WithMemoryClient(&localMockMCPClient{}, domain_config.MemoryConfig{
+				Server:       "plur",
+				InjectBudget: 2000,
+			}),
+			validate: func(t *testing.T, a *agent) {
+				require.NotNil(t, a.memoryClient)
+				require.Equal(t, "plur", a.memorySeed.Server)
+				require.Equal(t, 2000, a.memorySeed.InjectBudget)
+			},
+		},
+		{
+			name:   "WithMemoryClient_NilClient",
+			option: WithMemoryClient(nil, domain_config.MemoryConfig{Server: "plur"}),
+			validate: func(t *testing.T, a *agent) {
+				require.Nil(t, a.memoryClient, "nil client must be stored as-is (inert integration)")
+				require.Equal(t, "plur", a.memorySeed.Server)
 			},
 		},
 	}

--- a/internal/agent/orchestrator/engine.go
+++ b/internal/agent/orchestrator/engine.go
@@ -87,6 +87,11 @@ type Engine struct {
 // engineOption allows configuring the Engine.
 type engineOption func(*Engine, *engineConfig)
 
+// EngineOption is the exported alias of engineOption, allowing callers
+// (e.g. the agent's initComponents DI wiring) to build an opts slice and
+// append options conditionally before calling NewEngine.
+type EngineOption = engineOption
+
 // WithEngineClock sets a custom clock implementation.
 func WithEngineClock(c clock.Clock) engineOption {
 	return func(e *Engine, cfg *engineConfig) {
@@ -339,7 +344,7 @@ func (e *Engine) ExecuteTurn(parentCtx context.Context, Turn *Turn) error {
 
 	err := e.runPhaseLoop(ctxWithTrace, Turn)
 
-	e.finalizeTurnTrace(trace, err)
+	e.finalizeTurnTrace(trace, Turn, err)
 	if err := events.SafePublish(ctx, e.events, events.TraceEvent{Trace: trace}); err != nil {
 		if !errors.Is(err, events.ErrBusNotInitialized) {
 			e.getLogger().Error("event_publish_failed",
@@ -367,11 +372,14 @@ func (e *Engine) runPhaseLoop(ctx context.Context, Turn *Turn) error {
 	return nil
 }
 
-func (e *Engine) finalizeTurnTrace(trace *telemetry.TurnTrace, err error) {
+func (e *Engine) finalizeTurnTrace(trace *telemetry.TurnTrace, Turn *Turn, err error) {
 	trace.EndTime = e.clock.Now()
 	trace.FinalStatus = "success"
 	if err != nil {
 		trace.FinalStatus = "error"
+	}
+	if Turn.State.Metadata != nil && len(Turn.State.Metadata.Warnings) > 0 {
+		trace.AddWarnings(Turn.State.Metadata.Warnings...)
 	}
 }
 

--- a/internal/agent/orchestrator/engine_test.go
+++ b/internal/agent/orchestrator/engine_test.go
@@ -1146,3 +1146,48 @@ func TestInferenceStep_InvokeModel_InferenceStartedEvent_PublishError(t *testing
 	assert.True(t, sl.CalledWith("Error", "Failed to publish InferenceStartedEvent; UI may not show inference status"),
 		"expected logger to capture InferenceStartedEvent publish failure")
 }
+
+// TestEngine_FinalizeTurnTrace_Warnings verifies the finalizeTurnTrace
+// contract after the ADR-068 §8 signature change: the trace's Warnings are
+// populated from Turn.State.Metadata.Warnings under lock, an absent/nil
+// Metadata leaves them empty, and the error path still sets FinalStatus.
+func TestEngine_FinalizeTurnTrace_Warnings(t *testing.T) {
+	mockClock := &agenttest.MockClock{}
+	mockClock.SetCurrentTime(time.Now())
+	e := &Engine{clock: mockClock}
+
+	t.Run("metadata warnings populate trace", func(t *testing.T) {
+		trace := telemetry.NewTurnTrace()
+		turn := &Turn{
+			State: &TurnState{
+				Metadata: &sessctx.ContextMetadata{
+					Warnings: []string{"injected_engrams:e1,e2", "injected_engrams:e3"},
+				},
+			},
+		}
+		e.finalizeTurnTrace(trace, turn, nil)
+
+		assert.Equal(t, "success", trace.FinalStatus)
+		require.Len(t, trace.Warnings, 2)
+		assert.Equal(t, "injected_engrams:e1,e2", trace.Warnings[0])
+		assert.Equal(t, "injected_engrams:e3", trace.Warnings[1])
+	})
+
+	t.Run("nil metadata leaves warnings empty", func(t *testing.T) {
+		trace := telemetry.NewTurnTrace()
+		turn := &Turn{State: &TurnState{}} // Metadata is nil
+		e.finalizeTurnTrace(trace, turn, nil)
+
+		assert.Equal(t, "success", trace.FinalStatus)
+		assert.Empty(t, trace.Warnings)
+	})
+
+	t.Run("error sets final status error", func(t *testing.T) {
+		trace := telemetry.NewTurnTrace()
+		turn := &Turn{State: &TurnState{}}
+		e.finalizeTurnTrace(trace, turn, errors.New("boom"))
+
+		assert.Equal(t, "error", trace.FinalStatus)
+		assert.Empty(t, trace.Warnings)
+	})
+}

--- a/internal/agent/session/session_manager.go
+++ b/internal/agent/session/session_manager.go
@@ -121,6 +121,7 @@ func (o *sessionManager) Run(ctx context.Context, sc SessionConfig, sd ports.Cha
 		LogPath:      paths.LogPath,
 		TracePath:    paths.TracePath,
 		ConfigPath:   sc.GetConfigPath(),
+		MemoryServer: cfg.Memory.Server,
 	}
 	chatAgent, err := o.AgentFactory(ctx, sd, chatterCfg)
 	if err != nil {

--- a/internal/app/chatter.go
+++ b/internal/app/chatter.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 
 	"github.com/gosharplite/tell-me-go/internal/agent"
+	domain_config "github.com/gosharplite/tell-me-go/internal/domain/config"
 	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	domain_skills "github.com/gosharplite/tell-me-go/internal/domain/skills"
 )
@@ -78,6 +79,17 @@ func NewChatter(ctx context.Context, deps ports.ChatterComposer, cfg ports.Chatt
 	reg, err := deps.GetRegistry()
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve tool registry: %w", err)
+	}
+
+	// Memory integration seam (ADR-068): look up the MCP client for the
+	// memory server after the registry build so the factory stash is
+	// populated. A nil client is legal — the agent constructs an inert
+	// memory integration and the runtime nil-client guards fail open.
+	if cfg.MemoryServer != "" {
+		client, _ := deps.GetMCPClient(cfg.MemoryServer)
+		seed := domain_config.DefaultMemoryConfig()
+		seed.Server = cfg.MemoryServer
+		opts = append(opts, agent.WithMemoryClient(client, seed))
 	}
 
 	return agent.NewAgent(

--- a/internal/app/chatter_test.go
+++ b/internal/app/chatter_test.go
@@ -56,6 +56,8 @@ type mockSessionDeps struct {
 	sessionProvider ports.SessionProvider
 	skillRepo       domain_skills.SkillRepository
 	summarizer      ports.Summarizer
+	mcpClients      map[string]tools.MCPClient
+	mcpClientCalls  []string
 }
 
 func (d *mockSessionDeps) GetGateway() llm.LLMGateway              { return d.gw }
@@ -79,7 +81,12 @@ func (d *mockSessionDeps) GetClient() llm.LLMClient                             
 func (d *mockSessionDeps) GetSkillRepository() domain_skills.SkillRepository    { return d.skillRepo }
 func (d *mockSessionDeps) GetSummarizer() ports.Summarizer                      { return d.summarizer }
 func (d *mockSessionDeps) GetConfigWatcher() domain_config.ConfigWatcher        { return nil }
-func (d *mockSessionDeps) RegisterTrace(path string)                            {}
+func (d *mockSessionDeps) GetMCPClient(name string) (tools.MCPClient, bool) {
+	d.mcpClientCalls = append(d.mcpClientCalls, name)
+	c, ok := d.mcpClients[name]
+	return c, ok
+}
+func (d *mockSessionDeps) RegisterTrace(path string) {}
 
 var _ ports.ChatterComposer = (*mockSessionDeps)(nil)
 
@@ -161,6 +168,20 @@ type mockTracker struct {
 	pricing.CostTracker
 }
 
+// fakeMCPClient is a minimal tools.MCPClient double so tests can exercise
+// the MemoryServer seam without contacting a live MCP endpoint.
+type fakeMCPClient struct{}
+
+func (f *fakeMCPClient) ListTools(ctx context.Context) ([]tools.MCPToolDefinition, error) {
+	return nil, nil
+}
+
+func (f *fakeMCPClient) CallTool(ctx context.Context, name string, args map[string]interface{}) (tools.ToolResult, error) {
+	return tools.ToolResult{}, nil
+}
+
+func (f *fakeMCPClient) Close() error { return nil }
+
 func TestNewChatter(t *testing.T) {
 	deps, cfg := setupNilDepTest(t)
 
@@ -193,6 +214,65 @@ func TestNewChatter(t *testing.T) {
 		_, err := NewChatter(context.Background(), deps, cfg)
 		if err == nil || !strings.Contains(err.Error(), "failed to retrieve tool registry") {
 			t.Errorf("expected 'failed to retrieve tool registry' error, got: %v", err)
+		}
+	})
+}
+
+// TestNewChatter_MemoryClientLookup exercises the memory integration seam
+// (ADR-068): when cfg.MemoryServer is set, NewChatter must look the client
+// up via deps.GetMCPClient after the registry build and still succeed
+// (a nil client is legal); when MemoryServer is empty, the lookup must not
+// happen at all.
+func TestNewChatter_MemoryClientLookup(t *testing.T) {
+	t.Run("memory server configured returns client", func(t *testing.T) {
+		deps, cfg := setupNilDepTest(t)
+		deps.mcpClients = map[string]tools.MCPClient{"plur": &fakeMCPClient{}}
+		cfg.MemoryServer = "plur"
+
+		chatter, err := NewChatter(context.Background(), deps, cfg)
+		if err != nil {
+			t.Fatalf("NewChatter failed: %v", err)
+		}
+		if chatter == nil {
+			t.Fatal("expected chatter to be non-nil")
+		}
+		if len(deps.mcpClientCalls) != 1 || deps.mcpClientCalls[0] != "plur" {
+			t.Errorf("GetMCPClient calls = %v, want [plur]", deps.mcpClientCalls)
+		}
+	})
+
+	t.Run("memory server configured but client skipped degrades to nil", func(t *testing.T) {
+		// Server key set but the deps stash has no entry: GetMCPClient
+		// returns (nil, false). NewChatter must still succeed — the nil
+		// client yields an inert memory integration, never a panic.
+		deps, cfg := setupNilDepTest(t)
+		cfg.MemoryServer = "plur"
+
+		chatter, err := NewChatter(context.Background(), deps, cfg)
+		if err != nil {
+			t.Fatalf("NewChatter failed: %v", err)
+		}
+		if chatter == nil {
+			t.Fatal("expected chatter to be non-nil")
+		}
+		if len(deps.mcpClientCalls) != 1 || deps.mcpClientCalls[0] != "plur" {
+			t.Errorf("GetMCPClient calls = %v, want [plur]", deps.mcpClientCalls)
+		}
+	})
+
+	t.Run("empty memory server skips lookup", func(t *testing.T) {
+		deps, cfg := setupNilDepTest(t)
+		cfg.MemoryServer = ""
+
+		chatter, err := NewChatter(context.Background(), deps, cfg)
+		if err != nil {
+			t.Fatalf("NewChatter failed: %v", err)
+		}
+		if chatter == nil {
+			t.Fatal("expected chatter to be non-nil")
+		}
+		if len(deps.mcpClientCalls) != 0 {
+			t.Errorf("GetMCPClient calls = %v, want none", deps.mcpClientCalls)
 		}
 	})
 }

--- a/internal/domain/config/config.go
+++ b/internal/domain/config/config.go
@@ -167,6 +167,7 @@ type Config struct {
 	SelectedProvider   string                     `yaml:"SELECTED_PROVIDER"`
 	Providers          map[string]LLMProvider     `yaml:"PROVIDERS"`
 	MCPServers         map[string]MCPServerConfig `yaml:"MCP_SERVERS"`
+	Memory             MemoryConfig               `yaml:"MEMORY"`
 	FailoverOrder      []string                   `yaml:"FAILOVER_ORDER"`
 }
 
@@ -277,6 +278,13 @@ func (c *Config) ValidateMCPServers() error {
 		}
 	}
 	return nil
+}
+
+// ValidateMemory validates the MEMORY section. It is invoked at config load
+// and on every hot-reload re-parse (via the loader), mirroring
+// ValidateMCPServers.
+func (c *Config) ValidateMemory() error {
+	return c.Memory.validate()
 }
 
 // ValidateBounds checks every non-negative int field on Config and returns

--- a/internal/domain/config/memory_config.go
+++ b/internal/domain/config/memory_config.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MemoryLearnTier is the automatic-learning tier of Memory. Exactly one tier
+// is active; batch is the default.
+type MemoryLearnTier string
+
+const (
+	MemoryLearnOff     MemoryLearnTier = "off"
+	MemoryLearnCapture MemoryLearnTier = "capture"
+	MemoryLearnBatch   MemoryLearnTier = "batch"
+	MemoryLearnFull    MemoryLearnTier = "full"
+)
+
+// defaultMemoryInjectBudget is the default token budget for plur_inject_hybrid.
+const defaultMemoryInjectBudget = 2000
+
+// defaultMemoryMaxLearnsPerSession is the default flood bound for the full tier.
+const defaultMemoryMaxLearnsPerSession = 3
+
+// MemoryConfig defines configuration for automatic PLUR memory integration
+// (YAML key MEMORY). Mirrors MCPServerConfig's placement: domain-owned config
+// with yaml tags, validated at load and on every hot-reload re-parse.
+type MemoryConfig struct {
+	Enabled             bool            `yaml:"ENABLED"`
+	Server              string          `yaml:"SERVER"`                 // key of the MCP_SERVERS entry backing memory; session-fixed (restart-level)
+	InjectBudget        int             `yaml:"INJECT_BUDGET"`          // tokens for plur_inject_hybrid per turn; hot-reloadable
+	LearnTier           MemoryLearnTier `yaml:"LEARN"`                  // off|capture|batch|full; default batch; hot-reloadable
+	Scope               string          `yaml:"SCOPE"`                  // optional scope override; precedence: override-if-set -> .plur.yaml -> one surfaced warning
+	MaxLearnsPerSession int             `yaml:"MAX_LEARNS_PER_SESSION"` // flood bound for the full tier; hot-reloadable
+}
+
+// DefaultMemoryConfig returns the zero-behavior default: disabled, server
+// "plur", batch tier, budget 2000, flood bound 3. Enabled defaults to false
+// so existing users see zero behavior change.
+func DefaultMemoryConfig() MemoryConfig {
+	return MemoryConfig{
+		Enabled:             false,
+		Server:              "plur",
+		InjectBudget:        defaultMemoryInjectBudget,
+		LearnTier:           MemoryLearnBatch,
+		MaxLearnsPerSession: defaultMemoryMaxLearnsPerSession,
+	}
+}
+
+// normalizeTier trims and lowercases the tier label.
+func normalizeTier(t MemoryLearnTier) MemoryLearnTier {
+	return MemoryLearnTier(strings.ToLower(strings.TrimSpace(string(t))))
+}
+
+// EffectiveLearnTier resolves the active tier, normalizing case/whitespace
+// and defaulting an empty value to batch (mirrors MCPServerConfig.EffectiveAuth).
+func (c *MemoryConfig) EffectiveLearnTier() MemoryLearnTier {
+	if c.LearnTier == "" {
+		return MemoryLearnBatch
+	}
+	return normalizeTier(c.LearnTier)
+}
+
+// validate reports hard configuration errors. Mirrors MCPServerConfig.validate:
+// most-specific-error-wins ordering, MEMORY.-prefixed messages, empty tier
+// accepted (means default batch).
+func (c *MemoryConfig) validate() error {
+	if c.Enabled && strings.TrimSpace(c.Server) == "" {
+		return fmt.Errorf("MEMORY.SERVER must not be empty when ENABLED is true")
+	}
+	if c.InjectBudget < 0 {
+		return fmt.Errorf("MEMORY.INJECT_BUDGET must be >= 0, got %d", c.InjectBudget)
+	}
+	if c.MaxLearnsPerSession < 0 {
+		return fmt.Errorf("MEMORY.MAX_LEARNS_PER_SESSION must be >= 0, got %d", c.MaxLearnsPerSession)
+	}
+	switch c.EffectiveLearnTier() {
+	case MemoryLearnOff, MemoryLearnCapture, MemoryLearnBatch, MemoryLearnFull:
+		return nil
+	default:
+		return fmt.Errorf("MEMORY.LEARN must be one of %q, %q, %q, %q, got %q",
+			MemoryLearnOff, MemoryLearnCapture, MemoryLearnBatch, MemoryLearnFull, c.EffectiveLearnTier())
+	}
+}

--- a/internal/domain/config/memory_config_test.go
+++ b/internal/domain/config/memory_config_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestDefaultMemoryConfig pins the zero-behavior default: disabled, server
+// "plur", batch tier, budget 2000, flood bound 3. Enabled defaults to false
+// so existing users see zero behavior change.
+func TestDefaultMemoryConfig(t *testing.T) {
+	got := DefaultMemoryConfig()
+
+	if got.Enabled {
+		t.Error("DefaultMemoryConfig().Enabled = true; want false (zero behavior change)")
+	}
+	if got.Server != "plur" {
+		t.Errorf("DefaultMemoryConfig().Server = %q; want %q", got.Server, "plur")
+	}
+	if got.InjectBudget != defaultMemoryInjectBudget {
+		t.Errorf("DefaultMemoryConfig().InjectBudget = %d; want %d", got.InjectBudget, defaultMemoryInjectBudget)
+	}
+	if got.LearnTier != MemoryLearnBatch {
+		t.Errorf("DefaultMemoryConfig().LearnTier = %q; want %q", got.LearnTier, MemoryLearnBatch)
+	}
+	if got.MaxLearnsPerSession != defaultMemoryMaxLearnsPerSession {
+		t.Errorf("DefaultMemoryConfig().MaxLearnsPerSession = %d; want %d", got.MaxLearnsPerSession, defaultMemoryMaxLearnsPerSession)
+	}
+}
+
+// TestMemoryConfig_EffectiveLearnTier pins tier resolution: an empty value
+// defaults to batch; otherwise the label is normalized (lowercased and
+// whitespace-trimmed) without mutating the underlying config.
+func TestMemoryConfig_EffectiveLearnTier(t *testing.T) {
+	tests := []struct {
+		name string
+		tier MemoryLearnTier
+		want MemoryLearnTier
+	}{
+		{"empty defaults to batch", "", MemoryLearnBatch},
+		{"off passthrough", MemoryLearnOff, MemoryLearnOff},
+		{"capture passthrough", MemoryLearnCapture, MemoryLearnCapture},
+		{"batch passthrough", MemoryLearnBatch, MemoryLearnBatch},
+		{"full passthrough", MemoryLearnFull, MemoryLearnFull},
+		{"uppercase normalized", "BATCH", MemoryLearnBatch},
+		{"mixed case normalized", "Full", MemoryLearnFull},
+		{"surrounding whitespace trimmed", " full ", MemoryLearnFull},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &MemoryConfig{LearnTier: tt.tier}
+			if got := c.EffectiveLearnTier(); got != tt.want {
+				t.Errorf("EffectiveLearnTier(%q) = %q; want %q", tt.tier, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMemoryConfig_Validate pins the hard-validation contract: the default
+// config and an explicit full config are valid; ENABLED with an empty SERVER,
+// a negative INJECT_BUDGET, a negative MAX_LEARNS_PER_SESSION, and an unknown
+// LEARN tier are all rejected with MEMORY.-prefixed messages. An empty tier
+// is valid (it means default batch).
+func TestMemoryConfig_Validate(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         MemoryConfig
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:    "valid default",
+			cfg:     DefaultMemoryConfig(),
+			wantErr: false,
+		},
+		{
+			name: "valid explicit full",
+			cfg: MemoryConfig{
+				Enabled:             true,
+				Server:              "plur",
+				InjectBudget:        5000,
+				LearnTier:           MemoryLearnFull,
+				Scope:               "team-x",
+				MaxLearnsPerSession: 5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "enabled with empty server rejected",
+			cfg: MemoryConfig{
+				Enabled: true,
+				Server:  "  ",
+			},
+			wantErr:     true,
+			errContains: "MEMORY.SERVER must not be empty when ENABLED is true",
+		},
+		{
+			name: "disabled with empty server is valid",
+			cfg: MemoryConfig{
+				Enabled: false,
+				Server:  "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative inject budget rejected",
+			cfg: MemoryConfig{
+				InjectBudget: -1,
+			},
+			wantErr:     true,
+			errContains: "MEMORY.INJECT_BUDGET must be >= 0, got -1",
+		},
+		{
+			name: "negative max learns rejected",
+			cfg: MemoryConfig{
+				MaxLearnsPerSession: -1,
+			},
+			wantErr:     true,
+			errContains: "MEMORY.MAX_LEARNS_PER_SESSION must be >= 0, got -1",
+		},
+		{
+			name: "invalid tier rejected",
+			cfg: MemoryConfig{
+				LearnTier: "weekly",
+			},
+			wantErr:     true,
+			errContains: `MEMORY.LEARN must be one of "off", "capture", "batch", "full", got "weekly"`,
+		},
+		{
+			name: "empty tier valid (defaults to batch)",
+			cfg: MemoryConfig{
+				LearnTier: "",
+			},
+			wantErr: false,
+		},
+		{
+			name: "mixed-case tier valid after normalization",
+			cfg: MemoryConfig{
+				LearnTier: " BATCH ",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cfg.validate()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("validate() expected error containing %q, got nil", tt.errContains)
+				}
+				if !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("validate() error = %q; want substring %q", err.Error(), tt.errContains)
+				}
+			} else if err != nil {
+				t.Errorf("validate() unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+// TestConfig_ValidateMemory pins the Config-level hook: it delegates to the
+// embedded MemoryConfig.validate, so an invalid MEMORY section surfaces
+// through Config.ValidateMemory.
+func TestConfig_ValidateMemory(t *testing.T) {
+	cfg := &Config{Memory: MemoryConfig{Enabled: true, Server: ""}}
+	err := cfg.ValidateMemory()
+	if err == nil {
+		t.Fatal("ValidateMemory() expected error for ENABLED with empty SERVER, got nil")
+	}
+	if !strings.Contains(err.Error(), "MEMORY.SERVER") {
+		t.Errorf("ValidateMemory() error = %q; want substring %q", err.Error(), "MEMORY.SERVER")
+	}
+
+	cfg = &Config{Memory: DefaultMemoryConfig()}
+	if err := cfg.ValidateMemory(); err != nil {
+		t.Errorf("ValidateMemory() unexpected error for default config: %v", err)
+	}
+}

--- a/internal/domain/config/watcher.go
+++ b/internal/domain/config/watcher.go
@@ -30,4 +30,11 @@ type ConfigWatcher interface {
 	GetLimits() (tokens, toolTurns, historyTurns int)
 	GetContextWindow() int
 	ApplyLimits(l events.Limits)
+
+	// GetMemoryConfig returns the current MEMORY configuration. It is the
+	// hot-reload surface for ENABLED/LEARN/INJECT_BUDGET/MAX_LEARNS_PER_SESSION;
+	// SERVER is restart-level. The agent's prepareRuntimeConfig reads it
+	// pre-chain (like Limits) and shares it with the memory components via an
+	// atomic pointer.
+	GetMemoryConfig() MemoryConfig
 }

--- a/internal/domain/config/watcher_noop.go
+++ b/internal/domain/config/watcher_noop.go
@@ -18,6 +18,7 @@ type noOpConfigWatcher struct {
 	maxToolTurns     int
 	maxHistoryTurns  int
 	contextWindow    int
+	memory           MemoryConfig
 }
 
 // NewNoOpConfigWatcher creates a ConfigWatcher with static default values.
@@ -27,6 +28,7 @@ func NewNoOpConfigWatcher(tokens, toolTurns, historyTurns int) ConfigWatcher {
 		maxToolTurns:     toolTurns,
 		maxHistoryTurns:  historyTurns,
 		contextWindow:    1000000,
+		memory:           DefaultMemoryConfig(),
 	}
 }
 
@@ -57,6 +59,12 @@ func (cw *noOpConfigWatcher) GetContextWindow() int {
 	cw.mu.RLock()
 	defer cw.mu.RUnlock()
 	return cw.contextWindow
+}
+
+func (cw *noOpConfigWatcher) GetMemoryConfig() MemoryConfig {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+	return cw.memory
 }
 
 func (cw *noOpConfigWatcher) ApplyLimits(l events.Limits) {

--- a/internal/domain/config/watcher_noop_test.go
+++ b/internal/domain/config/watcher_noop_test.go
@@ -159,3 +159,13 @@ func TestNoOpConfigWatcher_GetContextWindow(t *testing.T) {
 		}
 	})
 }
+
+func TestNoOpConfigWatcher_GetMemoryConfig(t *testing.T) {
+	cw := NewNoOpConfigWatcher(100, 10, 20)
+
+	got := cw.GetMemoryConfig()
+	want := DefaultMemoryConfig()
+	if got != want {
+		t.Errorf("GetMemoryConfig() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/domain/ports/session.go
+++ b/internal/domain/ports/session.go
@@ -96,6 +96,11 @@ type ChatterConfig struct {
 	// ConfigPath is the filesystem path to the main YAML configuration file.
 	// Used by the config watcher to detect and apply runtime config changes.
 	ConfigPath string
+	// MemoryServer is the key of the MCP_SERVERS entry backing the memory
+	// integration (threaded from Config.Memory.Server by the session manager,
+	// exactly as ProviderName/Model/Mode are threaded). Empty means memory is
+	// not configured; deterministic seam — no refresh-ordering coupling.
+	MemoryServer string
 }
 
 // ChatterFactory defines the functional signature for creating a Chatter instance.
@@ -121,6 +126,11 @@ type ChatterComposer interface {
 	GetSummarizer() Summarizer
 	// GetConfigWatcher returns the runtime configuration watcher. May be nil (agent uses no-op fallback).
 	GetConfigWatcher() domain_config.ConfigWatcher
+	// GetMCPClient returns the live MCP client for a configured server key.
+	// It returns (nil, false) when the server was skipped at DI construction
+	// (client construction/token failure) — callers must treat this as
+	// "server unavailable" and degrade (log + disable), never panic.
+	GetMCPClient(name string) (tools.MCPClient, bool)
 	// RegisterTrace subscribes an execution trace recorder for the given file path.
 	RegisterTrace(path string)
 }

--- a/internal/domain/telemetry/trace.go
+++ b/internal/domain/telemetry/trace.go
@@ -26,6 +26,11 @@ type TurnTrace struct {
 	InferenceDuration time.Duration        `json:"inference_duration"`
 	ToolExecutions    []ToolExecutionTrace `json:"tool_executions"`
 	FinalStatus       string               `json:"final_status"`
+
+	// Warnings collects non-fatal diagnostics from the context pipeline (e.g.
+	// injected_engrams:<ids>) — a general field reusable by any transformer,
+	// not specific to memory (ADR-068 §8).
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 type contextKey struct{}
@@ -61,6 +66,19 @@ func (t *TurnTrace) RecordToolExecution(trace ToolExecutionTrace) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.ToolExecutions = append(t.ToolExecutions, trace)
+}
+
+// AddWarnings appends non-fatal diagnostics to the trace under lock.
+// Consumed by the orchestrator's finalizeTurnTrace to surface context
+// pipeline warnings (e.g. injected_engrams:<ids>) on the telemetry
+// trace (ADR-068 §8).
+func (t *TurnTrace) AddWarnings(warnings ...string) {
+	if t == nil || len(warnings) == 0 {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.Warnings = append(t.Warnings, warnings...)
 }
 
 // CumulativeToolDuration returns the sum of all tool execution durations.

--- a/internal/domain/telemetry/trace_test.go
+++ b/internal/domain/telemetry/trace_test.go
@@ -5,7 +5,9 @@ package telemetry
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -149,4 +151,34 @@ func TestTurnTrace_CumulativeToolDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTurnTrace_WarningsJSON pins the JSON contract of the general Warnings
+// field (ADR-068 §8): present with the "warnings" key when populated, and
+// omitted (omitempty) when empty.
+func TestTurnTrace_WarningsJSON(t *testing.T) {
+	t.Run("warnings present marshal with key", func(t *testing.T) {
+		tt := NewTurnTrace()
+		tt.Warnings = []string{"injected_engrams:e1,e2"}
+
+		data, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if !strings.Contains(string(data), `"warnings":["injected_engrams:e1,e2"]`) {
+			t.Errorf("marshaled JSON = %s; want warnings key present", data)
+		}
+	})
+
+	t.Run("empty warnings omit key", func(t *testing.T) {
+		tt := NewTurnTrace() // Warnings is nil
+
+		data, err := json.Marshal(tt)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		if strings.Contains(string(data), "warnings") {
+			t.Errorf("marshaled JSON = %s; want warnings key omitted (omitempty)", data)
+		}
+	})
 }

--- a/internal/infrastructure/config/config.go
+++ b/internal/infrastructure/config/config.go
@@ -90,6 +90,15 @@ func load(path string) (*domain_config.Config, error) {
 		return nil, err
 	}
 
+	// Domain-level MEMORY validation: SERVER presence when ENABLED, budget
+	// and flood-bound bounds, and the LEARN tier set. Hard errors fail the
+	// load. This single hook covers both static load and every watcher
+	// hot-reload re-parse (Refresh → Loader.Load → load); a failed load
+	// leaves the watcher's prior state intact per ADR-029 §5.
+	if err := cfg.ValidateMemory(); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
 }
 
@@ -227,6 +236,7 @@ func setDefaults(cfg *domain_config.Config) {
 	cfg.HTTPTimeoutSeconds = domain_config.DefaultHTTPTimeoutSeconds
 	cfg.ShowThoughts = true
 	cfg.ShowTools = true
+	cfg.Memory = domain_config.DefaultMemoryConfig()
 }
 
 func syncLegacyFields(cfg *domain_config.Config) {

--- a/internal/infrastructure/config/config_test.go
+++ b/internal/infrastructure/config/config_test.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -828,6 +829,109 @@ func TestLoad_ValidateMCPServersError(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErrSub) {
 				t.Fatalf("load() error = %q, want substring %q", err.Error(), tt.wantErrSub)
+			}
+		})
+	}
+}
+
+// TestLoad_MemoryConfig_RoundTripAndValidation pins the MEMORY section
+// round-trip through Viper + mapstructure into domain Config.Memory and the
+// loader's invocation of ValidateMemory (config.go). A full MEMORY block
+// parses into the expected MemoryConfig; a bad LEARN tier and ENABLED with
+// an explicitly empty SERVER both fail the load with MEMORY.-prefixed
+// messages.
+//
+// DEVATION (Architect adjudication, T3): the spec's "ENABLED: true with no
+// SERVER fails Load" cannot hold — setDefaults seeds Server "plur", and
+// mapstructure merges absent keys, so an absent SERVER keeps the seeded
+// default (ADR-068 §5's "install once" default; the *dynamic* stage — server
+// missing from MCP_SERVERS — handles real absence, ADR-068 §5 two-stage
+// fallback). The static check fires on an explicitly empty SERVER, which is
+// what the third case pins; the second case documents that omitting SERVER
+// entirely yields the seeded default.
+func TestLoad_MemoryConfig_RoundTripAndValidation(t *testing.T) {
+	t.Setenv("TELL_ME_MODE", "")              // neutralize ambient env pollution
+	t.Setenv("TELL_ME_SELECTED_PROVIDER", "") // neutralize ambient env pollution
+
+	tests := []struct {
+		name        string
+		fileContent string
+		want        *domain_config.MemoryConfig
+		wantErr     bool
+		errFrag     string
+	}{
+		{
+			name: "full MEMORY block round-trips",
+			fileContent: "MEMORY:\n" +
+				"  ENABLED: true\n" +
+				"  SERVER: plur\n" +
+				"  INJECT_BUDGET: 5000\n" +
+				"  LEARN: full\n" +
+				"  SCOPE: team-x\n" +
+				"  MAX_LEARNS_PER_SESSION: 5\n",
+			want: &domain_config.MemoryConfig{
+				Enabled:             true,
+				Server:              "plur",
+				InjectBudget:        5000,
+				LearnTier:           domain_config.MemoryLearnFull,
+				Scope:               "team-x",
+				MaxLearnsPerSession: 5,
+			},
+		},
+		{
+			name: "invalid LEARN tier rejected",
+			fileContent: "MEMORY:\n" +
+				"  ENABLED: true\n" +
+				"  SERVER: plur\n" +
+				"  LEARN: weekly\n",
+			wantErr: true,
+			errFrag: `MEMORY.LEARN must be one of "off", "capture", "batch", "full"`,
+		},
+		{
+			name: "ENABLED with explicit empty SERVER rejected",
+			fileContent: "MEMORY:\n" +
+				"  ENABLED: true\n" +
+				"  SERVER: \"\"\n",
+			wantErr: true,
+			errFrag: "MEMORY.SERVER must not be empty when ENABLED is true",
+		},
+		{
+			name: "ENABLED without SERVER keeps the seeded plur default",
+			fileContent: "MEMORY:\n" +
+				"  ENABLED: true\n",
+			want: &domain_config.MemoryConfig{
+				Enabled:             true,
+				Server:              "plur",
+				InjectBudget:        2000,
+				LearnTier:           domain_config.MemoryLearnBatch,
+				MaxLearnsPerSession: 3,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			path := filepath.Join(tmpDir, "test_memory.yaml")
+			if err := os.WriteFile(path, []byte(tt.fileContent), 0644); err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			cfg, err := load(path)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("load() expected error containing %q, got nil", tt.errFrag)
+				}
+				if !strings.Contains(err.Error(), tt.errFrag) {
+					t.Fatalf("load() error = %q, want substring %q", err.Error(), tt.errFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("load() failed: %v", err)
+			}
+			if !reflect.DeepEqual(cfg.Memory, *tt.want) {
+				t.Errorf("Memory = %+v; want %+v", cfg.Memory, *tt.want)
 			}
 		})
 	}

--- a/internal/infrastructure/config/watcher.go
+++ b/internal/infrastructure/config/watcher.go
@@ -77,6 +77,7 @@ type fileConfigWatcher struct {
 	defaultToolTurns     int
 	defaultHistoryTurns  int
 	defaultWindow        int
+	memory               domain_config.MemoryConfig
 }
 
 // NewFileConfigWatcher creates a new fileConfigWatcher with default values.
@@ -96,6 +97,7 @@ func NewFileConfigWatcher(mainLoader domain_config.ConfigLoader, sessionLoader d
 		defaultToolTurns:     toolTurns,
 		defaultHistoryTurns:  historyTurns,
 		defaultWindow:        defaultWindow,
+		memory:               domain_config.DefaultMemoryConfig(),
 	}
 }
 
@@ -241,6 +243,8 @@ func (cw *fileConfigWatcher) applyMainConfig(cfg *domain_config.Config, info os.
 	cw.maxHistoryTurns = cfg.MaxHistoryTurns
 
 	cw.contextWindow = resolveContextWindow(cfg, model, cw.defaultWindow)
+
+	cw.memory = cfg.Memory
 }
 
 // applySessionLimits applies non-nil session config overrides to the watcher's
@@ -291,6 +295,15 @@ func (cw *fileConfigWatcher) GetContextWindow() int {
 	cw.mu.RLock()
 	defer cw.mu.RUnlock()
 	return cw.contextWindow
+}
+
+// GetMemoryConfig returns the current cached MEMORY configuration. It is the
+// hot-reload surface for ENABLED/LEARN/INJECT_BUDGET/MAX_LEARNS_PER_SESSION;
+// SERVER is restart-level.
+func (cw *fileConfigWatcher) GetMemoryConfig() domain_config.MemoryConfig {
+	cw.mu.RLock()
+	defer cw.mu.RUnlock()
+	return cw.memory
 }
 
 // getDefaultWindow returns the default context window value.

--- a/internal/infrastructure/config/watcher_test.go
+++ b/internal/infrastructure/config/watcher_test.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -786,5 +787,44 @@ MAX_TURNS: 99
 	_, toolTurns, _ = cw.GetLimits()
 	if toolTurns != 99 {
 		t.Errorf("MAX_TURNS after update: got %d, want 99", toolTurns)
+	}
+}
+
+// TestFileConfigWatcher_GetMemoryConfig pins the hot-reload surface for
+// MEMORY (ADR-068 §5): GetMemoryConfig returns DefaultMemoryConfig() before
+// any reload, and after a reload through the loader
+// (Refresh → Loader.Load → applyMainConfig) it reflects the config's Memory
+// section. The stub loader returns a config with Memory set, so the watcher's
+// cached value must update under the write lock. Zero time.Sleep — the future
+// mod time on stubFileStat triggers the reload deterministically.
+func TestFileConfigWatcher_GetMemoryConfig(t *testing.T) {
+	cw := NewFileConfigWatcher(nil, nil, 100, 10, 20, nil)
+	fcw := cw.(*fileConfigWatcher)
+
+	// 1. Before any reload: the zero-behavior default.
+	got := cw.GetMemoryConfig()
+	want := domain_config.DefaultMemoryConfig()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("GetMemoryConfig() before reload = %+v; want %+v", got, want)
+	}
+
+	// 2. After a reload with a stub loader returning a config with Memory set.
+	memCfg := domain_config.MemoryConfig{
+		Enabled:             true,
+		Server:              "plur",
+		InjectBudget:        5000,
+		LearnTier:           domain_config.MemoryLearnFull,
+		Scope:               "team-x",
+		MaxLearnsPerSession: 5,
+	}
+	fcw.FS = stubFileStat{modTime: time.Now().Add(time.Hour)}
+	fcw.Loader = stubConfigLoader{cfg: &domain_config.Config{Memory: memCfg}}
+	fcw.SetPaths("/fake/main.yaml", "")
+
+	fcw.Refresh("gpt-5")
+
+	got = cw.GetMemoryConfig()
+	if !reflect.DeepEqual(got, memCfg) {
+		t.Errorf("GetMemoryConfig() after reload = %+v; want %+v", got, memCfg)
 	}
 }

--- a/internal/infrastructure/di/container.go
+++ b/internal/infrastructure/di/container.go
@@ -113,6 +113,7 @@ func (b *Bootstrapper) BuildSessionDependencies(ctx stdctx.Context, cfg *config.
 		lazyProvider:         lazyProvider{client: lazyClient},
 		summarizer:           summarizer,
 		configWatcher:        configWatcher,
+		toolchain:            b.toolchainFactory,
 	}
 
 	deps.health = b.wireHealth(cfg, sessionProvider, lazyClient)
@@ -253,6 +254,9 @@ type sessionDeps struct {
 	skillRepo     domain_skills.SkillRepository
 	summarizer    ports.Summarizer
 	configWatcher config.ConfigWatcher
+	// toolchain owns the stashed MCP clients (via the toolchain factory's
+	// mcpFactory), enabling the ChatterComposer.GetMCPClient seam.
+	toolchain toolchainFactory
 }
 
 var _ ports.ChatterComposer = (*sessionDeps)(nil)
@@ -270,6 +274,16 @@ func (d *sessionDeps) GetSummarizer() ports.Summarizer {
 
 func (d *sessionDeps) GetConfigWatcher() config.ConfigWatcher {
 	return d.configWatcher
+}
+
+// GetMCPClient returns the stashed MCP client for a server key, or
+// (nil, false) when the server was skipped at DI construction. A nil
+// toolchain (e.g. bare sessionDeps in tests) degrades to "unavailable".
+func (d *sessionDeps) GetMCPClient(name string) (tools.MCPClient, bool) {
+	if d.toolchain == nil {
+		return nil, false
+	}
+	return d.toolchain.GetMCPClient(name)
 }
 
 func (d *sessionDeps) RegisterTrace(path string) {

--- a/internal/infrastructure/di/container_test.go
+++ b/internal/infrastructure/di/container_test.go
@@ -1752,6 +1752,10 @@ func (f *captureToolchainFactory) BuildHealthChecker() ports.HealthChecker { ret
 
 func (f *captureToolchainFactory) CloseMCPClients() error { return nil }
 
+func (f *captureToolchainFactory) GetMCPClient(name string) (tools.MCPClient, bool) {
+	return nil, false
+}
+
 func TestWireToolRegistry_PopulatesMCPServers(t *testing.T) {
 	ctx := context.Background()
 	tempDir := t.TempDir()
@@ -1971,4 +1975,77 @@ func TestBuildSessionDependencies_CleanupClosesMCPClients(t *testing.T) {
 	for i, c := range constructed {
 		assert.Equal(t, 1, c.closeCalls, "client[%d] Close calls", i)
 	}
+}
+
+// TestSessionDeps_GetMCPClient_StashedAfterRegistryBuild proves the
+// ChatterComposer.GetMCPClient seam (ADR-068): the mcpFactory stashes
+// clients by server name during Build (which runs lazily on the first
+// GetRegistry), and sessionDeps delegates to the toolchain factory. Before
+// the registry build the lookup reports unavailable; after it, the stashed
+// client is returned for a healthy server and (nil, false) for a skipped
+// or never-configured server.
+func TestSessionDeps_GetMCPClient_StashedAfterRegistryBuild(t *testing.T) {
+	ctx := context.Background()
+	tempDir := t.TempDir()
+
+	sm := new(mockConfigurableSecurityManager)
+
+	bcfg := DefaultBootstrapperConfig()
+	bcfg.HomeDir = tempDir
+	bcfg.SM = sm
+	bcfg.Version = "1.0.0"
+	bcfg.Stdout = io.Discard
+	bcfg.Stderr = io.Discard
+	bcfg.ClientFactory = ports.ClientFactoryFunc(func(cfg *config.Config, pricingData pricing.PricingData, bus events.EventBus, logger ports.Logger) (llm.ExtendedClient, error) {
+		return new(mockLLMClient), nil
+	})
+
+	b := NewBootstrapper(bcfg)
+
+	// Replace the MCP client constructor so no live endpoint is contacted:
+	// the "ok" server builds fine, the "skip" server fails construction.
+	tf := b.toolchainFactory.(*defaultToolchainFactory)
+	tf.mcpFactory.newClientFor = func(cfg config.MCPServerConfig) (tools.MCPClient, error) {
+		if strings.HasSuffix(cfg.URL, "/skip") {
+			return nil, errors.New("boom")
+		}
+		return &fakeMCPClient{}, nil
+	}
+
+	testCfg := &config.Config{
+		Mode:  "assistant",
+		Model: "test-model",
+		MCPServers: map[string]config.MCPServerConfig{
+			"ok":   {URL: "https://example.com/mcp/ok"},
+			"skip": {URL: "https://example.com/mcp/skip"},
+		},
+	}
+
+	deps, _, cleanup, err := b.BuildSessionDependencies(ctx, testCfg, "config.yaml", false, nil)
+	require.NoError(t, err)
+	require.NotNil(t, deps)
+	defer func() { _ = cleanup(ctx) }()
+
+	// Before the registry build the stash is empty — the lookup must
+	// report "unavailable" without panicking.
+	client, ok := deps.GetMCPClient("ok")
+	assert.Nil(t, client)
+	assert.False(t, ok)
+
+	// Registry (and therefore MCP client) construction is lazy; force it now.
+	_, err = deps.GetRegistry()
+	require.NoError(t, err)
+
+	// After the registry build, the healthy server's client is stashed.
+	client, ok = deps.GetMCPClient("ok")
+	assert.True(t, ok)
+	assert.NotNil(t, client)
+
+	// The skipped server and an unknown key both report unavailable.
+	client, ok = deps.GetMCPClient("skip")
+	assert.Nil(t, client)
+	assert.False(t, ok)
+	client, ok = deps.GetMCPClient("missing")
+	assert.Nil(t, client)
+	assert.False(t, ok)
 }

--- a/internal/infrastructure/di/lazy_test.go
+++ b/internal/infrastructure/di/lazy_test.go
@@ -173,9 +173,11 @@ func TestLazyRegistry_ConcurrentInit_ErrorCached(t *testing.T) {
 type mockToolchainFactory struct {
 	BuildRegistryFunc      func(params toolchainParams) (tools.Registry, error)
 	BuildHealthCheckerFunc func() ports.HealthChecker
+	GetMCPClientFunc       func(name string) (tools.MCPClient, bool)
 
 	buildRegistryCalls      int
 	buildHealthCheckerCalls int
+	getMCPClientCalls       int
 }
 
 func (m *mockToolchainFactory) BuildRegistry(params toolchainParams) (tools.Registry, error) {
@@ -195,6 +197,14 @@ func (m *mockToolchainFactory) BuildHealthChecker() ports.HealthChecker {
 }
 
 func (m *mockToolchainFactory) CloseMCPClients() error { return nil }
+
+func (m *mockToolchainFactory) GetMCPClient(name string) (tools.MCPClient, bool) {
+	m.getMCPClientCalls++
+	if m.GetMCPClientFunc != nil {
+		return m.GetMCPClientFunc(name)
+	}
+	return nil, false
+}
 
 // stubHealthChecker is a minimal ports.HealthChecker for tests.
 type stubHealthChecker struct{}

--- a/internal/infrastructure/di/mcp_factory.go
+++ b/internal/infrastructure/di/mcp_factory.go
@@ -51,6 +51,12 @@ type mcpFactory struct {
 	// clients tracks every successfully constructed MCP client so that
 	// session teardown can close them cleanly.
 	clients []tools.MCPClient
+
+	// byName stashes every successfully constructed MCP client keyed by its
+	// configured server name so the client survives tool registration (the
+	// plugin.MCPServerDependency map produced by Build is not retained). It
+	// is guarded by mu, like clients.
+	byName map[string]tools.MCPClient
 }
 
 // newMCPFactory constructs the default MCP dependency factory. The default
@@ -63,6 +69,7 @@ func newMCPFactory(logger *slog.Logger) *mcpFactory {
 	}
 	return &mcpFactory{
 		logger: logger,
+		byName: make(map[string]tools.MCPClient),
 		tokenResolver: func() (string, error) {
 			out, err := exec.Command("gh", "auth", "token").Output()
 			if err != nil {
@@ -160,7 +167,13 @@ func (f *mcpFactory) Build(servers map[string]config.MCPServerConfig) map[string
 			continue
 		}
 		f.mu.Lock()
+		if f.byName == nil {
+			// Zero-value / struct-literal factories (tests) have a nil
+			// byName; map assignment would panic, so initialize lazily.
+			f.byName = make(map[string]tools.MCPClient)
+		}
 		f.clients = append(f.clients, res.client)
+		f.byName[res.name] = res.client
 		f.mu.Unlock()
 		deps[res.name] = plugin.MCPServerDependency{
 			Client:          res.client,
@@ -184,6 +197,16 @@ func (f *mcpFactory) Close() error {
 		}
 	}
 	return errors.Join(errs...)
+}
+
+// Client returns the stashed client for a server name, or (nil, false)
+// when the server was skipped during Build or never configured. Safe to
+// call concurrently with Build/Close.
+func (f *mcpFactory) Client(name string) (tools.MCPClient, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	c, ok := f.byName[name]
+	return c, ok
 }
 
 // resolveServerToken resolves the credentials (username, token) for a single

--- a/internal/infrastructure/di/toolchain_factory.go
+++ b/internal/infrastructure/di/toolchain_factory.go
@@ -32,6 +32,9 @@ type toolchainFactory interface {
 	BuildRegistry(params toolchainParams) (tools.Registry, error)
 	BuildHealthChecker() ports.HealthChecker
 	CloseMCPClients() error
+	// GetMCPClient returns the stashed MCP client for a server key, or
+	// (nil, false) when the server was skipped at construction.
+	GetMCPClient(name string) (tools.MCPClient, bool)
 }
 
 type toolchainParams struct {
@@ -133,6 +136,12 @@ func (f *defaultToolchainFactory) BuildRegistry(params toolchainParams) (tools.R
 // closed when the chat session ends.
 func (f *defaultToolchainFactory) CloseMCPClients() error {
 	return f.mcpFactory.Close()
+}
+
+// GetMCPClient returns the stashed MCP client for a server key, or
+// (nil, false) when the server was skipped at construction.
+func (f *defaultToolchainFactory) GetMCPClient(name string) (tools.MCPClient, bool) {
+	return f.mcpFactory.Client(name)
 }
 
 // registerSkillsShTools registers the four skills.sh ecosystem tools

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -106,6 +106,14 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestStdio_LauncherTreePassThrough":                         {Line: 216, Complexity: 13, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
 		"TestStdio_ChildDeathMidSession":                            {Line: 278, Complexity: 13, FilePath: "internal/infrastructure/mcp/stdio_client_integration_test.go"},
 		"TestResolveCommand":                                        {Line: 25, Complexity: 13, FilePath: "internal/infrastructure/mcp/stdio_client_test.go"},
+		"(*plurHook).AfterTurn":                                     {Line: 80, Complexity: 21, FilePath: "internal/agent/memory/hook.go"},
+		"(*plurInjector).Transform":                                 {Line: 64, Complexity: 16, FilePath: "internal/agent/memory/injector.go"},
+		"metadataIDs":                                               {Line: 226, Complexity: 11, FilePath: "internal/agent/memory/injector.go"},
+		"TestHookBatch":                                             {Line: 209, Complexity: 14, FilePath: "internal/agent/memory/hook_test.go"},
+		"TestHookFull":                                              {Line: 273, Complexity: 15, FilePath: "internal/agent/memory/hook_test.go"},
+		"TestInjectorEnabledInsert":                                 {Line: 108, Complexity: 22, FilePath: "internal/agent/memory/injector_test.go"},
+		"TestNewChatter_MemoryClientLookup":                         {Line: 226, Complexity: 12, FilePath: "internal/app/chatter_test.go"},
+		"newServer":                                                 {Line: 104, Complexity: 13, FilePath: "tests/e2e/testdata/fakeplur/main.go"},
 	}
 
 	require.Equal(t, expectedCataloged, cataloged)

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -135,7 +135,7 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		start int
 		end   int
 	}{
-		{"config.go call-site error branch", "internal/domain/config/config.go", 250, 252},
+		{"config.go call-site error branch", "internal/domain/config/config.go", 251, 253},
 		{"task_service.go AppendTask body", "internal/domain/services/task_service.go", 101, 103},
 		{"manager.go groupTurns error branch", "internal/agent/session/context/manager.go", 526, 528},
 		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 571, 573},
@@ -233,7 +233,7 @@ func TestDetailedCoverageReport_CatalogedGapsNotActionable(t *testing.T) {
 	require.NotContains(t, report, "[HIGH PRIORITY GAPS]")
 	// ... and the formerly-HIGH block is reported as an ACCEPTED cataloged gap.
 	require.Contains(t, report, "[CATALOGED GAPS (ACCEPTED)]")
-	require.Contains(t, report, "config.go (Lines 250-252)")
+	require.Contains(t, report, "config.go (Lines 251-253)")
 	require.Contains(t, report, "validateProviderUniqueness")
 }
 

--- a/scripts/modelith-layers.sh
+++ b/scripts/modelith-layers.sh
@@ -25,6 +25,7 @@ exceptions() {
 Turn|hybrid domain+application — the orchestrator Turn carries runtime deps
 Context|package of cooperating types, not a single struct (by design)
 Provider|LLMProvider lives in config; model documents the concept
+Memory|MemoryConfig lives in config; model documents the concept
 Pricing|consolidated into domain/pricing types (ModelPricing, PricingData)
 Tool|tool declarations in domain/tools package
 History|persistence lives in infrastructure; model documents the domain view
@@ -35,7 +36,7 @@ EOF
 
 entities=$(grep -E '^  [A-Z][A-Za-z]+:$' "$MODEL" \
   | sed 's/^  //;s/:$//' \
-  | grep -v '^ProviderType$' | grep -v '^LLMError$' | grep -v '^ToolCategory$' | grep -v '^APIFamily$')
+  | grep -v '^ProviderType$' | grep -v '^LLMError$' | grep -v '^ToolCategory$' | grep -v '^APIFamily$' | grep -v '^MemoryLearnTier$')
 
 # ── 2. Build exception map ─────────────────────────────────────────────────
 

--- a/tests/e2e/memory_helpers_test.go
+++ b/tests/e2e/memory_helpers_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// buildFakePlur compiles the stdio fake PLUR MCP server
+// (tests/e2e/testdata/fakeplur) into a per-test temp directory and returns
+// the binary path. A per-test build of a tiny stdlib-only package is
+// acceptable; this deliberately does not touch e2e_test.go's TestMain.
+func buildFakePlur(t *testing.T) string {
+	t.Helper()
+	bin := filepath.Join(t.TempDir(), "fakeplur")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	cmd := exec.Command("go", "build", "-o", bin, "./tests/e2e/testdata/fakeplur")
+	cmd.Dir = projectRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build fake plur server: %v\nOutput: %s", err, out)
+	}
+	return bin
+}
+
+// writeSeedFile writes a JSON array of out-of-band pinned engrams to path
+// and returns the path. The seed format is the documented no-pin-tool E2E
+// setup step (ADR-068 §13): [{"id","text","keywords",...,"pinned":true}].
+func writeSeedFile(t *testing.T, path string, engrams []map[string]interface{}) string {
+	t.Helper()
+	data, err := json.Marshal(engrams)
+	if err != nil {
+		t.Fatalf("failed to marshal seed engrams: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write seed file: %v", err)
+	}
+	return path
+}
+
+// memoryE2EConfig writes a config file that mirrors createTempConfig's shape
+// (provider openai, SELECTED_PROVIDER mock) plus the memory integration
+// surface: MCP_SERVERS.plur pointing at the fake binary and MEMORY enabled
+// with the given LEARN tier. Returns the config path.
+func memoryE2EConfig(t *testing.T, mockURL, fakePlurPath string, learn string) string {
+	t.Helper()
+	content := fmt.Sprintf(`
+MODE: "assistant"
+SELECTED_PROVIDER: "mock"
+PROVIDERS:
+  mock:
+    TYPE: "openai"
+    URL: "%s"
+    API_KEY: "dummy"
+    MODEL: "gpt-4"
+MCP_SERVERS:
+  plur:
+    COMMAND: '%s'
+MEMORY:
+  ENABLED: true
+  SERVER: "plur"
+  INJECT_BUDGET: 2000
+  LEARN: "%s"
+`, mockURL, fakePlurPath, learn)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write memory config: %v", err)
+	}
+	return path
+}
+
+// memoryEnv builds the standard environment for a memory E2E CLI run:
+// TELL_ME_HOME (the persona home), HOME (a temp dir, keeping the advisory
+// flock lock file out of the real home), TELL_ME_DEBUG=1 (surfaces the
+// Info-level memory_injected log on stderr — the CLI's default level is
+// Warn), FAKE_PLUR_STORE, TELL_ME_MOCK_URL, and FAKE_PLUR_SEED when given.
+// The harness filters TELL_ME_* from the parent env but passes this slice
+// through to the CLI child, which forwards its own env to the stdio-spawned
+// fake.
+func memoryEnv(t *testing.T, homeDir, mockURL, storePath, seedPath string) []string {
+	t.Helper()
+	env := []string{
+		"TELL_ME_HOME=" + homeDir,
+		"HOME=" + filepath.Join(t.TempDir(), "home"),
+		"TELL_ME_DEBUG=1",
+		"FAKE_PLUR_STORE=" + storePath,
+		"TELL_ME_MOCK_URL=" + mockURL,
+	}
+	if seedPath != "" {
+		env = append(env, "FAKE_PLUR_SEED="+seedPath)
+	}
+	return env
+}
+
+// runMemoryCLI runs the CLI once against the memory config with a fresh
+// session. The caller-supplied env must include TELL_ME_HOME,
+// FAKE_PLUR_STORE and TELL_ME_MOCK_URL (see memoryEnv); FAKE_PLUR_SEED is
+// optional.
+func runMemoryCLI(t *testing.T, homeDir string, env []string, configPath, prompt string) (stdout, stderr string, err error) {
+	t.Helper()
+	return runCommandWithEnvInDir(homeDir, env, "", "-c", configPath, "--new", prompt)
+}
+
+// validateMemoryInjection asserts that an intercepted LLM request carries
+// the ## PLUR MEMORY block with the given engram id, and that the block
+// lives in a system/developer message.
+func validateMemoryInjection(t *testing.T, interceptedRequest, wantID string) {
+	t.Helper()
+	if interceptedRequest == "" {
+		t.Fatal("no request intercepted by mock server")
+	}
+	assertContains(t, interceptedRequest, "## PLUR MEMORY")
+	assertContains(t, interceptedRequest, wantID)
+
+	var req struct {
+		Messages []struct {
+			Role    string `json:"role"`
+			Content string `json:"content"`
+		} `json:"messages"`
+	}
+	if err := json.Unmarshal([]byte(interceptedRequest), &req); err != nil {
+		t.Fatalf("failed to unmarshal intercepted request: %v", err)
+	}
+	found := false
+	for _, msg := range req.Messages {
+		if (msg.Role == "system" || msg.Role == "developer") &&
+			strings.Contains(msg.Content, "## PLUR MEMORY") &&
+			strings.Contains(msg.Content, wantID) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("memory block with id %q not found in a system/developer message. Request: %s", wantID, interceptedRequest)
+	}
+}
+
+// plurStoreFile is the on-disk shape of the fake's store
+// (tests/e2e/testdata/fakeplur/main.go).
+type plurStoreFile struct {
+	Engrams []struct {
+		ID       string   `json:"id"`
+		Text     string   `json:"text"`
+		Keywords []string `json:"keywords"`
+		Pinned   bool     `json:"pinned"`
+	} `json:"engrams"`
+	Episodes []map[string]interface{} `json:"episodes"`
+}
+
+// readPlurStore reads and parses the fake's store file.
+func readPlurStore(t *testing.T, path string) plurStoreFile {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read plur store %s: %v", path, err)
+	}
+	var st plurStoreFile
+	if err := json.Unmarshal(data, &st); err != nil {
+		t.Fatalf("failed to parse plur store %s: %v", path, err)
+	}
+	return st
+}
+
+// findEngramByText returns the id of the first engram whose text exactly
+// matches, plus ok=false when none does.
+func findEngramByText(st plurStoreFile, text string) (id string, ok bool) {
+	for _, e := range st.Engrams {
+		if e.Text == text {
+			return e.ID, true
+		}
+	}
+	return "", false
+}
+
+// episodeTexts joins the "text" values of all stored episodes.
+func episodeTexts(st plurStoreFile) string {
+	var parts []string
+	for _, ep := range st.Episodes {
+		if text, ok := ep["text"].(string); ok && text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, "\n")
+}

--- a/tests/e2e/memory_injection_test.go
+++ b/tests/e2e/memory_injection_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestE2EMemoryInjection_PinnedEngramInjected is Leg (i) of the two-legged
+// PLUR memory E2E (ADR-068 §8 / issue #1404): a pinned engram seeded
+// out-of-band must be injected into a fresh persona's context on an
+// UNRELATED task — proving pinned engrams bypass the fake server's
+// relevance gate and that the whole plumbing (config → DI → stdio spawn →
+// plur_inject_hybrid → context transformer → system prompt) works offline
+// end-to-end. LEARN is off, so no learning happens in this leg.
+//
+// Surfaces asserted (ADR-068 §8 observability):
+//   - the intercepted LLM request carries the ## PLUR MEMORY block with the
+//     pinned engram id (in-process/telemetry surface);
+//   - stderr carries the Info-level memory_injected log (black-box surface;
+//     TELL_ME_DEBUG=1 in memoryEnv lowers the CLI's default Warn level).
+func TestE2EMemoryInjection_PinnedEngramInjected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+	t.Parallel()
+
+	server, reqChan := setupMockLLMServer(t)
+	fakePlur := buildFakePlur(t)
+
+	storePath := filepath.Join(t.TempDir(), "plur-store.json")
+	seedPath := writeSeedFile(t, filepath.Join(t.TempDir(), "plur-seed.json"),
+		[]map[string]interface{}{
+			{
+				"id":       "e2e-pinned-1",
+				"text":     "Always use the E2E_MEMORY convention in test code.",
+				"keywords": []interface{}{"unrelated-keyword"},
+				"pinned":   true,
+			},
+		})
+
+	homeDir := t.TempDir()
+	configPath := memoryE2EConfig(t, server.URL, fakePlur, "off")
+	env := memoryEnv(t, homeDir, server.URL, storePath, seedPath)
+
+	// The prompt is deliberately unrelated to the seeded engram: only the
+	// pinned flag can select it.
+	stdout, stderr, err := runMemoryCLI(t, homeDir, env, configPath, "Write a hello world program")
+	if err != nil {
+		t.Fatalf("CLI failed: %v\nStderr: %s\nStdout: %s", err, stderr, stdout)
+	}
+
+	// In-process/telemetry surface: the mock LLM request carries the memory
+	// block with the pinned engram id.
+	interceptedRequest := <-reqChan
+	validateMemoryInjection(t, interceptedRequest, "e2e-pinned-1")
+
+	// Black-box surface: the Info-level memory_injected log renders on
+	// stderr with the injected engram id (slog text handler: msg=memory_injected
+	// engrams=e2e-pinned-1 — the in-process warning string is
+	// injected_engrams:e2e-pinned-1, ADR-068 §8).
+	errOut := stripANSI(stderr)
+	assertContains(t, errOut, "memory_injected")
+	assertContains(t, errOut, "e2e-pinned-1")
+
+	// The fake ran: it created the store file at startup even though LEARN
+	// is off (no mutations in this leg).
+	if _, statErr := os.Stat(storePath); statErr != nil {
+		t.Fatalf("fake plur store file %s was not created (fake did not run): %v", storePath, statErr)
+	}
+}

--- a/tests/e2e/memory_learning_test.go
+++ b/tests/e2e/memory_learning_test.go
@@ -1,0 +1,188 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+package e2e
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestE2EMemoryLearning_TeachOneInjectAnother is Leg (ii)(a) of the
+// two-legged PLUR memory E2E (ADR-068 §8 / issue #1404): a gated direct
+// learn in one persona lands in the shared store, and a second persona with
+// a FRESH home but the SAME store receives it via plur_inject_hybrid.
+//
+// Persona A (LEARN: full) teaches with a "please remember" correction frame
+// → the hook's gated plur_learn fires and persists a fakeplur-<n> engram.
+// Persona B (LEARN: full, fresh home, same FAKE_PLUR_STORE) asks a
+// semantically adjacent question (no correction frame → no new learn) and
+// receives the learned engram in its context. The subtests sharing one
+// store file run sequentially — never t.Parallel.
+func TestE2EMemoryLearning_TeachOneInjectAnother(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+
+	serverA, reqChanA := setupMockLLMServer(t)
+	fakePlur := buildFakePlur(t)
+	storePath := filepath.Join(t.TempDir(), "plur-store.json")
+	statement := "please remember: always use the LEGACY_X approach for this codebase"
+
+	// Persona A teaches into the shared store.
+	homeA := t.TempDir()
+	configA := memoryE2EConfig(t, serverA.URL, fakePlur, "full")
+	envA := memoryEnv(t, homeA, serverA.URL, storePath, "")
+	_, stderrA, err := runMemoryCLI(t, homeA, envA, configA, statement)
+	if err != nil {
+		t.Fatalf("persona A CLI failed: %v\nStderr: %s", err, stderrA)
+	}
+	// Drain persona A's intercepted request (proves the run reached the LLM).
+	if req := <-reqChanA; req == "" {
+		t.Fatal("persona A produced no intercepted LLM request")
+	}
+
+	// The gated learn landed in the shared store.
+	st := readPlurStore(t, storePath)
+	learnedID, ok := findEngramByText(st, statement)
+	if !ok {
+		t.Fatalf("statement %q not found in shared store; store: %+v", statement, st)
+	}
+	if !strings.HasPrefix(learnedID, "fakeplur-") {
+		t.Errorf("learned id %q does not match the deterministic fakeplur-<n> shape", learnedID)
+	}
+
+	// Persona B: fresh home, same store; semantically adjacent prompt with
+	// no correction frame (no new learn).
+	serverB, reqChanB := setupMockLLMServer(t)
+	homeB := t.TempDir()
+	configB := memoryE2EConfig(t, serverB.URL, fakePlur, "full")
+	envB := memoryEnv(t, homeB, serverB.URL, storePath, "")
+	_, stderrB, err := runMemoryCLI(t, homeB, envB, configB, "what should I know about LEGACY_X?")
+	if err != nil {
+		t.Fatalf("persona B CLI failed: %v\nStderr: %s", err, stderrB)
+	}
+
+	intercepted := <-reqChanB
+	validateMemoryInjection(t, intercepted, learnedID)
+
+	errOutB := stripANSI(stderrB)
+	assertContains(t, errOutB, "memory_injected")
+	assertContains(t, errOutB, learnedID)
+}
+
+// TestE2EMemoryLearning_BatchFlushAtSessionEnd is Leg (ii)(a2): it proves
+// the session-end plur_learn_batch flush end-to-end. With LEARN: batch and
+// a plain prompt (no correction frame), the hook buffers the turn's episode
+// and Chat's `defer FlushSession` (internal/agent/agent.go) drains the ring
+// buffer on the success path — the plur_learn_batch payload lands in the
+// store's episodes section before the CLI process exits.
+func TestE2EMemoryLearning_BatchFlushAtSessionEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+
+	server, reqChan := setupMockLLMServer(t)
+	fakePlur := buildFakePlur(t)
+	storePath := filepath.Join(t.TempDir(), "plur-store.json")
+
+	homeDir := t.TempDir()
+	configPath := memoryE2EConfig(t, server.URL, fakePlur, "batch")
+	env := memoryEnv(t, homeDir, server.URL, storePath, "")
+
+	_, stderr, err := runMemoryCLI(t, homeDir, env, configPath, "summarize the session notes")
+	if err != nil {
+		t.Fatalf("CLI failed: %v\nStderr: %s", err, stderr)
+	}
+	// Drain the intercepted request (proves the run reached the LLM).
+	if req := <-reqChan; req == "" {
+		t.Fatal("CLI produced no intercepted LLM request")
+	}
+
+	// The defer FlushSession fired on the success path: the store's episodes
+	// section is non-empty and contains the model response text (the mock
+	// always answers "I will write a Go function.").
+	st := readPlurStore(t, storePath)
+	if len(st.Episodes) == 0 {
+		t.Fatal("expected batch episodes in the store after session end; plur_learn_batch did not land")
+	}
+	if texts := episodeTexts(st); !strings.Contains(texts, "I will write a Go function.") {
+		t.Errorf("stored episodes do not contain the model response text; episodes: %q", texts)
+	}
+}
+
+// TestE2EMemoryLearning_BestEffortSemanticAdjacency is Leg (ii)(b): a
+// semantically-adjacent-but-not-self-revealing prompt in persona B surfaces
+// the learned engram. The fake's selection is a deterministic case-insensitive
+// keyword substring gate, so the match is crafted to be deterministic: the
+// learned statement's keywords include "gizmo" and persona B's prompt shares
+// that keyword ("is the GIZMO flag needed?") without repeating the full
+// instruction.
+//
+// Best-effort posture per the issue's acceptance criteria: this leg is
+// explicitly NON-GATING. On a miss the test logs the reason and re-runs
+// persona B ONCE (the documented re-run allowance); if the re-run also
+// misses it logs that the allowance is exhausted and PASSES — it never
+// calls t.Fail for a missed injection. The stderr assertion (the
+// memory_injected Info log carrying the learned id) runs only after a
+// successful injection.
+func TestE2EMemoryLearning_BestEffortSemanticAdjacency(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow E2E test in short mode")
+	}
+
+	serverA, reqChanA := setupMockLLMServer(t)
+	fakePlur := buildFakePlur(t)
+	storePath := filepath.Join(t.TempDir(), "plur-store.json")
+	statement := "please remember: the GIZMO flag must be set for cache-busting"
+
+	// Persona A teaches.
+	homeA := t.TempDir()
+	configA := memoryE2EConfig(t, serverA.URL, fakePlur, "full")
+	envA := memoryEnv(t, homeA, serverA.URL, storePath, "")
+	_, stderrA, err := runMemoryCLI(t, homeA, envA, configA, statement)
+	if err != nil {
+		t.Fatalf("persona A CLI failed: %v\nStderr: %s", err, stderrA)
+	}
+	if req := <-reqChanA; req == "" {
+		t.Fatal("persona A produced no intercepted LLM request")
+	}
+	st := readPlurStore(t, storePath)
+	learnedID, ok := findEngramByText(st, statement)
+	if !ok {
+		t.Fatalf("statement %q not learned into the shared store; store: %+v", statement, st)
+	}
+
+	// Persona B: adjacent prompt sharing the "GIZMO" keyword.
+	runPersonaB := func() string {
+		serverB, reqChanB := setupMockLLMServer(t)
+		homeB := t.TempDir()
+		configB := memoryE2EConfig(t, serverB.URL, fakePlur, "full")
+		envB := memoryEnv(t, homeB, serverB.URL, storePath, "")
+		_, stderrB, err := runMemoryCLI(t, homeB, envB, configB, "is the GIZMO flag needed?")
+		if err != nil {
+			t.Fatalf("persona B CLI failed: %v\nStderr: %s", err, stderrB)
+		}
+		intercepted := <-reqChanB
+		if !strings.Contains(intercepted, "## PLUR MEMORY") || !strings.Contains(intercepted, learnedID) {
+			t.Logf("persona B run missed injection of %q (intercepted request lacks the learned id)", learnedID)
+			return ""
+		}
+		return stripANSI(stderrB)
+	}
+
+	errOutB := runPersonaB()
+	if errOutB == "" {
+		// Documented re-run allowance: exactly one re-run, then log-and-pass.
+		t.Logf("best-effort leg (ii)(b) missed on the first persona B run (learned id %q); exercising the documented re-run allowance", learnedID)
+		errOutB = runPersonaB()
+	}
+	if errOutB == "" {
+		t.Logf("best-effort leg did not converge; documented re-run allowance exhausted (learned id %q never injected) — passing per acceptance criteria", learnedID)
+		return
+	}
+
+	assertContains(t, errOutB, "memory_injected")
+	assertContains(t, errOutB, learnedID)
+}

--- a/tests/e2e/memory_live_test.go
+++ b/tests/e2e/memory_live_test.go
@@ -1,0 +1,93 @@
+//go:build e2e_live
+
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Live legs for the PLUR memory integration (ADR-068 §8): these tests are
+// compiled only under -tags=e2e_live and are skipped by default — they are
+// never part of make check-full, which must stay 100% offline.
+//
+// Environment verification procedure:
+//
+//	go test -tags=e2e_live ./tests/e2e/ -run TestLivePlur -v
+//
+// Prerequisites: Node/npx + network access, and a MEMORY.SERVER: plur
+// config pointing at a real `npx -y @plur-ai/mcp` server. Seed a pinned
+// engram out-of-band via the PLUR CLI (`plur learn` / store edit) — the
+// documented no-pin-tool step (ADR-068 §13) — then verify it is injected.
+//
+// Posture: best-effort, log-and-pass — never a hard gate. Either
+// memory_injected (Info) or memory_injection_failed (Warn) in stderr proves
+// the injector reached the real server and the handshake happened.
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// liveMemoryE2EConfig writes a config identical to memoryE2EConfig except
+// that MCP_SERVERS.plur launches the real `npx -y @plur-ai/mcp` server.
+func liveMemoryE2EConfig(t *testing.T, mockURL string) string {
+	t.Helper()
+	content := fmt.Sprintf(`
+MODE: "assistant"
+SELECTED_PROVIDER: "mock"
+PROVIDERS:
+  mock:
+    TYPE: "openai"
+    URL: "%s"
+    API_KEY: "dummy"
+    MODEL: "gpt-4"
+MCP_SERVERS:
+  plur:
+    COMMAND: "npx"
+    ARGS: ["-y", "@plur-ai/mcp"]
+MEMORY:
+  ENABLED: true
+  SERVER: "plur"
+  INJECT_BUDGET: 2000
+  LEARN: "off"
+`, mockURL)
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write live memory config: %v", err)
+	}
+	return path
+}
+
+// TestLivePlurMemoryInjection verifies the real PLUR handshake against a
+// live npx-spawned server. Best-effort: any outcome (run failure, absent
+// surface, or observed handshake) is logged and passed — this test never
+// gates the build.
+func TestLivePlurMemoryInjection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping slow live E2E test in short mode")
+	}
+
+	server, _ := setupMockLLMServer(t)
+	homeDir := t.TempDir()
+	configPath := liveMemoryE2EConfig(t, server.URL)
+	env := []string{
+		"TELL_ME_HOME=" + homeDir,
+		"HOME=" + filepath.Join(t.TempDir(), "home"),
+		"TELL_ME_DEBUG=1", // surface the Info-level memory_injected log
+		"TELL_ME_MOCK_URL=" + server.URL,
+	}
+
+	_, stderr, err := runMemoryCLI(t, homeDir, env, configPath, "Write a hello world program")
+	if err != nil {
+		t.Logf("live PLUR run did not complete (npx/network unavailable?): %v\nStderr: %s", err, stripANSI(stderr))
+		return // log-and-pass — never a hard gate
+	}
+
+	errOut := stripANSI(stderr)
+	if strings.Contains(errOut, "memory_injected") || strings.Contains(errOut, "memory_injection_failed") {
+		t.Logf("live PLUR handshake verified: the injector reached the real npx server (memory_injected / memory_injection_failed observed)")
+		return
+	}
+	t.Logf("live PLUR run completed but no injector surface was observed in stderr; check the environment procedure (seeded pinned engram + MEMORY.SERVER: plur). Stderr:\n%s", errOut)
+}

--- a/tests/e2e/testdata/fakeplur/main.go
+++ b/tests/e2e/testdata/fakeplur/main.go
@@ -1,0 +1,497 @@
+// Copyright (c) 2026 gosharplite@gmail.com
+// SPDX-License-Identifier: MIT
+
+// Command fakeplur is a stdio MCP server that stands in for the PLUR MCP
+// server in the offline two-legged E2E suite (issue #1404 / ADR-068). It
+// speaks raw newline-delimited JSON-RPC over stdin/stdout with the Go
+// standard library only — it must never import the MCP SDK
+// (verify-mcp-sdk-confinement greps the whole repo except
+// internal/infrastructure/mcp/).
+//
+// It implements the six tools the tell-me-go memory integration touches:
+// plur_inject_hybrid, plur_learn, plur_capture, plur_learn_batch,
+// plur_recall, plur_status. In-memory state is guarded by a mutex and
+// persisted to the file named by FAKE_PLUR_STORE (atomic write: temp file +
+// rename, after every mutation). Out-of-band pinned engrams are seeded from
+// the JSON file named by FAKE_PLUR_SEED — the documented no-pin-tool E2E
+// setup step (ADR-068 §13). Ids are deterministic (fakeplur-<counter>);
+// no randomness is used.
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// engram is one memory record in the fake store.
+type engram struct {
+	ID       string   `json:"id"`
+	Text     string   `json:"text"`
+	Keywords []string `json:"keywords,omitempty"`
+	Pinned   bool     `json:"pinned"`
+	Agent    string   `json:"agent,omitempty"`
+	Scope    string   `json:"scope,omitempty"`
+}
+
+// episode is one captured learning episode (mirrors the plur_learn_batch
+// wire contract defined by internal/agent/memory/buffer.go episode).
+type episode struct {
+	Agent     string    `json:"agent,omitempty"`
+	SessionID string    `json:"session_id,omitempty"`
+	Text      string    `json:"text,omitempty"`
+	Error     string    `json:"error,omitempty"`
+	Prompt    string    `json:"prompt,omitempty"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// store is the persisted fake state.
+type store struct {
+	Engrams  []engram  `json:"engrams"`
+	Episodes []episode `json:"episodes"`
+	Counter  int       `json:"counter"`
+}
+
+// server owns the fake's state and the store file path.
+type server struct {
+	mu        sync.Mutex // guards store
+	store     store
+	storePath string
+}
+
+// rpcMessage is a JSON-RPC 2.0 message as received from the client. The id
+// is kept raw so numeric and string ids are echoed back verbatim.
+type rpcMessage struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+// rpcResponse is a JSON-RPC 2.0 response written back to the client.
+type rpcResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  interface{}     `json:"result,omitempty"`
+	Error   *rpcError       `json:"error,omitempty"`
+}
+
+// rpcError is a JSON-RPC protocol-level error object.
+type rpcError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func main() {
+	storePath := os.Getenv("FAKE_PLUR_STORE")
+	seedPath := os.Getenv("FAKE_PLUR_SEED")
+
+	s := newServer(storePath, seedPath)
+	if err := s.run(); err != nil {
+		fmt.Fprintf(os.Stderr, "fakeplur: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// newServer loads any existing store, merges the out-of-band pinned seed
+// engrams, and ensures the store file exists even when the session performs
+// no mutations (the leg (i) "the fake ran" assertion depends on this).
+func newServer(storePath, seedPath string) *server {
+	s := &server{
+		store:     store{Engrams: []engram{}, Episodes: []episode{}},
+		storePath: storePath,
+	}
+	if storePath != "" {
+		if data, err := os.ReadFile(storePath); err == nil {
+			_ = json.Unmarshal(data, &s.store)
+		}
+		if s.store.Engrams == nil {
+			s.store.Engrams = []engram{}
+		}
+		if s.store.Episodes == nil {
+			s.store.Episodes = []episode{}
+		}
+		// Defensive: never mint an id that already exists in a hand-edited
+		// store (the counter is authoritative for ids we mint ourselves).
+		if s.store.Counter < len(s.store.Engrams) {
+			s.store.Counter = len(s.store.Engrams)
+		}
+	}
+	if seedPath != "" {
+		if data, err := os.ReadFile(seedPath); err == nil {
+			var seeds []engram
+			if json.Unmarshal(data, &seeds) == nil {
+				s.mu.Lock()
+				known := make(map[string]struct{}, len(s.store.Engrams))
+				for _, e := range s.store.Engrams {
+					known[e.ID] = struct{}{}
+				}
+				for _, seed := range seeds {
+					if _, dup := known[seed.ID]; dup {
+						continue
+					}
+					s.store.Engrams = append(s.store.Engrams, seed)
+					known[seed.ID] = struct{}{}
+				}
+				s.mu.Unlock()
+			}
+		}
+	}
+	if storePath != "" {
+		_ = s.persist()
+	}
+	return s
+}
+
+// run reads newline-delimited JSON-RPC messages from stdin until EOF and
+// writes single-line responses to stdout, flushing after every write.
+func (s *server) run() error {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	writer := bufio.NewWriter(os.Stdout)
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		resp, respond := s.handleLine(line)
+		if !respond {
+			continue
+		}
+		data, err := json.Marshal(resp)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(append(data, '\n')); err != nil {
+			return err
+		}
+		if err := writer.Flush(); err != nil {
+			return err
+		}
+	}
+	return scanner.Err()
+}
+
+// handleLine parses one JSON-RPC message and produces the response (plus
+// whether a response is expected). Notifications (no id) never receive a
+// response, per JSON-RPC 2.0.
+func (s *server) handleLine(line string) (rpcResponse, bool) {
+	var msg rpcMessage
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		return rpcResponse{JSONRPC: "2.0", Error: &rpcError{Code: -32700, Message: "parse error"}}, true
+	}
+
+	if len(msg.ID) == 0 || string(msg.ID) == "null" {
+		return rpcResponse{}, false // notification
+	}
+
+	switch msg.Method {
+	case "initialize":
+		return rpcResponse{JSONRPC: "2.0", ID: msg.ID, Result: map[string]interface{}{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]interface{}{"tools": map[string]interface{}{}},
+			"serverInfo":      map[string]interface{}{"name": "fakeplur", "version": "1.0.0"},
+		}}, true
+	case "ping":
+		return rpcResponse{JSONRPC: "2.0", ID: msg.ID, Result: map[string]interface{}{}}, true
+	case "tools/list":
+		return rpcResponse{JSONRPC: "2.0", ID: msg.ID, Result: map[string]interface{}{
+			"tools": s.toolDefinitions(),
+		}}, true
+	case "tools/call":
+		return s.handleToolCall(msg), true
+	default:
+		return rpcResponse{JSONRPC: "2.0", ID: msg.ID,
+			Error: &rpcError{Code: -32601, Message: "method not found: " + msg.Method}}, true
+	}
+}
+
+// toolDefinitions returns the six tool declarations advertised by the fake.
+func (s *server) toolDefinitions() []map[string]interface{} {
+	names := []string{
+		"plur_inject_hybrid",
+		"plur_learn",
+		"plur_capture",
+		"plur_learn_batch",
+		"plur_recall",
+		"plur_status",
+	}
+	tools := make([]map[string]interface{}, 0, len(names))
+	for _, n := range names {
+		tools = append(tools, map[string]interface{}{
+			"name":        n,
+			"description": "fake PLUR tool for offline E2E",
+			"inputSchema": map[string]interface{}{"type": "object"},
+		})
+	}
+	return tools
+}
+
+// handleToolCall dispatches a tools/call request. Unknown tool names return
+// an MCP-level tool error (isError true with an error text), mirroring the
+// SDK's toolError convention so the caller sees a non-terminal ToolResult.
+func (s *server) handleToolCall(msg rpcMessage) rpcResponse {
+	var params struct {
+		Name      string          `json:"name"`
+		Arguments json.RawMessage `json:"arguments"`
+	}
+	if len(msg.Params) > 0 {
+		_ = json.Unmarshal(msg.Params, &params)
+	}
+	var args map[string]interface{}
+	if len(params.Arguments) > 0 && string(params.Arguments) != "null" {
+		_ = json.Unmarshal(params.Arguments, &args)
+	}
+	if args == nil {
+		args = map[string]interface{}{}
+	}
+
+	text, isErr := s.dispatchTool(params.Name, args)
+	return rpcResponse{JSONRPC: "2.0", ID: msg.ID, Result: map[string]interface{}{
+		"content": []map[string]interface{}{{"type": "text", "text": text}},
+		"isError": isErr,
+	}}
+}
+
+// dispatchTool routes a tool call to its handler and returns the result
+// text plus whether the call was an error.
+func (s *server) dispatchTool(name string, args map[string]interface{}) (string, bool) {
+	switch name {
+	case "plur_inject_hybrid", "plur_recall":
+		task := strArg(args, "task")
+		if task == "" {
+			task = strArg(args, "query")
+		}
+		return s.recall(task), false
+	case "plur_learn":
+		return s.learn(args), false
+	case "plur_capture":
+		return s.capture(args), false
+	case "plur_learn_batch":
+		return s.learnBatch(args), false
+	case "plur_status":
+		return s.status(), false
+	default:
+		return "unknown tool: " + name, true
+	}
+}
+
+// recall implements the shared inject/recall selection: pinned engrams
+// always; non-pinned engrams when any keyword is a case-insensitive
+// substring of the task. Pinned engrams come first, then non-pinned, both
+// in store insertion order.
+func (s *server) recall(task string) string {
+	lowerTask := strings.ToLower(task)
+
+	s.mu.Lock()
+	var pinned, matched []engram
+	for _, e := range s.store.Engrams {
+		if e.Pinned {
+			pinned = append(pinned, e)
+			continue
+		}
+		if keywordMatches(e.Keywords, lowerTask) {
+			matched = append(matched, e)
+		}
+	}
+	selected := append(pinned, matched...)
+	s.mu.Unlock()
+
+	if len(selected) == 0 {
+		return "No relevant memory."
+	}
+
+	var b strings.Builder
+	for i, e := range selected {
+		if i > 0 {
+			b.WriteString("\n\n")
+		}
+		// The engram_id: line satisfies the injector's documented regex
+		// fallback for extracting ids from ToolResult.Text when
+		// Metadata["ids"] is absent (internal/agent/memory/injector.go).
+		fmt.Fprintf(&b, "engram_id: %s\n%s", e.ID, e.Text)
+	}
+	return b.String()
+}
+
+// learn mints a deterministic fakeplur-<counter> id, stores the statement
+// as a non-pinned engram, and persists.
+func (s *server) learn(args map[string]interface{}) string {
+	statement := strArg(args, "statement")
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.Counter++
+	id := fmt.Sprintf("fakeplur-%d", s.store.Counter)
+	s.store.Engrams = append(s.store.Engrams, engram{
+		ID:       id,
+		Text:     statement,
+		Keywords: keywordsOf(statement),
+		Agent:    strArg(args, "agent"),
+		Scope:    strArg(args, "scope"),
+	})
+	s.persistLocked()
+	return "learned " + id
+}
+
+// capture appends one episode record to the store and persists.
+func (s *server) capture(args map[string]interface{}) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.store.Episodes = append(s.store.Episodes, episode{
+		Agent:     strArg(args, "agent"),
+		SessionID: strArg(args, "session_id"),
+		Text:      strArg(args, "text"),
+		Error:     strArg(args, "error"),
+		Prompt:    strArg(args, "prompt"),
+		Timestamp: time.Now(),
+	})
+	s.persistLocked()
+	return "captured"
+}
+
+// learnBatch appends each episode to the store's episodes section and
+// learns each non-empty episode as an engram too (so a later recall can
+// find it), then persists.
+func (s *server) learnBatch(args map[string]interface{}) string {
+	var episodes []map[string]interface{}
+	if raw, ok := args["episodes"].([]interface{}); ok {
+		for _, e := range raw {
+			if m, ok := e.(map[string]interface{}); ok {
+				episodes = append(episodes, m)
+			}
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, m := range episodes {
+		ep := episode{
+			Agent:     strArg(m, "agent"),
+			SessionID: strArg(m, "session_id"),
+			Text:      strArg(m, "text"),
+			Error:     strArg(m, "error"),
+			Prompt:    strArg(m, "prompt"),
+			Timestamp: time.Now(),
+		}
+		s.store.Episodes = append(s.store.Episodes, ep)
+		if strings.TrimSpace(ep.Text) != "" {
+			s.store.Counter++
+			s.store.Engrams = append(s.store.Engrams, engram{
+				ID:       fmt.Sprintf("fakeplur-%d", s.store.Counter),
+				Text:     ep.Text,
+				Keywords: keywordsOf(ep.Text),
+				Agent:    ep.Agent,
+			})
+		}
+	}
+	s.persistLocked()
+	return fmt.Sprintf("learned %d episodes", len(episodes))
+}
+
+// status reports the store's engram/episode counts.
+func (s *server) status() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return fmt.Sprintf("fakeplur status: engrams=%d episodes=%d", len(s.store.Engrams), len(s.store.Episodes))
+}
+
+// persist writes the store to disk atomically (temp + rename). Callers
+// must hold s.mu.
+func (s *server) persistLocked() {
+	if s.storePath == "" {
+		return
+	}
+	if err := atomicWrite(s.storePath, s.store); err != nil {
+		fmt.Fprintf(os.Stderr, "fakeplur: persist: %v\n", err)
+	}
+}
+
+// persist is the lock-taking wrapper used at startup.
+func (s *server) persist() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.storePath == "" {
+		return nil
+	}
+	return atomicWrite(s.storePath, s.store)
+}
+
+// atomicWrite marshals v to JSON and replaces path via a temp file +
+// rename, so a crash never leaves a truncated store.
+func atomicWrite(path string, v interface{}) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".fakeplur-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	if _, err := tmp.Write(append(data, '\n')); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		_ = os.Remove(tmpName)
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// keywordMatches reports whether any keyword is a case-insensitive
+// substring of lowerTask. The caller lowercases task beforehand.
+func keywordMatches(keywords []string, lowerTask string) bool {
+	for _, k := range keywords {
+		if k != "" && strings.Contains(lowerTask, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// keywordsOf derives the deterministic keyword list from a statement:
+// lowercased words split on non-alphanumerics, deduplicated, order
+// preserving. Mirrors the PLUR store's documented keyword extraction
+// contract for the fake (ADR-068 two-legged E2E).
+func keywordsOf(text string) []string {
+	lower := strings.ToLower(text)
+	fields := strings.FieldsFunc(lower, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+	})
+	seen := make(map[string]struct{}, len(fields))
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if f == "" {
+			continue
+		}
+		if _, dup := seen[f]; dup {
+			continue
+		}
+		seen[f] = struct{}{}
+		out = append(out, f)
+	}
+	return out
+}
+
+// strArg reads a string argument from a decoded JSON object.
+func strArg(args map[string]interface{}, key string) string {
+	if v, ok := args[key]; ok {
+		if s, ok := v.(string); ok {
+			return s
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Closes #1404.

## Summary

Implements **automatic PLUR memory integration** for tell-me-go (ADR-068): relevant engrams are injected into the context before each turn, and learnings/episodes are captured after each turn — via two extension seams:

- **Seam A — `plurInjector`** (`internal/agent/memory`, `sessctx.ContextTransformer`, priority 15): marker-keyed replace-in-place (`## PLUR MEMORY` / `[/PLUR-MEMORY]`), stateless content-driven strip-on-disable, fetch-per-turn `plur_inject_hybrid`, fail-open with strip semantics, defensive budget trim, `injected_engrams:` observability (in-process warnings + Info log + `TurnTrace.Warnings`).
- **Seam B — `plurHook`** (`orchestrator.TurnHook`, registered once at `initComponents`): three-way classification keyed on the hook `err`, `!IsTransient` filter, detached 3s ctx, four-tier `LEARN` (`off|capture|batch|full`, default `batch`) with a bounded per-session ring buffer + `FlushSession` defer, gated `full` tier (frame matcher + cap 3 + sha256 dedupe), advisory non-blocking flock (Unix-only), fail-open everywhere.
- **Config**: `MEMORY` section (`MemoryConfig` + `MemoryLearnTier`), hot-reloadable via `ConfigWatcher.GetMemoryConfig()` + atomic `runtimeConfig.Memory`; default disabled → zero behavior change; two-stage enabled-but-absent-server fallback.
- **DI**: `ChatterComposer.GetMCPClient(name)` + `ChatterConfig.MemoryServer` + factory stash + `agent.WithMemoryClient` — zero ADR-029 changes.
- **Governance**: `Memory` entity + `MemoryLearnTier` enum + 4 invariants + scenario in the domain model; `modelith-layers.sh` exceptions; ADR-068 indexed + linked.
- **E2E**: two-legged offline suite (fake plur stdio MCP server, stdlib only) — leg (i) pinned-engram injection, leg (ii) teach-in-one-persona → inject-in-another + batch flush + best-effort adjacency; live legs behind `-tags=e2e_live`.

The design was adversarially reviewed in two grill rounds (issue #1402 → #1403); all decisions are settled in issue #1404 and ADR-068 (14-row corrections table).

## Acceptance-criteria mapping

| Issue criterion | Where |
|---|---|
| ADR-068 at `docs/adr/2026-09-automatic-plur-memory-integration.md`, indexed + linked (`verify-adr-index`) | commit `dc23e7e7` |
| `MemoryConfig` parse/validate, two-stage fallback, hot-reload via `ConfigWatcher.GetMemoryConfig()` + atomic `runtimeConfig.Memory`, nil-client guard | commits `68b2f6b0`, `afb9d55c` |
| `ChatterComposer.GetMCPClient` + `ChatterConfig` server key + factory stash + `agent.WithMemoryClient`; zero ADR-029 changes | commit `368852f5` |
| `plurInjector`: priority 15, stateless strip, marker replace, fetch-per-turn, fail-open, token-counted, observability + `TurnTrace.Warnings` | commits `dedde26b`, `afb9d55c` |
| `plurHook`: once-at-init, three-way classification + `!IsTransient` + detached 3s ctx, four-tier `LEARN`, ring buffer + `FlushSession`, gated `full`, advisory flock, fail-open | commit `dedde26b` |
| Domain model: `Memory` entity, `MemoryLearnTier`, 4 invariants, scenario; `modelith-layers.sh` exceptions; yaml+md committed together | commit `b3d0296c` |
| Tests: race-safe `MockMCPClient`, `FakeClock`, zero `time.Sleep`/testify/SDK-outside-infra; `test-race` green | commit `dedde26b` |
| Two-legged E2E with offline fake plur server; live legs behind `-tags=e2e_live` | commit `4f7d5d7c` |

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, vulncheck, test, dead-code, test-race, test-coverage) | ✅ PASS (all checks incl. race detection) |
| `make verify-nonfix-catalog` (complexity + coverage pins) | ✅ PASS |
| `make verify-transitive-gate` (ADR-056 STRICT) | ✅ PASS |
| `make verify-ports-registry` / `verify-mcp-sdk-confinement` / `verify-no-test-sleep` / `verify-mock-pattern` | ✅ PASS |
| `make modelith-lint` / `modelith-check` / `modelith-layers` | ✅ PASS (Memory documented exception; no enum warning) |
| E2E legs (i) + (ii) offline | ✅ PASS (4/4) |
| 100% offline | ✅ (fake plur server locally compiled; live legs excluded by default) |

## Operational notes

- E2E binary cache at `~/.cache/tell-me-go/e2e-binary/` was refreshed (a stale pre-wiring binary caused a one-time failure; cleared and rebuilt).
- Fixups on top of the 7 task commits: `dbc80b20` (lint errcheck), `a7da9a97` (catalog pin re-anchor + noOp `GetMemoryConfig` coverage), `5169609e` (8 PLUR-memory complexity alerts cataloged with partition rows).
