### PR TITLE
feat(llm): enable vision for Z.AI glm-5.3-flash via capability allowlist (#1449)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Significant architectural decisions are documented in our [Architecture Decision
 *   **[ADR-068](docs/adr/2026-09-automatic-plur-memory-integration.md)** — automatic PLUR memory integration: `plurInjector` context transformer (priority 15, marker-keyed replace-in-place) and `plurHook` TurnHook (four-tier `LEARN`) over the `tools.MCPClient` domain port (issue #1404).
 *   **[ADR-069](docs/adr/2026-09-mcp-stdio-env-key-case-preservation.md)** — MCP stdio ENV key case preservation: total Viper bypass, byte-for-byte child env keys, deterministic collision rejection (issue #1407).
 *   **[ADR-070](docs/adr/2026-09-deepseek-vision-capability.md)** — DeepSeek vision capability via suffix-based classification and `FileUploadMode` enum decomposition; vision/video decoupling in the OpenAI transport; turn-scoped Files API lifecycle (issue #1429).
+*   **[ADR-071](docs/adr/2026-09-glm-53-flash-vision-capability.md)** — Z.AI GLM-5.3-Flash vision capability via OpenAI-compatible `image_url` blocks: explicit allowlist (no GLM naming convention), inline Base64 data URLs (`FileUploadMode: FileUploadNone`), no inline size guard (issue #1449).
 
 For the evolution of the shell-based environment management tooling — from simple bash aliases through Toby, Dobby, Porter, Sprawl, Winky, Flopsy, and Niffler — see [Evolution of Environment Management](docs/architect/environments/environment-management-evolution.md).
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ SPDX-License-Identifier: MIT
 
 # tell-me-go: A Multi-Provider Reasoning Agent for the Terminal
 
-A high-performance CLI assistant unifying the world's most powerful reasoning engines (**Gemini, OpenAI, DeepSeek, Claude, Kimi**) under a single, resilient interface.
+A high-performance CLI assistant unifying the world's most powerful reasoning engines (**Gemini, OpenAI, DeepSeek, Claude, Kimi, Z.ai**) under a single, resilient interface.
 
 ## Overview
-`tell-me-go` is a production-ready reasoning agent designed for complex developer workflows. By abstracting the complexities of diverse LLM providers (**Google Vertex AI, OpenAI, DeepSeek, Anthropic, Kimi-K3**) into a unified domain model, it provides a stable platform for tool-augmented intelligence and multi-turn reasoning. Built with the speed of Go, it prioritizes session durability through automated context maintenance, provides a rich TUI for history exploration, and prevents "hidden" expenses with deterministic cost auditing and safety guardrails.
+`tell-me-go` is a production-ready reasoning agent designed for complex developer workflows. By abstracting the complexities of diverse LLM providers (**Google Vertex AI, OpenAI, DeepSeek, Anthropic, Kimi-K3, GLM-5.3**) into a unified domain model, it provides a stable platform for tool-augmented intelligence and multi-turn reasoning. Built with the speed of Go, it prioritizes session durability through automated context maintenance, provides a rich TUI for history exploration, and prevents "hidden" expenses with deterministic cost auditing and safety guardrails.
 
 ## 🚀 Features
-*   **Multi-Provider Reasoning**: Native support for Gemini 3.0/3.1, GPT-5.4/5.5, DeepSeek V3.2/V4, Kimi-K3, and Claude 4.7 — across Google Vertex AI, OpenAI, DeepSeek, Moonshot, and Anthropic APIs.
+*   **Multi-Provider Reasoning**: Native support for Gemini 3.0/3.1, GPT-5.4/5.5, DeepSeek V3.2/V4, Kimi-K3, GLM-5.3 and Claude 4.7 — across Google Vertex AI, OpenAI, DeepSeek, Moonshot, Z.ai and Anthropic APIs.
 *   **Intelligence & Context**:
     *   **Skills.sh Ecosystem**: Discover, install, and remove skills on the fly from the open agent skills ecosystem. Skills are installed via `git clone` into `.skills/` and are available immediately. Requires user approval for installation.
     *   **Unified Domain Model**: Optimized for a provider-agnostic `Thought` architecture, ensuring consistent reasoning across models.

--- a/docs/adr/2026-09-glm-53-flash-vision-capability.md
+++ b/docs/adr/2026-09-glm-53-flash-vision-capability.md
@@ -1,0 +1,63 @@
+# ADR-071: GLM-5.3-Flash Vision Capability via OpenAI-Compatible image_url Blocks
+
+## Status
+Accepted (2026-09)
+
+## Context
+Z.AI's `glm-5.3-flash` (served via an OpenAI-compatible endpoint at `https://api.z.ai/api/paas/v4`, provider type `openai`) is natively multimodal — images, videos, and files — but tell-me-go dropped image parts for it: `ResolveCapabilities` never set `SupportsVision` for any `glm-*` model (only `kimi-*` and `deepseek-*-vision*` models got it), so the OpenAI transport's `hasSupportedMedia`/`mediaBlockFor` gates dropped the parts and `mediaOmittedFallback` substituted the placeholder "(image content omitted — this model does not support image input)".
+
+Two facts shaped the classification design:
+
+1. **There is no reliable naming convention across GLM generations.** Older vision models use a `V` suffix (`glm-4.5V`, `glm-4.6V`, `glm-4.6V-FlashX`); text models use bare `-flash` (`glm-4.7-flash` is text-only); and the first native multimodal GLM-5 model (`glm-5.3-flash`) has **no `V` marker at all**. A suffix/substring heuristic (`-flash`, `V`, `vision`) misclassifies either `glm-4.7-flash` or `glm-5.3-flash`.
+2. **The wire format is standard Chat Completions.** Z.AI documents image input as `{"type":"image_url","image_url":{"url": ...}}` content blocks where `url` accepts a Base64 Data URL — the exact block shape the OpenAI transport already emits for vision-capable models via `mediaBlockFor`/`resolveURL` (base64 data URI for unbound parts, `FileUploadMode: FileUploadNone`). No Responses API, no new block types, no upload API.
+
+## Decision
+
+### Decision 1: Explicit allowlist for GLM vision classification (seeded with `glm-5.3-flash`)
+`isGLMVisionModel(model)` returns true for exactly `glm-5.3-flash` (and the namespaced `*/glm-5.3-flash` form), mirroring the `isKimiK3Model` exact-match pattern. `resolveGLMFamily` sets only `SupportsVision`; `SupportsVideo` stays false, `FileUploadMode` stays `FileUploadNone`, and `MaxTokensField` stays `MaxTokensFieldLegacy` (correct for Z.AI's Chat Completions protocol). The allowlist is extended as Z.AI ships more multimodal GLM variants; a naming heuristic was rejected because `glm-4.7-flash` (text) and `glm-5.3-flash` (multimodal) are indistinguishable by pattern.
+
+### Decision 2: Inline Base64 data URLs (`FileUploadMode: FileUploadNone`)
+Images are sent inline as `data:<mime>;base64,...` inside `image_url.url` — the path Z.AI documents and the transport already implements for OpenAI-family vision models. No turn-scoped Files API lifecycle (the DeepSeek `FileUploadDeepSeek` upload/delete machinery) is used.
+
+### Decision 3: No new size guard for the GLM inline path
+The OpenAI-family inline path has no byte/dimension guard today (`maxInlineMediaBytes`/`maxRequestBodyBytes` are consulted only by `checkDeepSeekMediaSizes` under `FileUploadMode == FileUploadDeepSeek`). For v1 this stays: Z.AI publishes no inline-image size limit, so inventing one would be a guess; oversized images are rejected by the provider (a recoverable 4xx). The gap is documented here; a transport-sanity byte ceiling reusing `maxRequestBodyBytes` remains a candidate if Z.AI publishes a limit.
+
+## Consequences
+
+### Positive
+- Image input works on `zai-flash` (`glm-5.3-flash`) with a capability-layer-only change — zero transport modification.
+- Text-only turns are byte-identical to before; `glm-5.3` and `glm-4.7-flash` remain text-only (`SupportsVision: false`), pinned by tests.
+- The allowlist is honest about the absence of a GLM naming convention and rot-resistant for a family with a handful of models.
+
+### Negative / Accepted Trade-offs
+- Allowlist rot: a future multimodal GLM variant not added to the allowlist is silently text-only until recorded. Mitigated by the D1 rationale and architect review on model additions.
+- No inline size guard: an oversized image fails at the provider (4xx) rather than client-side (Decision 3).
+- Out of scope: video input (`video_url`), file input (`file_url`), and `reasoning_effort`/`thinking` control for GLM (the existing config already works; Z.AI documents `thinking.type` supports only `enabled`).
+
+### Neutral
+- The GLM resolver is additive — no existing family's capability output changes.
+- `SupportsVideo` and `FileUploadMode` remain kimi/deepseek-scoped; GLM video is a separate follow-up (one extra capability flag + test).
+
+## Alternatives Considered
+
+1. **Naming heuristic (`glm-` prefix ∧ suffix rule).** Rejected — `glm-4.7-flash` (text) vs `glm-5.3-flash` (multimodal) are indistinguishable by pattern; the `V`-suffix convention does not extend to GLM-5.
+2. **Transport-sanity byte ceiling (Decision 3 Option B).** Deferred — Z.AI publishes no inline-image size limit; a client-side guess adds surface without provider backing.
+
+## Verification
+- `internal/domain/llm/capabilities_test.go`: `TestResolveCapabilities` rows for `glm-5.3-flash` (true), namespaced `z.ai/glm-5.3-flash` (true), `glm-5.3` (false), `glm-4.7-flash` (false), `glm-4.5V` (false); `TestResolveCapabilities_FileUploadMode` row (`glm-5.3-flash` → `FileUploadNone`); `TestCapabilities_FileUploadMode_OutOfRange` row.
+- `internal/infrastructure/llm/openai/client_vision_test.go`: `TestVision_GLMImagePayload` — a `glm-5.3-flash` client serializes a user image as `{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}` with the text block, and no `file`/`file_id`/`ms://` blocks.
+- `make check-full` passes (including `verify-nonfix-catalog` and `verify-adr-index`).
+
+## Related ADRs
+- [ADR-070](2026-09-deepseek-vision-capability.md) — the vision-classification + `FileUploadMode` decomposition precedent this decision extends.
+- [ADR-024](2026-04-openai-budget-field-divergence.md) — enums-over-booleans precedent; `FileUploadMode`/`MaxTokensField` are reused, not extended.
+
+## References
+- Z.AI GLM-5.3-Flash model page: https://docs.z.ai/guides/vlm/glm-5.3-flash.md
+- Z.AI Chat Completion API reference: https://docs.z.ai/api-reference/llm/chat-completion.md
+- Z.AI GLM-5.3 (text-only) page: https://docs.z.ai/guides/llm/glm-5.3.md
+- Issue #1449.
+- ADR-070 files-changed precedent: `internal/domain/llm/capabilities.go`, `internal/infrastructure/llm/openai/{client.go,files.go}`, test files, `configs/butler.yaml`, `README.md`.
+
+---
+*Last Updated: 2026-09 (issue #1449)*

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -76,6 +76,7 @@ This directory contains Architectural Decision Records (ADRs) documenting signif
 | **ADR-068** | Automatic PLUR Memory Integration | 2026-09 | Accepted | [2026-09-automatic-plur-memory-integration.md](2026-09-automatic-plur-memory-integration.md) |
 | **ADR-069** | MCP stdio ENV key case preservation — total Viper bypass | 2026-09 | Accepted | [2026-09-mcp-stdio-env-key-case-preservation.md](2026-09-mcp-stdio-env-key-case-preservation.md) |
 | **ADR-070** | DeepSeek Vision Capability and FileUploadMode Decomposition | 2026-09 | Accepted | [2026-09-deepseek-vision-capability.md](2026-09-deepseek-vision-capability.md) |
+| **ADR-071** | GLM-5.3-Flash Vision Capability via OpenAI-Compatible image_url Blocks | 2026-09 | Accepted | [2026-09-glm-53-flash-vision-capability.md](2026-09-glm-53-flash-vision-capability.md) |
 
 ## How to Create a New ADR
 

--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -98,8 +98,8 @@ type Capabilities struct {
 	// parts are serialized as base64 image_url blocks rather than being
 	// silently dropped.
 	//
-	// Set for: kimi-* models (K3, K2.7, K2.6) and the Z.AI GLM allowlist
-	// (glm-5.3-flash).
+	// Set for: kimi-* models (K3, K2.7, K2.6), deepseek-*-vision* models,
+	// and the Z.AI GLM allowlist (glm-5.3-flash).
 	SupportsVision bool
 	// SupportsVideo indicates the model natively understands video via
 	// video_url content parts in the messages array. When true, InlineData

--- a/internal/domain/llm/capabilities.go
+++ b/internal/domain/llm/capabilities.go
@@ -98,7 +98,8 @@ type Capabilities struct {
 	// parts are serialized as base64 image_url blocks rather than being
 	// silently dropped.
 	//
-	// Set for: kimi-* models (K3, K2.7, K2.6).
+	// Set for: kimi-* models (K3, K2.7, K2.6) and the Z.AI GLM allowlist
+	// (glm-5.3-flash).
 	SupportsVision bool
 	// SupportsVideo indicates the model natively understands video via
 	// video_url content parts in the messages array. When true, InlineData
@@ -189,6 +190,25 @@ func isKimiK3Model(model string) bool {
 	return model == "kimi-k3" || strings.HasSuffix(model, "/kimi-k3")
 }
 
+// isGLMVisionModel returns true for the Z.AI GLM model IDs that natively
+// accept image input via image_url content blocks. Explicit allowlist —
+// there is no reliable naming convention across GLM generations: older
+// vision models use a V suffix (glm-4.5V, glm-4.6V), text models use bare
+// -flash (glm-4.7-flash is text-only), and the first native multimodal
+// GLM-5 (glm-5.3-flash) has no V marker at all. Extend as Z.AI ships more
+// multimodal GLM variants. Mirrors the isKimiK3Model exact-match pattern.
+func isGLMVisionModel(model string) bool {
+	return model == "glm-5.3-flash" || strings.HasSuffix(model, "/glm-5.3-flash")
+}
+
+// resolveGLMFamily derives GLM capabilities from the model string. For
+// v1 this sets ONLY SupportsVision (images via inline base64 image_url
+// blocks, FileUploadMode None). Video, file input, and reasoning-effort
+// control for GLM are explicitly out of scope (issue #1449).
+func resolveGLMFamily(model string) (supportsVision bool) {
+	return isGLMVisionModel(model)
+}
+
 // resolveGPTFamily derives GPT and o-series capabilities from the model string.
 func resolveGPTFamily(model string) (isReasoner bool, requireResponses bool) {
 	v := parseGPTVersion(model)
@@ -242,6 +262,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 	isReasoner, requireResponses := resolveGPTFamily(model)
 	isDeepSeek, dsReasoningContent, dsThinkingToggle, vertexThinkingKwargs, dsVision, dsFileMode := resolveDeepSeekFamily(model, baseURL)
 	kReasoningContent, kThinkingToggle, kVision, kVideo, kFileMode, kReasoningEffort, isKimiK3 := resolveKimiFamily(model)
+	gVision := resolveGLMFamily(model)
 
 	fileUploadMode := FileUploadNone
 	if dsFileMode != FileUploadNone {
@@ -258,7 +279,7 @@ func ResolveCapabilities(model, baseURL string) Capabilities {
 		IsDeepSeek:                   isDeepSeek,
 		SupportsReasoningContent:     dsReasoningContent || kReasoningContent,
 		SupportsThinkingToggle:       dsThinkingToggle || kThinkingToggle,
-		SupportsVision:               dsVision || kVision,
+		SupportsVision:               dsVision || kVision || gVision,
 		SupportsVideo:                kVideo,
 		FileUploadMode:               fileUploadMode,
 		RequiresVertexThinkingKwargs: vertexThinkingKwargs,

--- a/internal/domain/llm/capabilities_test.go
+++ b/internal/domain/llm/capabilities_test.go
@@ -296,6 +296,61 @@ func TestResolveCapabilities(t *testing.T) {
 			supportsVision:           false,
 			supportsVideo:            false,
 		},
+		{
+			name:                     "glm-5.3-flash is native multimodal (Z.AI)",
+			model:                    "glm-5.3-flash",
+			supportsReasoningEffort:  false,
+			requiresResponsesAPI:     false,
+			useDeveloperRole:         false,
+			maxTokensField:           MaxTokensFieldLegacy,
+			isDeepSeek:               false,
+			supportsReasoningContent: false,
+			supportsVision:           true,
+		},
+		{
+			name:                     "glm-5.3-flash namespaced (z.ai/glm-5.3-flash)",
+			model:                    "z.ai/glm-5.3-flash",
+			supportsReasoningEffort:  false,
+			requiresResponsesAPI:     false,
+			useDeveloperRole:         false,
+			maxTokensField:           MaxTokensFieldLegacy,
+			isDeepSeek:               false,
+			supportsReasoningContent: false,
+			supportsVision:           true,
+		},
+		{
+			name:                     "glm-5.3 is text-only per Z.AI docs",
+			model:                    "glm-5.3",
+			supportsReasoningEffort:  false,
+			requiresResponsesAPI:     false,
+			useDeveloperRole:         false,
+			maxTokensField:           MaxTokensFieldLegacy,
+			isDeepSeek:               false,
+			supportsReasoningContent: false,
+			supportsVision:           false,
+		},
+		{
+			name:                     "glm-4.7-flash is text-only (allowlist, not suffix heuristic)",
+			model:                    "glm-4.7-flash",
+			supportsReasoningEffort:  false,
+			requiresResponsesAPI:     false,
+			useDeveloperRole:         false,
+			maxTokensField:           MaxTokensFieldLegacy,
+			isDeepSeek:               false,
+			supportsReasoningContent: false,
+			supportsVision:           false,
+		},
+		{
+			name:                     "glm-4.5V not in allowlist (V-suffix heuristic rejected)",
+			model:                    "glm-4.5V",
+			supportsReasoningEffort:  false,
+			requiresResponsesAPI:     false,
+			useDeveloperRole:         false,
+			maxTokensField:           MaxTokensFieldLegacy,
+			isDeepSeek:               false,
+			supportsReasoningContent: false,
+			supportsVision:           false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -393,6 +448,7 @@ func TestResolveCapabilities_FileUploadMode(t *testing.T) {
 		{"deepseek-v4-pro", FileUploadNone},
 		{"deepseek-reasoner", FileUploadNone},
 		{"gpt-5.5", FileUploadNone},
+		{"glm-5.3-flash", FileUploadNone},
 	}
 	for _, tt := range tests {
 		t.Run(tt.model, func(t *testing.T) {
@@ -408,6 +464,7 @@ func TestCapabilities_FileUploadMode_OutOfRange(t *testing.T) {
 		"gpt-5.5", "deepseek-v4-flash", "deepseek-v4-pro", "deepseek-v4-flash-vision-exp",
 		"deepseek-reasoner", "kimi-k3", "kimi-k2.7-code", "kimi-k2.6",
 		"claude-opus-4-7", "gemini-3-flash-preview",
+		"glm-5.3-flash",
 	}
 	for _, m := range models {
 		t.Run(m, func(t *testing.T) {

--- a/internal/infrastructure/llm/openai/client_vision_test.go
+++ b/internal/infrastructure/llm/openai/client_vision_test.go
@@ -653,3 +653,47 @@ func TestMediaOmittedFallback(t *testing.T) {
 		})
 	}
 }
+
+func TestVision_GLMImagePayload(t *testing.T) {
+	c := NewClient("", "glm-5.3-flash",
+		&auth.BearerAuth{Token: "test"},
+		WithLogger(&ports.NoOpLogger{}),
+	)
+	if !c.capabilities.SupportsVision {
+		t.Fatal("glm-5.3-flash should have SupportsVision")
+	}
+	if c.capabilities.SupportsVideo {
+		t.Fatal("glm-5.3-flash should NOT have SupportsVideo")
+	}
+	if c.capabilities.FileUploadMode != llm.FileUploadNone {
+		t.Fatalf("expected FileUploadNone mode, got %d", c.capabilities.FileUploadMode)
+	}
+
+	history := []*llm.Content{{
+		Role: "user",
+		Parts: []*llm.Part{
+			{InlineData: &llm.Blob{MIMEType: "image/png", Data: []byte{0x89, 0x50}}},
+			{Text: "describe this"},
+		},
+	}}
+
+	msgs, err := c.toStandardMessages(context.Background(), history, nil)
+	if err != nil {
+		t.Fatalf("toStandardMessages failed: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(msgs))
+	}
+	b, err := json.Marshal(msgs[0])
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	s := string(b)
+	assertVisionJSONContains(t, s, `"type":"image_url"`, "image_url block")
+	assertVisionJSONContains(t, s, "data:image/png;base64", "base64 data URI")
+	assertVisionJSONContains(t, s, `"type":"text"`, "text block")
+	assertVisionJSONContains(t, s, "describe this", "text content")
+	assertVisionJSONAbsent(t, s, `"type":"file"`, "file block")
+	assertVisionJSONAbsent(t, s, "file_id", "file_id")
+	assertVisionJSONAbsent(t, s, "ms://", "ms:// reference")
+}


### PR DESCRIPTION
## Summary

Enables vision (image input) for Z.AI `glm-5.3-flash` (the `zai-flash` provider) via OpenAI-compatible `image_url` blocks. Capability-layer-only change — the existing OpenAI transport already emits the exact `{"type":"image_url","image_url":{"url":"data:...;base64,..."}}` block shape Z.AI documents.

Fixes #1449.

## Changes

**T1 — `feat(llm)` (454a1cf5)**
- `internal/domain/llm/capabilities.go`: `isGLMVisionModel` allowlist helper (`glm-5.3-flash` + namespaced `*/glm-5.3-flash`, mirroring `isKimiK3Model`), single-branch `resolveGLMFamily` resolver, wired as `SupportsVision: dsVision || kVision || gVision`. No new exported symbols; `SupportsVideo`/`FileUploadMode`/`MaxTokensField` untouched.
- `internal/domain/llm/capabilities_test.go`: 5 new `TestResolveCapabilities` rows (glm-5.3-flash → true; namespaced → true; glm-5.3 / glm-4.7-flash / glm-4.5V → false) + FileUploadMode row + OutOfRange row. Rows only — CC pin (13) preserved.
- `internal/infrastructure/llm/openai/client_vision_test.go`: `TestVision_GLMImagePayload` appended at file end — asserts image_url + base64 data URI + text, no file/ms:// blocks.

**T2 — `docs(adr)` (d9bd4445)**
- New `docs/adr/2026-09-glm-53-flash-vision-capability.md` (ADR-071): D1 explicit allowlist, D2 inline base64 data URLs, D3 no inline size guard (Z.AI publishes no limit), consequences, alternatives, verification, references.
- `docs/adr/README.md` index row + `README.md` Design Decisions bullet.

**T3 — `docs(llm)` nit (65f6a6f9)** (post-review)
- Completed the `SupportsVision` doc comment to name all three sources (`kimi-*`, `deepseek-*-vision*`, and the Z.AI GLM allowlist).

## Acceptance criteria mapping (issue #1449)

- [x] D1/D2/D3 recorded in ADR-071 with ratified choices in code + tests
- [x] `ResolveCapabilities("glm-5.3-flash")` → `SupportsVision: true`; boundary holds (`glm-5.3`, `glm-4.7-flash` → false)
- [x] Image part via `zai-flash` → `image_url` block with base64 data URI (unit-proven wire shape); no drop, no `mediaOmittedFallback`
- [x] Text-only turns unaffected (no image_url block when no media parts)
- [x] `glm-5.3` remains text-only
- [x] `make check-full` passes

**Remaining (user-verified):** live `POST /paas/v4/chat/completions` with a real Z.AI API key (needs credentials; unit test proves the exact wire shape).

## Verification

| Gate | Result |
|---|---|
| `go test ./internal/domain/llm/ ./internal/infrastructure/llm/openai/` | PASS |
| `go test -race ./internal/domain/llm/ ./internal/infrastructure/llm/openai/` | PASS |
| `make verify-nonfix-catalog` | PASS (4 pins unmoved: capabilities_test.go:10, client_vision_test.go:18/129/244) |
| `make verify-adr-index` | PASS (ADR-071 indexed) |
| `make check-full` | **PASS** — `All checks passed (including race detection).` (orchestrator re-run, exit 0) |

## Out of scope (per issue)

Video input, file input, `reasoning_effort`/`thinking` control for GLM — tracked as follow-ups in #1449's out-of-scope section.