### PR TITLE
test(analysis): cover headerBuildLabel read-error branch and // +build extraction (#1457)

### DIFF
--- a/internal/tools/analysis/buildtag_test.go
+++ b/internal/tools/analysis/buildtag_test.go
@@ -66,3 +66,28 @@ func TestBuildTagExcluded(t *testing.T) {
 		require.Equal(t, "windows", label)
 	})
 }
+
+// TestHeaderBuildLabel is the issue #1457 direct-call contract for
+// headerBuildLabel. Direct calls are required: the os.ReadFile error branch
+// (buildtag.go:38-40) is unreachable deterministically through
+// buildTagExcluded — MatchFile errors on a missing file and returns before
+// the call — and permission-based fault injection is host-dependent (root on
+// POSIX, ACLs on Windows), violating ADR-036 determinism. The legacy
+// // +build extraction branch (buildtag.go:47-49) has no coverage through
+// buildTagExcluded either. Host-independent; no GOOS skip.
+func TestHeaderBuildLabel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unreadable file returns empty", func(t *testing.T) {
+		t.Parallel()
+		got := headerBuildLabel(filepath.Join(t.TempDir(), "missing.go"))
+		require.Empty(t, got)
+	})
+
+	t.Run("legacy +build constraint extracted", func(t *testing.T) {
+		t.Parallel()
+		path := filepath.Join(t.TempDir(), "legacy.go")
+		require.NoError(t, os.WriteFile(path, []byte("// +build anunexpectedtag\n\npackage x\nfunc W() {}\n"), 0644))
+		require.Equal(t, "anunexpectedtag", headerBuildLabel(path))
+	})
+}


### PR DESCRIPTION
Closes #1457

## Summary

Test-only change closing the repo's last uncataloged **medium-priority** detailed-coverage gap: the `headerBuildLabel` read-error branch (`internal/tools/analysis/buildtag.go:38-40`, the `os.ReadFile` error path returning `""`). Extends the existing `buildtag_test.go` with `TestHeaderBuildLabel` (direct white-box call — the branch is unreachable deterministically through `buildTagExcluded`, since `build.Default.MatchFile` errors on a missing file and returns before the call, and permission-based fault injection would violate ADR-036 determinism).

Two subtests:
- **`unreadable file returns empty`** — nonexistent path under `t.TempDir()` → `""` (closes `buildtag.go:38.16,40.3`, the medium gap; pins the graceful-degradation ladder's bottom rung: `//go:build` label → suffix label → `"unspecified"`).
- **`legacy +build constraint extracted`** — `// +build anunexpectedtag` header → `"anunexpectedtag"` (closes `buildtag.go:47.48,49.5`; the optional hardening the issue offered — this branch had no coverage anywhere, and legacy `// +build` is live repo syntax).

Zero production-code changes; zero changes to `INTENTIONAL_NON_FIXES.md` and the partition test (no catalog entry — we fixed the gap per the `triage-loop-closed` direction).

## Acceptance criteria (issue #1457 checklist)

- [x] `TestHeaderBuildLabel` added to `buildtag_test.go` with the nonexistent-path case pinning `""` on read failure (closes lines 38-40).
- [x] Test is deterministic and race-safe per ADR-036 (no sleeps, `t.TempDir()`, `t.Parallel()` at top level and per subtest).
- [x] Zero production-code changes; zero changes to `INTENTIONAL_NON_FIXES.md` and the partition test (`git diff dev --stat`: exactly one file, +25/−0).
- [x] `buildtag.go` absent from the fresh detailed-coverage gap report (Medium Priority: **1 → 0**; both target blocks `38.16,40.3` and `47.48,49.5` at count=1; `headerBuildLabel` at **100.0%**).
- [x] `make check-full` green.

## Verification

| Check | Result |
|---|---|
| `go test -run 'TestBuildTagExcluded\|TestHeaderBuildLabel' -v ./internal/tools/analysis` | PASS — 4 existing + 2 new subtests |
| `go test -race ./internal/tools/analysis` | PASS (ok, 3.844s) |
| Coverage profile | `buildtag.go:38.16,40.3 1 1`, `buildtag.go:47.48,49.5 1 1`; `go tool cover -func` → `headerBuildLabel 100.0%`; accepted residuals (`:30`, `:68`) untouched as scoped |
| Detailed-coverage report (default nine test-double exclusions) | High 0, **Medium 0**, `buildtag.go` absent from every itemized section |
| `make verify-nonfix-catalog` | PASS — all seven gate lines; catalog and partition test unchanged |
| `make check-full` | PASS — "All checks passed (including race detection)" |

**Note on the gap-count delta:** the issue predicted `664 → 663` against its authoring-time snapshot; the accepted optional hardening (`// +build`) closes a second block, so the architect re-baselined the prediction to 664 → 662. On the current `dev` (v1.9.10 landed after the issue snapshot) the fresh report reads 664 total = 0 architectural + **0 medium** + 371 low + 293 cataloged — the absolute totals shifted with the tree between snapshot and execution, but the issue's promised invariants hold exactly: **medium 1 → 0** and **`buildtag.go` absent from all itemized sections**.

## Pipeline provenance

Produced by the Architect–Coder loop (issue-to-PR orchestration): the Architect authored the profile-proven spec (verifying no line drift, proving the `//go:build` direct call redundant and the `// +build` call live-uncovered) and independently re-verified the Coder's commit before declaring DONE; all gates re-run by the orchestrator.

🤖 Generated with [tell-me-go](https://github.com/gosharplite/tell-me-go)
