### PR TITLE
fix(agent): Fix Gemini vertex API rejection of mixed media responses (#1441)

### DIFF
--- a/internal/agent/executor/executor.go
+++ b/internal/agent/executor/executor.go
@@ -368,7 +368,6 @@ func (e *Dispatcher) extractFunctionCalls(respContent *llm.Content) []*llm.Funct
 func (e *Dispatcher) AssembleResponse(calls []*llm.FunctionCall, results []tools.ToolResult) *llm.Content {
 	var responseParts []*llm.Part
 	for i, tr := range results {
-		responseParts = append(responseParts, e.strategy.Format(calls[i], tr))
 		for _, b := range tr.BinaryData {
 			responseParts = append(responseParts, &llm.Part{
 				InlineData: &llm.Blob{
@@ -377,6 +376,7 @@ func (e *Dispatcher) AssembleResponse(calls []*llm.FunctionCall, results []tools
 				},
 			})
 		}
+		responseParts = append(responseParts, e.strategy.Format(calls[i], tr))
 	}
 	return &llm.Content{
 		Role:  "user",

--- a/tests/integration/agent/executor/executor_table_test.go
+++ b/tests/integration/agent/executor/executor_table_test.go
@@ -544,8 +544,8 @@ func TestDispatcher_AssembleResponse_Binary(t *testing.T) {
 		if len(content.Parts) != 2 {
 			t.Fatalf("Got %d parts, want 2", len(content.Parts))
 		}
-		assertFunctionResponse(t, content.Parts[0], "Here is your image")
-		assertInlineData(t, content.Parts[1], "image/png", []byte("blob"))
+		assertInlineData(t, content.Parts[0], "image/png", []byte("blob"))
+		assertFunctionResponse(t, content.Parts[1], "Here is your image")
 	})
 
 	t.Run("Multiple Binary Parts", func(t *testing.T) {
@@ -561,8 +561,8 @@ func TestDispatcher_AssembleResponse_Binary(t *testing.T) {
 		if len(content.Parts) != 3 {
 			t.Fatalf("Got %d parts, want 3", len(content.Parts))
 		}
-		assertInlineData(t, content.Parts[1], "application/pdf", []byte{1, 2, 3})
-		assertInlineData(t, content.Parts[2], "text/plain", []byte{4, 5, 6})
+		assertInlineData(t, content.Parts[0], "application/pdf", []byte{1, 2, 3})
+		assertInlineData(t, content.Parts[1], "text/plain", []byte{4, 5, 6})
 	})
 
 	t.Run("Multi-blob Interleaving and Ordering", func(t *testing.T) {
@@ -576,9 +576,9 @@ func TestDispatcher_AssembleResponse_Binary(t *testing.T) {
 			},
 		}}
 		content := e.AssembleResponse(calls, results)
-		assertFunctionResponse(t, content.Parts[0], "Captured 2 photos")
-		assertInlineData(t, content.Parts[1], "image/jpeg", []byte("photo1"))
-		assertInlineData(t, content.Parts[2], "image/jpeg", []byte("photo2"))
+		assertInlineData(t, content.Parts[0], "image/jpeg", []byte("photo1"))
+		assertInlineData(t, content.Parts[1], "image/jpeg", []byte("photo2"))
+		assertFunctionResponse(t, content.Parts[2], "Captured 2 photos")
 	})
 
 	t.Run("Binary Data with No Text", func(t *testing.T) {
@@ -594,8 +594,8 @@ func TestDispatcher_AssembleResponse_Binary(t *testing.T) {
 		if len(content.Parts) != 2 {
 			t.Fatalf("Got %d parts, want 2", len(content.Parts))
 		}
-		assertFunctionResponse(t, content.Parts[0], "")
-		assertInlineData(t, content.Parts[1], "image/png", []byte("data"))
+		assertInlineData(t, content.Parts[0], "image/png", []byte("data"))
+		assertFunctionResponse(t, content.Parts[1], "")
 	})
 }
 

--- a/tests/integration/agent/regression_test.go
+++ b/tests/integration/agent/regression_test.go
@@ -179,38 +179,56 @@ func TestAgent_MultiModalFlow(t *testing.T) {
 
 func newMultiModalMockClient() *agenttest.MockLLMClient {
 	return &agenttest.MockLLMClient{
-		SendChatFn: func(ctx context.Context, history []*domain_llm.Content, tools []*tools.ToolDeclaration, resolver domain_llm.AssetResolver) (*domain_llm.Content, *domain_llm.Metrics, error) {
-			// 1. Identify the last user prompt
-			lastUserPrompt := ""
-			for i := len(history) - 1; i >= 0; i-- {
-				if history[i].Role == "user" && len(history[i].Parts) > 0 && history[i].Parts[0].Text != "" && !strings.Contains(history[i].Parts[0].Text, "System") {
-					lastUserPrompt = history[i].Parts[0].Text
-					break
-				}
-			}
-
-			// 2. Handle Tool Response state
-			if len(history) > 0 && len(history[len(history)-1].Parts) > 0 && history[len(history)-1].Parts[0].FunctionResponse != nil {
-				return &domain_llm.Content{
-					Role:  "model",
-					Parts: []*domain_llm.Part{{Text: "I see the cat image."}},
-				}, &domain_llm.Metrics{}, nil
-			}
-
-			// 3. Handle Initial Prompt state
-			if lastUserPrompt == "Show me a cat" {
-				return &domain_llm.Content{
-					Role: "model",
-					Parts: []*domain_llm.Part{
-						{FunctionCall: &domain_llm.FunctionCall{ID: "call_123", Name: "get_image", Args: map[string]interface{}{}}},
-					},
-				}, &domain_llm.Metrics{}, nil
-			}
-
-			return &domain_llm.Content{
-				Role:  "model",
-				Parts: []*domain_llm.Part{{Text: "Default response"}},
-			}, &domain_llm.Metrics{}, nil
-		},
+		SendChatFn: multiModalSendChat,
 	}
+}
+
+func multiModalSendChat(ctx context.Context, history []*domain_llm.Content, tools []*tools.ToolDeclaration, resolver domain_llm.AssetResolver) (*domain_llm.Content, *domain_llm.Metrics, error) {
+	lastUserPrompt := getLastUserPrompt(history)
+	hasFunctionResponse := hasFuncResp(history)
+
+	// 2. Handle Tool Response state
+	if hasFunctionResponse {
+		return &domain_llm.Content{
+			Role:  "model",
+			Parts: []*domain_llm.Part{{Text: "I see the cat image."}},
+		}, &domain_llm.Metrics{}, nil
+	}
+
+	// 3. Handle Initial Prompt state
+	if lastUserPrompt == "Show me a cat" {
+		return &domain_llm.Content{
+			Role: "model",
+			Parts: []*domain_llm.Part{
+				{FunctionCall: &domain_llm.FunctionCall{ID: "call_123", Name: "get_image", Args: map[string]interface{}{}}},
+			},
+		}, &domain_llm.Metrics{}, nil
+	}
+
+	return &domain_llm.Content{
+		Role:  "model",
+		Parts: []*domain_llm.Part{{Text: "Default response"}},
+	}, &domain_llm.Metrics{}, nil
+}
+
+func getLastUserPrompt(history []*domain_llm.Content) string {
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "user" && len(history[i].Parts) > 0 && history[i].Parts[0].Text != "" && !strings.Contains(history[i].Parts[0].Text, "System") {
+			return history[i].Parts[0].Text
+		}
+	}
+	return ""
+}
+
+func hasFuncResp(history []*domain_llm.Content) bool {
+	if len(history) == 0 {
+		return false
+	}
+	lastTurn := history[len(history)-1]
+	for _, p := range lastTurn.Parts {
+		if p.FunctionResponse != nil {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Resolves #1441

### Description
When a tool result contains both a `FunctionResponse` and `InlineData` (e.g. from `read_image`), the Gemini API (Vertex AI) requires the parts to be ordered such that `InlineData` precedes the `FunctionResponse`. If the order is reversed, the API parser silently strips or invalidates the entire user message containing the response. This causes the preceding model turn to appear unanswered, triggering an immediate `Error 400: Requests ending with a model turn are not supported`.

This PR reverses the appending order in `AssembleResponse` so that `InlineData` correctly precedes `FunctionResponse`.

### Changes
*   Reversed appending order in `AssembleResponse` in `internal/agent/executor/executor.go`
*   Updated `tests/integration/agent/executor/executor_table_test.go` to assert the new part ordering
*   Extracted mock test functions in `tests/integration/agent/regression_test.go` to adhere to cyclomatic complexity thresholds.