### PR TITLE
fix(analysis): protect errors.Wrapper.Unwrap from dead-code false positives

### DIFF
--- a/internal/tools/analysis/dead_code_contracts_test.go
+++ b/internal/tools/analysis/dead_code_contracts_test.go
@@ -83,6 +83,8 @@ func TestIsWellKnownContract_Table(t *testing.T) {
 		// --- Positive: legacy contracts ---
 		{"Error()string", "Error", nil, []string{"string"}, true},
 		{"String()string", "String", nil, []string{"string"}, true},
+		// --- Positive: errors.Wrapper.Unwrap (errors.Is / errors.As / %w) ---
+		{"Unwrap()error", "Unwrap", nil, []string{"error"}, true},
 		// --- Positive: io contracts (basic-kind-only) ---
 		{"Read([]byte)(int,error)", "Read", []string{"[]byte"}, []string{"int", "error"}, true},
 		{"Write([]byte)(int,error)", "Write", []string{"[]byte"}, []string{"int", "error"}, true},
@@ -101,6 +103,8 @@ func TestIsWellKnownContract_Table(t *testing.T) {
 
 		// --- Negative: matching name, wrong signature ---
 		{"Write(string)", "Write", []string{"string"}, nil, false},
+		{"Unwrap()string", "Unwrap", nil, []string{"string"}, false},
+		{"Unwrap()(error,error)", "Unwrap", nil, []string{"error", "error"}, false},
 		{"Close()(error,error)", "Close", nil, []string{"error", "error"}, false},
 		{"Read()", "Read", nil, nil, false},
 		{"MarshalJSON([]byte)error", "MarshalJSON", []string{"[]byte"}, []string{"error"}, false},

--- a/internal/tools/analysis/wellknown.go
+++ b/internal/tools/analysis/wellknown.go
@@ -29,6 +29,7 @@ import (
 //	encoding.TextUnmarshaler.UnmarshalText params=[[]byte] results=[error]
 //	encoding.BinaryMarshaler.MarshalBinary     params=[] results=[[]byte error]
 //	encoding.BinaryUnmarshaler.UnmarshalBinary params=[[]byte] results=[error]
+//	errors.Wrapper.Unwrap       params=[]       results=[error]
 //	http.Handler.ServeHTTP params=[net/http.ResponseWriter *net/http.Request] results=[]
 //	sql.Scanner.Scan       params=[any] results=[error]
 //
@@ -95,6 +96,12 @@ var wellKnownContractMethods = map[string][]wellKnownContractSignature{
 	"ServeHTTP": {{params: []string{"net/http.ResponseWriter", "*net/http.Request"}, results: nil}},
 	// database/sql.Scanner.Scan
 	"Scan": {{params: []string{"any"}, results: []string{"error"}}},
+	// errors.Wrapper.Unwrap — consumed structurally by errors.Is / errors.As /
+	// fmt.Errorf("%w") (Go 1.13+ protocol). The call sites live inside the
+	// stdlib, so static analysis never sees the method's name; without this
+	// entry every error type with an Unwrap() error method (e.g. MediaSizeError,
+	// agentError) is a DEAD/PRIVATE false positive.
+	"Unwrap": {{params: nil, results: []string{"error"}}},
 	// github.com/charmbracelet/bubbletea.Model.Init
 	"Init": {{params: nil, results: []string{"github.com/charmbracelet/bubbletea.Cmd"}}},
 	// github.com/charmbracelet/bubbletea.Model.Update


### PR DESCRIPTION
## Summary

Fixes a dead-code analyzer false positive: `Unwrap() error` methods were flagged as DEAD because the method is consumed **structurally** by Go's error-unwrapping protocol (`errors.Is` / `errors.As` / `fmt.Errorf("%w")`) — the call sites live inside the stdlib, invisible to AST reference analysis.

`Unwrap` was missing from the analyzer's well-known-contract map (`internal/tools/analysis/wellknown.go`), which already protects the same class of protocol methods (`Error`, `String`, `MarshalJSON`, `Read`, `Write`, ...). This surfaced after #1448 landed `MediaSizeError.Unwrap` (`internal/domain/llm`):

```
$ make dead-code
[DEAD] internal/domain/llm.(MediaSizeError).Unwrap (Method) — No references found within the module
       (including interfaces/tests). [WARNING: Text search found potential cross-package usage.
       Verify this is not a false positive due to structural typing.]
```

The tool's own warning called it — it was a structural-typing false positive (the method is load-bearing: pinned by `errors.Is(err, llm.ErrTerminal)` tests and documented in ADR-073).

## Change

- `internal/tools/analysis/wellknown.go` — add `errors.Wrapper.Unwrap` (`func() error`) to `wellKnownContractMethods` with rationale comment; probe-reference comment updated.
- `internal/tools/analysis/dead_code_contracts_test.go` — positive row (`Unwrap()error` → true) + two wrong-signature negatives (`Unwrap()string`, `Unwrap()(error,error)` → false).

This protects **all** `Unwrap() error` methods (current: `MediaSizeError.Unwrap`, `agentError.Unwrap`; future error types) — a root-cause fix, not a per-type workaround.

## Verification

| Check | Result |
|---|---|
| `go test ./internal/tools/analysis/` | ✅ PASS |
| `make dead-code` | ✅ **"No dead code found."** (was: DEAD `MediaSizeError.Unwrap`) |
| `gofmt -l` | ✅ clean |
| `go vet ./internal/tools/analysis/` | ✅ clean |
| `make verify-nonfix-catalog` | ✅ PASS (arch-tagged) |

## Notes

- No feature-code changes; the analyzer's contract map is extended, matching its documented purpose ("stdlib single-method interfaces that may be satisfied structurally").
- No catalog edits (the dead-code gate is report-only; no `AcceptanceClass` fits a load-bearing protocol method).