### PR TITLE
fix(memory): gate memory_server_unavailable warn on Enabled master switch (#1424)

### DIFF
--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -168,7 +168,7 @@ func (a *agent) initComponents() error {
 	// absent-server → warn and disable (two-stage fallback): a nil client
 	// yields an inert, stable DI shape; the runtime nil-client guards fail
 	// open.
-	if a.memoryClient != nil || a.memorySeed.Server != "" {
+	if a.memoryClient != nil || (a.memorySeed.Enabled && a.memorySeed.Server != "") {
 		if a.memoryClient == nil {
 			a.getLogger().Warn("memory_server_unavailable", "server", a.memorySeed.Server)
 			a.memorySeed.Enabled = false // effective disable — inert DI shape

--- a/internal/agent/memory_wiring_test.go
+++ b/internal/agent/memory_wiring_test.go
@@ -91,6 +91,26 @@ func TestNewAgent_NoMemory_NoWarnNoComponents(t *testing.T) {
 	}
 }
 
+// TestNewAgent_DefaultMemoryConfig_NoWarnNoComponents verifies the real
+// production default shape (issue #1424): a config with no MEMORY block
+// yields DefaultMemoryConfig() — Enabled:false, Server:"plur" — wired via
+// WithMemoryClient(nil, seed) from chatter.go:88. The wiring guard must key
+// on the Enabled master switch, not the defaulted server name: no
+// memory_server_unavailable warn and no memory components. Fails pre-fix
+// (the old Server != "" guard warned and constructed inert components).
+func TestNewAgent_DefaultMemoryConfig_NoWarnNoComponents(t *testing.T) {
+	seed := domain_config.DefaultMemoryConfig() // {Enabled:false, Server:"plur", batch, 2000, 3}
+
+	_, a, spy := newMemoryTestAgent(t, WithMemoryClient(nil, seed))
+
+	if spy.CalledWith("Warn", "memory_server_unavailable") {
+		t.Error("expected NO memory_server_unavailable warn for default (unconfigured) memory")
+	}
+	if a.memoryHook != nil {
+		t.Error("expected memoryHook nil when memory is not configured (default config)")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // T4: Chat session-end memory write-failure surfacing (issue #1410 §4)
 // ---------------------------------------------------------------------------

--- a/internal/infrastructure/mcp/stdio_client.go
+++ b/internal/infrastructure/mcp/stdio_client.go
@@ -112,6 +112,17 @@ func NewStdioClient(cfg config.MCPServerConfig, logger *slog.Logger) (*StdioClie
 	session, err := sdk.Connect(connectCtx, &sdkmcp.IOTransport{Reader: stdout, Writer: stdin}, nil)
 	cancelConnect()
 	if err != nil {
+		// The SDK can surface its teardown EOF ("client is closing: EOF")
+		// when the connect deadline fires mid-initialize, losing the
+		// timeout signal. Normalize at the adapter boundary: a handshake
+		// that exceeded its bound IS a timeout. Preserves the documented
+		// wedge-vs-death taxonomy (deadline = wedge; EOF/exited = death) —
+		// pinned by TestStdio_HandshakeTimeoutKillsChild. The child-death
+		// case (Connect returns before the deadline, connectCtx.Err() == nil)
+		// is left untouched.
+		if connectCtx.Err() == context.DeadlineExceeded && !errors.Is(err, context.DeadlineExceeded) {
+			err = fmt.Errorf("%w (handshake exceeded %s): %v", context.DeadlineExceeded, timeout, err)
+		}
 		// Self-clean, never leak the child: cancel kills the direct child via
 		// CommandContext, then join the reaper before returning.
 		cancel()

--- a/internal/infrastructure/mcp/testdata/stdioserver/main.go
+++ b/internal/infrastructure/mcp/testdata/stdioserver/main.go
@@ -185,8 +185,15 @@ func launcher() {
 
 // neverInit writes nothing to stdout and blocks forever: the MCP handshake
 // never completes, pinning the constructor's handshake-timeout kill path.
+// A bare `select {}` in the main goroutine trips the Go runtime deadlock
+// detector (fatal error: all goroutines are asleep - deadlock!), killing
+// the process instantly — an EOF child-death, not the alive-but-silent
+// wedge the handshake-timeout test intends. Sleeping keeps the runtime's
+// timer heap live, so the child stays alive and silent until the client's
+// bounded connect times out and kills it (CommandContext cancel); the
+// client reaps the child before returning — no leak.
 func neverInit() {
-	select {}
+	time.Sleep(time.Hour)
 }
 
 // ignoreEOF is a functioning MCP server that completes the handshake and


### PR DESCRIPTION
Fixes #1424

## Summary

Two commits, one PR, on top of `v1.9.4` (`d076bd8e`):

**1. `fix(memory): gate memory_server_unavailable warn on Enabled master switch`**

A user who never configured `MEMORY:` saw a spurious `level=WARN msg=memory_server_unavailable server=plur` on **every** session start. Root cause: `DefaultMemoryConfig()` hardcodes `Server: "plur"` with `Enabled: false`, and the wiring guard in `agent.initComponents` keyed on `Server != ""` instead of the `Enabled` master switch — so "memory not configured" was indistinguishable from "enabled with a plur server" at the wiring layer, and the ADR-068 §5 two-stage fallback (enabled-but-absent → warn and disable) fired for the *defaulted-but-absent* case too.

Fix: gate the wiring/warn on `Enabled` at `internal/agent/agent.go:171`:

```go
if a.memoryClient != nil || (a.memorySeed.Enabled && a.memorySeed.Server != "") {
```

- `MEMORY` absent (default config) → **no** warn, no memory components (inert wiring). Zero behavior change for existing users (ADR-068 §5).
- `MEMORY.ENABLED: true` + absent server → warn + effective disable (unchanged).
- `MEMORY.ENABLED: true` + healthy server → normal injection/learning (unchanged).
- `Enabled: false` + present client → components still constructed (client clause) — preserves the hot-reload-enable path.

Regression test: `TestNewAgent_DefaultMemoryConfig_NoWarnNoComponents` constructs the agent through the **real production default shape** (`DefaultMemoryConfig()` + `WithMemoryClient(nil, seed)`) and asserts no warn + no hook. It fails pre-fix and passes post-fix. The previous no-warn test never caught this because it built the agent without `WithMemoryClient` (zero-value seed) — a shape production never produces.

**2. `fix(mcp): make stdio handshake-timeout deterministic (wedge fixture + deadline normalization)`**

`make check-full` was red on a **pre-existing, unrelated** failure: `TestStdio_HandshakeTimeoutKillsChild` failed deterministically (verified on the pristine base commit) because the fixture `never-init` was a bare `select {}`, which the Go runtime deadlock detector kills instantly — an EOF child-death, not the alive-but-silent wedge the handshake-timeout test intends. The 1s handshake deadline never fired, and the SDK surfaced `client is closing: EOF` instead of `DeadlineExceeded`.

Fix, in two parts:
- **Fixture**: `neverInit` now `time.Sleep(time.Hour)` — the child stays alive and silent until the client's bounded connect times out (and is reaped — no leak).
- **Adapter boundary** (`NewStdioClient`): when the connect deadline fires and the SDK surfaces its teardown EOF instead of the context error, normalize to `context.DeadlineExceeded`, preserving the documented wedge-vs-death taxonomy (deadline = wedge; EOF/exited = death).

The strict test is untouched and is the regression proof (5/5 PASS, ~1.0s each — the deadline now fires deterministically).

## Acceptance criteria (issue #1424)

- [x] `MEMORY` absent (default config) → **no** `memory_server_unavailable` WARN; memory components inert.
- [x] `MEMORY.ENABLED: true` + absent server → WARN + effective disable (unchanged).
- [x] `MEMORY.ENABLED: true` + healthy server → normal injection/learning (unchanged).
- [x] Regression test proves the default-config no-warn path through the real config flow (fails pre-fix).
- [x] `make check-full` green; no ADR/domain-model change required.

## Verification

| Gate | Result |
|---|---|
| `make check-full` (full pipeline incl. `test-race`, package-by-package) | **PASS — "All checks passed (including race detection)"** |
| `go test ./internal/agent/ -run 'TestNewAgent_' -v` | PASS (incl. new `TestNewAgent_DefaultMemoryConfig_NoWarnNoComponents`; `TestNewAgent_MemoryEnabledAbsentServer_WarnsAndDisables` unchanged/green) |
| `go test ./internal/infrastructure/mcp/ -run TestStdio_HandshakeTimeoutKillsChild -count=5` | PASS 5/5 (~1.0s each — deadline fires deterministically) |
| `go test ./internal/infrastructure/mcp/ -count=1` / `-race -count=1` | PASS |

## Commits

- `9092954` `fix(memory): gate memory_server_unavailable warn on Enabled master switch (#1424)`
- `2f8731b` `fix(mcp): make stdio handshake-timeout deterministic (wedge fixture + deadline normalization)`

## Notes

- No ADR or domain-model changes: behavioral fix to an existing fallback (ADR-068 §5); the MCP change stays inside the ADR-067-confined adapter and its fixture.
- The MCP fix addresses a pre-existing red test (reproducible on `v1.9.4`), required to land the memory fix through the repo's hard gate.
- Related: #1414 (same defect class — `Enabled` as master switch — fixed earlier in the learning hook).
