### PR TITLE
fix(analysis): coverage report noise — line-spec agenttest helpers.go catalog refs + default get_detailed_coverage exclusions (#1433)

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -376,7 +376,14 @@ catalog a new gap no one reviewed. Policy:
   `domainFS.Chmod` already documented below.
   The `agenttest/` package is already excluded from coverage metrics by the
   Makefile `test-coverage` target.
-- **See**: `internal/agent/agenttest/helpers.go`
+- **See**: `internal/agent/agenttest/helpers.go:33-34,35,36,37-38,39-40,41-42,43,44,45,48,58-59,315-317,356,360,390,391`
+  (Re-anchored 2026-09 (#1433): the previous See ref was file-only
+  (internal/agent/agenttest/helpers.go), which the coverage matcher drops —
+  interval-overlap matching requires a line spec — so all 16 methods surfaced
+  as uncataloged gaps in detailed-coverage reports. Re-anchored to per-method
+  line refs mirroring the 2026-08 "agent/agenttest + clitest/eventstest"
+  entry's comma-list pattern; partition-test rows added in the same commit
+  per the Drift Policy coordination rule.)
 
 ### agent/agenttest + clitest/eventstest — interface-satisfying mock stubs at 0%
 

--- a/internal/tools/analysis/health.go
+++ b/internal/tools/analysis/health.go
@@ -456,6 +456,23 @@ func (m *healthManager) recommendDeadCode(dead string) string {
 	return ""
 }
 
+// defaultCoverageExclusions mirrors the Makefile test-coverage grep -v list
+// and the coverage-exclusions-explicit invariant
+// (docs/domain-model/quality.modelith.yaml): the nine documented test-double
+// directories. filterExcludedBlocks matches these as SUBSTRINGS of the
+// block's File path, so each entry carries its trailing slash.
+var defaultCoverageExclusions = []string{
+	"internal/agent/agenttest/",
+	"internal/agent/orchestrator/orchestratortest/",
+	"internal/domain/config/configtest/",
+	"internal/tools/analysis/analysistest/",
+	"internal/cli/clitest/",
+	"internal/domain/events/eventstest/",
+	"internal/infrastructure/persistence/persistencetest/",
+	"internal/tools/toolstest/",
+	"internal/infrastructure/testing/",
+}
+
 func (m *healthManager) GetDetailedCoverage(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	path, ok := args["path"].(string)
 	if !ok {
@@ -471,6 +488,13 @@ func (m *healthManager) GetDetailedCoverage(ctx context.Context, args map[string
 				}
 			}
 		}
+	} else {
+		// Default to the nine documented test-double directories so an
+		// unfiltered run matches the Makefile test-coverage gate and the
+		// coverage-exclusions-explicit invariant (issue #1433). An explicitly
+		// passed list — even an empty one — always wins; only an ABSENT
+		// argument triggers the default.
+		excludedPackages = defaultCoverageExclusions
 	}
 
 	report, err := m.getDetailedCoverageReport(ctx, path, excludedPackages, hb)

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -768,6 +768,69 @@ func TestGetDetailedCoverage_ExcludedPackages(t *testing.T) {
 	}
 }
 
+func TestGetDetailedCoverage_DefaultExclusions(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := &mockExecutor{
+		OutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("github.com/user/repo"), nil
+		},
+		CombinedOutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-coverprofile=") {
+					path := strings.TrimPrefix(arg, "-coverprofile=")
+					coverageContent := "mode: set\n" +
+						"github.com/user/repo/internal/agent/agenttest/mock_agent.go:10.0,12.0 3 0\n" +
+						"github.com/user/repo/internal/domain/config/configtest/helper.go:1.0,2.0 1 0\n" +
+						"github.com/user/repo/internal/tools/toolstest/fake.go:1.0,2.0 1 0\n" +
+						"github.com/user/repo/internal/domain/logic.go:5.0,7.0 2 0\n"
+					if err := os.WriteFile(path, []byte(coverageContent), 0644); err != nil {
+						t.Errorf("failed to write mock coverage file: %v", err)
+					}
+				}
+			}
+			return []byte("ok"), nil
+		},
+	}
+	m := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
+
+	// No excluded_packages argument → the nine documented dirs are excluded by default.
+	args := map[string]interface{}{"path": "."}
+	result, err := m.GetDetailedCoverage(ctx, args, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(result.Text, "mock_agent.go") {
+		t.Error("expected agenttest block excluded by default")
+	}
+	if strings.Contains(result.Text, "configtest") {
+		t.Error("expected configtest block excluded by default")
+	}
+	if strings.Contains(result.Text, "toolstest") {
+		t.Error("expected toolstest block excluded by default")
+	}
+	if !strings.Contains(result.Text, "logic.go") {
+		t.Error("expected logic.go to appear in report")
+	}
+	if !strings.Contains(result.Text, "Total Gaps: 1") {
+		t.Errorf("expected 1 total gap after default exclusions, got: %s", result.Text)
+	}
+
+	// An explicitly passed EMPTY list overrides the default: nothing is excluded.
+	args = map[string]interface{}{"path": ".", "excluded_packages": []interface{}{}}
+	result, err = m.GetDetailedCoverage(ctx, args, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result.Text, "mock_agent.go") {
+		t.Error("expected explicit empty excluded_packages to keep all blocks")
+	}
+	if !strings.Contains(result.Text, "Total Gaps: 4") {
+		t.Errorf("expected 4 total gaps with explicit empty exclusions, got: %s", result.Text)
+	}
+}
+
 func TestRunTestsAndCoverage_ErrorPaths(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -795,7 +795,9 @@ func TestGetDetailedCoverage_DefaultExclusions(t *testing.T) {
 	}
 	m := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
-	// No excluded_packages argument → the nine documented dirs are excluded by default.
+	// No excluded_packages argument → the nine documented dirs are excluded by
+	// default: the three test-double blocks (agenttest, configtest, toolstest)
+	// vanish and only the real block survives.
 	args := map[string]interface{}{"path": "."}
 	result, err := m.GetDetailedCoverage(ctx, args, nil)
 	if err != nil {
@@ -804,22 +806,44 @@ func TestGetDetailedCoverage_DefaultExclusions(t *testing.T) {
 	if strings.Contains(result.Text, "mock_agent.go") {
 		t.Error("expected agenttest block excluded by default")
 	}
-	if strings.Contains(result.Text, "configtest") {
-		t.Error("expected configtest block excluded by default")
-	}
-	if strings.Contains(result.Text, "toolstest") {
-		t.Error("expected toolstest block excluded by default")
-	}
 	if !strings.Contains(result.Text, "logic.go") {
 		t.Error("expected logic.go to appear in report")
 	}
 	if !strings.Contains(result.Text, "Total Gaps: 1") {
 		t.Errorf("expected 1 total gap after default exclusions, got: %s", result.Text)
 	}
+}
+
+func TestGetDetailedCoverage_ExplicitEmptyOverridesDefault(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	mock := &mockExecutor{
+		OutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			return []byte("github.com/user/repo"), nil
+		},
+		CombinedOutputFunc: func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			for _, arg := range args {
+				if strings.HasPrefix(arg, "-coverprofile=") {
+					path := strings.TrimPrefix(arg, "-coverprofile=")
+					coverageContent := "mode: set\n" +
+						"github.com/user/repo/internal/agent/agenttest/mock_agent.go:10.0,12.0 3 0\n" +
+						"github.com/user/repo/internal/domain/config/configtest/helper.go:1.0,2.0 1 0\n" +
+						"github.com/user/repo/internal/tools/toolstest/fake.go:1.0,2.0 1 0\n" +
+						"github.com/user/repo/internal/domain/logic.go:5.0,7.0 2 0\n"
+					if err := os.WriteFile(path, []byte(coverageContent), 0644); err != nil {
+						t.Errorf("failed to write mock coverage file: %v", err)
+					}
+				}
+			}
+			return []byte("ok"), nil
+		},
+	}
+	m := &healthManager{Exec: mock, Runner: toolchain.NewGoRunner(mock)}
 
 	// An explicitly passed EMPTY list overrides the default: nothing is excluded.
-	args = map[string]interface{}{"path": ".", "excluded_packages": []interface{}{}}
-	result, err = m.GetDetailedCoverage(ctx, args, nil)
+	args := map[string]interface{}{"path": ".", "excluded_packages": []interface{}{}}
+	result, err := m.GetDetailedCoverage(ctx, args, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -488,3 +488,38 @@ func TestDetailedCoverageReport_ConfigPackageCataloged(t *testing.T) {
 	catalogedIdx := strings.Index(report, "[CATALOGED GAPS (ACCEPTED)]")
 	require.Greater(t, gapIdx, catalogedIdx, "redact.go (Lines 53-55) must appear under [CATALOGED GAPS (ACCEPTED)], not as an actionable gap")
 }
+
+// TestDetailedCoverageReport_AgentTestDefaultExclusions is the end-to-end
+// regression for the option-B default: the nine documented test-double
+// directories (defaultCoverageExclusions, mirroring the Makefile test-coverage
+// grep -v list) must remove ALL agenttest blocks from the report — the
+// package is entirely test doubles, so an excluded run reports zero gaps and
+// renders no helpers.go noise. Same full report path as the sibling
+// TestDetailedCoverageReport_* tests, scoped to ./internal/agent/agenttest.
+func TestDetailedCoverageReport_AgentTestDefaultExclusions(t *testing.T) {
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	executor := &exec.RealExecutor{}
+	m := &healthManager{
+		SP:          &mockSecurityProvider{},
+		Exec:        executor,
+		Runner:      toolchain.NewGoRunner(executor),
+		clk:         clock.RealClock{},
+		catalogPath: defaultNonFixCatalogPath,
+	}
+
+	report, err := m.getDetailedCoverageReport(context.Background(), "./internal/agent/agenttest", defaultCoverageExclusions, nil)
+	require.NoError(t, err)
+
+	// Every agenttest block matches the "internal/agent/agenttest/" substring
+	// pattern, so the exclusion list removes the whole package: zero gaps.
+	require.Contains(t, report, "- Total Gaps: 0")
+	require.NotContains(t, report, "helpers.go")
+	require.NotContains(t, report, "[HIGH PRIORITY GAPS]")
+}

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -187,6 +187,22 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		{"analysistest MockSymbolIndex HarvestDeclarations stub", "internal/tools/analysis/analysistest/mock_index.go", 61, 63},
 		{"process_executor.go LookPath delegation", "internal/tools/workspace/process_executor.go", 496, 498},
 		{"darwin system_metrics GetCPUStats fallback", "internal/infrastructure/telemetry/system_metrics_darwin_cgo.go", 38, 41},
+		{"helpers.go stubUIRenderer.RenderResponse", "internal/agent/agenttest/helpers.go", 33, 34},
+		{"helpers.go stubUIRenderer.LogTurnStatus", "internal/agent/agenttest/helpers.go", 35, 35},
+		{"helpers.go stubUIRenderer.LogSystemMessage", "internal/agent/agenttest/helpers.go", 36, 36},
+		{"helpers.go stubUIRenderer.LogUsage", "internal/agent/agenttest/helpers.go", 37, 38},
+		{"helpers.go stubUIRenderer.LogToolCall", "internal/agent/agenttest/helpers.go", 39, 40},
+		{"helpers.go stubUIRenderer.LogToolResult", "internal/agent/agenttest/helpers.go", 41, 42},
+		{"helpers.go stubUIRenderer.RenderHealthReport", "internal/agent/agenttest/helpers.go", 43, 43},
+		{"helpers.go stubUIRenderer.SetUseColor", "internal/agent/agenttest/helpers.go", 44, 44},
+		{"helpers.go stubUIRenderer.SetForceSpinner", "internal/agent/agenttest/helpers.go", 45, 45},
+		{"helpers.go stubUIRenderer.SetWordWrap", "internal/agent/agenttest/helpers.go", 48, 48},
+		{"helpers.go stubHistoryRenderer.Render", "internal/agent/agenttest/helpers.go", 58, 59},
+		{"helpers.go StubChatterComposer.GetSkillRepository", "internal/agent/agenttest/helpers.go", 315, 317},
+		{"helpers.go StubEventBus.Subscribe", "internal/agent/agenttest/helpers.go", 356, 356},
+		{"helpers.go StubEventBus.WaitStarted", "internal/agent/agenttest/helpers.go", 360, 360},
+		{"helpers.go StubCapturer.Warn", "internal/agent/agenttest/helpers.go", 390, 390},
+		{"helpers.go StubCapturer.Prompt", "internal/agent/agenttest/helpers.go", 391, 391},
 	}
 
 	for _, tt := range tests {

--- a/internal/tools/analysis/registration.go
+++ b/internal/tools/analysis/registration.go
@@ -54,7 +54,7 @@ func Register(r tools.Registry, sm domain_security.Manager, bus events.EventBus,
 						"excluded_packages": {
 							Type:        "ARRAY",
 							Items:       &tools.Schema{Type: "STRING"},
-							Description: "Patterns of packages to ignore (e.g., 'agenttest', 'testing'). Matches substrings in file paths.",
+							Description: "Patterns of packages to ignore (e.g., 'agenttest', 'testing'). Matches substrings in file paths. When omitted, defaults to the nine documented test-double directories (agenttest/, orchestratortest/, configtest/, analysistest/, clitest/, eventstest/, persistencetest/, toolstest/, internal/infrastructure/testing/).",
 						},
 					},
 					Required: []string{"path"},


### PR DESCRIPTION
Closes #1433.

## Summary

Fixes the two root causes behind the coverage-report noise observed in #1431/PR #1432 — a cataloged `agenttest` interface-stub accessor (`StubChatterComposer.GetSkillRepository`, `helpers.go:315-317`) surfacing as an uncataloged HIGH gap.

**Root cause 1 — file-only `See:` ref defeated the matcher** (commit `7f98858e`):
- The 2026-07 entry "agent/agenttest/helpers.go — 0% coverage on interface-satisfying stubs (16 methods)" had a file-only `See:` (`internal/agent/agenttest/helpers.go`, no `:line`). The coverage matcher drops file-only refs, so **all 16 cataloged methods** surfaced as uncataloged gaps — the same defect repaired for `cmd/tell-me-go/main.go` in #1431 T3.
- Re-anchored to a per-method comma-list ref (`helpers.go:33-34,35,36,37-38,39-40,41-42,43,44,45,48,58-59,315-317,356,360,390,391`) with a Drift-Policy re-anchor note, plus **16 partition-test rows in the same commit** (coordination rule). `TestVerifyCoveragePinsMatchLiveCatalog` now has 59 rows, all green.

**Root cause 2 — `get_detailed_coverage` defaulted to NO exclusions** (commits `989d3e4c`, `ef41d703`):
- `GetDetailedCoverage` (health.go) only filtered when the caller passed `excluded_packages`; default was empty, so unfiltered runs reported the nine documented test-double dirs as HIGH/MEDIUM noise — diverging from the Makefile `test-coverage` gate and the `coverage-exclusions-explicit` invariant.
- Added `defaultCoverageExclusions` (the nine directories, trailing-slash substring patterns, mirroring the Makefile grep -v list) applied **only when the argument is absent** — an explicit list (even empty) always wins. Tool description updated. Internal methods (`getDetailedCoverageReport`/`getDetailedCoverageJSON`/`filterExcludedBlocks`) untouched (their nil-means-unfiltered semantics are load-bearing for the e2e tests).
- Tests: `TestGetDetailedCoverage_DefaultExclusions` (absent → `Total Gaps: 1`, test-double blocks removed) + `TestGetDetailedCoverage_ExplicitEmptyOverridesDefault` (explicit empty → `Total Gaps: 4`) — split into two single-phase functions (CC 8/7) after the arch-tagged complexity partition alerted on the original two-phase test (CC 13); plus e2e `TestDetailedCoverageReport_AgentTestDefaultExclusions` (real `./internal/agent/agenttest` with the default list → `Total Gaps: 0`, no `helpers.go`, no HIGH).

**Result:** the `GetSkillRepository` gap now renders under `[CATALOGED GAPS (ACCEPTED)]` with the interface-stub title (matcher honored), and an unfiltered `get_detailed_coverage` run excludes the nine test-double directories by default — no more HIGH/MEDIUM noise from already-settled stubs. The `triage-loop-closed` and `catalog-authoritative` invariants hold.

**Deferred (out of scope, [TECHNICAL DEBT]):** the `determinePriority` context-line heuristic that labels the trivial accessor HIGH (error token on the preceding context line) — cosmetic once cataloged/excluded.

## Acceptance-criteria mapping

- [x] `GetDetailedCoverage` with no `excluded_packages` excludes the nine documented test-double dirs by default — unit + e2e proven (`Total Gaps: 1` / `Total Gaps: 0`)
- [x] 2026-07 helpers.go entry `See:` refs carry line specs for all 16 methods; partition rows updated in the same commit (coordination rule) — 16 rows in `7f98858e`
- [x] Unfiltered run: helpers.go block renders under `[CATALOGED GAPS (ACCEPTED)]` (16 partition rows prove matcher match) and the default run excludes the package entirely (e2e `Total Gaps: 0`)
- [x] `make check-full` green; total coverage **97.3%** (unchanged); `modelith-check` green (no domain-model edit)
- [x] Drift Policy: all 16 method lines re-verified against live source at write time; no drift

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-\*, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, test-race) | ✅ PASS ("All checks passed (including race detection)") |
| Total coverage (`go tool cover -func=coverage.out \| tail -1`) | ✅ **97.3%** (≥ 97.3%, unchanged) |
| `TestVerifyNonFixCatalog` (complexity partition) | ✅ PASS, `alerts` empty |
| `TestVerifyCoveragePinsMatchLiveCatalog` (59 rows incl. 16 new) | ✅ PASS |
| `TestDetailedCoverageReport_AgentTestDefaultExclusions` (e2e) | ✅ PASS (`Total Gaps: 0`, no `helpers.go`, no HIGH) |
| `make modelith-check` | ✅ PASS |

Changed files: 5 (3 commits) — catalog + partition test (T1), health.go + health_test.go + registration.go (T2 + revision).