### PR TITLE
fix(analysis): classify coverage blocks on own lines only; tighten err-identifier matching (#1435)

### DIFF
--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -33,6 +33,11 @@ type uncoveredBlock struct {
 	// catalog whose references cover this block's range, when one exists.
 	// A non-empty value marks the gap as deliberately accepted (not actionable).
 	CatalogTitle string `json:"catalog_title,omitempty"`
+	// classifyCode holds the block's own lines (no context line) for the
+	// priority classifier. Code keeps the one-line context prefix for display;
+	// the rules match against classifyCode so a preceding error-returning
+	// signature cannot drive classification. Unexported — never serialized.
+	classifyCode string
 }
 
 // classificationRule defines a rule for categorizing uncovered code blocks.
@@ -45,7 +50,7 @@ type errorHandlingRule struct{}
 
 func (r errorHandlingRule) category() string { return "ERROR_HANDLING" }
 func (r errorHandlingRule) match(b *uncoveredBlock) bool {
-	lowerCode := strings.ToLower(b.Code)
+	lowerCode := strings.ToLower(b.classificationText())
 	return strings.Contains(lowerCode, "if err != nil") ||
 		(strings.Contains(lowerCode, "return") && containsIdentErr(lowerCode)) ||
 		strings.Contains(lowerCode, "fmt.errorf") ||
@@ -123,6 +128,17 @@ var jsonMarshalIndent = json.MarshalIndent
 // variable to allow test injection of file-open failures for error-path coverage.
 var osOpenFile = os.Open
 
+// classificationText returns the text the classification rules match
+// against: the block's own lines when parseDetailedCoverage populated
+// classifyCode, falling back to Code for unit-constructed blocks and the
+// file-read-error path where no source lines exist.
+func (b *uncoveredBlock) classificationText() string {
+	if b.classifyCode != "" {
+		return b.classifyCode
+	}
+	return b.Code
+}
+
 // Classify categorizes the block and assigns a priority based on heuristics.
 func (b *uncoveredBlock) Classify() {
 	b.Category = "OTHER"
@@ -150,20 +166,15 @@ func (b *uncoveredBlock) determinePriority() string {
 	return "Low"
 }
 
-// extractFromLines extracts a range of lines from a slice, including one line of context before.
-func extractFromLines(lines []string, start, end int) string {
+// extractLines extracts the block's own lines [start, end] from a source
+// file's line slice, with no context line. Classification must match only
+// the block's own lines so a preceding signature cannot drive priority.
+func extractLines(lines []string, start, end int) string {
 	if len(lines) == 0 {
 		return ""
 	}
-
-	startWithContext := start
-	if startWithContext > 1 {
-		startWithContext--
-	}
-
-	startIdx := startWithContext - 1
+	startIdx := start - 1
 	endIdx := end
-
 	if startIdx < 0 {
 		startIdx = 0
 	}
@@ -173,8 +184,15 @@ func extractFromLines(lines []string, start, end int) string {
 	if startIdx >= endIdx {
 		return ""
 	}
-
 	return strings.Join(lines[startIdx:endIdx], "\n")
+}
+
+// extractFromLines extracts a range of lines from a slice, including one line of context before.
+func extractFromLines(lines []string, start, end int) string {
+	if start > 1 {
+		start-- // one line of context before
+	}
+	return extractLines(lines, start, end)
 }
 
 // getModuleName returns the module name from the environment.
@@ -365,6 +383,7 @@ func parseDetailedCoverage(ctx context.Context, r io.Reader, runner AnalysisGoRu
 			}
 
 			blocks[idx].Code = extractFromLines(lines, blocks[idx].Start, blocks[idx].End)
+			blocks[idx].classifyCode = extractLines(lines, blocks[idx].Start, blocks[idx].End)
 			blocks[idx].Classify()
 		}(i)
 	}

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -47,9 +47,40 @@ func (r errorHandlingRule) category() string { return "ERROR_HANDLING" }
 func (r errorHandlingRule) match(b *uncoveredBlock) bool {
 	lowerCode := strings.ToLower(b.Code)
 	return strings.Contains(lowerCode, "if err != nil") ||
-		(strings.Contains(lowerCode, "return") && strings.Contains(lowerCode, "err")) ||
+		(strings.Contains(lowerCode, "return") && containsIdentErr(lowerCode)) ||
 		strings.Contains(lowerCode, "fmt.errorf") ||
 		strings.Contains(lowerCode, "errors.new")
+}
+
+// containsIdentErr reports whether s contains the identifier err as a
+// standalone word — equivalent to the regexp \berr\b. It matches the
+// variable name err but not the type error, the errors package, or
+// composite identifiers like RegistryErr / ErrNotFound / xerr / errx.
+// Callers pass lowercased text.
+func containsIdentErr(s string) bool {
+	for idx := 0; ; {
+		i := strings.Index(s[idx:], "err")
+		if i == -1 {
+			return false
+		}
+		i += idx
+		beforeOK := i == 0 || !isIdentByte(s[i-1])
+		after := i + len("err")
+		afterOK := after >= len(s) || !isIdentByte(s[after])
+		if beforeOK && afterOK {
+			return true
+		}
+		idx = i + len("err")
+	}
+}
+
+// isIdentByte reports whether c is a Go identifier byte (word character),
+// matching the word-class of regexp \b.
+func isIdentByte(c byte) bool {
+	return c == '_' ||
+		('a' <= c && c <= 'z') ||
+		('A' <= c && c <= 'Z') ||
+		('0' <= c && c <= '9')
 }
 
 type businessLogicRule struct{}

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -141,6 +141,21 @@ func TestUncoveredBlock_Classify(t *testing.T) {
 			wantCat:  "ERROR_HANDLING",
 			wantPrio: "Medium",
 		},
+		{
+			name: "context line does not drive classification",
+			block: uncoveredBlock{
+				File: "internal/agent/agenttest/helpers.go",
+				Code: "func (s *StubChatterComposer) GetRegistry() (tools.Registry, error)      { return s.Registry, s.RegistryErr }\n" +
+					"func (s *StubChatterComposer) GetSkillRepository() domain_skills.SkillRepository {\n" +
+					"\treturn s.SkillRepo\n" +
+					"}",
+				classifyCode: "func (s *StubChatterComposer) GetSkillRepository() domain_skills.SkillRepository {\n" +
+					"\treturn s.SkillRepo\n" +
+					"}",
+			},
+			wantCat:  "BUSINESS_LOGIC",
+			wantPrio: "Medium",
+		},
 	}
 
 	for _, tt := range tests {
@@ -407,6 +422,39 @@ func TestExtractFromLines(t *testing.T) {
 			got := extractFromLines(l, tt.start, tt.end)
 			if got != tt.want {
 				t.Errorf("extractFromLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExtractLines(t *testing.T) {
+	t.Parallel()
+	lines := []string{"line1", "line2", "line3", "line4", "line5"}
+	tests := []struct {
+		name  string
+		start int
+		end   int
+		want  string
+	}{
+		{name: "middle", start: 3, end: 4, want: "line3\nline4"},
+		{name: "start", start: 1, end: 2, want: "line1\nline2"},
+		{name: "single line", start: 2, end: 2, want: "line2"},
+		{name: "end clamped", start: 1, end: 5, want: "line1\nline2\nline3\nline4\nline5"},
+		{name: "start clamped", start: 0, end: 1, want: "line1"},
+		{name: "start beyond end", start: 5, end: 2, want: ""},
+		{name: "empty lines", start: 1, end: 2, want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var l []string
+			if tt.name != "empty lines" {
+				l = lines
+			}
+			got := extractLines(l, tt.start, tt.end)
+			if got != tt.want {
+				t.Errorf("extractLines() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -727,6 +775,46 @@ func TestParseDetailedCoverage(t *testing.T) {
 	if blocks[0].Code != "line1\nline2" {
 		t.Errorf("expected code line1\nline2, got %q", blocks[0].Code)
 	}
+}
+
+func TestParseDetailedCoverage_ClassifiesOwnLinesOnly(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockAnalysisGoRunner{
+		getModulePathFunc: func(ctx context.Context) (string, error) {
+			return "github.com/user/repo", nil
+		},
+	}
+
+	// helpers.go:314-317-shaped source: line 1 is an error-returning
+	// signature whose `return ..., err` text previously bled into the
+	// next block's classification (issue #1435).
+	src := "func (s *StubChatterComposer) GetRegistry() (tools.Registry, error)      { return s.Registry, s.RegistryErr }\n" +
+		"func (s *StubChatterComposer) GetSkillRepository() domain_skills.SkillRepository {\n" +
+		"\treturn s.SkillRepo\n" +
+		"}\n"
+
+	content := "mode: set\ngithub.com/user/repo/internal/agent/agenttest/helpers.go:2.0,4.0 3 0\n"
+	r := strings.NewReader(content)
+
+	readFile := func(path string) ([]byte, error) {
+		if path == "internal/agent/agenttest/helpers.go" {
+			return []byte(src), nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	blocks, err := parseDetailedCoverage(ctx, r, mock, readFile)
+	require.NoError(t, err)
+	require.Len(t, blocks, 1)
+
+	// Display text still carries the context line (LLM readability) ...
+	require.Contains(t, blocks[0].Code, "GetRegistry")
+
+	// ... but classification uses only the block's own lines: the preceding
+	// error-returning signature must not drive ERROR_HANDLING / High.
+	require.Equal(t, "BUSINESS_LOGIC", blocks[0].Category)
+	require.Equal(t, "Medium", blocks[0].Priority)
 }
 
 func TestFormatDetailedCoverageReport(t *testing.T) {

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -78,6 +78,69 @@ func TestUncoveredBlock_Classify(t *testing.T) {
 			wantCat:  "OTHER",
 			wantPrio: "Low",
 		},
+		{
+			name: "return err is error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: "return err",
+			},
+			wantCat:  "ERROR_HANDLING",
+			wantPrio: "Medium",
+		},
+		{
+			name: "return tuple with err is error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: "return value, err",
+			},
+			wantCat:  "ERROR_HANDLING",
+			wantPrio: "Medium",
+		},
+		{
+			name: "error type token is not error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: "func foo() (X, error) {",
+			},
+			wantCat:  "OTHER",
+			wantPrio: "Low",
+		},
+		{
+			name: "XxxErr field name is not error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: "return nil, s.RegistryErr",
+			},
+			wantCat:  "OTHER",
+			wantPrio: "Low",
+		},
+		{
+			name: "ErrXxx sentinel is not error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: "return ErrNotFound",
+			},
+			wantCat:  "OTHER",
+			wantPrio: "Low",
+		},
+		{
+			name: "fmt.Errorf is error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: `return fmt.Errorf("boom")`,
+			},
+			wantCat:  "ERROR_HANDLING",
+			wantPrio: "Medium",
+		},
+		{
+			name: "errors.New is error handling",
+			block: uncoveredBlock{
+				File: "main.go",
+				Code: `errors.New("boom")`,
+			},
+			wantCat:  "ERROR_HANDLING",
+			wantPrio: "Medium",
+		},
 	}
 
 	for _, tt := range tests {
@@ -89,6 +152,42 @@ func TestUncoveredBlock_Classify(t *testing.T) {
 			}
 			if tt.block.Priority != tt.wantPrio {
 				t.Errorf("Classify() Priority = %v, want %v", tt.block.Priority, tt.wantPrio)
+			}
+		})
+	}
+}
+
+func TestContainsIdentErr(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{"bare err", "err", true},
+		{"return err", "return err", true},
+		{"return tuple with err", "return value, err", true},
+		{"if err != nil guard", "if err != nil", true},
+		{"err assignment", "err := f()", true},
+		{"field access s.err", "s.err", true},
+		{"error type token", "error", false},
+		{"error type in signature", "func foo() (x, error) {", false},
+		{"errors package", "errors.new", false},
+		{"XxxErr field name", "registryerr", false},
+		{"ErrXxx sentinel", "errnotfound", false},
+		{"err as identifier prefix", "errx", false},
+		{"err as identifier suffix", "xerr", false},
+		{"err with underscore prefix", "_err", false},
+		{"err with underscore suffix", "err_", false},
+		{"err inside larger word", "verror", false},
+		{"empty string", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := containsIdentErr(strings.ToLower(tt.text)); got != tt.want {
+				t.Errorf("containsIdentErr(%q) = %v, want %v", tt.text, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Closes #1435.

## Summary

Fixes the `get_detailed_coverage` priority classifier's two false-HIGH defects: context-line bleed and over-broad `"err"` substring matching. Two commits, exactly two files (`internal/tools/analysis/coverage_parser.go` + its test).

**Part 2 — `\berr\b`-style identifier matching** (`dac6d408`):
- Added `containsIdentErr`/`isIdentByte` (manual word-boundary scan, no new dependency, equivalent to regexp `\berr\b` on ASCII identifiers).
- `errorHandlingRule.match`'s `return` clause now requires a standalone `err` identifier: the type token `error`, field names like `RegistryErr`, and sentinels like `ErrNotFound` no longer trigger it. Genuine signals (`if err != nil`, `fmt.Errorf`, `errors.New`, `return err`/`return x, err`) still match.
- Tests: `TestContainsIdentErr` (17 rows) + 7 new `TestUncoveredBlock_Classify` rows.

**Part 1 — classification decoupled from display context** (`54ab0534`):
- New unexported `classifyCode` field holds the block's own lines (context-free, via new `extractLines`; `extractFromLines` re-expressed as a delegating wrapper, behavior-identical).
- `classificationText()` accessor: rules match `classifyCode` when populated, else fall back to `Code` (unit-constructed blocks + file-read-error path).
- `Code` keeps the one-line context prefix for display/JSON — the report's LLM readability and the `code,omitempty` JSON format are byte-identical (unexported field never serialized).
- Tests: `TestExtractLines` (7 rows), pipeline-level regression `TestParseDetailedCoverage_ClassifiesOwnLinesOnly` (helpers.go:314-317-shaped block → BUSINESS_LOGIC/Medium, not ERROR_HANDLING/High), and the `"context line does not drive classification"` unit row.

**Effect:** the observed `GetSkillRepository` case (preceded by an error-returning signature) now classifies BUSINESS_LOGIC/Medium instead of HIGH; priorities are monotone non-increasing (strict-subset match set) — High can never increase.

**Two spec deviations were flagged by the Coder and adjudicated ACCEPTED by the Architect** (each was a spec arithmetic slip, corrected per the spec's own authorization): (1) ERROR_HANDLING rows correctly expect `Medium` (single-rule match → Medium per `determinePriority`), (2) the `TestExtractLines` "end clamped" row correctly expects all 5 lines (endIdx == len is inclusive).

## Acceptance-criteria mapping

- [x] Context-bleed regression: helpers.go:315-317-shaped block classified from own lines only, NOT HIGH — `TestParseDetailedCoverage_ClassifiesOwnLinesOnly` + unit row (BUSINESS_LOGIC/Medium)
- [x] `\berr\b`-style matching: `error` type / `ErrXxx` / `XxxErr` no longer match — `TestContainsIdentErr` 17 rows + 3 classify rows (OTHER/Low)
- [x] Genuine error handling still ERROR_HANDLING: `if err != nil`, `return err`, `return x, err`, `fmt.Errorf`, `errors.New` rows
- [x] Existing `TestUncoveredBlock_Classify` pins stay green (additive extension only, 14 rows)
- [x] Full gate green: `go test -tags=arch -run "TestVerifyNonFixCatalog|TestVerifyCoveragePinsMatchLiveCatalog|TestDetailedCoverageReport"` + `make check-full`
- [x] e2e count-shift audit: zero e2e edits required (count pins on fully-cataloged packages; classifier strictly more restrictive)
- [x] Live unfiltered `get_detailed_coverage` run: High count **0** — unchanged vs baseline 0, never increases; formerly-HIGH context-bleed class no longer surfaces as actionable
- [x] No catalog / partition-test / ADR changes (Drift Policy honored; JSON byte-identical; no new dependencies)

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-\*, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, test-race) | ✅ PASS ("All checks passed (including race detection)") |
| Total coverage (`go tool cover -func=coverage.out \| tail -1`) | ✅ **97.3%** (unchanged) |
| Scoped arch gate (verify-nonfix-catalog regex) | ✅ PASS (7 e2e reports green) |
| Live unfiltered `./internal/agent` report | ✅ High: 0, Medium: 0, Low: 0, Cataloged: 1 (the `EditLastTurn` wrapper) |
| `gofmt` / `go vet` | ✅ clean |

Changed files: 2 (2 commits) — `coverage_parser.go` + `coverage_parser_test.go` only.