### PR TITLE
fix(analysis): analyzer fidelity, catalog re-anchoring, TUI dispatch coverage (#1455)

### DIFF
--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -1010,7 +1010,10 @@ catalog a new gap no one reviewed. Policy:
   it (T5 measurement); CC re-verified 13 (unchanged). Re-anchored 2026-09
   (#1412): line drifted 142→179 as the T1 delayFile/delayTool server fields
   and FAKE_PLUR_DELAY_* env wiring grew the file above it; CC re-verified
-  13 (unchanged).
+  13 (unchanged). Re-scoped 2026-09 (#1455): `testdata/` directories are
+  excluded from the complexity walk (R1); the mechanical gate no longer
+  measures these functions. Entry retained as the architectural acceptance
+  record; recorded CC values remain valid.
 - **See**: `tests/e2e/testdata/fakeplur/main.go:179`
 
 ### tests/e2e/testdata/fakeplur/main.go — (*server).dispatchTool (CC=14)
@@ -1029,7 +1032,10 @@ catalog a new gap no one reviewed. Policy:
   `plur_learn_batch` case were added (T5). Re-anchored 2026-09 (#1412):
   line drifted 381→419 as the T1 delayFile/delayTool plumbing grew the file
   above it; CC re-measured 13→14 — the delay guard adds one decision point,
-  still the same dispatch-structural class.
+  still the same dispatch-structural class. Re-scoped 2026-09 (#1455):
+  `testdata/` directories are excluded from the complexity walk (R1); the
+  mechanical gate no longer measures these functions. Entry retained as the
+  architectural acceptance record; recorded CC values remain valid.
 - **See**: `tests/e2e/testdata/fakeplur/main.go:419`
 
 ### tests/e2e/memory_live_test.go — TestLivePlurCapturePersists (CC=12)

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -654,12 +654,15 @@ catalog a new gap no one reviewed. Policy:
     `state.SetInfo` (`AtomicWrite` disk fault), `getConcurrencyLimit` (`runtime.NumCPU() < 1`
     structurally unreachable), `processWatcherEvents` (goroutine timing).
   Re-anchored 2026-09: sqlite_store RowsAffected refs 200/218 → 207-209/224-226 (actual gap lines); state.go:56 ref dropped (AtomicWrite branch covered).
+  Re-anchored 2026-09 (#1455): setupCommand 118→131-133 and
+  resolveAndValidateOutputPath Windows branch 356→368-378 as preceding code
+  grew; verified against the live source and a fresh coverage profile.
 - **See**: Inline architect-acceptance comments at each gap site:
   `internal/tools/analysis/propagate_named_interface_assertions.go:62`,
   `internal/tools/analysis/propagate_transitive.go:32`,
   `internal/tools/analysis/propagate_transitive.go:128`,
-  `internal/tools/workspace/process_executor.go:118`,
-  `internal/tools/workspace/process_executor.go:356`,
+  `internal/tools/workspace/process_executor.go:131-133`,
+  `internal/tools/workspace/process_executor.go:368-378`,
   `internal/tools/workspace/pipeline.go:56`,
   `internal/tools/analysis/complexity.go:125`,
   `internal/infrastructure/persistence/sqlite_store.go:207-209,224-226`,
@@ -1050,6 +1053,11 @@ catalog a new gap no one reviewed. Policy:
   acceptance class as `TestHistoryNavigation_CompleteWorkflow` (CC=15) —
   sequential workflow where steps depend on prior state; splitting would
   duplicate the expensive live-store setup. New 2026-09 (#1410, T7).
+  Re-scoped 2026-09 (#1455): build-tag-excluded files are skipped by the
+  complexity walk (R2); `tests/e2e/memory_live_test.go` carries
+  `//go:build e2e_live` (ADR-068 §8) and is never compiled on a plain host, so
+  the mechanical gate no longer measures this function. Entry retained as the
+  architectural acceptance record; recorded CC values remain valid.
 - **See**: `tests/e2e/memory_live_test.go:285`
 
 ### tests/e2e/e2e_test.go — newestSourceMTime (CC=13)

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -453,7 +453,14 @@ catalog a new gap no one reviewed. Policy:
   The package exists to enable deterministic time control in tests across the
   project. Every line of code is either an interface definition, a stdlib
   delegation, or a test fake. There is no business logic to cover.
-- **See**: `internal/pkg/clock/clock.go`
+  Re-anchored 2026-09 (#1455): the file-only See ref was dropped by the
+  coverage matcher (interval-overlap matching requires a line spec), so all
+  15 zero-coverage blocks surfaced as uncataloged gaps; replaced with
+  per-symbol line specs per the #1433 agenttest/helpers.go re-anchor pattern.
+- **See**: `internal/pkg/clock/clock.go:81-83,85-87,89-92,95-97,99-103,106-108`
+  (FakeClock test fakes: Now, Since, Sleep, After, NewTicker, Jitter),
+  `internal/pkg/clock/clock.go:116-118,120-122,124-127,131`
+  (FakeTicker methods + `realTicker.Stop`)
 
 ### ui/tui/progress/renderer.go — glamour render error paths
 

--- a/docs/architect/INTENTIONAL_NON_FIXES.md
+++ b/docs/architect/INTENTIONAL_NON_FIXES.md
@@ -491,6 +491,12 @@ catalog a new gap no one reviewed. Policy:
   structurally unreachable in normal operation, cosmetic degrade only.
   Re-anchored 2026-09 (#1431): lines drifted 746 → 669-676 as the
   #1419-style render-path additions grew the file above the function.
+  Re-scoped 2026-09 (#1455, T6): the closure's success path is now covered
+  deterministically by executing the returned `tea.Cmd` directly
+  (`TestRenderMarkdownAsyncCmd` — no TUI harness required, contrary to the
+  original premise); coverage 13.3% → 81.8%. The two glamour error branches
+  (`model.go:670-672`, `:674-676`) remain uncovered and still justify this
+  record; the See ref still overlaps both.
 - **See**: `internal/ui/tui/progress/model.go:669-676` (`renderMarkdownAsync`)
 
 ### ui/renderer.go — SetWordWrap renderer rebuild error branch

--- a/internal/tools/analysis/buildtag.go
+++ b/internal/tools/analysis/buildtag.go
@@ -1,0 +1,69 @@
+package analysis
+
+import (
+	"go/build"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// buildTagExcluded reports whether the .go file at dir/base is excluded from
+// the host build by build constraints (//go:build line or filename suffix,
+// e.g. proc_windows.go on non-Windows hosts). R2, issue #1455: such files are
+// never compiled by `go tool` on this host, so the complexity walk must skip
+// them and report them as skipped instead of analyzing them.
+// label is the build-tag description for the skip report: the //go:build
+// expression when present, else the filename-suffix tags, else "unspecified".
+// On a MatchFile error the file is treated as included (analyze normally;
+// a genuinely broken file soft-fails in the parse path).
+func buildTagExcluded(dir, base string) (label string, excluded bool) {
+	included, err := build.Default.MatchFile(dir, base)
+	if err != nil || included {
+		return "", false
+	}
+	if l := headerBuildLabel(filepath.Join(dir, base)); l != "" {
+		return l, true
+	}
+	if l := suffixLabel(base); l != "" {
+		return l, true
+	}
+	return "unspecified", true
+}
+
+// headerBuildLabel scans the file header for a //go:build or // +build line,
+// stopping at the first non-blank, non-comment line. Returns "" when the
+// header carries no build constraint or the file cannot be read.
+func headerBuildLabel(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "//") {
+			if strings.HasPrefix(trimmed, "//go:build ") {
+				return strings.TrimSpace(strings.TrimPrefix(trimmed, "//go:build "))
+			}
+			if strings.HasPrefix(trimmed, "// +build ") {
+				return strings.TrimSpace(strings.TrimPrefix(trimmed, "// +build "))
+			}
+			continue
+		}
+		break // first non-blank, non-comment line: the header has ended
+	}
+	return ""
+}
+
+// suffixLabel derives the build-tag label from the filename suffix:
+// proc_windows.go → "windows", shell_windows_test.go → "windows",
+// x_windows_encoding_test.go → "windows/encoding". Returns "" when the base
+// carries no suffix tag.
+func suffixLabel(base string) string {
+	s := strings.TrimSuffix(base, ".go")
+	s = strings.TrimSuffix(s, "_test")
+	parts := strings.Split(s, "_")
+	if len(parts) > 1 {
+		return strings.Join(parts[1:], "/")
+	}
+	return ""
+}

--- a/internal/tools/analysis/buildtag_test.go
+++ b/internal/tools/analysis/buildtag_test.go
@@ -1,0 +1,68 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildTagExcluded is the R2 (issue #1455) table-driven unit contract for
+// buildTagExcluded. Real files on disk are required — go/build.MatchFile
+// reads from the host filesystem. Host-relative by definition.
+func TestBuildTagExcluded(t *testing.T) {
+	t.Parallel()
+
+	writeFile := func(t *testing.T, dir, base, content string) {
+		t.Helper()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, base), []byte(content), 0644))
+	}
+
+	t.Run("go:build constraint excludes", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "tagged.go", "//go:build anunexpectedtag\n\npackage x\nfunc W() {}\n")
+
+		label, excluded := buildTagExcluded(dir, "tagged.go")
+		require.True(t, excluded, "anunexpectedtag matches no host build context")
+		require.Equal(t, "anunexpectedtag", label)
+	})
+
+	t.Run("filename suffix excludes", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == "windows" {
+			t.Skip("filename suffix compiles on windows; guarantee is host-relative")
+		}
+		dir := t.TempDir()
+		writeFile(t, dir, "x_windows.go", "package x\nfunc W() {}\n")
+
+		label, excluded := buildTagExcluded(dir, "x_windows.go")
+		require.True(t, excluded)
+		require.Equal(t, "windows", label)
+	})
+
+	t.Run("unconstrained file included", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		writeFile(t, dir, "plain.go", "package x\n")
+
+		label, excluded := buildTagExcluded(dir, "plain.go")
+		require.False(t, excluded)
+		require.Empty(t, label)
+	})
+
+	t.Run("readable label from //go:build wins over suffix", func(t *testing.T) {
+		t.Parallel()
+		if runtime.GOOS == "windows" {
+			t.Skip("build-tag file compiles on windows; guarantee is host-relative")
+		}
+		dir := t.TempDir()
+		writeFile(t, dir, "x_windows.go", "//go:build windows\n\npackage x\nfunc W() {}\n")
+
+		label, excluded := buildTagExcluded(dir, "x_windows.go")
+		require.True(t, excluded)
+		require.Equal(t, "windows", label)
+	})
+}

--- a/internal/tools/analysis/complexity.go
+++ b/internal/tools/analysis/complexity.go
@@ -96,7 +96,7 @@ func (a *defaultComplexityAnalyzer) GatherComplexities(ctx context.Context, root
 	var skippedMu sync.Mutex
 	count := 0
 
-	walkFn := a.makeWalkFunc(g, gCtx, sem, hb, &complexities, &mu, &skippedErrs, &skippedMu, &count)
+	walkFn := a.makeWalkFunc(root, g, gCtx, sem, hb, &complexities, &mu, &skippedErrs, &skippedMu, &count)
 	if err := a.fs.Walk(ctx, root, walkFn); err != nil {
 		return nil, nil, err
 	}
@@ -130,7 +130,7 @@ func (a *defaultComplexityAnalyzer) getConcurrencyLimit() int64 {
 	return limit
 }
 
-func (a *defaultComplexityAnalyzer) makeWalkFunc(g *errgroup.Group, ctx context.Context, sem *semaphore.Weighted, hb chan<- struct{}, complexities *[]funcComplexity, mu *sync.Mutex, skippedErrs *[]string, skippedMu *sync.Mutex, count *int) persistence.WalkFunc {
+func (a *defaultComplexityAnalyzer) makeWalkFunc(root string, g *errgroup.Group, ctx context.Context, sem *semaphore.Weighted, hb chan<- struct{}, complexities *[]funcComplexity, mu *sync.Mutex, skippedErrs *[]string, skippedMu *sync.Mutex, count *int) persistence.WalkFunc {
 	return func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -140,7 +140,17 @@ func (a *defaultComplexityAnalyzer) makeWalkFunc(g *errgroup.Group, ctx context.
 			return ctx.Err()
 		default:
 		}
-		if info.IsDir() || filepath.Ext(filePath) != ".go" {
+		if info.IsDir() {
+			// R1 (issue #1455): honor the Go convention — `go tool` never compiles
+			// testdata/ directories, so the reporting walk must not traverse them.
+			// An explicit walk ROOT named testdata is still honored (fixture
+			// workspaces are loaded by path); only nested testdata is skipped.
+			if info.Name() == "testdata" && filepath.Clean(filePath) != filepath.Clean(root) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if filepath.Ext(filePath) != ".go" {
 			return nil
 		}
 

--- a/internal/tools/analysis/complexity.go
+++ b/internal/tools/analysis/complexity.go
@@ -40,6 +40,14 @@ type funcComplexity struct {
 	FilePath   string
 }
 
+// walkSkips partitions the files the complexity walk skipped, so the tool
+// report can distinguish broken sources (parse errors) from files that are
+// legitimately outside the host build (R2, issue #1455).
+type walkSkips struct {
+	ParseErrors []string // "<path>: <parse error>"
+	NotCompiled []string // "<path>: build tag: <label>"
+}
+
 // normalizeGoWildcard strips a trailing "/..." Go package wildcard from path.
 // "..." at the end of a path means "this directory and all subdirectories"
 // in Go tooling. Since GatherComplexities already walks recursively,
@@ -66,7 +74,7 @@ func (a *defaultComplexityAnalyzer) Analyze(ctx context.Context, args map[string
 		return tools.ToolResult{}, err
 	}
 
-	complexities, skippedErrs, err := a.GatherComplexities(ctx, resolvedPath, hb)
+	complexities, skips, err := a.GatherComplexities(ctx, resolvedPath, hb)
 	if err != nil {
 		return tools.ToolResult{}, err
 	}
@@ -78,27 +86,32 @@ func (a *defaultComplexityAnalyzer) Analyze(ctx context.Context, args map[string
 		text = a.formatResults(complexities)
 	}
 
-	if len(skippedErrs) > 0 {
-		text += "\n\n⚠️ Skipped " + strconv.Itoa(len(skippedErrs)) +
-			" file(s) due to parse errors:\n" + strings.Join(skippedErrs, "\n")
+	if len(skips.ParseErrors) > 0 {
+		text += "\n\n⚠️ Skipped " + strconv.Itoa(len(skips.ParseErrors)) +
+			" file(s) due to parse errors:\n" + strings.Join(skips.ParseErrors, "\n")
+	}
+
+	if len(skips.NotCompiled) > 0 {
+		text += "\n\nℹ️ Skipped " + strconv.Itoa(len(skips.NotCompiled)) +
+			" file(s) not compiled on host:\n" + strings.Join(skips.NotCompiled, "\n")
 	}
 
 	return tools.ToolResult{Text: text}, nil
 }
 
-func (a *defaultComplexityAnalyzer) GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, []string, error) {
+func (a *defaultComplexityAnalyzer) GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, walkSkips, error) {
 	g, gCtx := errgroup.WithContext(ctx)
 	sem := semaphore.NewWeighted(a.getConcurrencyLimit())
 
 	var complexities []funcComplexity
 	var mu sync.Mutex
-	var skippedErrs []string
+	skips := walkSkips{}
 	var skippedMu sync.Mutex
 	count := 0
 
-	walkFn := a.makeWalkFunc(root, g, gCtx, sem, hb, &complexities, &mu, &skippedErrs, &skippedMu, &count)
+	walkFn := a.makeWalkFunc(root, g, gCtx, sem, hb, &complexities, &mu, &skips, &skippedMu, &count)
 	if err := a.fs.Walk(ctx, root, walkFn); err != nil {
-		return nil, nil, err
+		return nil, walkSkips{}, err
 	}
 
 	// Coverage gap accepted by architect — the g.Wait() error path
@@ -108,10 +121,10 @@ func (a *defaultComplexityAnalyzer) GatherComplexities(ctx context.Context, root
 	// returning errors after a successful Walk) requires a filesystem
 	// that fails selectively mid-traversal, which is not reproducible.
 	if err := g.Wait(); err != nil {
-		return nil, nil, fmt.Errorf("gathering complexity metrics: %w", err)
+		return nil, walkSkips{}, fmt.Errorf("gathering complexity metrics: %w", err)
 	}
 
-	return complexities, skippedErrs, nil
+	return complexities, skips, nil
 }
 
 // getConcurrencyLimit returns the number of goroutines to use for parallel
@@ -130,7 +143,7 @@ func (a *defaultComplexityAnalyzer) getConcurrencyLimit() int64 {
 	return limit
 }
 
-func (a *defaultComplexityAnalyzer) makeWalkFunc(root string, g *errgroup.Group, ctx context.Context, sem *semaphore.Weighted, hb chan<- struct{}, complexities *[]funcComplexity, mu *sync.Mutex, skippedErrs *[]string, skippedMu *sync.Mutex, count *int) persistence.WalkFunc {
+func (a *defaultComplexityAnalyzer) makeWalkFunc(root string, g *errgroup.Group, ctx context.Context, sem *semaphore.Weighted, hb chan<- struct{}, complexities *[]funcComplexity, mu *sync.Mutex, skips *walkSkips, skippedMu *sync.Mutex, count *int) persistence.WalkFunc {
 	return func(filePath string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -153,19 +166,28 @@ func (a *defaultComplexityAnalyzer) makeWalkFunc(root string, g *errgroup.Group,
 		if filepath.Ext(filePath) != ".go" {
 			return nil
 		}
+		// R2 (issue #1455): a file excluded from the host build by build
+		// constraints is never compiled by `go tool` on this host — skip it
+		// synchronously (single-threaded callback, no lock needed) and report
+		// it under NotCompiled instead of analyzing it.
+		if label, excluded := buildTagExcluded(filepath.Dir(filePath), filepath.Base(filePath)); excluded {
+			skips.NotCompiled = append(skips.NotCompiled,
+				fmt.Sprintf("%s: build tag: %s", filePath, label))
+			return nil
+		}
 
 		*count++
 		counter := *count
 		path := filePath
 
 		g.Go(func() error {
-			return a.processFileTask(ctx, sem, path, hb, counter, complexities, mu, skippedErrs, skippedMu)
+			return a.processFileTask(ctx, sem, path, hb, counter, complexities, mu, skips, skippedMu)
 		})
 		return nil
 	}
 }
 
-func (a *defaultComplexityAnalyzer) processFileTask(ctx context.Context, sem *semaphore.Weighted, path string, hb chan<- struct{}, counter int, complexities *[]funcComplexity, mu *sync.Mutex, skippedErrs *[]string, skippedMu *sync.Mutex) error {
+func (a *defaultComplexityAnalyzer) processFileTask(ctx context.Context, sem *semaphore.Weighted, path string, hb chan<- struct{}, counter int, complexities *[]funcComplexity, mu *sync.Mutex, skips *walkSkips, skippedMu *sync.Mutex) error {
 	if err := sem.Acquire(ctx, 1); err != nil {
 		return err
 	}
@@ -181,7 +203,7 @@ func (a *defaultComplexityAnalyzer) processFileTask(ctx context.Context, sem *se
 	fileComplexities, err := a.analyzeFile(path)
 	if err != nil {
 		skippedMu.Lock()
-		*skippedErrs = append(*skippedErrs, fmt.Sprintf("%s: %v", path, err))
+		skips.ParseErrors = append(skips.ParseErrors, fmt.Sprintf("%s: %v", path, err))
 		skippedMu.Unlock()
 		return nil // soft-fail: individual file errors don't stop the entire analysis
 	}

--- a/internal/tools/analysis/complexity_test.go
+++ b/internal/tools/analysis/complexity_test.go
@@ -161,10 +161,10 @@ func TestProcessFileTask_SemAcquireError(t *testing.T) {
 
 	var complexities []funcComplexity
 	var mu sync.Mutex
-	var skippedErrs []string
+	skips := walkSkips{}
 	var skippedMu sync.Mutex
 
-	err := analyzer.processFileTask(ctx, sem, "test.go", nil, 0, &complexities, &mu, &skippedErrs, &skippedMu)
+	err := analyzer.processFileTask(ctx, sem, "test.go", nil, 0, &complexities, &mu, &skips, &skippedMu)
 	if err == nil {
 		t.Error("expected error from sem.Acquire with cancelled context")
 	}
@@ -583,7 +583,7 @@ func TestGatherComplexities_ContextCancelled_MockFS(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel immediately, before GatherComplexities starts
 
-	complexities, skipped, err := analyzer.GatherComplexities(ctx, "testdata", nil)
+	complexities, skips, err := analyzer.GatherComplexities(ctx, "testdata", nil)
 	if err == nil {
 		t.Fatal("expected error from cancelled context, got nil")
 	}
@@ -593,9 +593,7 @@ func TestGatherComplexities_ContextCancelled_MockFS(t *testing.T) {
 	if complexities != nil {
 		t.Errorf("expected nil complexities on cancellation, got %d", len(complexities))
 	}
-	if skipped != nil {
-		t.Errorf("expected nil skipped on cancellation, got %d", len(skipped))
-	}
+	require.Equal(t, walkSkips{}, skips, "expected zero walkSkips on cancellation")
 }
 
 // TestComplexityAnalyzer_ErrgroupError exercises the g.Wait() error return

--- a/internal/tools/analysis/complexity_test.go
+++ b/internal/tools/analysis/complexity_test.go
@@ -284,6 +284,63 @@ func TestFormatResults_Truncation(t *testing.T) {
 	})
 }
 
+// TestGatherComplexities_ExcludesTestdata is the R1 (issue #1455) unit
+// regression: nested testdata/ directories are skipped by the complexity
+// walk (`go tool` never compiles them), while an explicit walk ROOT named
+// testdata is still honored (fixture workspaces are loaded by path).
+func TestGatherComplexities_ExcludesTestdata(t *testing.T) {
+	t.Parallel()
+
+	writeFile := func(t *testing.T, path, code string) {
+		t.Helper()
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0755))
+		require.NoError(t, os.WriteFile(path, []byte(code), 0644))
+	}
+
+	t.Run("nested testdata skipped", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		writeFile(t, filepath.Join(tmpDir, "a.go"), "package test\nfunc F() {}\n")
+		writeFile(t, filepath.Join(tmpDir, "testdata", "b.go"), "package test\nfunc G() {}\n")
+
+		analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, infra_persistence.NewOSFileSystem())
+		complexities, _, err := analyzer.GatherComplexities(context.Background(), tmpDir, nil)
+		require.NoError(t, err)
+		require.Len(t, complexities, 1)
+		require.Equal(t, "F", complexities[0].Name)
+		for _, c := range complexities {
+			for _, seg := range strings.Split(filepath.ToSlash(c.FilePath), "/") {
+				require.NotEqual(t, "testdata", seg, "no returned FilePath may contain a testdata segment")
+			}
+		}
+	})
+
+	t.Run("explicit testdata root honored", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		writeFile(t, filepath.Join(tmpDir, "testdata", "b.go"), "package test\nfunc G() {}\n")
+
+		analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, infra_persistence.NewOSFileSystem())
+		complexities, _, err := analyzer.GatherComplexities(context.Background(), filepath.Join(tmpDir, "testdata"), nil)
+		require.NoError(t, err)
+		require.Len(t, complexities, 1)
+		require.Equal(t, "G", complexities[0].Name)
+	})
+
+	t.Run("deeply nested testdata skipped", func(t *testing.T) {
+		t.Parallel()
+		tmpDir := t.TempDir()
+		writeFile(t, filepath.Join(tmpDir, "x", "a.go"), "package test\nfunc F() {}\n")
+		writeFile(t, filepath.Join(tmpDir, "x", "testdata", "deep", "c.go"), "package test\nfunc G() {}\n")
+
+		analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, infra_persistence.NewOSFileSystem())
+		complexities, _, err := analyzer.GatherComplexities(context.Background(), tmpDir, nil)
+		require.NoError(t, err)
+		require.Len(t, complexities, 1)
+		require.Equal(t, "F", complexities[0].Name)
+	})
+}
+
 func TestGatherComplexities_InvalidPath(t *testing.T) {
 	t.Parallel()
 	cache := newASTCache(".")

--- a/internal/tools/analysis/coverage_parser.go
+++ b/internal/tools/analysis/coverage_parser.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -319,6 +320,19 @@ func parseDataParts(parts []string, modulePrefix string) (*uncoveredBlock, error
 	return block, nil
 }
 
+// isTestDataPath reports whether a coverage-profile file path passes through
+// a testdata directory segment. R1 (issue #1455): `go tool` never compiles
+// testdata/ directories, so their blocks must never surface as gap rows; the
+// filter enforces that by construction rather than by go-tool behavior.
+func isTestDataPath(file string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(file), "/") {
+		if seg == "testdata" {
+			return true
+		}
+	}
+	return false
+}
+
 // parseCoverageProfile parses a go coverage profile and returns blocks with zero coverage.
 func parseCoverageProfile(ctx context.Context, r io.Reader, runner AnalysisGoRunner) ([]uncoveredBlock, error) {
 	var blocks []uncoveredBlock
@@ -332,6 +346,9 @@ func parseCoverageProfile(ctx context.Context, r io.Reader, runner AnalysisGoRun
 	for scanner.Scan() {
 		block, err := parseCoverageLine(scanner.Text(), modulePrefix)
 		if err != nil {
+			continue
+		}
+		if block != nil && isTestDataPath(block.File) {
 			continue
 		}
 		if block != nil {

--- a/internal/tools/analysis/coverage_parser_test.go
+++ b/internal/tools/analysis/coverage_parser_test.go
@@ -967,6 +967,58 @@ func TestGetDetailedCoverage_EmptyProfile(t *testing.T) {
 	}
 }
 
+// TestParseCoverageProfile_FiltersTestdataRows is the R1 coverage-side
+// regression (issue #1455): profile rows under any testdata/ directory are
+// dropped at parse time, so testdata blocks can never surface as gap rows
+// (`go tool` never compiles testdata/, but the filter enforces it by
+// construction).
+func TestParseCoverageProfile_FiltersTestdataRows(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	mock := &mockAnalysisGoRunner{
+		getModulePathFunc: func(ctx context.Context) (string, error) {
+			return "github.com/gosharplite/tell-me-go", nil
+		},
+	}
+
+	t.Run("testdata rows dropped, normal rows kept", func(t *testing.T) {
+		t.Parallel()
+		profile := "mode: count\n" +
+			"github.com/gosharplite/tell-me-go/internal/pkg/real.go:10.1,12.2 2 0\n" +
+			"github.com/gosharplite/tell-me-go/internal/pkg/testdata/fake.go:1.1,2.2 1 0\n" +
+			"testdata/root.go:1.1,2.2 1 0\n" +
+			"github.com/gosharplite/tell-me-go/internal/pkg/real.go:20.1,22.2 2 1\n"
+
+		blocks, err := parseCoverageProfile(ctx, strings.NewReader(profile), mock)
+		require.NoError(t, err)
+		require.Len(t, blocks, 1)
+		require.True(t, strings.HasSuffix(blocks[0].File, "real.go"), "expected real.go, got %q", blocks[0].File)
+		require.Equal(t, 10, blocks[0].Start)
+	})
+
+	t.Run("all-testdata profile yields zero blocks", func(t *testing.T) {
+		t.Parallel()
+		profile := "mode: count\n" +
+			"github.com/gosharplite/tell-me-go/internal/pkg/testdata/fake.go:1.1,2.2 1 0\n" +
+			"testdata/root.go:1.1,2.2 1 0\n"
+
+		blocks, err := parseCoverageProfile(ctx, strings.NewReader(profile), mock)
+		require.NoError(t, err)
+		require.Empty(t, blocks)
+	})
+
+	t.Run("malformed testdata row does not mask errors", func(t *testing.T) {
+		t.Parallel()
+		profile := "mode: count\n" +
+			"not a profile line\n" +
+			"github.com/gosharplite/tell-me-go/internal/pkg/testdata/fake.go:1.1,2.2 1 0\n"
+
+		blocks, err := parseCoverageProfile(ctx, strings.NewReader(profile), mock)
+		require.NoError(t, err)
+		require.Empty(t, blocks)
+	})
+}
+
 func TestParseCoverageProfile_MalformedLine(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/internal/tools/analysis/health_test.go
+++ b/internal/tools/analysis/health_test.go
@@ -484,8 +484,8 @@ type stubComplexityAnalyzer struct {
 func (s *stubComplexityAnalyzer) Analyze(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error) {
 	return tools.ToolResult{}, nil
 }
-func (s *stubComplexityAnalyzer) GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, []string, error) {
-	return s.complexities, nil, s.err
+func (s *stubComplexityAnalyzer) GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, walkSkips, error) {
+	return s.complexities, walkSkips{}, s.err
 }
 
 func TestCheckComplexity_AllPaths(t *testing.T) {

--- a/internal/tools/analysis/manager.go
+++ b/internal/tools/analysis/manager.go
@@ -17,7 +17,7 @@ import (
 // Analyzer interfaces for segregation and testing
 type complexityAnalyzer interface {
 	Analyze(ctx context.Context, args map[string]interface{}, hb chan<- struct{}) (tools.ToolResult, error)
-	GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, []string, error)
+	GatherComplexities(ctx context.Context, root string, hb chan<- struct{}) ([]funcComplexity, walkSkips, error)
 }
 
 type dependencyAnalyzer interface {

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -190,6 +190,47 @@ func TestVerifyNonFixCatalog_NoBuildTagExcludedFunctions(t *testing.T) {
 	require.True(t, found, "expected at least one shell_windows file reported as not compiled on host; got %v", skips.NotCompiled)
 }
 
+// TestDetailedCoverageReport_WorkspaceNoBuildTagOrTestdataRows is the R1/R2
+// coverage-side regression (issue #1455): the detailed-coverage report for
+// the workspace package must contain no testdata rows (parse-level filter)
+// and no build-tag-excluded rows (host compilation guarantee). The
+// proc_windows assertion is host-relative — skipped on Windows, where the
+// file compiles.
+func TestDetailedCoverageReport_WorkspaceNoBuildTagOrTestdataRows(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("proc_windows.go compiles on windows; guarantee is host-relative")
+	}
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	// Run from the module root so the coverage profile records repo-relative
+	// paths (catalog refs are repo-relative). The test binary's working
+	// directory is the package source directory, so chdir here and restore on
+	// cleanup. All arch-tagged tests are sequential, so the chdir cannot race
+	// a parallel test.
+	oldWD, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(repoRoot))
+	t.Cleanup(func() { _ = os.Chdir(oldWD) })
+
+	// Mirror production wiring (manager.go newAnalysisManager): the real `go`
+	// executor feeds both the runner and Exec; the catalog is the default live
+	// catalog; SP is the test mock (unused on this path).
+	executor := &exec.RealExecutor{}
+	m := &healthManager{
+		SP:          &mockSecurityProvider{},
+		Exec:        executor,
+		Runner:      toolchain.NewGoRunner(executor),
+		clk:         clock.RealClock{},
+		catalogPath: defaultNonFixCatalogPath,
+	}
+
+	report, err := m.getDetailedCoverageReport(context.Background(), "./internal/tools/workspace", nil, nil)
+	require.NoError(t, err)
+	require.NotContains(t, report, "testdata")
+	require.NotContains(t, report, "proc_windows")
+}
+
 // TestVerifyCoveragePinsMatchLiveCatalog is the coverage-pin regression gate
 // for the catalog matcher: it asserts the four formerly-HIGH coverage gaps
 // (config.go:249-251, task_service.go:101-103, manager.go:574-576,

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -67,6 +67,12 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		alerts = append(alerts, c.Name)
 	}
 
+	// R1 scope correction (issue #1455): testdata/ directories are excluded from
+	// the complexity walk, so the two tests/e2e/testdata/fakeplur/main.go
+	// functions left the measured population and are no longer gate-pinned.
+	// Their ACCEPTED catalog entries are retained (with drift notes) as the
+	// architectural acceptance record. The gate stays RED-first for every
+	// compiled over-threshold function it still measures.
 	expectedCataloged := map[string]funcComplexity{
 		"TestHistoryManager_SetPinned_WithFunctionCall":             {Line: 392, Complexity: 21, FilePath: "internal/infrastructure/history/history_test.go"},
 		"TestStartSpinnerLifecycle":                                 {Line: 176, Complexity: 17, FilePath: "internal/ui/renderer_spinner_test.go"},
@@ -112,8 +118,6 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestInjectorEnabledInsert":                                 {Line: 109, Complexity: 22, FilePath: "internal/agent/memory/injector_test.go"},
 		"TestLivePlurCapturePersists":                               {Line: 285, Complexity: 12, FilePath: "tests/e2e/memory_live_test.go"},
 		"TestNewChatter_MemoryClientLookup":                         {Line: 226, Complexity: 12, FilePath: "internal/app/chatter_test.go"},
-		"(*server).dispatchTool":                                    {Line: 419, Complexity: 14, FilePath: "tests/e2e/testdata/fakeplur/main.go"},
-		"newServer":                                                 {Line: 179, Complexity: 13, FilePath: "tests/e2e/testdata/fakeplur/main.go"},
 		"newestSourceMTime":                                         {Line: 79, Complexity: 13, FilePath: "tests/e2e/e2e_test.go"},
 		"TestToSDKContent_MixedUserTurn_OrdersInlineDataFirst":      {Line: 290, Complexity: 13, FilePath: "internal/infrastructure/llm/gemini/adapter_test.go"},
 		"TestToSDKContent_PoisonedPersistedShape_Normalizes":        {Line: 326, Complexity: 15, FilePath: "internal/infrastructure/llm/gemini/adapter_test.go"},
@@ -124,6 +128,26 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 
 	require.Equal(t, expectedCataloged, cataloged)
 	require.Empty(t, alerts)
+}
+
+// TestVerifyNonFixCatalog_NoTestdataInComplexityWalk is the R1 (issue #1455)
+// end-to-end regression: the live-repo complexity walk must never traverse a
+// testdata/ directory — `go tool` never compiles them, so they are outside
+// the analyzer's measured population.
+func TestVerifyNonFixCatalog_NoTestdataInComplexityWalk(t *testing.T) {
+	analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, persistencetest.NewPlainOSFileSystem())
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	complexities, _, err := analyzer.GatherComplexities(context.Background(), repoRoot, nil)
+	require.NoError(t, err)
+
+	for _, c := range complexities {
+		for _, seg := range strings.Split(filepath.ToSlash(c.FilePath), "/") {
+			require.NotEqual(t, "testdata", seg,
+				"complexity walk must not traverse testdata/ (R1, issue #1455): got %s", c.FilePath)
+		}
+	}
 }
 
 // TestVerifyCoveragePinsMatchLiveCatalog is the coverage-pin regression gate

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -260,6 +260,8 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		{"manager.go capBestBlock error branch", "internal/agent/session/context/manager.go", 571, 573},
 		{"failover.go ExtractDocument body", "internal/infrastructure/llm/failover.go", 131, 133},
 		{"resilient_client.go ExtractDocument body", "internal/infrastructure/llm/resilient_client.go", 106, 108},
+		{"clock.go FakeClock fake methods", "internal/pkg/clock/clock.go", 81, 108},
+		{"clock.go FakeTicker methods and realTicker.Stop", "internal/pkg/clock/clock.go", 116, 131},
 		{"mcp_factory.go resolveServerToken default case", "internal/infrastructure/di/mcp_factory.go", 246, 249},
 		{"mcp_factory.go gh auth token resolver", "internal/infrastructure/di/mcp_factory.go", 73, 75},
 		{"toolchain_factory.go registerSkillsShTools error", "internal/infrastructure/di/toolchain_factory.go", 127, 129},

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -294,6 +294,8 @@ func TestVerifyCoveragePinsMatchLiveCatalog(t *testing.T) {
 		{"container.go GetMCPClient nil-guard", "internal/infrastructure/di/container.go", 284, 286},
 		{"imports.go format.Node error branch", "internal/tools/analysis/imports.go", 50, 52},
 		{"process_executor.go RunCommand Start error", "internal/tools/workspace/process_executor.go", 90, 92},
+		{"process_executor.go setupCommand empty-parts guard", "internal/tools/workspace/process_executor.go", 131, 133},
+		{"process_executor.go resolveAndValidateOutputPath windows branch", "internal/tools/workspace/process_executor.go", 368, 378},
 		{"analysistest MockSymbolIndex HarvestDeclarations stub", "internal/tools/analysis/analysistest/mock_index.go", 61, 63},
 		{"process_executor.go LookPath delegation", "internal/tools/workspace/process_executor.go", 496, 498},
 		{"darwin system_metrics GetCPUStats fallback", "internal/infrastructure/telemetry/system_metrics_darwin_cgo.go", 38, 41},

--- a/internal/tools/analysis/real_nonfix_catalog_test.go
+++ b/internal/tools/analysis/real_nonfix_catalog_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -73,6 +74,12 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 	// Their ACCEPTED catalog entries are retained (with drift notes) as the
 	// architectural acceptance record. The gate stays RED-first for every
 	// compiled over-threshold function it still measures.
+	//
+	// R2 scope correction (issue #1455): build-tag-excluded files leave the
+	// measured population too — tests/e2e/memory_live_test.go carries
+	// //go:build e2e_live (ADR-068 §8), so TestLivePlurCapturePersists is no
+	// longer walked on a plain host and its gate row is removed. Its ACCEPTED
+	// catalog entry is retained as the architectural acceptance record.
 	expectedCataloged := map[string]funcComplexity{
 		"TestHistoryManager_SetPinned_WithFunctionCall":             {Line: 392, Complexity: 21, FilePath: "internal/infrastructure/history/history_test.go"},
 		"TestStartSpinnerLifecycle":                                 {Line: 176, Complexity: 17, FilePath: "internal/ui/renderer_spinner_test.go"},
@@ -116,7 +123,6 @@ func TestVerifyNonFixCatalog(t *testing.T) {
 		"TestHookCaptureBranchI":                                    {Line: 61, Complexity: 13, FilePath: "internal/agent/memory/hook_test.go"},
 		"TestHookFull":                                              {Line: 359, Complexity: 21, FilePath: "internal/agent/memory/hook_test.go"},
 		"TestInjectorEnabledInsert":                                 {Line: 109, Complexity: 22, FilePath: "internal/agent/memory/injector_test.go"},
-		"TestLivePlurCapturePersists":                               {Line: 285, Complexity: 12, FilePath: "tests/e2e/memory_live_test.go"},
 		"TestNewChatter_MemoryClientLookup":                         {Line: 226, Complexity: 12, FilePath: "internal/app/chatter_test.go"},
 		"newestSourceMTime":                                         {Line: 79, Complexity: 13, FilePath: "tests/e2e/e2e_test.go"},
 		"TestToSDKContent_MixedUserTurn_OrdersInlineDataFirst":      {Line: 290, Complexity: 13, FilePath: "internal/infrastructure/llm/gemini/adapter_test.go"},
@@ -148,6 +154,40 @@ func TestVerifyNonFixCatalog_NoTestdataInComplexityWalk(t *testing.T) {
 				"complexity walk must not traverse testdata/ (R1, issue #1455): got %s", c.FilePath)
 		}
 	}
+}
+
+// TestVerifyNonFixCatalog_NoBuildTagExcludedFunctions is the R2 (issue #1455)
+// end-to-end regression: files excluded by build constraints on the host are
+// skipped by the live-repo complexity walk and reported in NotCompiled, not
+// analyzed. Host-relative by definition — skipped on Windows hosts where
+// these files compile.
+func TestVerifyNonFixCatalog_NoBuildTagExcludedFunctions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("build-tag files compile on windows; guarantee is host-relative")
+	}
+	analyzer := newComplexityAnalyzer(newASTCache("."), &mockSecurityProvider{}, persistencetest.NewPlainOSFileSystem())
+	repoRoot, err := findModuleRoot()
+	require.NoError(t, err)
+
+	complexities, skips, err := analyzer.GatherComplexities(context.Background(), repoRoot, nil)
+	require.NoError(t, err)
+
+	for _, c := range complexities {
+		base := filepath.Base(c.FilePath)
+		require.NotEqual(t, "proc_windows.go", base,
+			"build-tag-excluded file must not be analyzed (R2, issue #1455): got %s", c.FilePath)
+		require.NotEqual(t, "shell_windows_test.go", base,
+			"build-tag-excluded file must not be analyzed (R2, issue #1455): got %s", c.FilePath)
+		require.NotEqual(t, "shell_windows_encoding_test.go", base,
+			"build-tag-excluded file must not be analyzed (R2, issue #1455): got %s", c.FilePath)
+	}
+	found := false
+	for _, s := range skips.NotCompiled {
+		if strings.Contains(s, filepath.Join("internal", "tools", "workspace", "shell_windows")) {
+			found = true
+		}
+	}
+	require.True(t, found, "expected at least one shell_windows file reported as not compiled on host; got %v", skips.NotCompiled)
 }
 
 // TestVerifyCoveragePinsMatchLiveCatalog is the coverage-pin regression gate

--- a/internal/ui/tui/progress/model_test.go
+++ b/internal/ui/tui/progress/model_test.go
@@ -5,6 +5,7 @@ package progress
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/gosharplite/tell-me-go/internal/domain/events"
 	"github.com/gosharplite/tell-me-go/internal/domain/llm"
+	"github.com/gosharplite/tell-me-go/internal/domain/ports"
 	"github.com/gosharplite/tell-me-go/internal/domain/tools"
 	"github.com/gosharplite/tell-me-go/internal/pkg/metricsfmt"
 	"github.com/stretchr/testify/assert"
@@ -1868,4 +1870,311 @@ func TestWaitEventsRenderSpinnerInView(t *testing.T) {
 			assert.True(t, foundFrame, "View() must contain a braille spinner frame")
 		})
 	}
+}
+
+// recordMetricsProvider records GetCPUStats/GetMemoryPercent calls. The first
+// GetCPUStats call returns the fixed (100, 40) baseline; subsequent calls
+// return cumulative totals so a second sample computes a real CPU delta.
+type recordMetricsProvider struct {
+	cpuCalls, memCalls int
+}
+
+func (r *recordMetricsProvider) GetCPUStats() (int64, int64) {
+	r.cpuCalls++
+	return int64(100 * r.cpuCalls), int64(40 * r.cpuCalls)
+}
+
+func (r *recordMetricsProvider) GetMemoryPercent() float64 {
+	r.memCalls++
+	return 42.5
+}
+
+// newDispatchTestModel returns a production-default model (NewModel) wired to
+// an already-closed event channel: an accidental waitForEvent returns
+// channelClosedMsg immediately instead of blocking (ADR-036 — no goroutines,
+// no waits, deterministic primitives only).
+func newDispatchTestModel(t *testing.T, provider ports.SystemMetricsProvider) *model {
+	t.Helper()
+	ch := make(chan events.Event)
+	close(ch)
+	return NewModel(context.Background(), ch, provider).(*model)
+}
+
+// unhandledEvent is an event type the domainEventMsg switch does not know,
+// for asserting the handleDomainEvent fallthrough.
+type unhandledEvent struct{}
+
+func (unhandledEvent) Type() string { return "unhandled" }
+
+func TestModel_Update_Dispatch(t *testing.T) {
+	t.Run("q key quits", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+		require.NotNil(t, cmd)
+		assert.IsType(t, tea.QuitMsg{}, cmd())
+	})
+
+	t.Run("ctrl+c quits", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+		require.NotNil(t, cmd)
+		assert.IsType(t, tea.QuitMsg{}, cmd())
+	})
+
+	t.Run("unmatched key leaves model unchanged", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		assert.Nil(t, cmd)
+		assert.Equal(t, stateIdle, updated.(*model).currentState)
+		assert.Equal(t, 80, updated.(*model).width)
+		assert.Equal(t, 24, updated.(*model).height)
+	})
+
+	t.Run("window size height above 8 sets body viewport", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+		assert.Nil(t, cmd)
+		assert.Equal(t, 100, updated.(*model).width)
+		assert.Equal(t, 30, updated.(*model).height)
+		assert.Equal(t, 22, updated.(*model).bodyVP.Height)
+	})
+
+	t.Run("window size height at or below 8 zeroes body viewport", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(tea.WindowSizeMsg{Width: 100, Height: 6})
+		assert.Nil(t, cmd)
+		assert.Equal(t, 0, updated.(*model).bodyVP.Height)
+	})
+
+	t.Run("matching-generation tick advances frame and reschedules", func(t *testing.T) {
+		m := newDispatchTestModel(t, &recordMetricsProvider{})
+		m.spinner.start("Working", false)
+		updated, cmd := m.Update(spinnerTickMsg{generation: m.spinner.generation})
+		assert.Equal(t, 1, updated.(*model).spinner.frame, "frame must advance 0→1")
+		assert.NotNil(t, cmd, "next tick must be scheduled")
+	})
+
+	t.Run("stale-generation tick is dropped", func(t *testing.T) {
+		m := newDispatchTestModel(t, &recordMetricsProvider{})
+		m.spinner.start("Working", false)
+		updated, cmd := m.Update(spinnerTickMsg{generation: m.spinner.generation - 1})
+		assert.Nil(t, cmd)
+		assert.False(t, updated.(*model).spinner.tickActive)
+	})
+
+	t.Run("session-complete suppresses ticks", func(t *testing.T) {
+		m := newDispatchTestModel(t, &recordMetricsProvider{})
+		m.spinner.start("Working", false)
+		m.sessionComplete = true
+		updated, cmd := m.Update(spinnerTickMsg{generation: m.spinner.generation})
+		assert.Nil(t, cmd)
+		assert.True(t, updated.(*model).sessionComplete)
+	})
+
+	t.Run("metrics-sampling tick populates metrics state", func(t *testing.T) {
+		m := newDispatchTestModel(t, &recordMetricsProvider{})
+		m.spinner.start("Working", true)
+		updated, cmd := m.Update(spinnerTickMsg{generation: m.spinner.generation})
+		rp := updated.(*model).metricsProvider.(*recordMetricsProvider)
+		assert.Equal(t, 1, rp.cpuCalls)
+		assert.Equal(t, 1, rp.memCalls)
+		assert.Equal(t, 42.5, updated.(*model).lastMemPercent)
+		assert.False(t, updated.(*model).lastSampleTime.IsZero())
+		assert.NotNil(t, cmd, "next tick must be scheduled")
+	})
+
+	t.Run("metrics throttle samples at most once per second", func(t *testing.T) {
+		m := newDispatchTestModel(t, &recordMetricsProvider{})
+		m.spinner.start("Working", true)
+		gen := m.spinner.generation
+		_, _ = m.Update(spinnerTickMsg{generation: gen})
+		updated, _ := m.Update(spinnerTickMsg{generation: gen})
+		rp := updated.(*model).metricsProvider.(*recordMetricsProvider)
+		assert.Equal(t, 1, rp.cpuCalls, "second consecutive tick must hit the <1s throttle")
+		assert.Equal(t, 2, updated.(*model).spinner.frame, "frame still advances on throttled tick")
+	})
+
+	t.Run("mdRenderCompleteMsg out-of-bounds indices leave bodyLines unchanged", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		m.bodyLines = append(m.bodyLines, bodyEntry{text: "Current", raw: "Current", needsRender: true})
+		for _, idx := range []int{-1, len(m.bodyLines)} {
+			updated, cmd := m.Update(mdRenderCompleteMsg{index: idx, rendered: "Stale"})
+			assert.Nil(t, cmd)
+			assert.Equal(t, "Current", updated.(*model).bodyLines[0].text)
+			assert.True(t, updated.(*model).bodyLines[0].needsRender)
+		}
+	})
+
+	t.Run("mdRenderCompleteMsg on non-renderable entry leaves it unchanged", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		m.bodyLines = append(m.bodyLines, bodyEntry{text: "Done", needsRender: false})
+		updated, cmd := m.Update(mdRenderCompleteMsg{index: 0, rendered: "Rendered"})
+		assert.Nil(t, cmd)
+		assert.Equal(t, "Done", updated.(*model).bodyLines[0].text)
+		assert.False(t, updated.(*model).bodyLines[0].needsRender)
+	})
+
+	t.Run("mdRenderCompleteMsg on renderable entry applies the render", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		m.bodyLines = append(m.bodyLines, bodyEntry{text: "raw fallback", raw: "raw", needsRender: true})
+		updated, cmd := m.Update(mdRenderCompleteMsg{index: 0, rendered: "Rendered"})
+		assert.Nil(t, cmd)
+		assert.Equal(t, "Rendered", updated.(*model).bodyLines[0].text)
+		assert.False(t, updated.(*model).bodyLines[0].needsRender)
+	})
+
+	t.Run("channelClosedMsg completes the session and quits", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(channelClosedMsg{})
+		require.NotNil(t, cmd)
+		assert.IsType(t, tea.QuitMsg{}, cmd())
+		assert.True(t, updated.(*model).sessionComplete)
+	})
+
+	t.Run("error message is stored", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(errors.New("boom"))
+		assert.Nil(t, cmd)
+		require.NotNil(t, updated.(*model).err)
+		assert.Equal(t, "boom", updated.(*model).err.Error())
+	})
+
+	t.Run("UserPromptEvent appends the prompt entry", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(domainEventMsg(events.UserPromptEvent{Text: "hi"}))
+		assert.NotNil(t, cmd, "dispatch must return the batched waitForEvent/render cmd")
+		require.Len(t, updated.(*model).bodyLines, 1)
+		assert.Equal(t, "[You] hi", updated.(*model).bodyLines[0].text)
+		assert.Equal(t, "hi", updated.(*model).bodyLines[0].raw)
+		assert.True(t, updated.(*model).bodyLines[0].needsRender)
+	})
+
+	t.Run("default branch leaves model unchanged", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(struct{}{})
+		assert.Nil(t, cmd)
+		assert.Equal(t, stateIdle, updated.(*model).currentState)
+		assert.Empty(t, updated.(*model).bodyLines)
+	})
+
+	t.Run("unhandled domain event falls through to waitForEvent", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		updated, cmd := m.Update(domainEventMsg(unhandledEvent{}))
+		assert.NotNil(t, cmd, "fallthrough returns waitForEvent")
+		assert.Equal(t, stateIdle, updated.(*model).currentState)
+		assert.Empty(t, updated.(*model).bodyLines)
+	})
+}
+
+func TestModel_Init_WaitForEvent(t *testing.T) {
+	t.Run("closed channel yields channelClosedMsg", func(t *testing.T) {
+		m := newDispatchTestModel(t, nil)
+		msg := m.Init()()
+		assert.IsType(t, channelClosedMsg{}, msg)
+	})
+
+	t.Run("buffered channel yields the wrapped domain event", func(t *testing.T) {
+		ch := make(chan events.Event, 1)
+		ch <- events.UserPromptEvent{Text: "hi"}
+		m := NewModel(context.Background(), ch, nil).(*model)
+		msg := m.Init()()
+		dm, ok := msg.(domainEventMsg)
+		require.True(t, ok, "expected domainEventMsg, got %T", msg)
+		assert.Equal(t, events.UserPromptEvent{Text: "hi"}, events.Event(dm))
+	})
+}
+
+func TestModel_SampleMetrics_CPUCompute(t *testing.T) {
+	m := newDispatchTestModel(t, &recordMetricsProvider{})
+
+	cpu1, mem1 := m.sampleMetrics(time.Now())
+	assert.Equal(t, 0.0, cpu1, "first sample has no delta: CPU percent stays zero")
+	assert.Equal(t, 42.5, mem1)
+
+	cpu2, mem2 := m.sampleMetrics(time.Now().Add(2 * time.Second))
+	assert.Equal(t, 60.0, cpu2, "(1 - 40/100) * 100 after a 100→200 total / 40→80 idle delta")
+	assert.Equal(t, 42.5, mem2)
+}
+
+func TestModel_SafeTruncate(t *testing.T) {
+	tests := []struct {
+		name   string
+		in     string
+		maxLen int
+		want   string
+	}{
+		{"short string returned as-is", "hello", 10, "hello"},
+		{"ascii cut at maxLen", "hello world", 5, "hello"},
+		{"multibyte cut never splits a rune", "héllo", 2, "hé"},
+		{"zero maxLen yields empty", "hello", 0, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, safeTruncate(tt.in, tt.maxLen))
+		})
+	}
+}
+
+func TestModel_LogToolCall_DedupReturn(t *testing.T) {
+	ch := make(chan events.Event)
+	close(ch)
+	m := NewModel(context.Background(), ch, nil).(*model)
+
+	dup := &llm.FunctionCall{ID: "call_1", Name: "read_file", Args: map[string]interface{}{"filepath": "main.go"}}
+	content := &llm.Content{Parts: []*llm.Part{{FunctionCall: dup}, {FunctionCall: dup}}}
+	m.Update(domainEventMsg(events.ResponseEvent{Content: content}))
+
+	assert.Len(t, m.bodyLines, 1, "duplicate call ID within one response logs only once (second hits the logToolCall dedup return)")
+}
+
+func TestModel_LogToolCall_TruncatesLongValues(t *testing.T) {
+	ch := make(chan events.Event)
+	close(ch)
+	m := NewModel(context.Background(), ch, nil).(*model)
+
+	long := strings.Repeat("x", 250)
+	m.logToolCall(&llm.FunctionCall{
+		ID:   "call_1",
+		Name: "read_file",
+		Args: map[string]interface{}{"content": long},
+	})
+
+	require.Len(t, m.bodyLines, 1)
+	action := m.bodyLines[0].text
+	assert.Contains(t, action, "read_file(content: ")
+	assert.Contains(t, action, "...", "long values must be truncated with an ellipsis")
+	assert.Less(t, len(action), len(long)+30, "truncated action must be far shorter than the raw value")
+}
+
+func TestModel_ToolResultEvent_EmptyTextIsNoOp(t *testing.T) {
+	m := newDispatchTestModel(t, nil)
+	before := len(m.bodyLines)
+	updated, cmd := m.Update(domainEventMsg(events.ToolResultEvent{
+		Name:   "read_file",
+		Result: tools.ToolResult{Text: ""},
+	}))
+	assert.NotNil(t, cmd)
+	assert.Len(t, updated.(*model).bodyLines, before, "empty result text must not append a log line")
+}
+
+func TestModel_RenderMarkdownAsyncCmd(t *testing.T) {
+	m := newDispatchTestModel(t, nil)
+	m.bodyLines = append(m.bodyLines, bodyEntry{text: "raw fallback", raw: "plain text", needsRender: true})
+
+	msg := m.renderMarkdownAsync("plain text", 80, 0)()
+	md, ok := msg.(mdRenderCompleteMsg)
+	require.True(t, ok, "expected mdRenderCompleteMsg, got %T", msg)
+	assert.Equal(t, 0, md.index)
+	assert.NotEmpty(t, md.rendered, "glamour render must produce output for plain text")
+
+	updated, _ := m.Update(md)
+	assert.Equal(t, md.rendered, updated.(*model).bodyLines[0].text)
+	assert.False(t, updated.(*model).bodyLines[0].needsRender)
+}
+
+func TestNewRenderer(t *testing.T) {
+	r := NewRenderer(nil)
+	require.NotNil(t, r)
+	_, ok := r.(ports.ProgressRenderer)
+	assert.True(t, ok, "NewRenderer must return a ports.ProgressRenderer")
 }


### PR DESCRIPTION
Closes #1455.

## Summary

Three-phase follow-up from the 2026-09 coverage & complexity architecture review, executed in the issue's mandated order 1 → 2 → 3 via the Architect→Coder pipeline (each task independently reviewed and gate-verified by the Architect). 7 commits, 11 files, +770/−32.

**Phase 1 — R1+R2 analyzer measurement fidelity** (`226746f4`, `88abc80e`, `fdba83f9`)
The complexity walk now honors the Go convention: `testdata/` directories are skipped (explicit walk roots still honored — fixture workspaces load by path unchanged), and build-tag-excluded files are reported as `skipped (not compiled on host; build tag: …)` via a structured `walkSkips{ParseErrors, NotCompiled}` return instead of being analyzed. A defensive `testdata/` filter in `parseCoverageProfile` makes the "zero testdata rows in detailed-coverage" criterion hold by construction, with regression tests. Effect: ~200 phantom fixture rows and the CC=10 `ComplexPrivate` fixture function leave the reports; `proc_windows.go`/`shell_windows_*` no longer surface as uncovered.

**Phase 2 — R3 catalog re-anchoring (Drift Policy)** (`e7f062a6`, `28f081a7`)
Maintenance only, per the Drift Policy — no new ACCEPTED entries: `process_executor.go` pins re-anchored (`setupCommand` 118→131-133, `resolveAndValidateOutputPath` Windows branch 356→368-378, verified against live source and fresh profiles); the `pkg/clock` file-only `See:` (dropped by the coverage matcher) replaced with per-symbol line specs — cataloged gaps **0 → 15**; `#1431` sweep re-confirmed accurate. Every catalog edit landed in the same commit as its `real_nonfix_catalog_test.go` partition rows (Coordination rule).

**Phase 3 — R4 TUI dispatch-branch coverage** (`2661b33d`, `0cd6a0a7`)
`(*model).Update` and `(*model).handleKeyMsg` now **100%** via a 17-subtest table-driven dispatch suite plus deterministic supplementals; package **85.7% → 95.3%**. ADR-036-clean (no `time.Sleep` — closed channels, executed cmds, explicit-time CPU-delta assertions), ADR-021-clean (hand-rolled function-field fakes), zero production edits. A closing catalog drift note records the `renderMarkdownAsync` coverage change.

## Acceptance-criteria mapping

**Phase 1**
- [x] Detailed-coverage report contains zero `testdata/` rows → parse-level filter (`isTestDataPath`) + unit tests; arch-gated e2e on the live workspace report
- [x] Complexity report contains no `testdata/` functions → walk skip + `TestVerifyNonFixCatalog_NoTestdataInComplexityWalk` (live-repo gather: 0 testdata paths)
- [x] Build-tag-excluded files reported as skipped → `walkSkips.NotCompiled` + `ℹ️ … not compiled on host` report block + `TestVerifyNonFixCatalog_NoBuildTagExcludedFunctions` (21 skips on this host incl. `shell_windows*`; `proc_windows.go` yields zero rows)
- [x] Analyzer changes unit-tested, table-driven → `complexity_test.go`, `buildtag_test.go`, `coverage_parser_test.go`
- [x] `make verify-nonfix-catalog` still passes, RED-first intact → population shrank twice via documented scope corrections (below); no tolerance/skip-list/baseline added
- [x] No production behavior change outside the reporting path → only `internal/tools/analysis` walkers/parsers; Makefile `test-coverage` exclusion list untouched (`coverage-exclusions-explicit` preserved)

**Phase 2**
- [x] `make verify-nonfix-catalog` passes with re-anchored pins resolving via interval overlap → 4 new partition rows (`process_executor` 131-133/368-378; `clock` 81-108/116-131)
- [x] Cataloged-gap count rises → `pkg/clock` 0 → 15 cataloged / 0 actionable; `setupCommand` + `resolveAndValidateOutputPath` blocks now carry `CatalogTitle` (block-level verified)
- [x] `make modelith-check` passes → green throughout

**Phase 3**
- [x] `Update`/`handleKeyMsg` dispatch branches covered, package ≥ 95% → 100% / 100%, total **95.3%**
- [x] New tests pass `go test -race` → PASS (and package-by-package via `make test-race`)
- [x] No new uncataloged over-threshold complexity → `TestVerifyNonFixCatalog` green (mechanically proves every new test function CC ≤ 10)

## Documented scope corrections (Drift Policy adjudications — no entries added or removed)

1. **fakeplur testdata rows (T1)**: `newServer`/`(*server).dispatchTool` (`tests/e2e/testdata/fakeplur/main.go`) left the measured population when R1 excluded `testdata/`; gate rows removed, ACCEPTED entries retained with Re-scoped drift notes, same commit.
2. **`e2e_live` row (T2)**: `TestLivePlurCapturePersists` carries `//go:build e2e_live` (ADR-068 §8) and was never compiled on a plain host — same class as `proc_windows.go`; gate row removed, entry retained, drift note recorded (T4).
3. **renderMarkdownAsync (T6 adjudication)**: the ≥95% criterion is mandatory and the statement math (irreducible `Run` + two error-branch floor) caps the package below 95% without the success path — so the success path was covered deterministically by executing the returned `tea.Cmd` (no TUI harness, no sleeps, production frozen). The two glamour error branches remain uncovered and still justify the ACCEPTED record; no pin drift (`See: 669-676` overlaps both remaining blocks); drift note recorded in `0cd6a0a7`.

## Verification

| Check | Status |
|-------|--------|
| `make check-full` (fmt, tidy, build, lint, all verify gates, modelith, fuzz-smoke, vulncheck, test, dead-code, coverage, test-race) | **PASS** — "All checks passed (including race detection)" |
| `verify-nonfix-catalog` | PASS — RED-first intact, 4 new pin rows, all three arch gate tests |
| `verify-adr-index` / `modelith-check` / `verify-no-test-sleep` / `verify-mock-pattern` | PASS |
| `go test -race ./internal/ui/tui/progress` | PASS |
| `ui/tui/progress` coverage | 95.3% (was 85.7%); `Update`/`handleKeyMsg` 100% |
| `pkg/clock` cataloged gaps | 0 → 15 |
| Live-repo complexity gather | 0 testdata paths; 21 build-tag skips reported |
