### PR TITLE
fix(llm): replace empty media-only content with truth-telling fallback on OpenAI transport (#1439)

### DIFF
--- a/docs/adr/2026-09-deepseek-vision-capability.md
+++ b/docs/adr/2026-09-deepseek-vision-capability.md
@@ -26,6 +26,8 @@ Following the ADR-024 `MaxTokensField` precedent (enums over coupled booleans ma
 ### Decision 3: Vision/video decoupling in the OpenAI transport
 `mediaBlocks(parts, ta, caps)` emits `image_url`/`file` blocks only when `SupportsVision` is true and `video_url` blocks only when `SupportsVideo` is true. Video parts on vision-only models are dropped, not proxied or error-coupled. Mode-aware block creation: DeepSeek bound parts → `file` blocks; Kimi bound parts → `ms://` `image_url`/`video_url` blocks; unbound parts → base64 data-URI `image_url` blocks.
 
+**Addendum (issue #1439):** when capability filtering drops *all* media parts from a user message that carries no text, `buildMessageContent` now replaces the would-be-empty content with a truth-telling placeholder string via `mediaOmittedFallback` — `"(video content omitted — this model does not support video input)"` for `video/*` on `!SupportsVideo` models, `"(image content omitted — this model does not support image input)"` for `image/*` on `!SupportsVision` models, and a generic `"(media content omitted — this model does not support this media type)"` fallback. The OpenAI-compatible endpoint rejects both a JSON `null` `content` (a typed-nil slice assigned to `interface{}` survives `omitempty`) and an omitted `content` key (an empty string is stripped by `omitempty`) with HTTP 400; the placeholder keeps `content` a valid non-empty string, preserves user-role message presence for strict role alternation, and leaks no transport capability into the domain layer.
+
 ### Decision 4: Turn-scoped Files API lifecycle with automated cleanup
 Uploaded files are bound in `turnAssets`, referenced via `file_id` blocks for the duration of the turn, and deleted via `DELETE /files/{id}` by `turnAssets.release`, deferred in `SendChat` on every exit path (success and error). Cleanup uses a detached context with a bounded timeout so it proceeds even when the caller's context is at deadline. Size guards fail loud before any request: single images > 64 MiB error with `image exceeds 64 MiB upload limit: %d bytes`; aggregate base64 size of inline images > 48 MiB errors with `aggregate inline image size exceeds 48 MiB limit`.
 
@@ -46,7 +48,7 @@ Uploaded files are bound in `turnAssets`, referenced via `file_id` blocks for th
 - Size guards fail loud before network I/O, preventing silent truncation or 4xx/5xx from oversized payloads.
 
 ### Negative / Accepted Trade-offs
-- Video parts on vision-only models are silently dropped (no proxy-to-image fallback).
+- Video parts on vision-only models are silently dropped (no proxy-to-image fallback). The dropping never produces an empty user message on the wire: `buildMessageContent` substitutes a truth-telling placeholder via `mediaOmittedFallback` (issue #1439), so `content` remains a valid non-empty string — the media itself is still not proxied or error-coupled.
 - Uploaded files leak on process crash mid-turn (turn-scoped cleanup is best-effort; no reaper).
 - The suffix-based vision detection (`strings.Contains(model, "vision")`) is a heuristic; a future non-vision model whose ID contains "vision" would be misclassified (mitigated by the `-exp` experimental naming and architect review on model additions).
 - The `FileUploadMode` enum adds a third dispatch dimension to the transport; each new mode must be handled in `parseFileUploadResponse`, `uploadMediaParts`/`mediaUploadPurpose`, and `mediaBlockFor`.
@@ -76,7 +78,8 @@ Uploaded files are bound in `turnAssets`, referenced via `file_id` blocks for th
 ## References
 - DeepSeek vision documentation snapshot (pinned): <https://gist.github.com/gosharplite/b723baa51271546edabd68ed8c988788> (commit `3d4d61e`).
 - Predecessor issue #1427 (superseded).
+- Issue #1439 (media-only content fallback addendum).
 - Files changed: `internal/domain/llm/capabilities.go`, `internal/infrastructure/llm/openai/{client.go,files.go}`, `internal/infrastructure/llm/openai/{client_vision_test.go,files_test.go,client_edge_test.go}`, `configs/butler.yaml`, `README.md`, `docs/user/niffler/ait-base/engineers/configs/butler.yaml`.
 
 ---
-*Last Updated: 2026-09*
+*Last Updated: 2026-09 (issue #1439 addendum)*

--- a/internal/infrastructure/llm/openai/client.go
+++ b/internal/infrastructure/llm/openai/client.go
@@ -491,20 +491,47 @@ func hasSupportedMedia(caps llm.Capabilities, mediaParts []*llm.Part) bool {
 // a plain text string when no media parts are present or the model lacks
 // vision/video support. Returns []any (mixed text + image_url/video_url blocks)
 // otherwise, with media blocks placed before text (media-first ordering).
+// Media parts dropped by capability filtering that would otherwise yield
+// empty content are replaced by mediaOmittedFallback.
 func (c *client) buildMessageContent(text string, mediaParts []*llm.Part, ta *turnAssets) any {
-	// Build content: array format when media present AND vision/video supported,
-	// string format otherwise.
 	if !hasSupportedMedia(c.capabilities, mediaParts) {
+		if text != "" {
+			return text
+		}
+		if len(mediaParts) > 0 {
+			return c.mediaOmittedFallback(mediaParts)
+		}
 		return text
 	}
-	// Media blocks are placed before text (media-first ordering). This is
-	// intentional for the describe-this-image use case — interleaved
-	// part ordering within a single history item is not preserved.
 	blocks := mediaBlocks(mediaParts, ta, c.capabilities)
 	if text != "" {
 		blocks = append(blocks, requestContentBlock{Type: "text", Text: text})
 	}
+	if len(blocks) == 0 {
+		return c.mediaOmittedFallback(mediaParts)
+	}
 	return blocks
+}
+
+// mediaOmittedFallback returns a descriptive, truth-telling placeholder for
+// user messages whose media parts were dropped because the active model does
+// not support them. A non-empty string keeps the OpenAI wire contract valid
+// (content must be a string or a list — never null or omitted) and preserves
+// user-role message presence for strict role alternation.
+func (c *client) mediaOmittedFallback(mediaParts []*llm.Part) string {
+	for _, p := range mediaParts {
+		if p.InlineData == nil || len(p.InlineData.Data) == 0 {
+			continue
+		}
+		mime := p.InlineData.MIMEType
+		switch {
+		case strings.HasPrefix(mime, "video/") && !c.capabilities.SupportsVideo:
+			return "(video content omitted — this model does not support video input)"
+		case strings.HasPrefix(mime, "image/") && !c.capabilities.SupportsVision:
+			return "(image content omitted — this model does not support image input)"
+		}
+	}
+	return "(media content omitted — this model does not support this media type)"
 }
 
 func (c *client) appendMessagesFromHistoryItem(

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -592,3 +592,64 @@ func TestVision_TextOnlyImageOnly_NoEmptyContent(t *testing.T) {
 		t.Errorf("exact JSON mismatch:\ngot  %s\nwant %s", b, want)
 	}
 }
+
+func TestMediaOmittedFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		caps  llm.Capabilities
+		parts []*llm.Part
+		want  string
+	}{
+		{
+			name:  "video dropped without video support",
+			caps:  llm.Capabilities{SupportsVision: true, SupportsVideo: false},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: []byte{1}}}},
+			want:  "(video content omitted — this model does not support video input)",
+		},
+		{
+			name:  "image dropped without vision support",
+			caps:  llm.Capabilities{SupportsVision: false, SupportsVideo: true},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}}},
+			want:  "(image content omitted — this model does not support image input)",
+		},
+		{
+			name:  "video supported falls through to generic",
+			caps:  llm.Capabilities{SupportsVision: true, SupportsVideo: true},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: []byte{1}}}},
+			want:  "(media content omitted — this model does not support this media type)",
+		},
+		{
+			name:  "image supported falls through to generic",
+			caps:  llm.Capabilities{SupportsVision: true, SupportsVideo: true},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{1}}}},
+			want:  "(media content omitted — this model does not support this media type)",
+		},
+		{
+			name:  "nil InlineData falls through to generic",
+			caps:  llm.Capabilities{SupportsVision: false, SupportsVideo: false},
+			parts: []*llm.Part{{InlineData: nil}},
+			want:  "(media content omitted — this model does not support this media type)",
+		},
+		{
+			name:  "empty data falls through to generic",
+			caps:  llm.Capabilities{SupportsVision: false, SupportsVideo: false},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "video/mp4"}}},
+			want:  "(media content omitted — this model does not support this media type)",
+		},
+		{
+			name:  "unsupported MIME falls through to generic",
+			caps:  llm.Capabilities{SupportsVision: false, SupportsVideo: false},
+			parts: []*llm.Part{{InlineData: &llm.Blob{MIMEType: "application/pdf", Data: []byte{1}}}},
+			want:  "(media content omitted — this model does not support this media type)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &client{capabilities: tt.caps}
+			got := c.mediaOmittedFallback(tt.parts)
+			if got != tt.want {
+				t.Errorf("mediaOmittedFallback() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -521,3 +521,74 @@ func assertVisionJSONAbsent(t *testing.T, s, needle, what string) {
 		t.Errorf("JSON payload should NOT contain %s (needle %q)", what, needle)
 	}
 }
+
+func TestVision_DeepSeekVideoOnly_NoEmptyContent(t *testing.T) {
+	c := NewClient("https://api.deepseek.com", "deepseek-v4-flash-vision-exp",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	if !c.capabilities.SupportsVision {
+		t.Fatal("deepseek-v4-flash-vision-exp should have SupportsVision")
+	}
+	if c.capabilities.SupportsVideo {
+		t.Fatal("deepseek-v4-flash-vision-exp should NOT have SupportsVideo")
+	}
+
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "video/mp4", Data: []byte{0x00, 0x00, 0x00, 0x18}}},
+		},
+	}}
+
+	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("toStandardMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	b, err := json.Marshal(msgs[0])
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	want := `{"role":"user","content":"(video content omitted — this model does not support video input)"}`
+	if string(b) != want {
+		t.Errorf("exact JSON mismatch:\ngot  %s\nwant %s", b, want)
+	}
+}
+
+func TestVision_TextOnlyImageOnly_NoEmptyContent(t *testing.T) {
+	c := NewClient("https://api.deepseek.com", "deepseek-v4-flash",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	if c.capabilities.SupportsVision {
+		t.Fatal("deepseek-v4-flash should NOT have SupportsVision")
+	}
+
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50, 0x4E, 0x47}}},
+		},
+	}}
+
+	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("toStandardMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+
+	b, err := json.Marshal(msgs[0])
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	want := `{"role":"user","content":"(image content omitted — this model does not support image input)"}`
+	if string(b) != want {
+		t.Errorf("exact JSON mismatch:\ngot  %s\nwant %s", b, want)
+	}
+}


### PR DESCRIPTION
Closes #1439

## Summary

Fixes the OpenAI-compatible transport serializing media-only user messages with invalid `content` payloads (`"content": null` or an omitted `content` key), which DeepSeek rejects with HTTP 400 (`content should be a string or a list`).

**Root cause:** when capability filtering drops all media parts from a user message that has no accompanying text, `buildMessageContent` returned either `[]any(nil)` (serialized as `"content": null` by Go's `omitempty` on a typed-nil slice inside an `interface{}`) or `string("")` (stripped entirely by `omitempty`).

**Fix (transport guard, confined to `internal/infrastructure/llm/openai/client.go`):** `buildMessageContent` now returns a truth-telling fallback string via the new `mediaOmittedFallback` helper whenever dropped media would leave empty content — `"(video content omitted — this model does not support video input)"`, `"(image content omitted — this model does not support image input)"`, or a generic fallback. This keeps `content` a valid non-empty string, preserves strict user/tool role alternation, and leaks no transport capability knowledge outside the adapter (hexagonal boundary intact). CC stays well below the policy threshold (6/8).

## Changes (4 commits)

| Commit | Change |
|--------|--------|
| `a0154785` | Transport guard: `mediaOmittedFallback` + `buildMessageContent` fallback logic (`client.go`) |
| `30938cae` | Two exact-wire-byte regression tests appended at the bottom of `client_vision_test.go` |
| `18e94928` | ADR-070 addendum (Decision 3 + Negative Trade-offs + References) |
| `9ac82f5f` | Coverage closure for `mediaOmittedFallback` defensive branches (`TestMediaOmittedFallback`) |

## Acceptance Criteria

- [x] `read_video` / media-only turns on `deepseek-v4-flash-vision-exp` serialize valid content — prompt receives `(video content omitted — this model does not support video input)`
- [x] Image-only parts on text-only models serialize with fallback text, not an omitted `content` key
- [x] Existing DeepSeek/Kimi image and Kimi video support intact (full existing vision suite green)
- [x] Two regression tests appended at the end of `client_vision_test.go` asserting exact JSON serialization bytes (`TestVision_DeepSeekVideoOnly_NoEmptyContent`, `TestVision_TextOnlyImageOnly_NoEmptyContent`)
- [x] ADR-070 addendum recorded in `docs/adr/2026-09-deepseek-vision-capability.md` (no new ADR — `verify-adr-index` preserved)
- [x] `make check-full` passes cleanly

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, verify-architecture, verify-transitive-gate, verify-exit-query, verify-nonfix-catalog, verify-ports-registry, verify-mock-pattern, verify-session-provider-mock, verify-tools-*-import, verify-mcp-sdk-confinement, verify-no-test-sleep, verify-adr-index, verify-no-context-window-cache, modelith-check, fuzz-smoke, vulncheck, test, dead-code, test-coverage, test-race) | **PASS** — "All checks passed (including race detection)" |
| `verify-nonfix-catalog` | PASS — catalog pins at `client_vision_test.go:18/129/244` unmoved; OpenAI package now 0 uncataloged medium-priority gaps |
| `verify-adr-index` | PASS — no index change |
| New tests | `TestVision_DeepSeekVideoOnly_NoEmptyContent`, `TestVision_TextOnlyImageOnly_NoEmptyContent`, `TestMediaOmittedFallback` (7 subtests) — all green; RED against the pre-fix code |

## Coordination Rules Honored

- New tests appended strictly to the bottom of `client_vision_test.go`; lines 1–244 byte-identical (pinned test-complexity entries unmoved)
- No NonFixCatalog entry (genuine transport bug, not an intentional non-fix)
- No new ADR file; ADR-070 addendum only
- Cross-transport audit confirmed: Anthropic and Gemini transports are safe (unchanged)
